### PR TITLE
linux/syscall: epoll_wait/select must block per spec, not return 0 early

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2739,14 +2739,45 @@ fn sys_select_linux(
     };
 
     if ready == 0 {
-        // SMP fix: pump x11 once, then retry up to 64 times yielding each iteration
-        // to give CPU 0's desktop loop time to finish writing replies.
-        let non_zero_timeout = timeout != 0;
+        // Per `man 2 select`: NULL timeout blocks indefinitely; a timeval of
+        // {0,0} returns immediately; otherwise block bounded by the timeval.
+        // Returning 0 early (the previous "yield 64 times" behaviour) caused
+        // applications using the canonical self-pipe-wakeup pattern to
+        // busy-loop instead of blocking until the peer thread wrote.
         crate::x11::poll();
-        for _ in 0..64 {
-            crate::sched::yield_cpu();
-            do_rescan(&mut ready);
-            if ready > 0 || !non_zero_timeout { break; }
+        let timeout_ms: i64 = if timeout == 0 {
+            -1 // NULL → infinite
+        } else if !crate::syscall::validate_user_ptr(timeout, 16) {
+            -1 // bad pointer — treat as infinite to be conservative
+        } else {
+            // struct timeval { tv_sec: i64, tv_usec: i64 } on x86_64.
+            let tv_sec  = unsafe { core::ptr::read_unaligned(timeout as *const i64) };
+            let tv_usec = unsafe { core::ptr::read_unaligned((timeout + 8) as *const i64) };
+            if tv_sec == 0 && tv_usec == 0 {
+                0
+            } else {
+                let ms = tv_sec.saturating_mul(1000)
+                    .saturating_add(tv_usec / 1000);
+                ms.max(1)
+            }
+        };
+
+        if timeout_ms != 0 {
+            let deadline_tick = if timeout_ms < 0 {
+                u64::MAX
+            } else {
+                let now = crate::arch::x86_64::irq::get_ticks();
+                now.saturating_add(((timeout_ms as u64) / 10).max(1))
+            };
+            loop {
+                crate::proc::sleep_ticks(1); // 10ms
+                crate::x11::poll();
+                do_rescan(&mut ready);
+                if ready > 0 { break; }
+                if signal_pending(pid) { return -4; } // EINTR
+                let now = crate::arch::x86_64::irq::get_ticks();
+                if now >= deadline_tick { break; }
+            }
         }
     }
     ready
@@ -5326,6 +5357,17 @@ fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
     }
 }
 
+/// Returns true if a deliverable (pending && !blocked) signal is queued for `pid`.
+/// Used by blocking syscalls (epoll_wait, select) to honour the POSIX contract
+/// that they must abort with EINTR when a signal is delivered during the wait.
+fn signal_pending(pid: u64) -> bool {
+    let procs = crate::proc::PROCESS_TABLE.lock();
+    procs.iter().find(|p| p.pid == pid)
+        .and_then(|p| p.signal_state.as_ref())
+        .map(|s| s.has_pending())
+        .unwrap_or(false)
+}
+
 /// epoll_create / epoll_create1 — allocate a new epoll fd.
 fn sys_epoll_create1(_flags: u32) -> i64 {
     let pid = crate::proc::current_pid();
@@ -5443,20 +5485,32 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     let mut fired: alloc::vec::Vec<EpollEvent> = alloc::vec::Vec::new();
     do_poll(&mut fired);
 
-    // If nothing ready and caller is willing to wait, sleep for the requested
-    // timeout then retry. Firefox's event loop depends on epoll_wait actually
-    // blocking for the full timeout — returning 0 too quickly causes Firefox
-    // to spin in a tight loop and never advance its internal timers.
+    // Per `man 2 epoll_wait`: the call must block until at least one fd is
+    // ready, the timeout expires, or a signal is delivered. Returning 0 early
+    // is a contract violation — applications that use the canonical self-pipe
+    // wakeup pattern (write to a pipe-write end to wake a sibling thread
+    // blocked in epoll_wait) will busy-loop instead of waking on demand.
+    //
+    // We poll on a 10ms cadence (1 tick) and re-check until one of the three
+    // termination conditions fires. Wake-on-readiness (notifying epoll
+    // instances directly when a watched fd transitions to ready) is a
+    // correctness-preserving optimisation tracked as follow-up work.
     if fired.is_empty() && timeout_ms != 0 {
-        let wait_ticks = if timeout_ms < 0 {
-            // Infinite timeout — sleep a reasonable amount then retry
-            10u64  // 100ms
+        let deadline_tick = if timeout_ms < 0 {
+            u64::MAX // infinite — block until ready or signal
         } else {
-            // Convert ms to ticks (100 Hz = 10ms/tick), minimum 1
-            ((timeout_ms as u64) / 10).max(1)
+            let now = crate::arch::x86_64::irq::get_ticks();
+            now.saturating_add(((timeout_ms as u64) / 10).max(1))
         };
-        crate::proc::sleep_ticks(wait_ticks);
-        do_poll(&mut fired);
+        loop {
+            crate::proc::sleep_ticks(1); // 10ms granularity
+            do_poll(&mut fired);
+            if !fired.is_empty() { break; }
+            // Signal pending → return -EINTR per spec.
+            if signal_pending(pid) { return -4; } // EINTR
+            let now = crate::arch::x86_64::irq::get_ticks();
+            if now >= deadline_tick { break; }
+        }
     }
 
     // ── Step 3: copy events to the caller's buffer ───────────────────────────

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -9712,6 +9712,111 @@ fn test_epoll_and_proc_fd() -> bool {
             }
         }
 
+        // ─── 7b. epoll_wait blocking contract (timeout actually waits) ──────
+        //
+        // Per `man 2 epoll_wait`: a non-zero positive timeout must block at
+        // least that long (modulo tick granularity) before returning 0 when
+        // no fd becomes ready.  Returning 0 early causes self-pipe-wakeup
+        // patterns to busy-loop.
+        {
+            // Empty epoll set (no watches) with timeout=30ms.
+            // Open a fresh epoll fd to avoid mutating the outer one.
+            let epfd2 = dispatch(291, 0, 0, 0, 0, 0, 0);
+            if epfd2 >= 0 {
+                let mut buf = [[0u8; 12]; 4];
+                let t0 = crate::arch::x86_64::irq::get_ticks();
+                let r = dispatch(232, epfd2 as u64, buf[0].as_mut_ptr() as u64,
+                                 4, 30, 0, 0); // timeout_ms=30
+                let t1 = crate::arch::x86_64::irq::get_ticks();
+                let elapsed_ticks = t1.saturating_sub(t0);
+                // 30ms = 3 ticks @ 100Hz; allow 2..=10 to absorb scheduling jitter.
+                if r == 0 && elapsed_ticks >= 2 {
+                    test_println!(
+                        "  epoll_wait(timeout=30ms) blocked {} ticks ok",
+                        elapsed_ticks);
+                } else {
+                    test_fail!("epoll_wait timeout block",
+                        "r={} elapsed_ticks={} (expected r=0, ticks>=2)",
+                        r, elapsed_ticks);
+                    ok = false;
+                }
+                let _ = dispatch(3, epfd2 as u64, 0, 0, 0, 0, 0);
+            } else {
+                test_println!("  epoll_wait timeout block: skipped (epoll_create1 failed)");
+            }
+        }
+
+        // ─── 7c. epoll_wait returns immediately when data already pending ──
+        //
+        // Sanity check: the retry loop must NOT introduce an unconditional
+        // sleep — when an fd is already ready at entry, the syscall must
+        // return without yielding.
+        {
+            let epfd3 = dispatch(291, 0, 0, 0, 0, 0, 0);
+            if epfd3 >= 0 {
+                let mut pipe_fds: [u64; 2] = [u64::MAX; 2];
+                if dispatch(22, pipe_fds.as_mut_ptr() as u64, 0, 0, 0, 0, 0) == 0 {
+                    let rfd = pipe_fds[0] as usize;
+                    let wfd = pipe_fds[1] as usize;
+                    let ev = make_ev(EPOLLIN, rfd as u64);
+                    let _ = dispatch(233, epfd3 as u64, CTL_ADD, rfd as u64,
+                                     ev.as_ptr() as u64, 0, 0);
+                    // Pre-write so the read-end is already readable.
+                    let msg = b"y";
+                    let _ = dispatch(1, wfd as u64, msg.as_ptr() as u64, 1, 0, 0, 0);
+
+                    let mut buf = [[0u8; 12]; 4];
+                    let t0 = crate::arch::x86_64::irq::get_ticks();
+                    // Use a long timeout so any erroneous sleep would show up.
+                    let r = dispatch(232, epfd3 as u64, buf[0].as_mut_ptr() as u64,
+                                     4, 1000, 0, 0);
+                    let t1 = crate::arch::x86_64::irq::get_ticks();
+                    let elapsed_ticks = t1.saturating_sub(t0);
+                    if r == 1 && elapsed_ticks <= 1 && (ev_events(&buf[0]) & EPOLLIN) != 0 {
+                        test_println!(
+                            "  epoll_wait returns immediately when ready ({} tick) ok",
+                            elapsed_ticks);
+                    } else {
+                        test_fail!("epoll_wait ready-fast-path",
+                            "r={} elapsed_ticks={} events={:#x}",
+                            r, elapsed_ticks, ev_events(&buf[0]));
+                        ok = false;
+                    }
+                    let _ = crate::vfs::close(pid, rfd);
+                    let _ = crate::vfs::close(pid, wfd);
+                }
+                let _ = dispatch(3, epfd3 as u64, 0, 0, 0, 0, 0);
+            }
+        }
+
+        // ─── 7d. select(2) blocking contract (timeval actually waits) ──────
+        //
+        // Mirror the epoll case for select: a non-NULL non-zero timeval must
+        // block until the deadline when no fd is ready.  Pass nfds=0 so the
+        // bitmasks are untouched and the call has no fds of interest.
+        {
+            // struct timeval { tv_sec: i64; tv_usec: i64 } = 30ms.
+            #[repr(C)]
+            struct Timeval { tv_sec: i64, tv_usec: i64 }
+            let tv = Timeval { tv_sec: 0, tv_usec: 30_000 };
+            let t0 = crate::arch::x86_64::irq::get_ticks();
+            // syscall 23: select(nfds, readfds, writefds, exceptfds, timeout)
+            let r = dispatch(23, 0, 0, 0, 0,
+                &tv as *const Timeval as u64, 0);
+            let t1 = crate::arch::x86_64::irq::get_ticks();
+            let elapsed_ticks = t1.saturating_sub(t0);
+            if r == 0 && elapsed_ticks >= 2 {
+                test_println!(
+                    "  select(timeout=30ms) blocked {} ticks ok",
+                    elapsed_ticks);
+            } else {
+                test_fail!("select timeout block",
+                    "r={} elapsed_ticks={} (expected r=0, ticks>=2)",
+                    r, elapsed_ticks);
+                ok = false;
+            }
+        }
+
         // ─── 8. close(epfd) cleans up ────────────────────────────────────────
         {
             let r = dispatch(3, epfd as u64, 0, 0, 0, 0, 0);


### PR DESCRIPTION
## Summary

`sys_epoll_wait` (nr=232 + nr=281) and `sys_select_linux` (nr=23 + nr=270) violated the POSIX blocking contract: they returned 0 early instead of blocking until an fd became ready / the deadline expired / a signal was delivered. This made every self-pipe-wakeup pattern busy-loop instead of blocking on the kernel side.

This PR replaces both single-shot sleeps with a proper retry loop. Wake-on-readiness (eliminate the residual 10 ms poll latency by waking blocked waiters directly from pipe_write / eventfd::write / unix::send / socket::send / timerfd::tick / signalfd::deliver) is a follow-up — see *Planned hardening* below.

## Smoking gun

Production trace `41709e420710.serial.log`:

- **tid=4** (Mozilla IPC dispatcher) called `epoll_wait(epfd=8, …, timeout=-1)` **3,480 times** at the same RIP `0x7effffb11d0d` over the run.
- epfd=8 watched fd=11/15 (pipe read ends); workers tid=1/7/8 wrote to fd=12 (the matching pipe write end). Canonical self-pipe wakeup.
- Loop frequency: ~7.6 Hz. Mozilla expects the dispatcher to block on `epoll_wait(timeout=-1)` until a worker writes the pipe; instead the kernel returned 0 every ~100 ms and the dispatcher re-issued.

Per `man 2 epoll_wait`:

> Specifying a timeout of -1 causes `epoll_wait()` to block indefinitely, while specifying a timeout equal to zero cause `epoll_wait()` to return immediately, even if no events are available.

Per `man 2 select`:

> If `timeout` is NULL (no timeout), `select()` can block indefinitely. If `timeout` is a non-null pointer, it specifies a maximum interval to wait.

We were never blocking — both calls fell through after one short sleep (epoll) or 64 yields (select), even on `timeout=-1` / `timeout=NULL`.

## Fix (Part 1 — this PR)

Both syscalls now:

1. Compute a deadline tick (saturating; `u64::MAX` for the infinite cases).
2. Sleep one tick (10 ms granularity).
3. Re-poll watched fds.
4. Check for a pending unblocked signal → return `-EINTR` per spec.
5. Check the deadline → return 0 if expired.
6. Otherwise loop.

`sys_select_linux` additionally now reads the user-provided `struct timeval` correctly (NULL → infinite, `{0,0}` → poll-once, otherwise bounded). The old code only inspected whether the pointer was non-NULL.

A small `signal_pending(pid)` helper consults `SignalState::has_pending()` for the EINTR check; previously the wait paths had no signal awareness at all.

## Planned hardening (Part 2 — follow-up PR)

Add a `wait_list: Vec<(Pid, Tid)>` to `EpollInstance` and have pipe_write / eventfd::write / unix::send / socket::send / timerfd::tick / signalfd::deliver wake registered waiters on the readability transition. That removes the 10 ms wakeup latency the retry loop currently leaves on the table. Splitting it lets us land the syscall-contract fix fast and verify the Firefox plateau actually moves before adding the queueing infrastructure.

## Tests

Extending test 59 (`test_epoll_and_proc_fd`):

- **7b** — `epoll_wait(empty-set, timeout=30ms)` must return 0 AND elapse ≥ 2 ticks.
- **7c** — `epoll_wait(pipe-with-data, timeout=1000ms)` must return 1 in 0–1 ticks (no spurious sleep when ready).
- **7d** — `select(nfds=0, timeout={0,30000us})` must return 0 AND elapse ≥ 2 ticks.

All three pass on test-mode build. Output:
```
  epoll_wait(timeout=30ms) blocked 4 ticks ok
  epoll_wait returns immediately when ready (0 tick) ok
  select(timeout=30ms) blocked 3 ticks ok
[PASS] epoll + /proc/self/fd (readlink+getdents) + /proc/self/status
```

## Test plan

- [x] test-mode build clean (32 pre-existing warnings, 0 errors)
- [x] firefox-test+kdb build clean
- [x] full kernel test suite: 193/201 pass — the 8 failures are the pre-existing `data.img` stub issues (`/disk/bin/{hello,tcc,busybox}` NotFound, glibc/musl/PIE ELFs missing); none are introduced by this PR
- [ ] post-merge: re-run firefox-test and confirm the IPC-dispatcher tid stops issuing thousands of `epoll_wait(timeout=-1)` calls and that Firefox advances past the post-PR-#119 plateau

## Diff size

177 lines added, 18 removed across 2 files (90 LOC kernel / 105 LOC tests). Within the soft target.