### PR TITLE
diag: raise THREAD_TABLE_DIAG_SPINS to 10M to suppress false positives under KVM

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -344,11 +344,17 @@ pub static THREAD_TABLE: Mutex<Vec<Thread>> = Mutex::new(Vec::new());
 /// the leaking owner across runs.
 ///
 /// `site` is a static string (e.g. `"proc::current_pid"`) included in the panic
-/// message.  `max_spins` bounds the wait — about 10 µs per iteration on TCG
-/// (much less under KVM), so the default `THREAD_TABLE_DIAG_SPINS` is roughly
-/// a 100 ms upper bound under TCG before declaring the lock leaked.
+/// message.  `max_spins` bounds the wait.  Each iteration is a `PAUSE` hint
+/// (~5–25 CPU cycles, ~2–10 ns on modern silicon under KVM), so the default
+/// `THREAD_TABLE_DIAG_SPINS` is roughly a 50–100 ms upper bound under KVM and
+/// several seconds under TCG before declaring the lock leaked.  A smaller
+/// bound (10_000 spins ≈ a few µs under KVM) caused false-positive panics
+/// during Firefox bringup once the cmdline-handler chain dispatched and many
+/// concurrent worker threads competed with the timer-ISR scheduler picker for
+/// `THREAD_TABLE`.  The bound exists to surface true deadlocks, not raw
+/// contention.
 #[cfg(feature = "firefox-test")]
-pub const THREAD_TABLE_DIAG_SPINS: u32 = 10_000;
+pub const THREAD_TABLE_DIAG_SPINS: u32 = 10_000_000;
 
 #[cfg(feature = "firefox-test")]
 #[inline]


### PR DESCRIPTION
## Summary

The diagnostic spin bound at \`THREAD_TABLE_DIAG_SPINS = 10_000\` (introduced in PR #56) was firing as a **false-positive** under KVM during Firefox bringup. 10K spins of \`core::hint::spin_loop\` (PAUSE) is ~50–100 µs on Quackie's i7 — far below the legitimate contention window observed when many concurrent worker threads compete with the timer-ISR scheduler picker for \`THREAD_TABLE\`.

Bumping to \`10_000_000\` keeps the diagnostic's original purpose (catch a true \`MutexGuard\` leak within ~100 ms of detection) while no longer aborting on legitimate contention bursts.

## Why this matters

Discovered while investigating the rung-3 (\`--screenshot file://...\`) headless-Firefox milestone. With \`DIAG_SPINS = 10_000\` the kernel panics shortly after \`/dev/shm/org.mozilla.ipc\` setup, aborting the boot before useful trace data can be collected. With the bump, Firefox bringup runs for >50 minutes without false-positive panic — making the actual dispatch barrier observable.

## Behavioural change

- True \`spin::Mutex\` leaks (held \`MutexGuard\` after \`panic = "abort"\`) still surface — the bound is now ~100ms (KVM) / a few seconds (TCG) instead of ~50µs / ~10ms. Plenty fast for human / agent diagnosis.
- Legitimate contention during high-thread-count workloads (Firefox, multi-process tests) no longer triggers false panics.
- Default builds unaffected — the diagnostic is \`firefox-test\`-gated.

## Test plan

- [x] Local Firefox bringup on Quackie under KVM no longer false-panics during \`/dev/shm\` IPC setup
- [x] Doc comment updated to reflect actual KVM iteration cost
- [x] Default builds byte-identical (feature-gated change only)

## Files

\`kernel/src/proc/mod.rs\` — single constant + doc comment (+10/-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)