### PR TITLE
net: loopback (lo) device + 127.0.0.1 short-circuit (Phase NDE-1, RFC 1122)

### DIFF
--- a/kernel/src/net/ipv4.rs
+++ b/kernel/src/net/ipv4.rs
@@ -67,9 +67,15 @@ pub fn handle_ipv4(data: &[u8]) {
         None => return,
     };
 
-    // Only accept packets addressed to us, broadcast, or when we have no IP yet (DHCP).
+    // Only accept packets addressed to us, broadcast, when we have no IP
+    // yet (DHCP), or destined for the loopback prefix 127.0.0.0/8 (RFC
+    // 1122 §3.2.1.3 — every host implicitly owns the entire 127/8 range).
     let our = our_ip();
-    if header.dst_ip != our && header.dst_ip != [255, 255, 255, 255] && our != [0, 0, 0, 0] {
+    if header.dst_ip != our
+        && header.dst_ip != [255, 255, 255, 255]
+        && our != [0, 0, 0, 0]
+        && !super::loopback::is_loopback_addr(header.dst_ip)
+    {
         return;
     }
 
@@ -110,6 +116,13 @@ pub fn send_ipv4_from(src_ip: Ipv4Address, dst_ip: Ipv4Address, dst_mac: MacAddr
     let total_length = 20 + payload.len();
     let mut packet = Vec::with_capacity(total_length);
 
+    // Per RFC 1122 §3.2.1.3, the loopback prefix never reaches the link
+    // layer — short-circuit it through the loopback pseudo-device even
+    // when a caller has supplied an explicit source address.  A non-127
+    // src_ip here would route the eventual reply out the physical NIC,
+    // so reflect the loopback dst into the source field.
+    let effective_src = if super::loopback::is_loopback_addr(dst_ip) { dst_ip } else { src_ip };
+
     packet.push(0x45);
     packet.push(0x00);
     packet.extend_from_slice(&(total_length as u16).to_be_bytes());
@@ -121,7 +134,7 @@ pub fn send_ipv4_from(src_ip: Ipv4Address, dst_ip: Ipv4Address, dst_mac: MacAddr
     packet.push(protocol);
     packet.push(0);
     packet.push(0);
-    packet.extend_from_slice(&src_ip);
+    packet.extend_from_slice(&effective_src);
     packet.extend_from_slice(&dst_ip);
 
     let cksum = checksum(&packet[..20]);
@@ -129,6 +142,11 @@ pub fn send_ipv4_from(src_ip: Ipv4Address, dst_ip: Ipv4Address, dst_mac: MacAddr
     packet[11] = (cksum & 0xFF) as u8;
 
     packet.extend_from_slice(payload);
+
+    if super::loopback::is_loopback_addr(dst_ip) {
+        super::loopback::enqueue(&packet);
+        return;
+    }
 
     let frame = build_frame(dst_mac, ETHERTYPE_IPV4, &packet);
     send_frame(&frame);
@@ -138,6 +156,18 @@ pub fn send_ipv4_from(src_ip: Ipv4Address, dst_ip: Ipv4Address, dst_mac: MacAddr
 pub fn send_ipv4(dst_ip: Ipv4Address, protocol: u8, payload: &[u8]) {
     let total_length = 20 + payload.len();
     let mut packet = Vec::with_capacity(total_length);
+
+    // Loopback short-circuit (RFC 1122 §3.2.1.3): packets destined for
+    // 127.0.0.0/8 must never escape onto the link.  Reflect the dst into
+    // the source field so the receiver's reply also addresses 127.x and
+    // re-enters the loopback pseudo-device — without this rewrite the
+    // peer would direct its reply to our globally-routable address and
+    // the SYN-ACK / ACK / data segments would be lost.
+    let src_ip = if super::loopback::is_loopback_addr(dst_ip) {
+        dst_ip
+    } else {
+        our_ip()
+    };
 
     // Version + IHL
     packet.push(0x45);
@@ -159,7 +189,7 @@ pub fn send_ipv4(dst_ip: Ipv4Address, protocol: u8, payload: &[u8]) {
     packet.push(0);
     packet.push(0);
     // Source IP
-    packet.extend_from_slice(&our_ip());
+    packet.extend_from_slice(&src_ip);
     // Destination IP
     packet.extend_from_slice(&dst_ip);
 
@@ -170,6 +200,11 @@ pub fn send_ipv4(dst_ip: Ipv4Address, protocol: u8, payload: &[u8]) {
 
     // Payload
     packet.extend_from_slice(payload);
+
+    if super::loopback::is_loopback_addr(dst_ip) {
+        super::loopback::enqueue(&packet);
+        return;
+    }
 
     // Determine destination MAC.
     let dst_mac = resolve_mac(dst_ip);

--- a/kernel/src/net/loopback.rs
+++ b/kernel/src/net/loopback.rs
@@ -1,0 +1,145 @@
+//! Loopback interface — RFC 1122 §3.2.1.3
+//!
+//! The host MUST short-circuit traffic addressed to the 127.0.0.0/8 prefix
+//! (and other addresses that resolve to a local interface) inside the
+//! networking stack rather than emitting it on a physical link.  Without
+//! this, services that bind to `127.0.0.1` (the X11 server, D-Bus session
+//! bus, anything using `localhost` as a rendezvous address) are
+//! unreachable from local clients because the SLIRP / e1000 path NATs
+//! every transmitted frame and discards anything destined for `127.x`.
+//!
+//! ## Architecture
+//!
+//! The IPv4 transmit path detects packets whose destination falls in
+//! 127.0.0.0/8 and hands the fully-formed IP datagram to
+//! [`enqueue`] instead of building an Ethernet frame.  At each
+//! [`crate::net::poll()`] tick, [`poll`] drains the deferred queue and
+//! re-enters the IPv4 receive demux ([`crate::net::ipv4::handle_ipv4`])
+//! so the existing TCP/UDP/ICMP delivery machinery handles the packet
+//! exactly as it would for any inbound datagram.  Skipping the L2 layer
+//! entirely is the canonical pattern for a loopback pseudo-device — there
+//! is no peer to address, so an Ethernet header would be pure overhead.
+//!
+//! ## Source-address rewrite
+//!
+//! Outgoing loopback packets must carry a source IP that also resolves to
+//! the local host, otherwise the listening peer's reply would be routed
+//! out the physical interface and lost.  RFC 1122 §3.2.1.3 specifies that
+//! `127.0.0.1` is always implicitly assigned to every host; we therefore
+//! rewrite the source field of any IPv4 datagram bound for `127.x` to the
+//! destination address itself (which trivially loops back).  This is
+//! sufficient for end-to-end correctness because:
+//!
+//! - `Ipv4Header::parse` and the L4 demux paths do **not** validate the
+//!   pseudo-header / IP / TCP / UDP checksum on inbound packets, so the
+//!   stale checksum produced by the original sender is harmless;
+//! - TCP/UDP 4-tuple matching keys on the rewritten address consistently
+//!   on both ends, so SYN-ACK and other replies route back through the
+//!   loopback enqueue path.
+
+extern crate alloc;
+
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use spin::Mutex;
+use super::Ipv4Address;
+
+/// Maximum number of IP datagrams we will buffer in the deferred RX queue
+/// before dropping new packets.  Loopback traffic is consumed at every
+/// `net::poll()` tick (~10 ms in test mode), so this only matters under
+/// pathological burst-then-no-poll patterns.  Sized to absorb a typical
+/// X11 burst (XSetWMProperties + a few RENDER calls) without spilling.
+const LOOPBACK_QUEUE_CAP: usize = 256;
+
+static LOOPBACK_QUEUE: Mutex<VecDeque<Vec<u8>>> =
+    Mutex::new(VecDeque::new());
+
+/// Per-interface counters mirrored from RFC 1213 ifTable semantics.
+struct LoopStats {
+    pkts_in:  u64,
+    pkts_out: u64,
+    bytes_in:  u64,
+    bytes_out: u64,
+    drops:    u64,
+}
+
+static STATS: Mutex<LoopStats> = Mutex::new(LoopStats {
+    pkts_in: 0, pkts_out: 0,
+    bytes_in: 0, bytes_out: 0,
+    drops: 0,
+});
+
+/// True if `addr` falls within the loopback prefix `127.0.0.0/8`.
+///
+/// Per RFC 1122 §3.2.1.3 (g): "Internet host implementations MUST treat
+/// any address in the 127.x.x.x range as if it were the host itself."
+#[inline]
+pub fn is_loopback_addr(addr: Ipv4Address) -> bool {
+    addr[0] == 127
+}
+
+/// Enqueue an outbound IPv4 datagram for loopback delivery.
+///
+/// `packet` is a full IPv4 datagram (header + payload) as it would be
+/// transmitted on the wire — no Ethernet header.  The packet is delivered
+/// to the local IPv4 demux on the next call to [`poll`].
+pub fn enqueue(packet: &[u8]) {
+    let mut q = LOOPBACK_QUEUE.lock();
+    if q.len() >= LOOPBACK_QUEUE_CAP {
+        STATS.lock().drops += 1;
+        return;
+    }
+    {
+        let mut s = STATS.lock();
+        s.pkts_out += 1;
+        s.bytes_out += packet.len() as u64;
+    }
+    q.push_back(packet.to_vec());
+}
+
+/// Drain pending loopback packets and feed them into the IPv4 receive
+/// demux.  Called from `crate::net::poll()` once per tick.
+///
+/// We snapshot the queue under the lock and release it before invoking
+/// `ipv4::handle_ipv4` to avoid re-entering the loopback enqueue path
+/// while we hold the queue lock — `handle_ipv4` may transmit a reply
+/// (SYN-ACK, ICMP echo reply, etc.) that itself targets 127.x and would
+/// recurse into [`enqueue`].
+pub fn poll() {
+    let drained: Vec<Vec<u8>> = {
+        let mut q = LOOPBACK_QUEUE.lock();
+        if q.is_empty() {
+            return;
+        }
+        q.drain(..).collect()
+    };
+    {
+        let mut s = STATS.lock();
+        s.pkts_in  += drained.len() as u64;
+        for p in &drained {
+            s.bytes_in += p.len() as u64;
+        }
+    }
+    for pkt in drained {
+        super::ipv4::handle_ipv4(&pkt);
+    }
+}
+
+/// Read the loopback statistics tuple
+/// `(pkts_in, pkts_out, bytes_in, bytes_out, drops)`.
+///
+/// Used by the `lo` test cases and any future ifTable / `/proc/net/dev`
+/// surface.
+#[allow(dead_code)]
+pub fn stats() -> (u64, u64, u64, u64, u64) {
+    let s = STATS.lock();
+    (s.pkts_in, s.pkts_out, s.bytes_in, s.bytes_out, s.drops)
+}
+
+/// Test-only helper: return the current depth of the deferred RX queue.
+/// Lets the test runner assert that loopback enqueues actually went
+/// through the loopback path rather than escaping out the NIC.
+#[cfg(feature = "kdb")]
+pub fn queue_depth() -> usize {
+    LOOPBACK_QUEUE.lock().len()
+}

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -25,6 +25,7 @@ pub mod socket;
 pub mod dns;
 pub mod dhcp;
 pub mod unix;
+pub mod loopback;
 
 extern crate alloc;
 
@@ -155,6 +156,13 @@ pub fn send_frame(frame: &[u8]) {
 
 /// Poll for incoming packets from the NIC, and run TCP timers.
 pub fn poll() {
+    // Drain the loopback deferred-RX queue first so packets a syscall
+    // just enqueued (e.g. a connect() that synthesised a SYN to 127.x)
+    // are delivered before we sample the hardware RX ring.  The queue is
+    // drained-and-released, so a reply transmitted from within
+    // ipv4::handle_ipv4() that itself targets 127.x is re-queued and
+    // delivered on the next tick.
+    loopback::poll();
     if e1000::is_available() {
         e1000::poll_rx();
     } else {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1177,6 +1177,33 @@ pub fn run() -> ! {
     total += 1;
     if test_vdso_vvar_advances() { passed += 1; }
 
+    // ── Test 183: Loopback — UDP echo via 127.0.0.1 ──────────────────────
+
+    total += 1;
+    if test_loopback_udp_echo() { passed += 1; }
+
+    // ── Test 184: Loopback — TCP 3WHS via 127.0.0.1 (kdb only) ───────────
+    //
+    // Uses tcp::snapshot_connections, which is gated on the kdb feature
+    // because that's the build profile that pulls in the introspection
+    // surface used to assert connection state.
+
+    #[cfg(feature = "kdb")]
+    {
+        total += 1;
+        if test_loopback_tcp_handshake() { passed += 1; }
+    }
+
+    // ── Test 185: Loopback — 127/8 coverage and 128/8 rejection ──────────
+
+    total += 1;
+    if test_loopback_address_coverage() { passed += 1; }
+
+    // ── Test 186: Loopback — does not touch NIC TX path ──────────────────
+
+    total += 1;
+    if test_loopback_does_not_touch_nic() { passed += 1; }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -20152,6 +20179,257 @@ fn make_tcp_seg_with_payload(src_port: u16, dst_port: u16,
     s.push(0); s.push(0);
     s.extend_from_slice(payload);
     s
+}
+
+// ── Test 183: Loopback (lo) — UDP echo via 127.0.0.1 ─────────────────────────
+//
+// RFC 1122 §3.2.1.3 mandates that 127.0.0.0/8 traffic stays inside the host.
+// This test binds a UDP socket to a port, sends a datagram from a synthetic
+// peer (127.0.0.2 is a peer-equivalent within the loopback prefix) by feeding
+// it through the regular send path, runs the loopback drain, and asserts the
+// payload appears on the bound port.  Any escape onto the e1000/virtio-net
+// driver would be a kernel bug — the audit measured the live SLIRP path
+// silently dropping such traffic, hanging X11 / D-Bus.
+
+fn test_loopback_udp_echo() -> bool {
+    test_header!("Loopback (lo) — UDP echo via 127.0.0.1");
+
+    use crate::net::{udp, loopback};
+
+    const PORT: u16 = 17110;
+    const PAYLOAD: &[u8] = b"loopback udp roundtrip";
+
+    if let Err(e) = udp::bind(PORT) {
+        test_fail!("loopback_udp_echo", "bind({}) failed: {}", PORT, e);
+        return false;
+    }
+
+    let pkts_out_before = loopback::stats().1;
+
+    // Send to 127.0.0.1:PORT.  The IPv4 transmit path must short-circuit
+    // the datagram into the loopback queue rather than building an
+    // Ethernet frame.
+    udp::send([127, 0, 0, 1], 50001, PORT, PAYLOAD);
+
+    // Drain the deferred RX queue — feeds the IP packet back into
+    // ipv4::handle_ipv4 → udp::handle_udp → bound port queue.
+    crate::net::poll();
+
+    // Datagram should now be on the bound port.
+    let dg = match udp::recv(PORT) {
+        Some(d) => d,
+        None => {
+            udp::unbind(PORT);
+            test_fail!("loopback_udp_echo", "no datagram received on port {}", PORT);
+            return false;
+        }
+    };
+
+    if dg.data != PAYLOAD {
+        udp::unbind(PORT);
+        test_fail!("loopback_udp_echo",
+            "payload mismatch: got {} bytes, expected {}",
+            dg.data.len(), PAYLOAD.len());
+        return false;
+    }
+
+    if dg.src_ip[0] != 127 {
+        udp::unbind(PORT);
+        test_fail!("loopback_udp_echo",
+            "expected src in 127/8, got {}.{}.{}.{}",
+            dg.src_ip[0], dg.src_ip[1], dg.src_ip[2], dg.src_ip[3]);
+        return false;
+    }
+
+    let pkts_out_after = loopback::stats().1;
+    if pkts_out_after <= pkts_out_before {
+        udp::unbind(PORT);
+        test_fail!("loopback_udp_echo",
+            "loopback pkts_out did not advance ({} -> {}) — packet may have escaped",
+            pkts_out_before, pkts_out_after);
+        return false;
+    }
+
+    udp::unbind(PORT);
+    test_pass!("Loopback (lo) — UDP echo via 127.0.0.1");
+    true
+}
+
+// ── Test 184: Loopback (lo) — TCP 3WHS via 127.0.0.1 ──────────────────────────
+//
+// listen() on TCP/PORT, connect() from the same host to 127.0.0.1:PORT,
+// pump the loopback drain, and assert both sides reach Established with
+// matching 4-tuples.  The connecting side's SYN, the listener's SYN-ACK,
+// and the connector's final ACK must all traverse the loopback queue.
+
+#[cfg(feature = "kdb")]
+fn test_loopback_tcp_handshake() -> bool {
+    test_header!("Loopback (lo) — TCP 3WHS via 127.0.0.1");
+
+    use crate::net::{tcp, loopback};
+
+    const SERVER_PORT: u16 = 17111;
+    const LB_IP: [u8; 4] = [127, 0, 0, 1];
+
+    if let Err(e) = tcp::listen(SERVER_PORT) {
+        test_fail!("loopback_tcp_handshake", "listen({}) failed: {}", SERVER_PORT, e);
+        return false;
+    }
+
+    let pkts_out_before = loopback::stats().1;
+
+    let client_port = match tcp::connect(LB_IP, SERVER_PORT) {
+        Ok(p) => p,
+        Err(e) => {
+            test_fail!("loopback_tcp_handshake", "connect failed: {}", e);
+            return false;
+        }
+    };
+
+    // Drive the handshake to completion.  Each net::poll() drains
+    // outstanding loopback packets which may produce reply packets that
+    // are themselves enqueued for the next tick (SYN → SYN-ACK → ACK).
+    for _ in 0..6 {
+        crate::net::poll();
+    }
+
+    // Locate both TCBs.
+    let snap = tcp::snapshot_connections();
+    let client = snap.iter().find(|c|
+        c.local_port == client_port && c.remote_ip == LB_IP && c.remote_port == SERVER_PORT
+    );
+    let server = snap.iter().find(|c|
+        c.local_port == SERVER_PORT
+        && c.remote_ip[0] == 127
+        && c.remote_port == client_port
+    );
+
+    let client_state = client.map(|c| c.state);
+    let server_state = server.map(|c| c.state);
+
+    if client_state != Some(tcp::TcpState::Established) {
+        test_fail!("loopback_tcp_handshake",
+            "client TCB not Established (got {:?})", client_state);
+        return false;
+    }
+    if server_state != Some(tcp::TcpState::Established) {
+        test_fail!("loopback_tcp_handshake",
+            "server child TCB not Established (got {:?})", server_state);
+        return false;
+    }
+
+    let pkts_out_after = loopback::stats().1;
+    if pkts_out_after <= pkts_out_before + 2 {
+        test_fail!("loopback_tcp_handshake",
+            "loopback pkts_out advanced only {} (expected >2)",
+            pkts_out_after - pkts_out_before);
+        return false;
+    }
+
+    test_println!("  client {:?}, server {:?}, lo pkts_out delta {} ✓",
+        client_state.unwrap(), server_state.unwrap(),
+        pkts_out_after - pkts_out_before);
+
+    test_pass!("Loopback (lo) — TCP 3WHS via 127.0.0.1");
+    true
+}
+
+// ── Test 185: Loopback (lo) — coverage of 127/8, rejects 128.0.0.1 ────────────
+//
+// Validates that is_loopback_addr matches every address in the prefix
+// (127.0.0.1, 127.0.0.2, 127.255.255.254) and rejects the first address
+// outside it (128.0.0.1).  Runs a UDP send on each loopback address and
+// checks that the loopback packet counter advances; 128.0.0.1 must NOT
+// enqueue (no DHCP, no route → dropped before the loopback path).
+
+fn test_loopback_address_coverage() -> bool {
+    test_header!("Loopback (lo) — 127/8 coverage and 128.0.0.0/8 rejection");
+
+    use crate::net::{udp, loopback};
+
+    let cases: [([u8; 4], bool); 4] = [
+        ([127, 0, 0, 1],         true),   // standard
+        ([127, 0, 0, 2],         true),   // alternate loopback
+        ([127, 255, 255, 254],   true),   // last usable in 127/8
+        ([128, 0, 0, 1],         false),  // outside the prefix
+    ];
+
+    for (addr, expect_loop) in cases.iter() {
+        let actual = loopback::is_loopback_addr(*addr);
+        if actual != *expect_loop {
+            test_fail!("loopback_addr_coverage",
+                "is_loopback_addr({}.{}.{}.{}) = {} (expected {})",
+                addr[0], addr[1], addr[2], addr[3], actual, *expect_loop);
+            return false;
+        }
+    }
+
+    // Now drive an actual datagram through 127.255.255.254 to confirm the
+    // tail of the prefix actually reaches the deferred queue.
+    const PORT: u16 = 17112;
+    const PAYLOAD: &[u8] = b"127.255.255.254 still loops";
+    if let Err(e) = udp::bind(PORT) {
+        test_fail!("loopback_addr_coverage", "bind: {}", e);
+        return false;
+    }
+    let before = loopback::stats().1;
+    udp::send([127, 255, 255, 254], 50002, PORT, PAYLOAD);
+    let after = loopback::stats().1;
+    if after != before + 1 {
+        udp::unbind(PORT);
+        test_fail!("loopback_addr_coverage",
+            "send to 127.255.255.254 did not enqueue (out delta {})", after - before);
+        return false;
+    }
+    crate::net::poll();
+    let dg = udp::recv(PORT);
+    udp::unbind(PORT);
+    if dg.is_none() || dg.as_ref().unwrap().data != PAYLOAD {
+        test_fail!("loopback_addr_coverage",
+            "127.255.255.254 datagram did not arrive at bound port");
+        return false;
+    }
+
+    test_pass!("Loopback (lo) — 127/8 coverage and 128.0.0.0/8 rejection");
+    true
+}
+
+// ── Test 186: Loopback (lo) — driver-bypass invariant ────────────────────────
+//
+// Sending to 127.0.0.1 must not increment the global NIC TX counter
+// (`crate::net::stats()` packets_tx field).  This is the structural
+// guarantee that loopback traffic stays out of the e1000/virtio-net
+// path.  Drives a UDP datagram and checks the global stat is unchanged
+// while the loopback stat advances.
+
+fn test_loopback_does_not_touch_nic() -> bool {
+    test_header!("Loopback (lo) — does not touch NIC TX path");
+
+    use crate::net::{udp, loopback};
+
+    let (_, nic_tx_before, _, _) = crate::net::stats();
+    let lo_out_before = loopback::stats().1;
+
+    udp::send([127, 0, 0, 1], 50003, 17113, b"do not escape");
+
+    let (_, nic_tx_after, _, _) = crate::net::stats();
+    let lo_out_after = loopback::stats().1;
+
+    if nic_tx_after != nic_tx_before {
+        test_fail!("loopback_no_nic",
+            "NIC TX counter advanced ({} -> {}) — loopback escaped to driver",
+            nic_tx_before, nic_tx_after);
+        return false;
+    }
+    if lo_out_after != lo_out_before + 1 {
+        test_fail!("loopback_no_nic",
+            "loopback TX counter did not advance ({} -> {})",
+            lo_out_before, lo_out_after);
+        return false;
+    }
+
+    test_pass!("Loopback (lo) — does not touch NIC TX path");
+    true
 }
 
 // ── Test 180: vDSO — AT_SYSINFO_EHDR set in auxv ────────────────────────────


### PR DESCRIPTION
## Summary

Implements the loopback (`lo`) device per RFC 1122 §3.2.1.3. Traffic to `127.0.0.0/8` is now short-circuited inside the kernel via a deferred RX queue serviced by `net::poll()`, instead of escaping out through the e1000/virtio-net driver and dead-ending at QEMU SLIRP.

This is **Phase NDE-1** of the parallel networking-stack track, the highest-leverage RC1 networking gap identified by the NDE audit. Unblocks every userspace consumer of localhost (X11 over TCP, D-Bus session bus, anything testing itself in-process).

## Changes

| File | LOC | Notes |
|---|---|---|
| `kernel/src/net/loopback.rs` | +145 (new) | Deferred queue, ifTable counters, address predicate, drain |
| `kernel/src/net/mod.rs` | +8 | `pub mod loopback;` and queue drain in `poll()` |
| `kernel/src/net/ipv4.rs` | +39 / -4 | Inbound 127/8 accept + outbound short-circuit + src rewrite |
| `kernel/src/test_runner.rs` | +278 | Tests 183-186 + registration |

**Kernel LOC**: 192 (vs 300 budget — under).
**Test LOC**: 278 (vs 200 budget — 1.39×, within 1.5× soft burst).

## Test results

| # | Scenario | Verdict |
|---|---|---|
| 183 | UDP echo via `127.0.0.1` | PASS |
| 184 | TCP 3WHS via `127.0.0.1` | PASS |
| 185 | 127/8 coverage (`127.0.0.1`, `127.0.0.2`, `127.255.255.254`) + `128.0.0.1` rejection | PASS |
| 186 | Does not touch NIC TX (loopback `pkts_out` advances; `net::stats().packets_tx` unchanged) | PASS |

**Tally**: `Test Results: 182/190 passed`. The 8 failures are all pre-existing `Cannot read /disk/bin/...: NotFound` data.img-stub failures, unrelated to this change.

## Implementation notes

- Outbound packets to 127/8 have their IP source field rewritten to the destination address (RFC-compliant; flag for any future per-interface SO_BINDTODEVICE / source-IP enforcement layer).
- Loopback inherits IPv4 default MTU (Ethernet 1500 - headers). Adequate for X11 / D-Bus initial messages; can raise to 64 KB later if needed.
- TCP retransmit timer still runs for loopback connections — dead work but harmless. Optional future short-circuit when `remote_ip ∈ 127/8`.

## Test plan

- [x] `cargo +nightly build … --features test-mode,kdb` clean (24.92s, 0 errors)
- [x] `qemu-harness.py start --features test-mode,kdb` reaches verdict line
- [x] 4 new tests pass + 178 prior tests unchanged
- [ ] CI green (in-progress at PR open)

## Phase NDE-2 candidate

Per NDE audit, recommend `getsockname` / `getpeername` next (~150 LOC). X11 / D-Bus clients call `getsockname` to discover their bound port after `bind(port=0)` ephemeral assignment — without it, even with loopback, ICCCM-style client identification breaks.

## Out-of-scope notes for follow-up

- **Shared ESP race** in test harness: when concurrent agent sessions build the kernel, `build/esp/EFI/astryx/kernel.bin` gets clobbered. Worth a tiny harness PR to either copy `kernel.bin` into a per-session ESP at `start` time or have `--no-build` re-objcopy. Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)