### PR TITLE
syscall: harden CLONE_CHILD_CLEARTID exit-time futex wake (refs #52)

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -941,12 +941,19 @@ pub fn exit_thread(exit_code: i64) {
                 .map(|t| t.clear_child_tid)
                 .unwrap_or(0)
         };
+        #[cfg(feature = "firefox-test")]
+        crate::serial_println!(
+            "[CLEARTID] tid={} pid={} clear_addr={:#x}",
+            tid, pid, clear_addr
+        );
         if clear_addr != 0 {
             // Write 0 to the tid address (in the process's user address space).
             let cr3 = {
                 let procs = PROCESS_TABLE.lock();
                 procs.iter().find(|p| p.pid == pid).map(|p| p.cr3).unwrap_or(0)
             };
+            #[cfg(feature = "firefox-test")]
+            crate::serial_println!("[CLEARTID] tid={} cr3={:#x}", tid, cr3);
             if cr3 != 0 {
                 crate::syscall::write_u32_to_user_pub(cr3, clear_addr, 0);
             }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1593,13 +1593,20 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // in r8 (arg5) through the syscall; the child does:  mov rdi, r8; call *rdx.
         // We must preserve these into the new thread's registers via user_entry_rdx/r8.
         435 => {
-            if arg2 < 56 || arg1 == 0 { return -22i64; } // EINVAL: struct too small
+            // CLONE_ARGS_SIZE_VER0 = 64 bytes (covers flags..tls).  Anything
+            // smaller cannot supply a tls offset; reject per clone(2).
+            if arg2 < 64 || arg1 == 0 { return -22i64; } // EINVAL: struct too small
             let clone_flags   = unsafe { *(arg1 as *const u64) };
             let stack_ptr     = unsafe { *((arg1 + 40) as *const u64) };
             let stack_size    = unsafe { *((arg1 + 48) as *const u64) };
             let tls           = unsafe { *((arg1 + 56) as *const u64) };
             let child_tidptr  = unsafe { *((arg1 + 16) as *const u64) };
             let parent_tidptr = unsafe { *((arg1 + 24) as *const u64) };
+            #[cfg(feature = "firefox-test")]
+            crate::serial_println!(
+                "[CLONE3] flags={:#x} child_tid={:#x} parent_tid={:#x} arg2_size={}",
+                clone_flags, child_tidptr, parent_tidptr, arg2
+            );
             let sp = if stack_ptr != 0 { stack_ptr + stack_size } else { 0 };
             const CLONE_THREAD: u64 = 0x00010000;
             const CLONE_VM:     u64 = 0x00000100;
@@ -4285,6 +4292,11 @@ pub fn sys_futex_linux(uaddr: u64, futex_op: u64, val: u64, timeout_ptr: u64, ua
             }
 
             let tid = crate::proc::current_tid();
+            #[cfg(feature = "firefox-test")]
+            crate::serial_println!(
+                "[FUTEX_WAIT_REG] tid={} pid={} uaddr={:#x} val={} op={:#x}",
+                tid, pid, uaddr, val, futex_op
+            );
             {
                 let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
                 waiters.entry((pid, uaddr)).or_insert_with(Vec::new).push(tid);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -944,8 +944,14 @@ pub fn write_u32_to_user_pub(cr3: u64, vaddr: u64, val: u32) {
 /// Wake futex waiters from the exit path (CLONE_CHILD_CLEARTID).
 /// This is called from proc::exit_thread when a thread with clear_child_tid exits.
 pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
+    #[cfg(feature = "firefox-test")]
+    let key_present;
     let tids_to_wake: alloc::vec::Vec<u64> = {
         let mut waiters = FUTEX_WAITERS.lock();
+        #[cfg(feature = "firefox-test")]
+        {
+            key_present = waiters.contains_key(&(pid, uaddr));
+        }
         if let Some(list) = waiters.get_mut(&(pid, uaddr)) {
             let mut result = alloc::vec::Vec::new();
             let mut woken = 0u64;
@@ -961,6 +967,20 @@ pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
             alloc::vec::Vec::new()
         }
     };
+    #[cfg(feature = "firefox-test")]
+    {
+        // Snapshot remaining keys for diagnosis if our lookup missed.
+        let waiters = FUTEX_WAITERS.lock();
+        let other_keys: alloc::vec::Vec<(u64, u64)> = waiters
+            .keys()
+            .filter(|&&(p, _)| p == pid)
+            .copied()
+            .collect();
+        crate::serial_println!(
+            "[FUTEX_WAKE_EXIT] pid={} uaddr={:#x} key_present={} woken={:?} remaining_pid_keys={:?}",
+            pid, uaddr, key_present, tids_to_wake, other_keys
+        );
+    }
     // Wake the threads (no lock held).
     let mut threads = crate::proc::THREAD_TABLE.lock();
     for wake_tid in tids_to_wake {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -713,6 +713,10 @@ pub fn run() -> ! {
     total += 1;
     if test_access_w_ok_readonly() { passed += 1; }
 
+    // ── Test 98e: CLONE_CHILD_CLEARTID exit-time futex wake ──────────────
+    total += 1;
+    if test_cleartid_futex_wake() { passed += 1; }
+
     // ── Test 99: procfs self/maps — per-process VMA listing ──────────────
 
     total += 1;
@@ -19390,6 +19394,136 @@ fn test_access_w_ok_readonly() -> bool {
     test_println!("  access(/, W_OK) = 0 ✓");
 
     test_pass!("access(path, mode) — F_OK / R_OK / W_OK / X_OK semantics");
+    true
+}
+
+/// Regression test for the CLONE_CHILD_CLEARTID exit-time futex wake.
+///
+/// Per clone(2), a thread spawned with CLONE_CHILD_CLEARTID stores a user
+/// virtual address (`child_tid`); when that thread terminates the kernel
+/// writes 0 to the address and performs a futex wake on it.  glibc 2.34+
+/// uses this hand-shake to implement pthread_join: the joiner sleeps in
+/// FUTEX_WAIT_BITSET on the same address (the `joinstate` field of the
+/// pthread descriptor) and is unblocked by the kernel's wake when the
+/// child exits.
+///
+/// This test pins the wake-side dispatch.  It does not run a real user
+/// thread (the BSP test runner cannot block); instead it inserts a fake
+/// waiter into the `(pid, uaddr)` queue, calls `futex_wake_for_exit`,
+/// and asserts:
+///   - the queue entry was consumed (key removed when last waiter pops),
+///   - the same call with no matching key is a no-op (no panic, no entry
+///     created).
+///
+/// The two failure modes this catches are exactly the keying / dispatch
+/// regressions that broke pthread_join in earlier kernels:
+///   - a (pid, uaddr) lookup-key mismatch leaves the waiter in the queue,
+///   - a stale entry left behind on a missing key would inadvertently
+///     wake a future, unrelated waiter on the same address.
+///
+/// Coverage gap (intentional, called out for future regressions):
+///   - clone3's storage of `child_tid` into the spawned thread's
+///     `clear_child_tid` slot is NOT exercised here; an end-to-end
+///     pthread_create / pthread_join repro requires a real user thread
+///     and is left to the firefox-test integration path.
+///   - the exit-path's lookup of `clear_addr` from THREAD_TABLE before
+///     calling `futex_wake_for_exit` is NOT exercised here; this test
+///     calls the wake function directly with a synthetic key.
+///   - the FUTEX_WAIT_BITSET ↔ FUTEX_WAKE_ON_EXIT interaction (per
+///     futex(2): a wake without an explicit bitset must match a
+///     WAIT_BITSET waiter, which Linux models as `FUTEX_BITSET_MATCH_ANY
+///     = ~0u32`) is NOT exercised here; the wake-side caller's bitset
+///     handling is covered by the regular FUTEX_WAKE syscall tests.
+fn test_cleartid_futex_wake() -> bool {
+    test_header!("CLONE_CHILD_CLEARTID exit-time futex wake (key match + dequeue)");
+
+    use crate::syscall::{FUTEX_WAITERS, futex_wake_for_exit};
+
+    // Pick a synthetic (pid, uaddr) pair that no real thread is using.
+    // The high tid value 0xFEED_1234 ensures we do not collide with any
+    // live thread; futex_wake_for_exit's secondary thread-state update
+    // is a benign no-op when the tid does not exist.
+    let fake_pid: u64    = 0xDEAD_BEEF;
+    let fake_uaddr: u64  = 0x7EFF_FF44_9990; // shape matches glibc joinstate addr
+    let fake_tid: u64    = 0xFEED_1234;
+
+    // Step 1: register a fake waiter.
+    {
+        let mut waiters = FUTEX_WAITERS.lock();
+        waiters.entry((fake_pid, fake_uaddr))
+            .or_insert_with(alloc::vec::Vec::new)
+            .push(fake_tid);
+    }
+    test_println!("  inserted fake waiter (pid={:#x}, uaddr={:#x}, tid={:#x})",
+        fake_pid, fake_uaddr, fake_tid);
+
+    // Step 2: call the same wake path proc::exit_thread invokes.
+    futex_wake_for_exit(fake_pid, fake_uaddr, 1);
+
+    // Step 3: the (pid, uaddr) key must be gone (last waiter popped).
+    {
+        let waiters = FUTEX_WAITERS.lock();
+        if waiters.contains_key(&(fake_pid, fake_uaddr)) {
+            drop(waiters);
+            test_fail!("cleartid_futex_wake",
+                "FUTEX_WAITERS still contains (pid={:#x}, uaddr={:#x}) after wake",
+                fake_pid, fake_uaddr);
+            // Best-effort cleanup so a failed run does not leak the entry.
+            FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+            return false;
+        }
+    }
+    test_println!("  futex_wake_for_exit consumed the waiter ✓");
+
+    // Step 4: idempotent no-op on missing key — must not insert anything.
+    futex_wake_for_exit(fake_pid, fake_uaddr, 1);
+    {
+        let waiters = FUTEX_WAITERS.lock();
+        if waiters.contains_key(&(fake_pid, fake_uaddr)) {
+            drop(waiters);
+            test_fail!("cleartid_futex_wake",
+                "wake-on-missing-key fabricated a stale entry");
+            FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+            return false;
+        }
+    }
+    test_println!("  wake-on-missing-key is a clean no-op ✓");
+
+    // Step 5: queue with multiple waiters — wake 1 leaves the rest.
+    {
+        let mut waiters = FUTEX_WAITERS.lock();
+        let v = waiters.entry((fake_pid, fake_uaddr))
+            .or_insert_with(alloc::vec::Vec::new);
+        v.push(0xAAA1);
+        v.push(0xAAA2);
+        v.push(0xAAA3);
+    }
+    futex_wake_for_exit(fake_pid, fake_uaddr, 1);
+    let remaining = {
+        let waiters = FUTEX_WAITERS.lock();
+        waiters.get(&(fake_pid, fake_uaddr)).map(|v| v.len()).unwrap_or(0)
+    };
+    if remaining != 2 {
+        // Cleanup before failing.
+        FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+        test_fail!("cleartid_futex_wake",
+            "expected 2 remaining waiters, got {}", remaining);
+        return false;
+    }
+    test_println!("  wake-1 of 3 leaves 2 remaining ✓");
+    // Drain the rest so we leave FUTEX_WAITERS clean.
+    futex_wake_for_exit(fake_pid, fake_uaddr, u64::MAX);
+    let leftover = {
+        let waiters = FUTEX_WAITERS.lock();
+        waiters.contains_key(&(fake_pid, fake_uaddr))
+    };
+    if leftover {
+        FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+        test_fail!("cleartid_futex_wake", "drain wake left a stale key");
+        return false;
+    }
+
+    test_pass!("CLONE_CHILD_CLEARTID exit-time futex wake (key match + dequeue)");
     true
 }
 


### PR DESCRIPTION
> Re-opens after PR #53 auto-closed when its base branch \`fix/libffi-mount-loop\` was deleted on PR #51 merge. Branch rebased onto current master; same single commit, same content (174+/1−), all caveats from the prior review already addressed.

## Summary

Defensive hardening + regression test for the \`pthread_create\` / \`CLONE_CHILD_CLEARTID\` exit-time futex-wake handshake, prompted by issue #52.

The deadlock reported in #52 — \`pthread_create\` worker spawned via \`clone3(CLONE_CHILD_CLEARTID)\` cleanly exits but the joiner's \`FUTEX_WAIT_BITSET\` on glibc 2.43's \`joinstate\` field never wakes — was investigated under both KVM-accelerated and TCG-only QEMU runs and **could not be reproduced** on the current branch.

End-to-end traces confirm all three steps of the handshake fire correctly:

\`\`\`
[CLONE3] flags=0x3d0f00 child_tid=0x7eff... arg2_size=88
[FUTEX_WAIT_REG] tid=1 pid=1 uaddr=0x7eff... val=2 op=0x109
[CLEARTID] tid=2 pid=1 clear_addr=0x7eff... cr3=0x...
[FUTEX_WAKE_EXIT] pid=1 uaddr=0x7eff... key_present=true woken=[1]
[SC-RET] pid=1 tid=1 nr=202 ret=0x0
\`\`\`

After the wake the joiner's \`FUTEX_WAIT_BITSET\` returns 0 and Firefox progresses well past the previously-reported sc=146 stop (sc≥620 under KVM, sc≥658 under TCG — both above #52's ≥500 acceptance bar).

## Why land this if there's no reproducing bug?

- **Diagnostic prints retained** under \`firefox-test\` (cost = 0 in default builds). A future regression in this path would surface immediately as a corrupt trace line rather than a silent hang. The commit message documents the expected trace shape so the diagnostic checklist is in-tree.
- **\`clone3\` input-size validation tightened** from \`arg2 < 56\` to \`arg2 < 64\` per \`clone(2)\` (\`CLONE_ARGS_SIZE_VER0\`) — the old threshold permitted a struct too small to hold the \`tls\` field at offset 56..63. No current callers affected (glibc 2.43 always passes \`CLONE_ARGS_SIZE_VER2 = 88\`); defensive correctness fix.
- **New regression test** (\`test_cleartid_futex_wake\`, slot 98e) pins the wake-side dispatch directly. Coverage gap deliberately documented in the test docstring (clone3 storage, exit-path lookup, BITSET ↔ wake interaction are NOT covered here — they're left to the firefox-test integration path) so future engineers know what this test does and does not catch.

## Issue #52 status

**Refs #52 (intentionally kept open as a monitor watch).** Since the original deadlock is not currently reproducing, closing #52 risks future regressions being dismissed as duplicates of a "fixed" issue. The hardening + test land here as a safety net; #52 stays open so any recurrence is recognised as a known regression class.

## Test plan

- [x] \`cargo +nightly check -p kernel --features test-mode\` — clean
- [x] New test \`test_cleartid_futex_wake\` — passes
- [x] Live Firefox boot under TCG: sc=658
- [x] Live Firefox boot under KVM: sc=620
- [x] No behavioural regressions

## Prior reviewer verdict

PR #53's review (review-agent verdict, relayed by the user): "Approve, with caveats" — both caveats addressed before this re-open:
- Test docstring now documents coverage gaps (clone3 storage / exit-path lookup / BITSET-wake interaction)
- "Closes #52" replaced with "Refs #52" + explicit monitor-watch rationale in commit + body

🤖 Generated with [Claude Code](https://claude.com/claude-code)