### PR TITLE
linux/syscall: sched_getaffinity must return bytes-copied not 0

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1464,28 +1464,49 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 204: sched_getaffinity(pid, cpusetsize, mask) — report all online CPUs.
         // Glibc reads the popcount of this mask to determine nproc; returning
         // only bit 0 would make it report 1 CPU even on SMP systems.
+        //
+        // Per `man 2 sched_getaffinity` ("C library/kernel differences"):
+        //   "On success, the raw sched_getaffinity() system call returns the
+        //    number of bytes placed copied into the mask buffer; this will be
+        //    the minimum of cpusetsize and the size (in bytes) of the
+        //    cpumask_t data type that is used internally by the kernel to
+        //    represent the CPU set bit mask."
+        //
+        // Glibc's `__pthread_getaffinity_np` and Mozilla's mozglue both
+        // check `rv > 0` to validate the bitmap; returning 0 here makes them
+        // treat the bitmap as invalid and silently fall back to single-CPU
+        // assumptions, which under-sizes thread pools.
+        //
+        // Cap at 128 bytes (1024 CPUs) — comfortably above MAX_CPUS=16.
         204 => {
             let buf = arg3 as *mut u8;
             let bufsiz = arg2 as usize;
-            if buf != core::ptr::null_mut() {
+            const KERNEL_CPUMASK_BYTES: usize = 128;
+            let written = bufsiz.min(KERNEL_CPUMASK_BYTES);
+            if buf == core::ptr::null_mut() || written == 0 {
+                // Nothing to write — preserve permissive 0 return for NULL/zero
+                // (real Linux returns -EFAULT here; glibc never invokes this path).
+                0
+            } else {
                 let ncpus = crate::arch::x86_64::apic::cpu_count() as usize;
                 let ncpus = ncpus.max(1); // always at least 1
                 // Zero the buffer, then set one bit per online CPU.
                 unsafe {
-                    core::ptr::write_bytes(buf, 0, bufsiz.min(128));
+                    core::ptr::write_bytes(buf, 0, written);
                     // Set bits 0..ncpus-1 in the cpuset bitmask (little-endian).
-                    // Each byte covers 8 CPUs.  We support up to bufsiz*8 CPUs.
+                    // Each byte covers 8 CPUs.  We support up to written*8 CPUs.
                     for cpu in 0..ncpus {
                         let byte_idx = cpu / 8;
                         let bit_idx  = cpu % 8;
-                        if byte_idx < bufsiz {
+                        if byte_idx < written {
                             let byte_ptr = buf.add(byte_idx);
                             *byte_ptr |= 1u8 << bit_idx;
                         }
                     }
                 }
+                // Return bytes-copied: min(cpusetsize, sizeof(cpumask_t)).
+                written as i64
             }
-            0
         }
         // 209: io_setup stub
         209 => -38,

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -16688,15 +16688,14 @@ fn test_membarrier_query() -> bool {
 // ── Test 125: sched_getaffinity reports all online CPUs ───────────────────────
 
 fn test_sched_getaffinity_shows_all_cpus() -> bool {
-    test_header!("sched_getaffinity(204): popcount == online CPU count");
+    test_header!("sched_getaffinity(204): bytes-copied return + popcount + small-buf");
 
     let ncpus_reported = crate::arch::x86_64::apic::cpu_count() as usize;
     let ncpus_reported = ncpus_reported.max(1);
 
-    // cpuset buffer — 128 bytes covers up to 1024 CPUs
+    // ── Sub-test 1: normal-sized buffer (128 bytes) ──────────────────────────
+    // Per `man 2 sched_getaffinity`: raw syscall returns bytes-copied (>0).
     let mut cpuset = [0u8; 128];
-
-    // sched_getaffinity(pid=0, cpusetsize=128, mask=&cpuset)
     let r = crate::syscall::dispatch_linux(
         204,
         0,                             // pid = 0 → caller
@@ -16704,24 +16703,49 @@ fn test_sched_getaffinity_shows_all_cpus() -> bool {
         cpuset.as_mut_ptr() as u64,
         0, 0, 0,
     );
-    test_println!("  sched_getaffinity(0) = {}", r);
-
-    if r != 0 {
-        test_fail!("sched_getaffinity_shows_all_cpus", "returned {} (expected 0)", r);
+    test_println!("  sched_getaffinity(bufsiz=128) = {}", r);
+    if r <= 0 || r > 128 {
+        test_fail!("sched_getaffinity_shows_all_cpus",
+            "bufsiz=128 returned {} (expected 1..=128)", r);
         return false;
     }
-
-    // Count bits set in the returned mask
+    if cpuset[0] & 0x01 == 0 {
+        test_fail!("sched_getaffinity_shows_all_cpus", "bit 0 not set in mask");
+        return false;
+    }
     let popcount: usize = cpuset.iter().map(|b| b.count_ones() as usize).sum();
-    test_println!("  cpuset popcount={} kernel_cpu_count={}", popcount, ncpus_reported);
-
     if popcount != ncpus_reported {
         test_fail!("sched_getaffinity_shows_all_cpus",
             "popcount={} != kernel cpu_count={}", popcount, ncpus_reported);
         return false;
     }
 
-    test_pass!("sched_getaffinity: popcount matches online CPU count");
+    // ── Sub-test 2: small buffer (8 bytes) → must return exactly 8 ───────────
+    let mut small = [0xFFu8; 8];
+    let r2 = crate::syscall::dispatch_linux(
+        204, 0, 8, small.as_mut_ptr() as u64, 0, 0, 0,
+    );
+    test_println!("  sched_getaffinity(bufsiz=8) = {}", r2);
+    if r2 != 8 {
+        test_fail!("sched_getaffinity_shows_all_cpus",
+            "bufsiz=8 returned {} (expected 8)", r2);
+        return false;
+    }
+    if small[0] & 0x01 == 0 {
+        test_fail!("sched_getaffinity_shows_all_cpus", "small buf: bit 0 not set");
+        return false;
+    }
+
+    // ── Sub-test 3: NULL buffer — preserve existing permissive behavior (0) ─
+    let r3 = crate::syscall::dispatch_linux(204, 0, 128, 0, 0, 0, 0);
+    test_println!("  sched_getaffinity(NULL) = {}", r3);
+    if r3 != 0 {
+        test_fail!("sched_getaffinity_shows_all_cpus",
+            "NULL buf returned {} (expected 0 — permissive)", r3);
+        return false;
+    }
+
+    test_pass!("sched_getaffinity: bytes-copied semantics correct");
     true
 }
 


### PR DESCRIPTION
## Summary

The raw `sched_getaffinity(2)` syscall has C-library/kernel-divergent semantics that AstryxOS was getting wrong: per the [man page](https://man7.org/linux/man-pages/man2/sched_getaffinity.2.html), "C library/kernel differences" section:

> On success, the raw sched_getaffinity() system call returns the number of bytes placed copied into the mask buffer; this will be the minimum of cpusetsize and the size (in bytes) of the cpumask_t data type that is used internally by the kernel to represent the CPU set bit mask.

We were writing the bitmap correctly but returning `0` after success.

## Wedge mechanism

Three parallel investigation leads (strace-diff, userspace stack walker, ABI audit) converged on this single line as the cause of the headless-Firefox-115ESR static-init wedge on AstryxOS:

1. AstryxOS `sched_getaffinity` returns `0` (this bug).
2. Glibc's `__pthread_getaffinity_np` checks `rv > 0` → treats `rv == 0` as an error.
3. Mozilla's `mozglue` falls back to a degraded CPU-detection path.
4. `nsThreadPool` is sized for ≤2 CPUs instead of 16.
5. Thread spawn cascade halts at 18 (vs 82 native).
6. The dispatcher orchestrator that would queue work to those workers never gets spawned.
7. 8 worker tids park on `mozilla::CondVar` / `PR_WaitCondVar` / Rust `std::thread::park` forever — kernel records 0 `FUTEX_WAKE` events on any of their uaddrs because no producer thread exists.

This matches Plan A (PR #114) walker's "0 syscalls during the wedge for 10 min" observation: the parking is a downstream symptom, not a kernel-wake-delivery bug.

## Fix

`kernel/src/subsys/linux/syscall.rs:1488` — return `min(cpusetsize, KERNEL_CPUMASK_BYTES=128)` instead of fall-through `0`. NULL-pointer case keeps existing permissive 0 (real Linux returns -EFAULT, but glibc never invokes that path).

## Tests

Test 125 (`test_sched_getaffinity_shows_all_cpus`) was extended to exercise three sub-cases:

1. `bufsiz=128` → returns 128, popcount matches kernel CPU count
2. `bufsiz=8` → returns 8 (small-buffer clamp)
3. `NULL buf` → returns 0 (preserved permissive behaviour)

All three sub-tests pass under SMP=2 boot. 8 pre-existing test failures (data.img-related) unchanged.

## Test plan

- [x] Test 125 passes with bufsiz=128, 8, NULL
- [x] No regressions in adjacent tests (test count unchanged)
- [ ] Smoke CI passes (kernel-smoke, qemu-harness-smoke)
- [ ] Firefox launch progresses past 18-thread halt under SMP=16 (verification deferred to follow-up dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)