### PR TITLE
firefox-test: enable E10S spawn attempt + headless screenshot argv (#88 prep)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -855,10 +855,13 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // Reports/ creation and the subsequent fatal-on-error writes that
         // bubble up through CrashReporter::SetupExtraData().
         "MOZ_CRASHREPORTER_DISABLE=1",
-        // Force single-process mode — no content process fork.
-        "MOZ_FORCE_DISABLE_E10S=1",
-        // Skip GPU/glxtest process — we don't support fork+exec yet.
-        // Tell Firefox to use software rendering without probing.
+        // E10S (multi-process) is left enabled so libxul attempts to launch
+        // plugin-container.  This drives the parent through
+        // GeckoChildProcessHost::PerformAsyncLaunch (chromium IPC LaunchProcess
+        // path), which exercises clone(), execve(), socketpair(AF_UNIX,
+        // SOCK_SEQPACKET), and SCM_RIGHTS cmsg delivery — all needed for
+        // issue #88.  See https://wiki.mozilla.org/Electrolysis.
+        // Skip GPU/glxtest process — software rendering only.
         "MOZ_GFX_TESTING_NO_CHILD_PROCESS=1",
         "MOZ_X11_EGL=0",
         "MOZ_ACCELERATED=0",

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -436,8 +436,19 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // `MOZ_HEADLESS=1` (set in the spawn envp) as equivalent triggers
             // for headless rendering; we set both for defence in depth.
             // See: https://firefox-source-docs.mozilla.org/widget/headless.html
+            //
+            // `--screenshot <PATH> <URL>` is the documented headless flag that
+            // drives the HeadlessShell command-line handler (see Mozilla's
+            // browser/components/shell/HeadlessShell.sys.mjs).  Passing it
+            // causes the handler to load the URL and write a PNG, which is
+            // the headless demo bar for issue #88.  /tmp/hello.html is staged
+            // into the data image by scripts/create-data-disk.sh.  Note that
+            // reaching the handler requires the JS engine to start running;
+            // if MOZ_FORCE_DISABLE_E10S is set, the parent never spawns a
+            // content child but the JS dispatch can still fire in single-
+            // process mode.
             gui::terminal::launch_process(
-                "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance",
+                "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html",
             );
 
             // Run for up to 30000 ticks (~300 s), polling output and network.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -442,11 +442,9 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // browser/components/shell/HeadlessShell.sys.mjs).  Passing it
             // causes the handler to load the URL and write a PNG, which is
             // the headless demo bar for issue #88.  /tmp/hello.html is staged
-            // into the data image by scripts/create-data-disk.sh.  Note that
-            // reaching the handler requires the JS engine to start running;
-            // if MOZ_FORCE_DISABLE_E10S is set, the parent never spawns a
-            // content child but the JS dispatch can still fire in single-
-            // process mode.
+            // into the data image by scripts/create-data-disk.sh.  Reaching
+            // the handler requires the JS event loop to advance to cmdline-
+            // handler dispatch — see issue #88 for the current barrier.
             gui::terminal::launch_process(
                 "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html",
             );


### PR DESCRIPTION
## Summary

Two preparatory commits on the content-process spawn track (#88), bundled per user direction (Plan 9A from Phase 9 dispatch report):

1. **`b3a8702` — pass `--screenshot file:///tmp/hello.html /tmp/out.png` in the firefox-test launch argv** (+12/-1 LOC). Without an argv that produces user-visible work, `BrowserContentHandler` had nothing to dispatch on, so the parent never tried to spawn a content child. This is the demo-bar parameterisation.
2. **`1149a56` — remove `MOZ_FORCE_DISABLE_E10S=1` from the launch envp** (+6/-3 LOC). This was a defensive flag that explicitly told libxul to never spawn a content process; with the kernel's MOUNTS-recursion deadlock chain now closed (PR #74/#77/#81/#86), there's no reason to keep it. Sandbox-related envvars (`MOZ_DISABLE_CONTENT_SANDBOX`, etc.) are kept since AstryxOS doesn't yet have seccomp.

**Total diff: +18 / -4 across 2 files.**

## What this enables

Real forward progress vs the prior epoll_wait(fd=8) plateau. Firefox now:
- Probes `/disk/opt/firefox/distribution/extensions` (ENOENT, expected)
- Initializes `/tmp/ff-profile/cookies.sqlite` (`fallocate`, `dup3`, `unlink` for journal lifecycle)
- Probes `/proc/self/mountinfo` (ENOENT — sandbox-init probe; defensible since sandbox is disabled in our build)
- Issues 9+ distinct syscall numbers in tid=1's recent histogram (vs Phase 9 baseline dominated by `epoll_wait` alone)

## What this does NOT (yet) enable

**No spawn-family syscall fires.** `clone3` non-thread, `fork`, `vfork`, `execve`, `socketpair`, `sendmsg`/`recvmsg` are still all zero. The plateau cause has shifted from "E10S explicitly disabled" to "JS event-loop dispatch barrier prevents `BrowserContentHandler.handle()` from running."

Tid=1's last syscall before parking is `mprotect(R-X)` on a JIT page. Tid=4 takes over with `epoll_wait(fd=8, timeout=-1)` returning 0 indefinitely. This matches the Phase 5 vDSO `clock_gettime` busy-poll signature documented in `project_firefox_phase5_postvdso.md` — the main thread is in a JS event-pump loop satisfied entirely by vDSO `__vdso_clock_gettime` and never advances to the cmdline-handler dispatch.

The Phase 11 research dispatch will identify the specific JS state machine / promise / observer / spin-loop holding tid=1 in busy-poll. Estimated scope: 0-50 kernel LOC. Likely deliverable is "kernel side needs to emit signal X / accept syscall Y / advance tick Z," not a major new subsystem.

## Verification

| Run | Features | Wall | Outcome |
|---|---|---|---|
| sid `071b4ed96627` | `firefox-test,syscall-trace` | ~14 min | Significant new lifecycle work; tid=1 plateau in JS busy-poll (vs E10S barrier); no spawn-family syscalls |
| sid `2bc8c402bcfb` | `test-mode` | ~7 min | **172/179 tests pass — zero new regressions vs the 7 known `data.img` baseline failures** |

Firefox ESR oracle test ("still running after 60s — progressing") passes, confirming no destabilisation of the FF launch.

## Test plan

- [x] Builds clean under `firefox-test,kdb`
- [x] Cold-boot KVM run shows new lifecycle work past the prior plateau
- [x] Test-mode regression check: 172/179, zero new failures
- [ ] CI green on master merge target

## Followup

- Phase 11 (next): research dispatch to identify the JS event-loop dispatch barrier. Will land as a separate issue.
- The original Phase 9 plans (B socketpair / C SCM_RIGHTS / D SHM polish) remain valid sequencing for the post-JS-dispatch work, but Phase 11 must come first since those primitives are unreachable today.

Refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)