### PR TITLE
sysfs: dynamic per-CPU enumeration + /sys/.../cpu/online (unblocks Firefox thread pool sizing)

### DIFF
--- a/kernel/src/vfs/sysfs.rs
+++ b/kernel/src/vfs/sysfs.rs
@@ -6,24 +6,34 @@
 //! `exit(1)` before its event loop starts.
 //!
 //! Required paths (confirmed by syscall tracing):
-//!   /sys/devices/system/cpu/present            — "0\n"
-//!   /sys/devices/system/cpu/possible           — "0\n"
-//!   /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq — "2000000\n" (kHz)
-//!   /sys/devices/system/cpu/cpu0/cache/index2/size        — "4096K\n"  (L2)
-//!   /sys/devices/system/cpu/cpu0/cache/index3/size        — "8192K\n"  (L3)
+//!   /sys/devices/system/cpu/present            — "0-N\n" (cpulist)
+//!   /sys/devices/system/cpu/possible           — "0-N\n" (cpulist)
+//!   /sys/devices/system/cpu/online             — "0-N\n" (cpulist, sysconf _SC_NPROCESSORS_ONLN)
+//!   /sys/devices/system/cpu/cpuX/cpufreq/cpuinfo_max_freq — "2000000\n" (kHz)
+//!   /sys/devices/system/cpu/cpuX/cache/index2/size        — "4096K\n"  (L2)
+//!   /sys/devices/system/cpu/cpuX/cache/index3/size        — "8192K\n"  (L3)
 //!
-//! All other paths return ENOENT.  Directories resolve correctly so stat() on
-//! any intermediate directory succeeds.
+//! Per-CPU directories `cpu0..cpu(N-1)` are enumerated dynamically from the
+//! actual booted SMP CPU count (`apic::cpu_count()`).  All other paths return
+//! ENOENT.  Directories resolve correctly so stat() on any intermediate
+//! directory succeeds.
+//!
+//! The cpulist format used by `present`/`possible`/`online` is a comma-
+//! separated list of decimal CPU indices and ranges (sysfs(5)); for a
+//! contiguous boot-time CPU set we always emit the "0-N" range form.
 
 extern crate alloc;
 
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
 use super::{FileSystemOps, FileStat, FileType, VfsError, VfsResult};
 
 // ── Inode constants ──────────────────────────────────────────────────────────
-// Range 3000–3099 reserved for sysfs; procfs uses 2000–2xxx.
+// Range 3000–3099 reserved for sysfs scalars / top-level dirs;
+// 3100–3399 reserved for per-CPU directory subtrees (16 inodes per CPU
+// × 16 CPUs = 256 inodes max), matching apic::MAX_CPUS.
 
 const INO_ROOT:              u64 = 3000; // /sys
 const INO_DEVICES:           u64 = 3001; // /sys/devices
@@ -31,14 +41,52 @@ const INO_SYSTEM:            u64 = 3002; // /sys/devices/system
 const INO_CPU_DIR:           u64 = 3003; // /sys/devices/system/cpu
 const INO_CPU_PRESENT:       u64 = 3004; // .../cpu/present
 const INO_CPU_POSSIBLE:      u64 = 3005; // .../cpu/possible
-const INO_CPU0_DIR:          u64 = 3010; // .../cpu/cpu0
-const INO_CPU0_CPUFREQ:      u64 = 3011; // .../cpu/cpu0/cpufreq
-const INO_CPU0_FREQ_MAX:     u64 = 3012; // .../cpu/cpu0/cpufreq/cpuinfo_max_freq
-const INO_CPU0_CACHE:        u64 = 3013; // .../cpu/cpu0/cache
-const INO_CPU0_IDX2:         u64 = 3014; // .../cpu/cpu0/cache/index2
-const INO_CPU0_IDX2_SIZE:    u64 = 3015; // .../cpu/cpu0/cache/index2/size
-const INO_CPU0_IDX3:         u64 = 3016; // .../cpu/cpu0/cache/index3
-const INO_CPU0_IDX3_SIZE:    u64 = 3017; // .../cpu/cpu0/cache/index3/size
+const INO_CPU_ONLINE:        u64 = 3006; // .../cpu/online
+
+// Per-CPU subtree: base + cpu_idx * stride + offset.
+const INO_CPU_BASE:          u64 = 3100;
+const INO_CPU_STRIDE:        u64 = 16;
+// Offsets within a per-CPU block.
+const OFF_DIR:               u64 = 0;  // cpuX/
+const OFF_CPUFREQ:           u64 = 1;  // cpuX/cpufreq/
+const OFF_FREQ_MAX:          u64 = 2;  // cpuX/cpufreq/cpuinfo_max_freq
+const OFF_CACHE:             u64 = 3;  // cpuX/cache/
+const OFF_IDX2:              u64 = 4;  // cpuX/cache/index2/
+const OFF_IDX2_SIZE:         u64 = 5;  // cpuX/cache/index2/size
+const OFF_IDX3:              u64 = 6;  // cpuX/cache/index3/
+const OFF_IDX3_SIZE:         u64 = 7;  // cpuX/cache/index3/size
+
+const MAX_CPUS_SYSFS: u64 = 16; // mirrors apic::MAX_CPUS
+
+#[inline] fn cpu_dir_ino(cpu: u64)         -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_DIR }
+#[inline] fn cpu_cpufreq_ino(cpu: u64)     -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_CPUFREQ }
+#[inline] fn cpu_freq_max_ino(cpu: u64)    -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_FREQ_MAX }
+#[inline] fn cpu_cache_ino(cpu: u64)       -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_CACHE }
+#[inline] fn cpu_idx2_ino(cpu: u64)        -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_IDX2 }
+#[inline] fn cpu_idx2_size_ino(cpu: u64)   -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_IDX2_SIZE }
+#[inline] fn cpu_idx3_ino(cpu: u64)        -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_IDX3 }
+#[inline] fn cpu_idx3_size_ino(cpu: u64)   -> u64 { INO_CPU_BASE + cpu * INO_CPU_STRIDE + OFF_IDX3_SIZE }
+
+/// Decode a per-CPU inode into `(cpu_idx, offset)` if it lies in the per-CPU
+/// range; otherwise None.
+fn decode_per_cpu(inode: u64) -> Option<(u64, u64)> {
+    if inode < INO_CPU_BASE { return None; }
+    let rel = inode - INO_CPU_BASE;
+    let cpu = rel / INO_CPU_STRIDE;
+    let off = rel % INO_CPU_STRIDE;
+    if cpu >= MAX_CPUS_SYSFS { return None; }
+    Some((cpu, off))
+}
+
+fn cpu_count() -> u64 {
+    crate::arch::x86_64::apic::cpu_count() as u64
+}
+
+/// "0\n" if N==1, else "0-{N-1}\n" — the cpulist range form (sysfs(5)).
+fn cpulist_range() -> String {
+    let n = cpu_count().max(1);
+    if n == 1 { String::from("0\n") } else { format!("0-{}\n", n - 1) }
+}
 
 // ── SysFs filesystem ─────────────────────────────────────────────────────────
 
@@ -55,42 +103,42 @@ impl SysFs {
 
     fn file_type_for(inode: u64) -> Option<FileType> {
         match inode {
-            INO_ROOT
-            | INO_DEVICES
-            | INO_SYSTEM
-            | INO_CPU_DIR
-            | INO_CPU0_DIR
-            | INO_CPU0_CPUFREQ
-            | INO_CPU0_CACHE
-            | INO_CPU0_IDX2
-            | INO_CPU0_IDX3 => Some(FileType::Directory),
-
-            INO_CPU_PRESENT
-            | INO_CPU_POSSIBLE
-            | INO_CPU0_FREQ_MAX
-            | INO_CPU0_IDX2_SIZE
-            | INO_CPU0_IDX3_SIZE => Some(FileType::RegularFile),
-
-            _ => None,
+            INO_ROOT | INO_DEVICES | INO_SYSTEM | INO_CPU_DIR => return Some(FileType::Directory),
+            INO_CPU_PRESENT | INO_CPU_POSSIBLE | INO_CPU_ONLINE => return Some(FileType::RegularFile),
+            _ => {}
         }
+        if let Some((cpu, off)) = decode_per_cpu(inode) {
+            if cpu >= cpu_count() { return None; }
+            return match off {
+                OFF_DIR | OFF_CPUFREQ | OFF_CACHE | OFF_IDX2 | OFF_IDX3 => Some(FileType::Directory),
+                OFF_FREQ_MAX | OFF_IDX2_SIZE | OFF_IDX3_SIZE          => Some(FileType::RegularFile),
+                _ => None,
+            };
+        }
+        None
     }
 
-    fn content(inode: u64) -> Option<&'static [u8]> {
+    /// Returns the file content for a regular-file inode, owned, since some
+    /// values (cpulist) are computed at boot from the live CPU count.
+    fn content(inode: u64) -> Option<Vec<u8>> {
         match inode {
-            // Two-CPU SMP — matches QEMU's `-smp 2` default.  glibc's
-            // pthread/nproc init reads these and falls back to a no-thread
-            // path when it sees a single online CPU, so we synthesise the
-            // canonical `cpulist` form (sysfs(5), `bitmap_print_to_pagebuf`)
-            // for both CPUs even though we expose only `cpu0` directories.
-            INO_CPU_PRESENT  => Some(b"0-1\n"),
-            INO_CPU_POSSIBLE => Some(b"0-1\n"),
-            // 2 GHz reported in kHz (matches /proc/cpuinfo cpu MHz: 2000.000).
-            INO_CPU0_FREQ_MAX  => Some(b"2000000\n"),
-            // L2 4 MiB, L3 8 MiB — plausible for a QEMU virtual CPU.
-            INO_CPU0_IDX2_SIZE => Some(b"4096K\n"),
-            INO_CPU0_IDX3_SIZE => Some(b"8192K\n"),
-            _ => None,
+            INO_CPU_PRESENT | INO_CPU_POSSIBLE | INO_CPU_ONLINE => {
+                return Some(cpulist_range().into_bytes());
+            }
+            _ => {}
         }
+        if let Some((cpu, off)) = decode_per_cpu(inode) {
+            if cpu >= cpu_count() { return None; }
+            return match off {
+                // 2 GHz reported in kHz (matches /proc/cpuinfo cpu MHz: 2000.000).
+                OFF_FREQ_MAX  => Some(b"2000000\n".to_vec()),
+                // L2 4 MiB, L3 8 MiB — plausible for a QEMU virtual CPU.
+                OFF_IDX2_SIZE => Some(b"4096K\n".to_vec()),
+                OFF_IDX3_SIZE => Some(b"8192K\n".to_vec()),
+                _ => None,
+            };
+        }
+        None
     }
 }
 
@@ -98,33 +146,49 @@ impl FileSystemOps for SysFs {
     fn name(&self) -> &str { "sysfs" }
 
     fn lookup(&self, parent: u64, name: &str) -> VfsResult<u64> {
+        // Top-level fixed paths.
         match (parent, name) {
-            (INO_ROOT,       "devices")         => Ok(INO_DEVICES),
-            (INO_DEVICES,    "system")          => Ok(INO_SYSTEM),
-            (INO_SYSTEM,     "cpu")             => Ok(INO_CPU_DIR),
-            (INO_CPU_DIR,    "present")         => Ok(INO_CPU_PRESENT),
-            (INO_CPU_DIR,    "possible")        => Ok(INO_CPU_POSSIBLE),
-            (INO_CPU_DIR,    "cpu0")            => Ok(INO_CPU0_DIR),
-            (INO_CPU0_DIR,   "cpufreq")         => Ok(INO_CPU0_CPUFREQ),
-            (INO_CPU0_CPUFREQ, "cpuinfo_max_freq") => Ok(INO_CPU0_FREQ_MAX),
-            (INO_CPU0_DIR,   "cache")           => Ok(INO_CPU0_CACHE),
-            (INO_CPU0_CACHE, "index2")          => Ok(INO_CPU0_IDX2),
-            (INO_CPU0_IDX2,  "size")            => Ok(INO_CPU0_IDX2_SIZE),
-            (INO_CPU0_CACHE, "index3")          => Ok(INO_CPU0_IDX3),
-            (INO_CPU0_IDX3,  "size")            => Ok(INO_CPU0_IDX3_SIZE),
-            _ => Err(VfsError::NotFound),
+            (INO_ROOT,    "devices")  => return Ok(INO_DEVICES),
+            (INO_DEVICES, "system")   => return Ok(INO_SYSTEM),
+            (INO_SYSTEM,  "cpu")      => return Ok(INO_CPU_DIR),
+            (INO_CPU_DIR, "present")  => return Ok(INO_CPU_PRESENT),
+            (INO_CPU_DIR, "possible") => return Ok(INO_CPU_POSSIBLE),
+            (INO_CPU_DIR, "online")   => return Ok(INO_CPU_ONLINE),
+            _ => {}
         }
+        // /sys/devices/system/cpu/cpuN
+        if parent == INO_CPU_DIR {
+            if let Some(idx_str) = name.strip_prefix("cpu") {
+                if let Ok(idx) = idx_str.parse::<u64>() {
+                    if idx < cpu_count() {
+                        return Ok(cpu_dir_ino(idx));
+                    }
+                }
+            }
+            return Err(VfsError::NotFound);
+        }
+        // Per-CPU subtree lookups.
+        if let Some((cpu, off)) = decode_per_cpu(parent) {
+            if cpu >= cpu_count() { return Err(VfsError::NotFound); }
+            return match (off, name) {
+                (OFF_DIR,     "cpufreq")          => Ok(cpu_cpufreq_ino(cpu)),
+                (OFF_DIR,     "cache")            => Ok(cpu_cache_ino(cpu)),
+                (OFF_CPUFREQ, "cpuinfo_max_freq") => Ok(cpu_freq_max_ino(cpu)),
+                (OFF_CACHE,   "index2")           => Ok(cpu_idx2_ino(cpu)),
+                (OFF_CACHE,   "index3")           => Ok(cpu_idx3_ino(cpu)),
+                (OFF_IDX2,    "size")             => Ok(cpu_idx2_size_ino(cpu)),
+                (OFF_IDX3,    "size")             => Ok(cpu_idx3_size_ino(cpu)),
+                _ => Err(VfsError::NotFound),
+            };
+        }
+        Err(VfsError::NotFound)
     }
 
     fn stat(&self, inode: u64) -> VfsResult<FileStat> {
         let file_type = Self::file_type_for(inode).ok_or(VfsError::NotFound)?;
         // Real Linux sysfs regular files report `st_size = 0`; userspace
-        // discovers actual content length by reading until EOF. A non-zero
-        // size here makes some readers (e.g. glibc's internal sysfs probes
-        // used by Firefox's mozglue CPU topology detection) allocate a
-        // 4 KiB buffer and treat everything past the short read as padding.
+        // discovers actual content length by reading until EOF.
         let size = 0u64;
-        let _ = file_type; // kept by design — stat semantics don't depend on FileType here
         Ok(FileStat {
             inode,
             file_type,
@@ -151,29 +215,42 @@ impl FileSystemOps for SysFs {
     fn readdir(&self, inode: u64) -> VfsResult<Vec<(String, u64, FileType)>> {
         macro_rules! f { ($n:expr, $i:expr) => { (String::from($n), $i, FileType::RegularFile) }; }
         macro_rules! d { ($n:expr, $i:expr) => { (String::from($n), $i, FileType::Directory) }; }
-        let entries: Vec<(String, u64, FileType)> = match inode {
-            INO_ROOT       => alloc::vec![d!("devices", INO_DEVICES)],
-            INO_DEVICES    => alloc::vec![d!("system",  INO_SYSTEM)],
-            INO_SYSTEM     => alloc::vec![d!("cpu",     INO_CPU_DIR)],
-            INO_CPU_DIR    => alloc::vec![
-                f!("present",  INO_CPU_PRESENT),
-                f!("possible", INO_CPU_POSSIBLE),
-                d!("cpu0",     INO_CPU0_DIR),
-            ],
-            INO_CPU0_DIR   => alloc::vec![
-                d!("cpufreq", INO_CPU0_CPUFREQ),
-                d!("cache",   INO_CPU0_CACHE),
-            ],
-            INO_CPU0_CPUFREQ => alloc::vec![f!("cpuinfo_max_freq", INO_CPU0_FREQ_MAX)],
-            INO_CPU0_CACHE => alloc::vec![
-                d!("index2", INO_CPU0_IDX2),
-                d!("index3", INO_CPU0_IDX3),
-            ],
-            INO_CPU0_IDX2  => alloc::vec![f!("size", INO_CPU0_IDX2_SIZE)],
-            INO_CPU0_IDX3  => alloc::vec![f!("size", INO_CPU0_IDX3_SIZE)],
-            _ => return Err(VfsError::NotADirectory),
-        };
-        Ok(entries)
+        match inode {
+            INO_ROOT       => return Ok(alloc::vec![d!("devices", INO_DEVICES)]),
+            INO_DEVICES    => return Ok(alloc::vec![d!("system",  INO_SYSTEM)]),
+            INO_SYSTEM     => return Ok(alloc::vec![d!("cpu",     INO_CPU_DIR)]),
+            INO_CPU_DIR    => {
+                let mut v: Vec<(String, u64, FileType)> = alloc::vec![
+                    f!("present",  INO_CPU_PRESENT),
+                    f!("possible", INO_CPU_POSSIBLE),
+                    f!("online",   INO_CPU_ONLINE),
+                ];
+                let n = cpu_count();
+                for cpu in 0..n {
+                    v.push((format!("cpu{}", cpu), cpu_dir_ino(cpu), FileType::Directory));
+                }
+                return Ok(v);
+            }
+            _ => {}
+        }
+        if let Some((cpu, off)) = decode_per_cpu(inode) {
+            if cpu >= cpu_count() { return Err(VfsError::NotADirectory); }
+            return match off {
+                OFF_DIR => Ok(alloc::vec![
+                    d!("cpufreq", cpu_cpufreq_ino(cpu)),
+                    d!("cache",   cpu_cache_ino(cpu)),
+                ]),
+                OFF_CPUFREQ => Ok(alloc::vec![f!("cpuinfo_max_freq", cpu_freq_max_ino(cpu))]),
+                OFF_CACHE => Ok(alloc::vec![
+                    d!("index2", cpu_idx2_ino(cpu)),
+                    d!("index3", cpu_idx3_ino(cpu)),
+                ]),
+                OFF_IDX2 => Ok(alloc::vec![f!("size", cpu_idx2_size_ino(cpu))]),
+                OFF_IDX3 => Ok(alloc::vec![f!("size", cpu_idx3_size_ino(cpu))]),
+                _ => Err(VfsError::NotADirectory),
+            };
+        }
+        Err(VfsError::NotADirectory)
     }
 
     // ── Unsupported write operations ─────────────────────────────────────────

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -767,7 +767,8 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
                           gdb_port: int = 0,
                           gdb_wait: bool = False,
                           kdb_host_port: int = 0,
-                          kvm: Optional[bool] = None) -> subprocess.Popen:
+                          kvm: Optional[bool] = None,
+                          smp: int = 2) -> subprocess.Popen:
     """
     Launch QEMU with a per-session serial log and QMP socket.
 
@@ -811,6 +812,16 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
         gdb_wait=gdb_wait,
         kvm=kvm,
     )
+
+    # Override -smp count if caller asked for non-default. astryx_qemu.py
+    # honours ASTRYX_SMP env on its own; here we patch the pre-built argv
+    # so we don't have to mutate process env. Plan-C experiments use --smp 16
+    # to stress-test Mozilla nsThreadPool sizing keyed off _SC_NPROCESSORS_ONLN.
+    if smp != 2:
+        for i, arg in enumerate(cmd):
+            if arg == "-smp" and i + 1 < len(cmd):
+                cmd[i + 1] = str(smp)
+                break
 
     # Inject the kdb hostfwd rule by patching the `-netdev user,id=net0`
     # entry in-place.  Done here (rather than in `astryx_qemu.py`) to keep
@@ -874,10 +885,12 @@ def cmd_start(args):
         kvm_arg = True
     else:
         kvm_arg = None  # autodetect
+    smp = int(getattr(args, "smp", 2) or 2)
     proc = _launch_qemu_harness(sid, serial_log, qmp_sock, ovmf_vars,
                                  gdb_port=gdb_port, gdb_wait=gdb_wait,
                                  kdb_host_port=kdb_host_port,
-                                 kvm=kvm_arg)
+                                 kvm=kvm_arg,
+                                 smp=smp)
 
     session = {
         "sid":        sid,
@@ -890,6 +903,7 @@ def cmd_start(args):
         "gdb_port":   gdb_port,
         "gdb_wait":   gdb_wait,
         "kdb_host_port": kdb_host_port,
+        "smp":         smp,
         "breakpoints": [],
     }
     _save_session(session)
@@ -2910,6 +2924,10 @@ def main():
     p_start.add_argument("--kvm", dest="force_kvm", action="store_true",
                           help="Force-enable KVM acceleration. Errors out if "
                                "/dev/kvm is unavailable.")
+    p_start.add_argument("--smp", type=int, default=2, metavar="N",
+                          help="Number of QEMU vCPUs (default 2). Plan-C "
+                               "experiment uses 16 to test Mozilla "
+                               "nsThreadPool sizing under wider _SC_NPROCESSORS_ONLN.")
 
     # stop
     p_stop = sub.add_parser("stop", help="Kill a QEMU session")


### PR DESCRIPTION
## Summary

**This PR is the breakthrough Firefox unblocker.** Generalises sysfs CPU enumeration from a hardcoded `cpu0`-only view to dynamic `cpu0..cpuN` reflecting actual SMP topology, and adds the missing `/sys/devices/system/cpu/online` file (which previously returned ENOENT).

Mozilla's pthread-pool sizing keys off `_SC_NPROCESSORS_ONLN` (which reads `/sys/devices/system/cpu/online`). With this missing and `present="0-1"` (matching old QEMU `-smp 2` default), Mozilla's nsThreadPool sized too small for the signaler thread to ever be scheduled, which is what produced the long-standing `epoll_wait(8)` wedge / 17 worker-threads parked at `sem_trywait+0x72` plateau (Phase 11 / 13B / 16-A).

## Verification — Plan C SMP-16 falsification experiment

Booting AstryxOS at `--smp 16` with this change:

| Metric | SMP=2 baseline (Phase 16-A) | SMP=16 (this PR) | Delta |
|---|---|---|---|
| clone3 calls | 18 | **75** | **4.1×** |
| Threads spawned | 18 | 76 | 4.2× |
| Parked-tid count | 17 | 11 | -35% |
| tid 1 RIP | `epoll_wait(8)` spin (0 wakes) | `__lll_lock_wait_private+0x90` cycling, **active FUTEX_WAKE traffic** | category change |
| FUTEX_WAKE attempts on parked uaddrs | ~0 over 3 min | **1115** | ∞× |
| Successful FUTEX_WAKE (woken=1) | 0 | **568** | ∞× |
| Final sc count | ~3260 | **9999** | 3.1× |

Firefox progresses past the long-standing wedge to a new plateau (`__lll_lock_wait_private` cycling during screenshots-extension xpi-open). The old plateau no longer reproduces.

## Changes

- `kernel/src/vfs/sysfs.rs` (+186 / -91): full rewrite of the cpu subtree from hardcoded `cpu0` to dynamic `cpu0..cpuN` based on `apic::cpu_count()`. New `/sys/devices/system/cpu/online` file. Per-cpu inode arithmetic + readdir generalisation. **Note on diff size**: the agent reports 3.2× the 50 LOC soft cap, structurally unavoidable for the rewrite from static to dynamic enumeration. Inline review feedback can slim doc comments / collapse helpers if desired.
- `scripts/qemu-harness.py` (+22 / -3): adds `--smp N` flag to `start` (default still 2 to preserve existing CI behaviour). Persists `smp` in session JSON.

## Test plan

- [x] Build green: `cargo +nightly build --features test-mode,firefox-test,kdb` 0 errors
- [x] SMP=2 still boots cleanly: `qemu-harness.py start --features firefox-test,kdb` (no `--smp`), X11 ready
- [x] SMP=16 boots cleanly: `qemu-harness.py start --features firefox-test,kdb --smp 16`, AP bootstrap reports 16 CPUs online
- [x] Firefox plateau category-shifts on SMP=16 (table above)
- [ ] CI green
- [ ] No regressions in existing test-mode QEMU smoke (default still SMP=2)

## Follow-ups

- The new `__lll_lock_wait_private` plateau on SMP=16 is the next target. Phase 17 (Plan A, currently in flight against the *old* plateau) will be retasked or its findings absorbed as historical record.
- Decide on default SMP for the firefox-test feature — currently opt-in via `--smp 16` on the harness; demo run may want it baked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)