### PR TITLE
libffi unblock: ro/noexec mounts + O_TMPFILE rejection + access(2) mode bits (closes #42)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3717,16 +3717,95 @@ fn sys_sendfile(out_fd: usize, in_fd: usize, offset_ptr: u64, count: usize) -> i
 }
 
 /// access(pathname, mode) — Check user's permissions for a file.
-fn sys_access(pathname: u64, _mode: u64) -> i64 {
+///
+/// Per access(2):
+///   - F_OK (0): existence only — return 0 if the path resolves, -ENOENT otherwise.
+///   - R_OK (4): readable — granted unconditionally (no per-user perms yet).
+///   - W_OK (2): writable — denied with -EACCES on a read-only mount or when
+///     the inode mode lacks any of the write bits (mode & 0o222 == 0).
+///   - X_OK (1): executable — granted for directories (modulo the readability
+///     check above) or when the inode mode has any execute bit set.  On a
+///     `noexec` mount, X_OK is denied with -EACCES per mount(2).
+///
+/// The mount-flag set (ro / noexec) is derived from procfs::mount_opts_for
+/// which currently keys on (mountpoint, fstype).  Replacing that helper with
+/// per-mount flag plumbing later changes nothing here.
+fn sys_access(pathname: u64, mode: u64) -> i64 {
+    const F_OK: u64 = 0;
+    const X_OK: u64 = 1;
+    const W_OK: u64 = 2;
+    const R_OK: u64 = 4;
+
     let path_bytes = read_cstring_from_user(pathname);
     let path = match core::str::from_utf8(path_bytes) {
         Ok(s) => s,
-        Err(_) => return -22,
+        Err(_) => return -22, // EINVAL
     };
-    match crate::vfs::stat(path) {
-        Ok(_) => 0,
-        Err(_) => -2, // ENOENT
+
+    // Resolve to (mount_idx, inode).  Existence failure → -ENOENT.
+    let (mount_idx, inode) = match crate::vfs::resolve_path(path) {
+        Ok(t) => t,
+        Err(_) => return -2, // ENOENT
+    };
+
+    // F_OK alone: existence check passed already.
+    if mode == F_OK {
+        return 0;
     }
+
+    // Read inode mode bits and the mount's (path, fstype) under the lock,
+    // then drop it before consulting procfs::mount_opts_for to keep the
+    // critical section tight.
+    let (st, mount_path, fstype) = {
+        let mounts = crate::vfs::MOUNTS.lock();
+        let m = match mounts.get(mount_idx) {
+            Some(m) => m,
+            None => return -2,
+        };
+        let st = match m.fs.stat(inode) {
+            Ok(s) => s,
+            Err(_) => return -2,
+        };
+        (st, m.path.clone(), alloc::string::String::from(m.fs.name()))
+    };
+
+    let opts = crate::vfs::procfs::mount_opts_for(mount_path.as_str(), fstype.as_str());
+    let mount_ro     = opts.split(',').any(|t| t == "ro");
+    let mount_noexec = opts.split(',').any(|t| t == "noexec");
+    let perm = st.permissions;
+
+    // R_OK: we have no per-user / per-process credentials yet.  Treat every
+    // resolvable inode as readable.
+
+    // W_OK: deny on read-only mount, or if the mode bits lack any write bit.
+    if mode & W_OK != 0 {
+        if mount_ro || (perm & 0o222) == 0 {
+            return -13; // EACCES
+        }
+    }
+
+    // X_OK: directories are "executable" when readable (path-traversal bit).
+    // Regular files need at least one mode_t exec bit AND the mount must not
+    // be `noexec`.  Per access(2), X_OK on a noexec mount returns -EACCES.
+    if mode & X_OK != 0 {
+        let is_dir = st.file_type == crate::vfs::FileType::Directory;
+        if is_dir {
+            // No additional mode-bit gating for directory traversal.
+            // The noexec mount flag does not block directory traversal —
+            // it blocks only PROT_EXEC mappings of files on the mount.
+        } else if mount_noexec || (perm & 0o111) == 0 {
+            return -13; // EACCES
+        }
+    }
+
+    // Sanity for unknown bits: per access(2), passing bits other than R_OK |
+    // W_OK | X_OK | F_OK yields -EINVAL.  We accept any subset of those four
+    // and reject anything else.
+    if mode & !(R_OK | W_OK | X_OK | F_OK) != 0 {
+        return -22; // EINVAL
+    }
+
+    0
 }
 
 /// gettimeofday(tv, tz) — Get the time of day.

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2905,6 +2905,16 @@ pub fn sys_open_linux(pathname: u64, flags: u64, _mode: u64) -> i64 {
 }
 
 fn sys_open_linux_inner(pathname: u64, flags: u64, _mode: u64) -> i64 {
+    // O_TMPFILE (per open(2)) is encoded as 0x410000 (0x400000 | O_DIRECTORY).
+    // The detection bit is 0x400000.  The flag asks the kernel to create an
+    // unnamed inode under the given directory; we have no anonymous-inode
+    // support yet, so report -EOPNOTSUPP.  glibc's mkstemp falls back to the
+    // ordinary O_RDWR|O_CREAT|O_EXCL path which we already implement.
+    const O_TMPFILE_BIT: u64 = 0x0040_0000;
+    if flags & O_TMPFILE_BIT != 0 {
+        return -95; // EOPNOTSUPP
+    }
+
     let path_bytes = read_cstring_from_user(pathname);
     let path = match core::str::from_utf8(path_bytes) {
         Ok(s) => s,

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -14579,6 +14579,38 @@ fn test_procfs_mounts() -> bool {
     }
     test_println!("  root mount '/' present ok");
 
+    // Per proc(5), synthetic filesystems must advertise the "ro" and "noexec"
+    // mount options so userspace temp-exec scanners (libffi, glib, etc.) skip
+    // them when searching for a writable+executable directory via
+    // /proc/mounts + getmntent(3) / hasmntopt(3).  Search for a procfs line
+    // whose fstype field == "procfs" and whose opts field contains both
+    // "ro" and "noexec" as whole tokens.
+    let mut found_procfs_ro_noexec = false;
+    let mut start = 0;
+    for i in 0..n {
+        if content[i] == b'\n' {
+            let line = &content[start..i];
+            start = i + 1;
+            if line.is_empty() { continue; }
+            // Tokenise.
+            let s = match core::str::from_utf8(line) { Ok(s) => s, Err(_) => continue };
+            let toks: alloc::vec::Vec<&str> = s.split_whitespace().collect();
+            if toks.len() < 4 { continue; }
+            if toks[2] != "procfs" { continue; }
+            let opts: alloc::vec::Vec<&str> = toks[3].split(',').collect();
+            if opts.iter().any(|t| *t == "ro") && opts.iter().any(|t| *t == "noexec") {
+                found_procfs_ro_noexec = true;
+                break;
+            }
+        }
+    }
+    if !found_procfs_ro_noexec {
+        test_fail!("procfs_mounts",
+            "procfs mount line is missing ro/noexec opts (libffi mount loop will spin)");
+        return false;
+    }
+    test_println!("  procfs advertises ro,noexec ok");
+
     test_pass!("/proc/mounts fstab(5) format + recursive-lock regression");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1105,7 +1105,11 @@ pub fn run() -> ! {
     total += 1;
     if test_shebang_resolve() { passed += 1; }
 
-    // ── Test 177: TCP inbound 3WHS (SYN → SYN-ACK → ACK → Established) ──────
+    // ── Test 177: open(O_TMPFILE) returns -EOPNOTSUPP ──────────────────────
+    total += 1;
+    if test_open_tmpfile_eopnotsupp() { passed += 1; }
+
+    // ── Test 178: TCP inbound 3WHS (SYN → SYN-ACK → ACK → Established) ──────
     //
     // Gated on `kdb` because it relies on `tcp::snapshot_connections()`
     // to peek at the child-TCB created by the listener — the same API
@@ -19278,6 +19282,37 @@ fn test_openat2_basic() -> bool {
 
     crate::syscall::dispatch_linux(3, fd as u64, 0, 0, 0, 0, 0);
     test_pass!("openat2(437) basic — open /etc/passwd with open_how");
+    true
+}
+
+/// `open(path, O_TMPFILE|O_RDWR|O_EXCL, 0600)` must report -EOPNOTSUPP (95).
+///
+/// Per open(2) the flag asks the kernel to create an unnamed inode rooted at
+/// the given directory.  We have no anonymous-inode support yet, so userspace
+/// must see -EOPNOTSUPP and fall back to mkstemp(3) which uses a normal
+/// `open(name, O_RDWR|O_CREAT|O_EXCL, 0600)`.  Without the rejection,
+/// path-resolution succeeded and a directory fd was returned — libffi's
+/// open_temp_exec_file then operated on the directory inode and looped
+/// forever waiting for a working temp-file location.
+fn test_open_tmpfile_eopnotsupp() -> bool {
+    test_header!("open(O_TMPFILE) → -EOPNOTSUPP");
+
+    // O_RDWR(2) | O_EXCL(0x80) | O_DIRECTORY(0x10000) | O_TMPFILE bit (0x400000)
+    const O_TMPFILE: u64 = 0x0040_0000 | 0x0001_0000;
+    const O_RDWR:    u64 = 0x0000_0002;
+    const O_EXCL:    u64 = 0x0000_0080;
+
+    let path = b"/tmp\0";
+    let r = dispatch(2 /*open*/, path.as_ptr() as u64,
+                     O_TMPFILE | O_RDWR | O_EXCL, 0o600, 0, 0, 0);
+    if r != -95 {
+        test_fail!("open_tmpfile_eopnotsupp",
+            "open(O_TMPFILE,/tmp) = {} (expected -95 EOPNOTSUPP)", r);
+        return false;
+    }
+    test_println!("  open(/tmp, O_TMPFILE|O_RDWR|O_EXCL, 0600) = -EOPNOTSUPP ✓");
+
+    test_pass!("open(O_TMPFILE) → -EOPNOTSUPP");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -705,6 +705,14 @@ pub fn run() -> ! {
     total += 1;
     if test_procfs_mounts() { passed += 1; }
 
+    // ── Test 98c: open(O_TMPFILE) returns -EOPNOTSUPP ─────────────────────
+    total += 1;
+    if test_open_tmpfile_eopnotsupp() { passed += 1; }
+
+    // ── Test 98d: access(W_OK) on read-only mount returns -EACCES ─────────
+    total += 1;
+    if test_access_w_ok_readonly() { passed += 1; }
+
     // ── Test 99: procfs self/maps — per-process VMA listing ──────────────
 
     total += 1;
@@ -1105,11 +1113,7 @@ pub fn run() -> ! {
     total += 1;
     if test_shebang_resolve() { passed += 1; }
 
-    // ── Test 177: open(O_TMPFILE) returns -EOPNOTSUPP ──────────────────────
-    total += 1;
-    if test_open_tmpfile_eopnotsupp() { passed += 1; }
-
-    // ── Test 178: TCP inbound 3WHS (SYN → SYN-ACK → ACK → Established) ──────
+    // ── Test 177: TCP inbound 3WHS (SYN → SYN-ACK → ACK → Established) ──────
     //
     // Gated on `kdb` because it relies on `tcp::snapshot_connections()`
     // to peek at the child-TCB created by the listener — the same API
@@ -19313,6 +19317,79 @@ fn test_open_tmpfile_eopnotsupp() -> bool {
     test_println!("  open(/tmp, O_TMPFILE|O_RDWR|O_EXCL, 0600) = -EOPNOTSUPP ✓");
 
     test_pass!("open(O_TMPFILE) → -EOPNOTSUPP");
+    true
+}
+
+/// `access(path, mode)` honours the mode bits and the mount's read-only flag.
+///
+/// Per access(2):
+///   - F_OK (0)        → -ENOENT iff path doesn't exist, else 0
+///   - R_OK (4)        → 0 for any existing readable inode (no per-user perms)
+///   - W_OK (2)        → -EACCES on a read-only mount (procfs / sysfs)
+///   - X_OK (1)        → honours the inode mode bits (and `noexec` on the mount)
+///
+/// This is the access-side half of the libffi open_temp_exec_file_mnt fix:
+/// /proc and /sys must report -EACCES for W_OK so the loop advances to the
+/// next /etc/mtab entry rather than spinning on a synthetic mount.
+fn test_access_w_ok_readonly() -> bool {
+    test_header!("access(path, mode) — F_OK / R_OK / W_OK / X_OK semantics");
+
+    const F_OK: u64 = 0;
+    const W_OK: u64 = 2;
+    const R_OK: u64 = 4;
+
+    // F_OK: existing path must succeed.
+    let p_passwd = b"/etc/passwd\0";
+    let r = dispatch(21 /*access*/, p_passwd.as_ptr() as u64, F_OK, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("access_w_ok_readonly",
+            "access(/etc/passwd, F_OK) = {} (expected 0)", r);
+        return false;
+    }
+    test_println!("  access(/etc/passwd, F_OK) = 0 ✓");
+
+    // F_OK: missing path must fail with -ENOENT (-2).
+    let p_missing = b"/nonexistent_8b3f4d2c\0";
+    let r = dispatch(21, p_missing.as_ptr() as u64, F_OK, 0, 0, 0, 0);
+    if r != -2 {
+        test_fail!("access_w_ok_readonly",
+            "access(/nonexistent, F_OK) = {} (expected -2 ENOENT)", r);
+        return false;
+    }
+    test_println!("  access(/nonexistent, F_OK) = -ENOENT ✓");
+
+    // R_OK on /proc/cpuinfo: must succeed (procfs is readable).
+    let p_cpuinfo = b"/proc/cpuinfo\0";
+    let r = dispatch(21, p_cpuinfo.as_ptr() as u64, R_OK, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("access_w_ok_readonly",
+            "access(/proc/cpuinfo, R_OK) = {} (expected 0)", r);
+        return false;
+    }
+    test_println!("  access(/proc/cpuinfo, R_OK) = 0 ✓");
+
+    // W_OK on /proc/cpuinfo: must fail with -EACCES (-13) — procfs is ro.
+    // libffi's open_temp_exec_file_mnt skips any mount where access(dir,W_OK)
+    // is non-zero, so a correct -EACCES here lets the loop advance past /proc.
+    let r = dispatch(21, p_cpuinfo.as_ptr() as u64, W_OK, 0, 0, 0, 0);
+    if r != -13 {
+        test_fail!("access_w_ok_readonly",
+            "access(/proc/cpuinfo, W_OK) = {} (expected -13 EACCES on ro mount)", r);
+        return false;
+    }
+    test_println!("  access(/proc/cpuinfo, W_OK) = -EACCES ✓");
+
+    // W_OK on /: root ramfs is rw, must succeed.
+    let p_root = b"/\0";
+    let r = dispatch(21, p_root.as_ptr() as u64, W_OK, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("access_w_ok_readonly",
+            "access(/, W_OK) = {} (expected 0)", r);
+        return false;
+    }
+    test_println!("  access(/, W_OK) = 0 ✓");
+
+    test_pass!("access(path, mode) — F_OK / R_OK / W_OK / X_OK semantics");
     true
 }
 

--- a/kernel/src/vfs/procfs.rs
+++ b/kernel/src/vfs/procfs.rs
@@ -638,6 +638,26 @@ fn mangle_field(s: &str, out: &mut Vec<u8>) {
     }
 }
 
+/// Compute the fstab(5)-format mount options string for a (mountpoint, fstype) pair.
+///
+/// Per proc(5) and the kernel's MS_* mount flags, synthetic filesystems are
+/// always exposed read-only and non-executable (no point opening files there
+/// for `PROT_EXEC` mappings).  fat32 image data mounted under `/mnt` is the
+/// in-memory test stub and is treated read-only for the same reason; the
+/// real data disk at `/disk` is the only writable fat32 volume.  The root
+/// ramfs at `/` and any other mount fall back to the default `rw,relatime`.
+///
+/// The substrings "ro", "noexec", "nosuid", and "nodev" must be matchable as
+/// whole tokens by `hasmntopt(3)`-style consumers (libffi's
+/// `open_temp_exec_file_mnt` is one such caller, per fstab(5)/getmntent(3)).
+pub(crate) fn mount_opts_for(path: &str, fstype: &str) -> &'static str {
+    match fstype {
+        "procfs" | "sysfs" => "ro,noexec,nosuid,nodev,relatime",
+        "fat32" if path == "/mnt" => "ro,noexec,relatime",
+        _ => "rw,relatime",
+    }
+}
+
 /// Generate `/proc/mounts` content from the live mount table.
 ///
 /// Format per fstab(5): `<source> <mountpoint> <fstype> <opts> <freq> <passno>\n`
@@ -672,10 +692,11 @@ pub fn generate_mounts() -> Vec<u8> {
         // type
         mangle_field(fstype.as_str(), &mut out);
         out.push(b' ');
-        // options — "rw,relatime" is the canonical default (fstab(5)).
-        // Consumers that only check for "ro"/"noexec" substrings see neither
-        // here, which is the intended read-write no-restrictions semantics.
-        out.extend_from_slice(b"rw,relatime");
+        // options — derived from (mountpoint, fstype).  Synthetic filesystems
+        // (procfs, sysfs) and the in-memory fat32 test stub at /mnt are
+        // exposed read-only + noexec so userspace tools that scan /proc/mounts
+        // for an executable temp-file location (libffi, glib, etc.) skip them.
+        out.extend_from_slice(mount_opts_for(path, fstype).as_bytes());
         out.push(b' ');
         // freq, passno — both zero for all synthetic mounts.
         out.extend_from_slice(b"0 0\n");


### PR DESCRIPTION
## Summary

Three small kernel fixes that, together, unblock Firefox's libffi `open_temp_exec_file_mnt` retry loop. Verified live: Firefox now progresses past the previous freeze at sc=1072 and advances through full libxul/libc/libX11/libgtk dynamic loading before stopping at a *new* exit point in X11/GTK init (separate follow-up).

### Commits (each independently correct, citing only public specs)

- `c7cb74e` — **procfs: advertise `ro,noexec` on synthetic mounts in /proc/mounts**.
  Per `proc(5)`, synthetic filesystems are inherently non-writable and non-executable. Userspace temp-exec scanners (e.g. libffi via `getmntent(3)` + `hasmntopt(3)` per `fstab(5)`) skip mounts whose options contain `ro` or `noexec`. Output `ro,noexec,nosuid,nodev,relatime` for procfs/sysfs, `ro,noexec,relatime` for the in-memory fat32 stub at /mnt, and keep `rw,relatime` for the root ramfs and writable data disk at /disk.

- `81f1638` — **syscall: reject open(O_TMPFILE) with -EOPNOTSUPP**.
  Per `open(2)`, `O_TMPFILE` (encoded as `0x410000 = 0x400000 | O_DIRECTORY`) requests an unnamed inode. We have no anonymous-inode support, so without a guard the open handler returned a directory fd which userspace then tried to write to. Detect bit `0x400000` at the top of the openat handler and return -EOPNOTSUPP (errno 95) so glibc's `mkstemp(3)` falls back to the canonical `O_RDWR|O_CREAT|O_EXCL` path which already works.

- `ea9bd60` — **syscall: implement access(2) mode bits — F_OK/R_OK/W_OK/X_OK** *(Closes #42)*.
  `access(pathname, mode)` previously ignored `mode` and returned 0 for any existing path. Now correctly honours all four mode bits per `access(2)`, including -EACCES on read-only mounts for W_OK and on noexec mounts for X_OK. Mount RO/noexec status derived from the same per-mount heuristic used by `procfs::mount_opts_for` so a future per-mount-flag plumbing replaces both call sites in lockstep.

## Verification

Built `kernel/x86_64-astryx.json --features test-mode` clean.

Live boot under TCG (`scripts/qemu-harness.py start --features "firefox-test,syscall-trace,pf-trace,kdb" --no-kvm`):

- **Before** (master): livelock in libffi `open_temp_exec_file_mnt` after `/proc/mounts` read, sc=1072 frozen for ~190s, watchdog bugcheck at tick 75002.
- **After** (this branch): clean voluntary `exit_group(1)` at tick=6984, sc=615, pf=1560, with libxul + libc + libX11 + libgtk fully loaded. libffi found a writable temp dir from env vars *before* hitting the mount loop — exactly the expected outcome.

The new exit point is in X11/GTK display-connect territory (Firefox writes 31 + 52 bytes to fd=2 immediately before exit). Out of scope for this PR — separate next-blocker investigation underway.

## Test plan

- [x] `cargo +nightly check -p kernel --features test-mode` — clean
- [x] 3 new tests added (`test_open_tmpfile_eopnotsupp`, `test_access_w_ok_readonly`, `test_procfs_mounts` updated) — all pass
- [x] Pre-existing 5 data.img-stub failures unchanged (Musl hello, pie_elf, TCC compile, sigchld, ascension)
- [x] Firefox boot: progresses past previous freeze, advances through full dynamic loading, hits new (unrelated) exit point

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)