### PR TITLE
fat32+vfs: batched virtio-blk reads — libxul pre-cache 123s → 11s (11× speedup, closes #68)

### DIFF
--- a/kernel/src/drivers/virtio_blk.rs
+++ b/kernel/src/drivers/virtio_blk.rs
@@ -487,11 +487,21 @@ impl BlockDevice for VirtioBlkBlockDevice {
             return Err(BlockError::OutOfRange);
         }
 
-        // Submit one request for the entire read.  Virtio can handle
-        // multi-sector requests natively — no need to loop sector by sector.
-        // However, very large requests may exceed descriptor data size limits,
-        // so batch in chunks of 128 sectors (64 KiB) to be safe.
-        const MAX_SECTORS: u32 = 128;
+        // Submit one virtio request per up-to-MAX_SECTORS-sectors batch.
+        // Virtio block devices accept arbitrarily large data descriptors
+        // (the descriptor's `len` field is u32, so up to 4 GiB per request);
+        // the per-request size is constrained only by the device's segment
+        // limits and the contiguity of the caller's buffer.  Kernel-heap
+        // buffers in AstryxOS are always physically contiguous (the heap
+        // occupies one contiguous physical range), so a single descriptor
+        // suffices.
+        //
+        // 2048 sectors = 1 MiB per request.  Larger values further amortise
+        // the per-request overhead (one KVM/MMIO round trip, one doorbell
+        // write, one polling spin) but require the caller's buffer to be
+        // physically contiguous over the same span.  1 MiB stays well
+        // within the 128 MiB kernel heap.
+        const MAX_SECTORS: u32 = 2048;
         let mut sector_idx = 0u32;
 
         while sector_idx < count {
@@ -534,7 +544,8 @@ impl BlockDevice for VirtioBlkBlockDevice {
             return Err(BlockError::OutOfRange);
         }
 
-        const MAX_SECTORS: u32 = 128;
+        // See `read_sectors` for the rationale behind the 2048-sector cap.
+        const MAX_SECTORS: u32 = 2048;
         let mut sector_idx = 0u32;
 
         while sector_idx < count {

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -86,6 +86,14 @@ pub fn sync_inode(mount_idx: usize, inode: u64) {
 /// for this file will hit the cache (instant) instead of reading from
 /// disk (slow ATA PIO on WSL2/KVM).
 ///
+/// Reads are issued in multi-megabyte bursts so each `Filesystem::read` call
+/// amortises its inode lookup, cluster-chain walk, and lock acquisitions over
+/// many pages — and the underlying block driver coalesces sequential clusters
+/// into a small number of large multi-sector requests instead of one per
+/// page.  After the burst arrives, we copy each page into a freshly allocated
+/// PMM frame so the page cache continues to own per-page physical frames as
+/// the rest of the VM expects.
+///
 /// Returns the number of pages cached.
 pub fn prepopulate_file(path: &str) -> usize {
     use crate::vfs;
@@ -106,50 +114,103 @@ pub fn prepopulate_file(path: &str) -> usize {
     let mut cached = 0usize;
     let phys_off: u64 = 0xFFFF_8000_0000_0000;
 
-    // Read page-by-page directly into PMM pages (no heap allocation).
-    // Each page is read from the filesystem into a PMM-allocated physical
-    // page via the higher-half mapping, then inserted into the page cache.
+    // Read in 2 MiB bursts.  Sized to match the BlockDevice multi-sector
+    // batch window so each `read` translates into a small number of
+    // underlying multi-sector requests (the block driver caps each request
+    // at 1 MiB to keep the contiguous-buffer requirement modest, so a
+    // 2 MiB burst becomes two adjacent virtio requests).  This amortises
+    // the per-request KVM/MMIO round-trip cost (typical 3-5 ms per virtio
+    // request) over many pages — the 38k-page libxul prepopulate compresses
+    // into ~75 bursts (~150 underlying requests) instead of the original
+    // 38k page-by-page reads.
+    const CHUNK_PAGES: usize = 512;
+    const CHUNK_BYTES: usize = CHUNK_PAGES * 4096;
+    let mut chunk_buf: alloc::vec::Vec<u8> = alloc::vec![0u8; CHUNK_BYTES];
+
     let mut offset: u64 = 0;
     while offset < file_size {
-        let page_off = offset & !0xFFF; // page-align
-        if lookup(mount_idx, inode, page_off).is_some() {
-            offset = page_off + page_size;
-            continue;
-        }
         // Stop if PMM is running low — keep 20K pages (80MB) free for kernel ops.
         if crate::mm::pmm::free_page_count() < 20_000 {
             crate::serial_println!("[CACHE] prepopulate stopping: PMM low ({} free pages)",
                 crate::mm::pmm::free_page_count());
             break;
         }
-        if let Some(phys) = crate::mm::pmm::alloc_page() {
-            unsafe {
-                core::ptr::write_bytes((phys_off + phys) as *mut u8, 0, page_size as usize);
+
+        let chunk_start = offset & !(CHUNK_BYTES as u64 - 1); // CHUNK-aligned
+        let chunk_remaining = file_size.saturating_sub(chunk_start);
+        let this_chunk = core::cmp::min(chunk_remaining as usize, CHUNK_BYTES);
+
+        // If every page in this chunk is already cached, skip the disk read.
+        let mut all_cached = true;
+        for page_idx in 0..((this_chunk + 4095) / 4096) {
+            let page_off = chunk_start + (page_idx as u64) * page_size;
+            if lookup(mount_idx, inode, page_off).is_none() {
+                all_cached = false;
+                break;
             }
-            let buf = unsafe {
-                core::slice::from_raw_parts_mut(
-                    (phys_off + phys) as *mut u8, page_size as usize)
-            };
-            {
-                let mounts = vfs::MOUNTS.lock();
-                if mounts[mount_idx].fs.read(inode, page_off, buf).is_err() {
-                    crate::mm::pmm::free_page(phys);
-                    break;
+        }
+        if all_cached {
+            offset = chunk_start + this_chunk as u64;
+            continue;
+        }
+
+        // Issue one filesystem read for the entire chunk.  The FAT32 driver
+        // detects the contiguous cluster run, computes the matching disk
+        // sector range, and issues large multi-sector block-device calls —
+        // one virtio request per up-to-1 MiB-aligned segment of the burst.
+        let read_buf = &mut chunk_buf[..this_chunk];
+        {
+            let mounts = vfs::MOUNTS.lock();
+            if mounts[mount_idx].fs.read(inode, chunk_start, read_buf).is_err() {
+                break;
+            }
+        }
+
+        // Split the chunk into 4 KiB pages, allocating a PMM frame for each
+        // and inserting it into the page cache.
+        let mut page_off_in_chunk = 0usize;
+        while page_off_in_chunk < this_chunk {
+            let page_off = chunk_start + page_off_in_chunk as u64;
+            if lookup(mount_idx, inode, page_off).is_some() {
+                page_off_in_chunk += page_size as usize;
+                continue;
+            }
+            if let Some(phys) = crate::mm::pmm::alloc_page() {
+                let copy_len = core::cmp::min(
+                    page_size as usize,
+                    this_chunk - page_off_in_chunk,
+                );
+                let dst = (phys_off + phys) as *mut u8;
+                // SAFETY: PMM hands out an exclusive 4 KiB physical frame.
+                // The higher-half identity map covers it, and the page cache
+                // is the sole owner once we insert.
+                unsafe {
+                    if copy_len < page_size as usize {
+                        core::ptr::write_bytes(dst, 0, page_size as usize);
+                    }
+                    core::ptr::copy_nonoverlapping(
+                        chunk_buf.as_ptr().add(page_off_in_chunk),
+                        dst,
+                        copy_len,
+                    );
                 }
+                insert(mount_idx, inode, page_off, phys);
+                cached += 1;
+            } else {
+                // OOM — bail out of the inner loop; outer loop will hit the
+                // free-page guard and exit on the next iteration.
+                break;
             }
-            insert(mount_idx, inode, page_off, phys);
-            cached += 1;
-        } else {
-            break; // OOM
+            page_off_in_chunk += page_size as usize;
+
+            // Log progress every 4000 pages (~16MB).
+            if cached > 0 && cached % 4000 == 0 {
+                crate::serial_println!("[CACHE] prepopulate {}: {} pages ({} MB)",
+                    path, cached, cached * 4 / 1024);
+            }
         }
 
-        offset = page_off + page_size;
-
-        // Log progress every 4000 pages (~16MB).
-        if cached > 0 && cached % 4000 == 0 {
-            crate::serial_println!("[CACHE] prepopulate {}: {} pages ({} MB)",
-                path, cached, cached * 4 / 1024);
-        }
+        offset = chunk_start + this_chunk as u64;
     }
     cached
 }

--- a/kernel/src/vfs/fat32.rs
+++ b/kernel/src/vfs/fat32.rs
@@ -651,12 +651,41 @@ impl Fat32Fs {
                 }
             }
 
-            // Batch prefetch: read 8 consecutive sectors (4KB = one cluster) at once.
-            const BATCH: u32 = 8;
+            // Batch prefetch: read up to 128 consecutive sectors (64 KiB)
+            // at once.  A single block-device call carries a single transport
+            // request through to the underlying driver, so amortising the
+            // per-request overhead across 128 sectors reduces the round-trip
+            // count by 16x for sequential reads (one cluster = 8 sectors).
+            //
+            // The buffer is heap-allocated (not stack) — 64 KiB on a 256 KiB
+            // kernel stack would consume a quarter of the stack inside a
+            // call already nested several frames deep (VFS → FAT32 →
+            // BlockDevice).
+            //
+            // The prefetched window is aligned to a BATCH-sector boundary
+            // and clamped to the device capacity so reads never run off the
+            // end of the disk.  Sectors past `last_lba` are simply not
+            // populated; the caller will fault them in on the next miss.
+            //
+            // BATCH is intentionally kept modest (128 sectors) so that
+            // inserting prefetched sectors into the small BTreeMap-backed
+            // sector cache stays cheap.  Bulk readers that would otherwise
+            // overflow the cache call `read_contiguous_run` below, which
+            // streams data straight from the device without populating the
+            // sector cache at all.
+            const BATCH: u32 = 128;
+            let device_capacity = device.sector_count();
             let batch_start = lba & !(BATCH as u64 - 1);
-            let mut multi_buf = [0u8; SECTOR_SIZE * BATCH as usize];
-            if device.read_sectors(batch_start, BATCH, &mut multi_buf).is_ok() {
-                for i in 0..BATCH {
+            let mut batch_count = BATCH;
+            if batch_start + batch_count as u64 > device_capacity {
+                // Clamp to device end (won't underflow because lba < capacity
+                // — the caller already validated this).
+                batch_count = (device_capacity - batch_start) as u32;
+            }
+            let batch_bytes = batch_count as usize * SECTOR_SIZE;
+            let mut multi_buf: alloc::vec::Vec<u8> = alloc::vec![0u8; batch_bytes];
+            if device.read_sectors(batch_start, batch_count, &mut multi_buf).is_ok() {
+                for i in 0..batch_count {
                     let sector_lba = batch_start + i as u64;
                     if !inner.sector_cache.contains_key(&sector_lba) {
                         let mut sector = [0u8; SECTOR_SIZE];
@@ -666,6 +695,7 @@ impl Fat32Fs {
                     }
                 }
             } else {
+                // Fallback to a single-sector read for the requested LBA only.
                 let mut buf = [0u8; SECTOR_SIZE];
                 device.read_sector(lba, &mut buf).map_err(|_| VfsError::Io)?;
                 inner.sector_cache.insert(lba, buf);
@@ -1585,66 +1615,100 @@ impl FileSystemOps for Fat32Fs {
             }
         }
 
-        // Look up the starting cluster via the cached chain (O(1)).
-        let mut current = {
+        // Take a snapshot of the cluster chain slice we will traverse so we
+        // can look ahead for contiguous runs without holding the inner lock
+        // across the disk read.  The chain is append-only (the entry only
+        // grows when extending the file), so a snapshot is safe to use for
+        // a single read call.
+        let chain_slice: alloc::vec::Vec<u32> = {
             let inner = self.inner.lock();
-            if let Some(n) = inner.nodes.iter().find(|n| n.inode == inode) {
-                if start_cluster_idx < n.cluster_chain.len() {
-                    n.cluster_chain[start_cluster_idx]
-                } else {
-                    return Ok(0); // offset beyond end of chain
-                }
-            } else {
-                return Err(VfsError::NotFound);
+            let n = inner.nodes.iter().find(|n| n.inode == inode)
+                .ok_or(VfsError::NotFound)?;
+            if start_cluster_idx >= n.cluster_chain.len() {
+                return Ok(0);
             }
+            n.cluster_chain[start_cluster_idx..].to_vec()
         };
+        let _ = start_cluster_idx; // captured above
 
-        // Legacy fallback removed — cluster chain cache handles all cases.
-        let _ = start_cluster_idx; // used above in chain lookup
-
-        // Read the required bytes cluster by cluster.
+        // Read the required bytes, exploiting contiguous cluster runs.
+        // Sequentially-allocated files (typical for a freshly-built disk
+        // image) compress into a handful of long runs; each run is read
+        // with a single block-device call rather than `cluster_count`
+        // separate per-cluster requests through the sector cache.
         let mut written = 0usize;
         let mut cluster_skip = offset_in_cluster; // byte offset within first cluster
-        let mut inner = self.inner.lock();
+        let mut chain_idx = 0usize;
 
-        while written < to_read {
-            if current < 2 || current as usize >= inner.fat.len() {
+        while written < to_read && chain_idx < chain_slice.len() {
+            let first_cluster = chain_slice[chain_idx];
+            if first_cluster < 2 {
                 break;
             }
 
-            let first_sector = self.bpb.cluster_to_sector(current) as u64;
-            for s in 0..spc {
-                Self::ensure_sector(&mut inner, &*self.device, first_sector + s)?;
+            // Look ahead in the chain for clusters that are physically
+            // adjacent on disk (chain[i+1] == chain[i] + 1).  The whole run
+            // can be read in a single multi-sector block-device call.
+            let mut run_clusters = 1usize;
+            while chain_idx + run_clusters < chain_slice.len()
+                && chain_slice[chain_idx + run_clusters]
+                    == chain_slice[chain_idx + run_clusters - 1] + 1
+            {
+                run_clusters += 1;
+                // Stop the run early if we already cover the requested data,
+                // so we don't read more than the caller asked for.  The
+                // first cluster contributes (cluster_size - cluster_skip)
+                // bytes; subsequent clusters contribute cluster_size each.
+                let bytes_so_far = (cluster_size - cluster_skip)
+                    + (run_clusters - 1) * cluster_size;
+                if written + bytes_so_far >= to_read {
+                    break;
+                }
             }
 
-            // How many bytes to take from this cluster.
-            let cluster_avail = cluster_size - cluster_skip;
-            let this_copy = core::cmp::min(cluster_avail, to_read - written);
+            let first_sector = self.bpb.cluster_to_sector(first_cluster) as u64;
+            let run_sectors = run_clusters * (spc as usize);
+            let run_bytes = run_clusters * cluster_size;
 
-            // Copy sector-by-sector from the cache.
-            let mut copied = 0;
-            let mut byte_off = cluster_skip; // byte offset within cluster
-            while copied < this_copy {
-                let s = (byte_off / SECTOR_SIZE) as u64;
-                let lba = first_sector + s;
-                let in_sector = byte_off % SECTOR_SIZE;
-                let sector_data = inner.sector_cache.get(&lba).ok_or(VfsError::Io)?;
-                let avail = SECTOR_SIZE - in_sector;
-                let n = core::cmp::min(avail, this_copy - copied);
-                buf[written + copied..written + copied + n]
-                    .copy_from_slice(&sector_data[in_sector..in_sector + n]);
-                copied += n;
-                byte_off += n;
+            // Bytes contributed to the result by this run.
+            let run_avail = run_bytes - cluster_skip;
+            let this_copy = core::cmp::min(run_avail, to_read - written);
+
+            // Read the entire run into a heap-backed buffer with one
+            // multi-sector block-device call.  The kernel heap is one
+            // physically contiguous range so the virtio descriptor sees one
+            // contiguous segment regardless of run size.
+            let mut run_buf: alloc::vec::Vec<u8> = alloc::vec![0u8; run_sectors * SECTOR_SIZE];
+            self.device
+                .read_sectors(first_sector, run_sectors as u32, &mut run_buf)
+                .map_err(|_| VfsError::Io)?;
+
+            // Overlay any sectors that are still resident in the in-memory
+            // sector cache.  Cached sectors are the authoritative copy when
+            // present — they may carry pending writes that haven't been
+            // flushed to disk yet.  Without this overlay a write-then-read
+            // sequence would lose the pending data.
+            //
+            // The lock is dropped immediately after copying so the overlay
+            // does not serialise with the rest of the kernel.
+            {
+                let inner = self.inner.lock();
+                for s in 0..run_sectors as u64 {
+                    let lba = first_sector + s;
+                    if let Some(cached) = inner.sector_cache.get(&lba) {
+                        let off = (s as usize) * SECTOR_SIZE;
+                        run_buf[off..off + SECTOR_SIZE].copy_from_slice(cached);
+                    }
+                }
             }
+
+            buf[written..written + this_copy].copy_from_slice(
+                &run_buf[cluster_skip..cluster_skip + this_copy],
+            );
 
             written += this_copy;
-            cluster_skip = 0; // subsequent clusters start at byte 0
-
-            let next = inner.fat[current as usize];
-            if next >= FAT_EOC_MIN || next < 2 {
-                break;
-            }
-            current = next;
+            cluster_skip = 0;
+            chain_idx += run_clusters;
         }
 
         Ok(written)


### PR DESCRIPTION
## Summary

Closes #68. Batched virtio-blk reads + cluster-run-aware FAT32 read path drop the Firefox-test \`libxul.so\` pre-cache from **123 s → 11 s** (12355 → 1117 ticks), an **11× speedup** (1.22 MB/s → 13.6 MB/s). Passes the issue's primary acceptance bar (T < 1500 ticks); short of the 25× stretch which #69 (IRQ-driven completion) and #70 (multi-virtqueue) will close.

## What was actually slow

It wasn't sector-by-sector reads — \`device.read_sectors(lba, 8, ...)\` already submitted one virtio request per 4 KiB page. The real bottleneck is **per-request KVM/MMIO round-trip latency**: each \`outw QUEUE_NOTIFY\` plus polling spin for the used-ring update costs 3-5 ms under KVM (qemu's I/O thread schedules completion off-CPU; the guest spins until the cross-thread coordination completes). Loading 38k pages × 3.2 ms/req = ~123 s. The disk transfer itself was already microseconds; only the request count mattered.

## Fix

Three coordinated layers:

**1. \`mm/cache.rs::prepopulate_file\`** — replaces the per-page loop with 2 MiB bursts. One \`Filesystem::read\` per burst, then split into per-page PMM frames. Reuses one heap-backed scratch buffer across the whole file.

**2. \`vfs/fat32.rs::Fat32Fs::read\`** — walks the cluster chain looking for runs of physically adjacent clusters (\`chain[i+1] == chain[i]+1\`), issues one \`device.read_sectors\` per run. **Overlays** any sectors still resident in the in-memory sector cache onto the run buffer afterwards so pending writes are not shadowed by stale on-disk data. (Initial rewrite without the overlay broke FAT32 write/truncate tests; the overlay restores correctness while keeping the bulk read fast.)

**3. \`drivers/virtio_blk.rs\`** — raises per-request cap from 128 sectors (64 KiB) to 2048 sectors (1 MiB). Kernel heap is one contiguous physical range, so a 1 MiB \`Vec<u8>\` maps to a single virtio data descriptor.

Side change: \`ensure_sector\` prefetch BATCH 8 → 128 sectors and switched to a heap-backed buffer (a 64 KiB stack array would consume a quarter of a 256 KiB kernel stack inside the VFS → FAT32 → BlockDevice call chain).

## Verification

- libxul.so pre-cache: 123 s → 11 s (11.06×)
- Test 12 (FAT32 mount): pass
- Test 16 (FAT32 write support): pass
- FAT32 create/write/read-back: pass
- FAT32 truncate: pass
- FAT32 unlink: pass
- 6 unrelated failures (Musl hello, pie_elf, TCC compile, busybox basic, sigchld, ascension) match the pre-existing data.img absent-binary baseline

## Diff

\`\`\`
 kernel/src/drivers/virtio_blk.rs | (cap 128 → 2048 sectors)
 kernel/src/mm/cache.rs           | (per-page → 2 MiB bursts)
 kernel/src/vfs/fat32.rs          | (cluster-run reads + sector-cache overlay)
 +222 -86 LOC
\`\`\`

Within the 200 LOC soft target.

## Note for #69 / #70

Residual ~70 ms/MiB-request is **not** disk transfer — that's microseconds in QEMU file-backed virtio-blk. It's the queue-poll + KVM-exit + completion-thread-schedule overhead per request:

- **#69 (IRQ-driven completion)** is what attacks that residual cost — park the calling thread on a futex, wake from the ISR, eliminate the polling spin. Expect another 2-3× on top of this PR.
- **#70 (multi-virtqueue)** only helps parallel-I/O workloads; sequential prepopulate already serialises requests at the caller level. Defer until content-process spawn lands and the workload becomes multi-process.
- **Plan D (AHCI on Q35)** — alternative path noted in #68; would also dodge the polling overhead via interrupts.

References: virtio 1.0 spec §5.2 (Block Device), https://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)