### PR TITLE
test: remove ci-skip-test-104 gate — closes #57

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,16 +154,13 @@ jobs:
       # is intentionally off in CI: QEMU SLIRP drops external ICMP
       # without CAP_NET_ADMIN, so those four tests would soft-pass
       # uninformatively.  See kernel/Cargo.toml.
-      - name: Build kernel (test-mode + ci-skip-test-104)
+      - name: Build kernel (test-mode)
         run: |
-          # `ci-skip-test-104` skips one test that hangs under GitHub
-          # Actions' slow TCG (sc=332 wakeup race; passes on real hardware).
-          # Tracked separately; the rest of the suite stays observable.
           cargo +nightly build \
             --package astryx-kernel \
             --target kernel/x86_64-astryx.json \
             --profile release \
-            --features test-mode,ci-skip-test-104 \
+            --features test-mode \
             -Zbuild-std=core,alloc \
             -Zbuild-std-features=compiler-builtins-mem \
             -Zjson-target-spec
@@ -269,13 +266,13 @@ jobs:
           restore-keys: |
             kernel-build-${{ runner.os }}-
 
-      - name: Build kernel (test-mode + ci-skip-test-104)
+      - name: Build kernel (test-mode)
         run: |
           cargo +nightly build \
             --package astryx-kernel \
             --target kernel/x86_64-astryx.json \
             --profile release \
-            --features test-mode,ci-skip-test-104 \
+            --features test-mode \
             -Zbuild-std=core,alloc \
             -Zbuild-std-features=compiler-builtins-mem \
             -Zjson-target-spec

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -39,14 +39,6 @@ pf-trace = []
 # byte-identical to the pre-kdb artefact; every code path is cfg-gated.
 # See docs/HARNESS.md.
 kdb = []
-# Skip Test 104 ("execve VmSpace teardown — no PMM leak across exec") in
-# CI builds.  The test passes deterministically on real hardware (36/36
-# local runs on a desktop Intel i7) but hangs at sc=332 under the slow TCG
-# of GitHub-hosted runners — a kernel-side wakeup race exposed (not caused)
-# by the per-CPU PID change to the timer ISR.  Enable in CI so the rest of
-# the suite stays observable; remove this gate once the underlying wakeup
-# race is fixed.  Tracking issue filed alongside this feature flag.
-ci-skip-test-104 = []
 
 [dependencies]
 astryx-shared = { path = "../shared" }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -749,17 +749,9 @@ pub fn run() -> ! {
     if test_wm_title_renders_via_gdi() { passed += 1; }
 
     // ── Test 104: execve VmSpace teardown — no PMM leak across exec ────
-    //
-    // Gated behind `ci-skip-test-104` because under GitHub Actions' slow TCG
-    // the test triggers a kernel-side wakeup race that hangs the runner at
-    // sc=332.  The race passes deterministically on real hardware and on
-    // local KVM (36/36 runs) — see the feature comment in kernel/Cargo.toml.
 
-    #[cfg(not(feature = "ci-skip-test-104"))]
-    {
-        total += 1;
-        if test_execve_no_pmm_leak() { passed += 1; }
-    }
+    total += 1;
+    if test_execve_no_pmm_leak() { passed += 1; }
 
     // ── Test 105: Heap guard pages — PTE verification ─────────────────────
     // Non-destructive: verifies that guard PTEs are not-present and that the


### PR DESCRIPTION
## Summary

- Removes the `ci-skip-test-104` Cargo feature and the matching `#[cfg(not(feature = ...))]` guard around Test 104 (`execve VmSpace teardown — no PMM leak across exec`).
- Removes both `--features test-mode,ci-skip-test-104` invocations in the CI workflow (kernel-smoke and qemu-harness-smoke jobs); both now build with plain `--features test-mode`.
- Net: +6 / -25 LOC across 3 files.

## Why this works now

Issue #57 traced the CI-only Test 104 hang to a wakeup race exposed under GitHub Actions' slow TCG. The same wakeup-race signature class also affected Test 46 (`clone(CLONE_THREAD|CLONE_VM)` at sc=121). The shared root cause was that `futex(FUTEX_WAIT_BITSET, ...)` did not honour the absolute deadline when `FUTEX_CLOCK_REALTIME` was set — see `futex(2)`: with that flag, the third argument is interpreted as an absolute realtime deadline and the wait must return `ETIMEDOUT` if the deadline has elapsed.

That root cause was fixed at the futex layer in `6bb53ef`. Once absolute deadlines were respected, both Test 46 and Test 104 stopped hanging in CI-class TCG conditions.

## Test plan

Local verification on this branch (Quackie / WSL2 / 6-core x86_64):

- [x] **KVM** — 1 run: 175/180 passed; Test 46 ✓, Test 104 ✓.
- [x] **TCG / `--no-kvm`** — 3 solo runs: each 175/180 passed; Test 46 ✓, Test 104 ✓ on every run; no sc=332 plateau, no sc=121 plateau, no panic.
- [x] The 5 failures in every run are pre-existing data.img / network gaps (`Musl hello`, `pie_elf`, `TCC compile`, `sigchld`, `ascension`) that the CI workflow already documents as expected gaps when the data disk is the 32 MiB stub.
- [ ] CI: kernel-smoke + qemu-harness-smoke jobs green on this draft PR (this is what the draft is here to verify).

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)