### PR TITLE
kernel: per-CPU lockless PID lookup eliminates THREAD_TABLE re-entrancy in interrupt context (closes #55)

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -923,8 +923,10 @@ pub extern "C" fn ap_rust_entry() -> ! {
         THREAD_TABLE.lock().push(ap_thread);
     }
 
-    // Set this AP's current thread ID
+    // Set this AP's current thread ID and matching PID for the lock-free
+    // current_pid_lockless() path used by interrupt handlers.
     crate::proc::set_current_tid(ap_idle_tid);
+    crate::proc::set_current_pid(0); // AP idle is on PID 0 (the idle process).
 
     // Mark ourselves as started
     AP_STARTED[apic_id as usize].store(true, Ordering::Release);

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -552,7 +552,18 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
         }
     }
 
-    let pid = crate::proc::recover_current_pid();
+    // Lockless PID lookup: the page-fault handler runs in interrupt context
+    // (IF=0 on entry via the interrupt gate).  A kernel-mode #PF can fire
+    // while a syscall on the same CPU already holds THREAD_TABLE — taking
+    // the lock here would either deadlock the same CPU on its own held lock
+    // (spin::Mutex is not reentrant) or, under panic=abort, surface a stuck
+    // 0x01 lock byte forever after any earlier panic stranded the guard.
+    // The per-CPU PID atomic is updated at every context switch (see
+    // proc::set_current_pid) so this read is always current for a non-idle
+    // thread.  An idle thread on this CPU (pid=0) has no VmSpace to consult,
+    // so we bail out and let the existing PROCESS_TABLE.iter().find() miss
+    // path return false.
+    let pid = crate::proc::current_pid_lockless();
 
     // Look up the faulting address in the process's VmSpace.
     // For vfork children (sharing parent's CR3), also check the parent's VmSpace

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -253,9 +253,12 @@ extern "C" fn timer_tick() {
             // Don't watchdog idle threads — they legitimately wait in hlt
             // without calling schedule() when no user threads are assigned.
             let current_tid = crate::proc::current_tid();
+            // Lockless PID read: timer ISR runs with IF=0 in interrupt
+            // context.  Acquiring THREAD_TABLE here could deadlock the same
+            // CPU if a syscall mid-flight on this CPU already holds it.
             let is_idle = current_tid == 0 || {
                 // AP idle threads have PID 0
-                crate::proc::recover_current_pid() == 0
+                crate::proc::current_pid_lockless() == 0
             };
             if is_idle {
                 WATCHDOG_COUNTER[cpu as usize].store(0, Ordering::Relaxed);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -448,31 +448,40 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 let now = arch::x86_64::irq::get_ticks();
                 let elapsed = now.wrapping_sub(t_launch);
 
-                // Log a heartbeat every 1000 ticks (~10s)
+                // Log a heartbeat every 1000 ticks (~10s).  Use try_lock so a
+                // contended/leaked THREAD_TABLE never wedges CPU0; the BSP must
+                // remain alive to drive net::poll, X11 polling, kdb, and to
+                // observe and report a deadlock rather than become its second
+                // victim.  When skipping, we still emit a heartbeat so the
+                // qemu-harness watchdog observes forward progress.
                 if elapsed / 1000 != last_log_tick / 1000 {
                     last_log_tick = elapsed;
                     let sc = crate::syscall::syscall_count();
                     let pf = crate::perf::page_faults();
-                    // Dump thread states to diagnose spin-wait
-                    {
-                        let threads = crate::proc::THREAD_TABLE.lock();
-                        let total = threads.len();
-                        let mut p1_run = 0u32;
-                        let mut p1_blk = 0u32;
-                        let mut p1_dead = 0u32;
-                        let mut p1_total = 0u32;
-                        for t in threads.iter().filter(|t| t.pid == 1) {
-                            p1_total += 1;
-                            match t.state {
-                                crate::proc::ThreadState::Running => p1_run += 1,
-                                crate::proc::ThreadState::Ready => p1_run += 1, // count as active
-                                crate::proc::ThreadState::Blocked => p1_blk += 1,
-                                crate::proc::ThreadState::Sleeping => p1_blk += 1,
-                                crate::proc::ThreadState::Dead => p1_dead += 1,
+                    match crate::proc::THREAD_TABLE.try_lock() {
+                        Some(threads) => {
+                            let total = threads.len();
+                            let mut p1_run = 0u32;
+                            let mut p1_blk = 0u32;
+                            let mut p1_dead = 0u32;
+                            let mut p1_total = 0u32;
+                            for t in threads.iter().filter(|t| t.pid == 1) {
+                                p1_total += 1;
+                                match t.state {
+                                    crate::proc::ThreadState::Running => p1_run += 1,
+                                    crate::proc::ThreadState::Ready => p1_run += 1, // count as active
+                                    crate::proc::ThreadState::Blocked => p1_blk += 1,
+                                    crate::proc::ThreadState::Sleeping => p1_blk += 1,
+                                    crate::proc::ThreadState::Dead => p1_dead += 1,
+                                }
                             }
+                            serial_println!("[FFTEST] tick={} sc={} pf={} total_th={} p1:{}(run={},blk={},dead={})",
+                                elapsed, sc, pf, total, p1_total, p1_run, p1_blk, p1_dead);
                         }
-                        serial_println!("[FFTEST] tick={} sc={} pf={} total_th={} p1:{}(run={},blk={},dead={})",
-                            elapsed, sc, pf, total, p1_total, p1_run, p1_blk, p1_dead);
+                        None => {
+                            serial_println!("[FFTEST] tick={} sc={} pf={} THREAD_TABLE busy, skipping",
+                                elapsed, sc, pf);
+                        }
                     }
                 }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -633,6 +633,14 @@ pub fn current_pid() -> Pid {
 /// user thread.  This slow-path fallback matches the kernel stack top
 /// (`get_current_kernel_rsp()`) against every thread's stack range to find
 /// the true owner.
+///
+/// **MUST NOT be called from interrupt context** — this function takes
+/// `THREAD_TABLE.lock()` on the slow path.  A kernel-mode #PF or timer ISR
+/// firing on a CPU that already holds `THREAD_TABLE` would re-enter the
+/// non-reentrant `spin::Mutex` and deadlock the CPU permanently (see #55).
+/// Interrupt handlers must use `current_tid()` (lock-free fast path) and
+/// accept the transient-zero window, or use `current_pid_lockless()` which
+/// is maintained per-CPU specifically for ISR consumption.
 pub fn recover_current_tid() -> Tid {
     let tid = current_tid();
     if tid != 0 { return tid; }
@@ -650,36 +658,6 @@ pub fn recover_current_tid() -> Tid {
                 && t.kernel_stack_base + t.kernel_stack_size == kstack_top
         })
         .map(|t| t.tid)
-        .unwrap_or(0)
-}
-
-/// Like `current_pid()` but uses `recover_current_tid()` to handle the
-/// transient tid=0 race condition.  Single THREAD_TABLE lock for the slow path.
-pub fn recover_current_pid() -> Pid {
-    let fast_tid = current_tid();
-    if fast_tid != 0 {
-        #[cfg(feature = "firefox-test")]
-        let threads = thread_table_try_lock_or_panic(
-            "proc::recover_current_pid (fast path)", THREAD_TABLE_DIAG_SPINS);
-        #[cfg(not(feature = "firefox-test"))]
-        let threads = THREAD_TABLE.lock();
-        return threads.iter().find(|t| t.tid == fast_tid).map(|t| t.pid).unwrap_or(0);
-    }
-    // Slow path: need to match by kernel stack top — do tid+pid in one pass
-    let kstack_top = crate::syscall::get_current_kernel_rsp();
-    if kstack_top == 0 { return 0; }
-    #[cfg(feature = "firefox-test")]
-    let threads = thread_table_try_lock_or_panic(
-        "proc::recover_current_pid (slow path)", THREAD_TABLE_DIAG_SPINS);
-    #[cfg(not(feature = "firefox-test"))]
-    let threads = THREAD_TABLE.lock();
-    threads.iter()
-        .find(|t| {
-            t.tid != 0
-                && t.kernel_stack_base > 0
-                && t.kernel_stack_base + t.kernel_stack_size == kstack_top
-        })
-        .map(|t| t.pid)
         .unwrap_or(0)
 }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -354,6 +354,24 @@ pub fn thread_table_try_lock_or_panic(
 static PER_CPU_CURRENT_TID: [AtomicU64; crate::arch::x86_64::apic::MAX_CPUS] =
     [const { AtomicU64::new(0) }; crate::arch::x86_64::apic::MAX_CPUS];
 
+/// Currently running process PID — per-CPU, kept in sync with `PER_CPU_CURRENT_TID`.
+///
+/// Maintained as a parallel atomic so interrupt-context code (notably the
+/// page-fault handler) can read the current PID without acquiring
+/// `THREAD_TABLE`.  Acquiring that lock from the PF handler is unsafe: a
+/// kernel-mode #PF can fire while a syscall on the same CPU already holds
+/// THREAD_TABLE, producing a non-recoverable same-CPU re-entrant deadlock on
+/// the non-reentrant `spin::Mutex`.  Reading this atomic is wait-free.
+///
+/// Update discipline: every `set_current_tid` call site that knows the PID
+/// must call `set_current_pid` immediately afterwards.  The two stores are
+/// independent atomics so there is a brief window during context switches
+/// where they disagree; readers in interrupt context must therefore tolerate
+/// a stale-but-self-consistent (tid, pid) pair — which is exactly the same
+/// invariant `recover_current_tid` already documents.
+static PER_CPU_CURRENT_PID: [AtomicU64; crate::arch::x86_64::apic::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::arch::x86_64::apic::MAX_CPUS];
+
 /// Kernel stack size per thread: 256 KiB (64 pages).
 /// Firefox's deep call chains (VFS → FAT32 → ATA + socket → DNS → NSS + signal
 /// delivery + serial formatting) can exceed 128 KiB.  256 KiB provides headroom
@@ -543,6 +561,7 @@ pub fn init() {
     PROCESS_TABLE.lock().push(idle_proc);
     THREAD_TABLE.lock().push(idle_thread);
     set_current_tid(0);
+    set_current_pid(0);
 
     crate::serial_println!(
         "[PROC] Process manager initialized (idle PID 0, TID 0, kstack={:#x}–{:#x})",
@@ -566,6 +585,32 @@ pub fn current_tid() -> Tid {
 /// Set the currently running thread's TID (per-CPU).
 pub fn set_current_tid(tid: Tid) {
     PER_CPU_CURRENT_TID[cpu_index()].store(tid, Ordering::Relaxed);
+}
+
+/// Set the currently running process's PID (per-CPU).
+///
+/// Must be called from every `set_current_tid` call site that knows the
+/// owning PID, so the PF handler's lockless `current_pid_lockless()` lookup
+/// stays in sync with the THREAD_TABLE-derived authoritative answer.
+pub fn set_current_pid(pid: Pid) {
+    PER_CPU_CURRENT_PID[cpu_index()].store(pid, Ordering::Relaxed);
+}
+
+/// Read the currently running process's PID without taking any lock.
+///
+/// Designed for interrupt-context callers (page-fault handler, NMI, etc.)
+/// where acquiring `THREAD_TABLE` could deadlock — a kernel-mode #PF can
+/// fire while a syscall on the same CPU already holds the lock, and
+/// `spin::Mutex` is not reentrant.
+///
+/// Returns 0 if no user thread is currently scheduled (idle thread, AP
+/// startup before first context switch).  Callers that hit a 0 result
+/// should treat the fault as unresolvable rather than retry-with-lock —
+/// the cost of dropping the resolution attempt is a SIGSEGV at worst,
+/// far better than a hard hang.
+#[inline]
+pub fn current_pid_lockless() -> Pid {
+    PER_CPU_CURRENT_PID[cpu_index()].load(Ordering::Relaxed)
 }
 
 /// Get the currently running process's PID.

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -313,6 +313,42 @@ pub static PROCESS_TABLE: Mutex<Vec<Process>> = Mutex::new(Vec::new());
 /// Thread table.
 pub static THREAD_TABLE: Mutex<Vec<Thread>> = Mutex::new(Vec::new());
 
+/// Bounded-spin acquire of `THREAD_TABLE` with a loud panic on exhaustion.
+///
+/// Used (under `firefox-test`) at hot read-only call sites that previously
+/// called `THREAD_TABLE.lock()` unconditionally.  A `MutexGuard` leaked from
+/// a prior panic (kernel builds with `panic = "abort"`) would otherwise turn
+/// every subsequent acquirer into a silent infinite spin — both vCPUs idle
+/// at the spin loop with no diagnostic output.  Converting the call to
+/// `thread_table_try_lock_or_panic` turns that silent hang into an immediate
+/// panic identifying the *next* contender, which is enough signal to triangulate
+/// the leaking owner across runs.
+///
+/// `site` is a static string (e.g. `"proc::current_pid"`) included in the panic
+/// message.  `max_spins` bounds the wait — about 10 µs per iteration on TCG
+/// (much less under KVM), so the default `THREAD_TABLE_DIAG_SPINS` is roughly
+/// a 100 ms upper bound under TCG before declaring the lock leaked.
+#[cfg(feature = "firefox-test")]
+pub const THREAD_TABLE_DIAG_SPINS: u32 = 10_000;
+
+#[cfg(feature = "firefox-test")]
+#[inline]
+pub fn thread_table_try_lock_or_panic(
+    site: &'static str,
+    max_spins: u32,
+) -> spin::MutexGuard<'static, Vec<Thread>> {
+    for _ in 0..max_spins {
+        if let Some(g) = THREAD_TABLE.try_lock() {
+            return g;
+        }
+        core::hint::spin_loop();
+    }
+    panic!(
+        "THREAD_TABLE deadlocked at {}: {} spins exhausted (likely lock leak from prior panic; build is panic=abort so MutexGuard::drop never runs)",
+        site, max_spins
+    );
+}
+
 /// Currently running thread ID — per-CPU, indexed by APIC ID.
 /// With SMP, each CPU tracks its own running thread.
 static PER_CPU_CURRENT_TID: [AtomicU64; crate::arch::x86_64::apic::MAX_CPUS] =
@@ -535,6 +571,10 @@ pub fn set_current_tid(tid: Tid) {
 /// Get the currently running process's PID.
 pub fn current_pid() -> Pid {
     let tid = current_tid();
+    #[cfg(feature = "firefox-test")]
+    let threads = thread_table_try_lock_or_panic(
+        "proc::current_pid", THREAD_TABLE_DIAG_SPINS);
+    #[cfg(not(feature = "firefox-test"))]
     let threads = THREAD_TABLE.lock();
     threads.iter().find(|t| t.tid == tid).map(|t| t.pid).unwrap_or(0)
 }
@@ -553,6 +593,10 @@ pub fn recover_current_tid() -> Tid {
     if tid != 0 { return tid; }
     let kstack_top = crate::syscall::get_current_kernel_rsp();
     if kstack_top == 0 { return 0; }
+    #[cfg(feature = "firefox-test")]
+    let threads = thread_table_try_lock_or_panic(
+        "proc::recover_current_tid", THREAD_TABLE_DIAG_SPINS);
+    #[cfg(not(feature = "firefox-test"))]
     let threads = THREAD_TABLE.lock();
     threads.iter()
         .find(|t| {
@@ -569,12 +613,20 @@ pub fn recover_current_tid() -> Tid {
 pub fn recover_current_pid() -> Pid {
     let fast_tid = current_tid();
     if fast_tid != 0 {
+        #[cfg(feature = "firefox-test")]
+        let threads = thread_table_try_lock_or_panic(
+            "proc::recover_current_pid (fast path)", THREAD_TABLE_DIAG_SPINS);
+        #[cfg(not(feature = "firefox-test"))]
         let threads = THREAD_TABLE.lock();
         return threads.iter().find(|t| t.tid == fast_tid).map(|t| t.pid).unwrap_or(0);
     }
     // Slow path: need to match by kernel stack top — do tid+pid in one pass
     let kstack_top = crate::syscall::get_current_kernel_rsp();
     if kstack_top == 0 { return 0; }
+    #[cfg(feature = "firefox-test")]
+    let threads = thread_table_try_lock_or_panic(
+        "proc::recover_current_pid (slow path)", THREAD_TABLE_DIAG_SPINS);
+    #[cfg(not(feature = "firefox-test"))]
     let threads = THREAD_TABLE.lock();
     threads.iter()
         .find(|t| {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -290,7 +290,7 @@ pub fn schedule() {
     // cli`: the dying/sleeping vCPU halts so the OTHER vCPU is not
     // starved competing for host CPU time under TCG, and the timer ISR
     // wakes us on the next tick.
-    let (next_tid, next_rsp, _next_pid, next_kstack_top, _next_first_run) = 'pick: loop {
+    let (next_tid, next_rsp, next_pid, next_kstack_top, _next_first_run) = 'pick: loop {
         // Re-establish IF=0 at the top of every iteration.  The wait
         // paths below execute `sti; hlt; cli` which leaves IF=0 on
         // return — this disable_interrupts() call is defence in depth
@@ -526,8 +526,11 @@ pub fn schedule() {
     // Record performance metric
     crate::perf::record_context_switch();
 
-    // Perform context switch.
+    // Perform context switch.  Update both the per-CPU TID and PID atomics
+    // together so the page-fault handler's lockless current_pid_lockless()
+    // sees a consistent (tid, pid) pair across the switch.
     proc::set_current_tid(next_tid);
+    proc::set_current_pid(next_pid);
 
     TICKS_REMAINING[cpu as usize].store(TIME_SLICE, Ordering::Relaxed);
 

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -29,7 +29,14 @@ pub const SIGCONT: u8 = 18;
 pub const SIGSTOP: u8 = 19;
 pub const SIGTSTP: u8 = 20;
 pub const SIGWINCH: u8 = 28;
-pub const MAX_SIGNAL: u8 = 32;
+// Per signal(7) on x86_64 Linux, _NSIG = 64 (32 standard + 32 real-time).
+// glibc uses signal numbers 32 (SIGCANCEL) and 33 (SIGSETXID) for its internal
+// thread-cancellation and setuid-broadcast machinery, both of which fail with
+// EINVAL when MAX_SIGNAL is 32 — a soft incompatibility that surfaces as
+// startup oddities on first thread-team initialisation.  Raising the cap to 64
+// matches the public POSIX/Linux ABI without changing on-the-wire behaviour:
+// `pending` and `blocked` are u64 so all 64 valid signal bits already fit.
+pub const MAX_SIGNAL: u8 = 64;
 
 /// Virtual address where the signal-return trampoline is mapped for every
 /// user-mode process.  The page contains two entry points:
@@ -113,7 +120,9 @@ impl SignalState {
     /// Queue a signal (set its pending bit).
     pub fn send(&mut self, sig: u8) {
         if sig > 0 && sig < MAX_SIGNAL {
-            self.pending |= 1 << sig;
+            // Explicit u64 literal: with MAX_SIGNAL=64, `sig` reaches 63 and a
+            // bare `1 << 63` would overflow the default i32 inference.
+            self.pending |= 1u64 << sig;
         }
     }
 
@@ -126,7 +135,7 @@ impl SignalState {
         }
         // Find lowest set bit
         let sig = deliverable.trailing_zeros() as u8;
-        self.pending &= !(1 << sig);
+        self.pending &= !(1u64 << sig);
         Some(sig)
     }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -20008,6 +20008,16 @@ fn test_tcp_read_from_isolation() -> bool {
 // the same PID a `THREAD_TABLE` walk would produce.  set_current_pid() is
 // called at every context-switch site to maintain this invariant; this test
 // asserts the invariant for the runtime context of the test runner itself.
+//
+// SCOPE LIMITATION: this test runs in the BSP test-runner context where
+// pid=0 (idle/bootstrap) is the typical observed value, so all three
+// readings (lockless, walked, locked) compare equal trivially when zero.
+// The test will NOT catch a regression that diverges set_current_tid from
+// set_current_pid only on a code path that doesn't run during the test
+// suite — that class of regression must be caught by the firefox-test
+// feature's loud-panic instrumentation in `current_pid` / `current_tid`.
+// This test guards against the simpler case: a global rename / refactor
+// that breaks the invariant outright.
 fn test_per_cpu_pid_lockless_consistent() -> bool {
     test_header!("per-CPU current_pid_lockless() matches THREAD_TABLE walk");
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1142,6 +1142,18 @@ pub fn run() -> ! {
         if test_tcp_read_from_isolation() { passed += 1; }
     }
 
+    // ── Test 179: per-CPU lock-free PID matches THREAD_TABLE walk ────────
+    //
+    // Regression guard for the THREAD_TABLE re-entrant deadlock fix.
+    // current_pid_lockless() reads PER_CPU_CURRENT_PID without taking any
+    // lock.  set_current_pid() must therefore stay in sync with the
+    // authoritative THREAD_TABLE-derived PID at every context-switch site.
+    // Walking THREAD_TABLE here under the test runner's idle PID 0 should
+    // observe exactly the same answer as the lockless read.
+
+    total += 1;
+    if test_per_cpu_pid_lockless_consistent() { passed += 1; }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -19987,6 +19999,42 @@ fn test_tcp_read_from_isolation() -> bool {
     }
 
     test_pass!("TCP read_from — 4-tuple isolation under shared port");
+    true
+}
+
+// ── Test 179: per-CPU lock-free PID matches THREAD_TABLE walk ──────────────
+//
+// The page-fault and timer ISRs depend on `current_pid_lockless()` returning
+// the same PID a `THREAD_TABLE` walk would produce.  set_current_pid() is
+// called at every context-switch site to maintain this invariant; this test
+// asserts the invariant for the runtime context of the test runner itself.
+fn test_per_cpu_pid_lockless_consistent() -> bool {
+    test_header!("per-CPU current_pid_lockless() matches THREAD_TABLE walk");
+
+    let lockless = crate::proc::current_pid_lockless();
+    let walked = {
+        let tid = crate::proc::current_tid();
+        let threads = crate::proc::THREAD_TABLE.lock();
+        threads.iter().find(|t| t.tid == tid).map(|t| t.pid).unwrap_or(0)
+    };
+    if lockless != walked {
+        test_fail!("per_cpu_pid_lockless",
+            "current_pid_lockless()={} but THREAD_TABLE walk gives {}",
+            lockless, walked);
+        return false;
+    }
+
+    // Cross-check against current_pid() (which is THREAD_TABLE-locked) so a
+    // future refactor that diverges the helpers fails the test, not Firefox.
+    let cur = crate::proc::current_pid();
+    if cur != lockless {
+        test_fail!("per_cpu_pid_lockless",
+            "current_pid()={} but current_pid_lockless()={}", cur, lockless);
+        return false;
+    }
+
+    test_println!("  current_pid_lockless()={} matches THREAD_TABLE walk and current_pid() ✓", lockless);
+    test_pass!("per-CPU current_pid_lockless() == THREAD_TABLE walk == current_pid()");
     true
 }
 


### PR DESCRIPTION
## Summary

Closes #55.  Fixes the SMP THREAD_TABLE spin-lock deadlock that was producing non-deterministic Firefox-test hangs (sc=1 / sc=120 / sc=124 across reruns) on master \`791ac4d\`.  Brings firefox-test runs to a deterministic baseline: **7 consecutive runs all completed at sc=615-616 (0.16% variance)** — a critical step on the path to the headless-Firefox public demo.

## Root cause

The kernel-mode page-fault handler (\`arch::x86_64::idt::handle_page_fault\`) and timer-ISR watchdog called paths that took \`THREAD_TABLE.lock()\` to resolve the current PID.  This is unsafe in interrupt context: a kernel-mode #PF on, say, a \`copy_to_user\` from a syscall handler that *already* holds \`THREAD_TABLE\` re-enters the same non-reentrant \`spin::Mutex\` on the same CPU → permanent hang.  Because the kernel is built with \`panic = "abort"\`, a panic inside any \`THREAD_TABLE\` critical section also permanently strands the lock (MutexGuard::drop never runs).

The Phase 1 diagnostic instrumentation (commit \`6f8a69d\`) tripped on the second TCG run with a clear message:

\`\`\`
THREAD_TABLE deadlocked at proc::recover_current_pid (fast path): 10000 spins exhausted
(likely lock leak from prior panic; build is panic=abort so MutexGuard::drop never runs)
\`\`\`

That panic localised the leak path: \`idt::handle_page_fault\` → \`recover_current_pid\` → \`THREAD_TABLE.lock()\`.  The CPU0 firefox-test heartbeat used try_lock-and-skip, staying alive long enough for the panic message to surface — without that quality-of-life change the bug would have remained a silent hang.

## Fix

Per-CPU lockless PID tracking via \`PER_CPU_CURRENT_PID: [AtomicU64; MAX_CPUS]\`, maintained in lockstep with the existing \`PER_CPU_CURRENT_TID\`:

- New API: \`proc::set_current_pid(pid)\` (called at every context-switch site — \`init_process_manager\`, \`apic::ap_init\`, \`sched::schedule\`) and \`proc::current_pid_lockless()\` (wait-free reader).
- \`idt::handle_page_fault\` now uses \`current_pid_lockless()\` — the leak path is gone.
- \`irq::timer_tick\` watchdog idle check uses the lockless reader for the same reason (timer ISR runs with IF=0).
- Idle threads (pid=0) cannot be the target of a recoverable #PF; the existing PROCESS_TABLE.iter().find() miss path returns false, kicking the fault to the SIGSEGV path that already handles unidentified faults gracefully.

The Phase 1 diagnostic instrumentation is **retained as a regression net**: any future code that re-introduces a held-THREAD_TABLE-during-interrupt path will now surface as a clear panic with the call-site name within ~100 ms instead of a silent hang.  Cost is zero in default builds (\`firefox-test\`-gated).

## Side-fix: MAX_SIGNAL 32 → 64

Per \`signal(7)\`, \`_NSIG = 64\` on x86_64 Linux.  glibc's \`SIGCANCEL = 32\` / \`SIGSETXID = 33\` previously failed \`rt_sigaction\` with -EINVAL; raising the cap matches the public ABI.  pending/blocked sets are already u64 so all 64 bits fit; bit-shift literals upgraded to \`1u64\` to stay correct at sig=63.

## Verification (demo bar: deterministic across runs)

Seven consecutive firefox-test runs on Quackie (TCG and KVM):

| Run | Acceleration | sc | Ticks | Outcome |
|-----|-------------|-----|-------|---------|
| #3 | TCG | 615 | 1509 | exit_group(1) |
| #4 | TCG | 615 | 1477 | exit_group(1) |
| #5 | TCG | 615 | 1437 | exit_group(1) |
| #6 | TCG | 615 | 1394 | exit_group(1) |
| #7 | TCG | 616 | 1367 | exit_group(1) |
| #8 | KVM | 616 | 1387 | exit_group(1) |
| #9 | KVM | 615 | 1385 | exit_group(1) |

sc-count variance: **0.16%** (615..616) — well under the demo-bar reliability target.

## Test plan

- [x] \`cargo +nightly check -p kernel --features test-mode\` — clean
- [x] New regression Test 179 asserts per-CPU PID matches THREAD_TABLE walk — passes
- [x] 5 TCG + 2 KVM firefox-test runs — all complete at sc=615-616
- [x] Test suite: 176/181 (delta +1 for the new test; the 5 pre-existing failures all trace to the missing build/data.img stub)

## Commits

- \`6f8a69d\` — Phase 1 diagnostic: try_lock + loud panic on THREAD_TABLE contention; heartbeat non-blocking; MAX_SIGNAL 32→64
- \`b5abfef\` — Phase 3 fix: lockless per-CPU PID lookup for interrupt handlers (closes #55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)