### PR TITLE
linux/syscall: spoof uname sysname=Linux for app compatibility

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2441,14 +2441,23 @@ pub(crate) fn alloc_unix_socket_fd(pid: u64, unix_id: u64) -> i64 {
 
 /// uname buffer layout (5 fields, 65 bytes each = 325 bytes):
 ///   sysname, nodename, release, version, machine
+///
+/// We report sysname="Linux" with a Linux-shaped release string so that
+/// glibc, NSS, NSPR, and applications such as Mozilla Firefox take their
+/// regular Linux code paths (their feature detection branches on
+/// `uname.sysname == "Linux"` and parses release as
+/// `<major>.<minor>.<patch>`; values < 3.0 disable modern features).
+/// The Linux-compatible release embeds an "-astryx" suffix so the OS is
+/// still self-identifying, and the version field carries the AstryxOS
+/// branding for any caller that prints it.  Per POSIX `uname(2)`.
 pub(crate) fn sys_uname(buf: *mut u8) -> i64 {
     const FIELD_LEN: usize = 65;
     let fields: [&[u8]; 5] = [
-        b"AstryxOS",      // sysname
-        b"astryx",        // nodename
-        b"0.1.0",         // release
-        b"Phase 6",       // version
-        b"x86_64",        // machine
+        b"Linux",                       // sysname
+        b"astryx",                      // nodename
+        b"5.15.0-astryx",               // release (Linux-compat, parses as 5.15.0)
+        b"#1 SMP AstryxOS Aether",      // version
+        b"x86_64",                      // machine
     ];
 
     let out = unsafe { core::slice::from_raw_parts_mut(buf, FIELD_LEN * 5) };

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -9247,17 +9247,41 @@ fn test_phase1_linux_syscalls() -> bool {
         }
     }
 
-    // ─── uname (63): check sysname filled ───────────────────────────────────
+    // ─── uname (63): sysname must be "Linux" and release must parse ≥ 3.0 ─
+    //
+    // Userspace (glibc, NSPR, Mozilla, etc.) branches on sysname == "Linux"
+    // for feature detection and parses release as <major>.<minor>.<patch>.
+    // Anything else routes apps onto non-Linux fallback paths and disables
+    // modern features (epoll, futex, clone3 ...).
     {
         // struct utsname: 6 × 65-byte fields = 390 bytes
         let mut buf = [0u8; 390];
         let r = dispatch(63, buf.as_mut_ptr() as u64, 0, 0, 0, 0, 0);
         let sysname_end = buf[..65].iter().position(|&b| b == 0).unwrap_or(65);
         let sysname = core::str::from_utf8(&buf[..sysname_end]).unwrap_or("");
-        if r == 0 && !sysname.is_empty() {
-            test_println!("  uname: sysname = \"{}\" ✓", sysname);
+        let release_end = buf[130..195].iter().position(|&b| b == 0).unwrap_or(65);
+        let release = core::str::from_utf8(&buf[130..130 + release_end]).unwrap_or("");
+        let machine_end = buf[260..325].iter().position(|&b| b == 0).unwrap_or(65);
+        let machine = core::str::from_utf8(&buf[260..260 + machine_end]).unwrap_or("");
+
+        // Parse "<major>.<minor>...." — major must be ≥ 3 for Mozilla etc.
+        let major: u32 = release
+            .split('.')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        if r == 0 && sysname == "Linux" && major >= 3 && machine == "x86_64" {
+            test_println!(
+                "  uname: sysname=\"{}\" release=\"{}\" machine=\"{}\" ✓",
+                sysname, release, machine,
+            );
         } else {
-            test_fail!("uname", "r={} sysname len={}", r, sysname_end);
+            test_fail!(
+                "uname",
+                "r={} sysname=\"{}\" release=\"{}\" major={} machine=\"{}\"",
+                r, sysname, release, major, machine,
+            );
             ok = false;
         }
     }


### PR DESCRIPTION
## Summary

- Change `sys_uname` to report `sysname=\"Linux\"` and a Linux-shaped `release=\"5.15.0-astryx\"`, so that glibc, NSPR, and applications such as Mozilla Firefox take their regular Linux code paths instead of non-Linux fallbacks (which can disable modern features like epoll, futex, clone3 and skip content-process spawn).
- Keep AstryxOS self-identifying via the `-astryx` suffix on `release` and an AstryxOS-branded `version` field. `nodename` and `machine` are unchanged.
- Tighten the Phase-1 syscall uname test: now asserts `sysname == \"Linux\"`, that `release` parses to major version `>= 3` (the threshold used by upstream feature-detection code), and that `machine == \"x86_64\"`.

## Why now

Phase 11 / 13B / 16-A investigation showed Mozilla worker threads parking on never-broadcast condition variables and the parent never attempting `socketpair`/`clone3` for content-process spawn. Reading public Mozilla source (`xpcom/system/nsSystemInfo.cpp`, `mozglue` feature detection) shows several branches on `uname.sysname == \"Linux\"`. Returning `\"AstryxOS\"` here is the lowest-cost candidate to unblock that plateau.

## Spec

Behaviour is permitted by POSIX `uname(2)` — `sysname`/`release`/`version` strings are implementation-defined. Returning a Linux-shaped result here is the same de-facto convention used by other Linux-compat layers (WSL1, FreeBSD's Linuxulator, etc.) for application compatibility.

## Test plan

- [x] `qemu-harness.py start --features test-mode` — Phase-1 Linux syscall block prints:
  `uname: sysname=\"Linux\" release=\"5.15.0-astryx\" machine=\"x86_64\" ✓`
- [x] All other test failures are pre-existing `data.img` stub issues (musl hello / dynamic_elf / pie_elf / TCC / busybox / sigchld / ascension / glibc_hello), unchanged by this PR.
- [ ] Re-run firefox-test after merge to see whether Mozilla now reaches `socketpair`+`clone3` and breaks past the SMP=2 sc=1979 / SMP=16 sc=6003 plateaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)