### PR TITLE
linux/syscall: socketpair(2) — type / SOCK_CLOEXEC / SOCK_NONBLOCK / SEQPACKET semantics

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             serial_println!("[X11-VIS] Creating X11 visual test window...");
             {
                 use crate::net::unix;
-                let cfd = unix::create();
+                let cfd = unix::create(unix::SockKind::Stream);
                 if cfd != u64::MAX && unix::connect(cfd, b"/tmp/.X11-unix/X0\0") >= 0 {
                     // X11 connection setup
                     let hello: [u8; 12] = [0x6C, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0];

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -1,7 +1,15 @@
 //! AF_UNIX (UNIX domain) socket implementation.
 //!
 //! Provides local inter-process communication via named (path-based) and
-//! unnamed (socketpair) UNIX sockets.  Supports SOCK_STREAM only.
+//! unnamed (socketpair) UNIX sockets.
+//!
+//! Supports two socket types per `man 7 unix`:
+//!   * `SOCK_STREAM`    — reliable byte-stream, no message boundaries.
+//!   * `SOCK_SEQPACKET` — reliable, ordered, datagram-style messages with
+//!     preserved boundaries.  A `read`/`recvmsg` returns at most one full
+//!     sender-side message; if the receiver buffer is shorter than the
+//!     message, the tail is discarded and `MSG_TRUNC` is set in the
+//!     resulting `msghdr.msg_flags` (caller-side responsibility).
 //!
 //! # Concurrency
 //! All state is protected by a single global Mutex.  Safe on AstryxOS's
@@ -19,6 +27,21 @@ const UNIX_PATH_MAX: usize = 108;
 const RECV_BUF_CAP: usize = 32768;
 /// Maximum number of pending connections in a listen backlog.
 const BACKLOG_CAP: usize = 8;
+/// Maximum number of queued message-length records for a SOCK_SEQPACKET
+/// socket.  Each `write` consumes one slot; each `read` releases one.
+/// Sized for typical IPC bursts; a slow reader receiving more than this many
+/// outstanding messages will see the writer get -EAGAIN.
+const SEQ_QUEUE_CAP: usize = 64;
+
+/// AF_UNIX socket type per `man 7 unix`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SockKind {
+    /// `SOCK_STREAM` — reliable byte-stream, no message boundaries.
+    Stream,
+    /// `SOCK_SEQPACKET` — reliable, ordered datagrams with preserved
+    /// message boundaries.  See `man 7 unix` §SOCK_SEQPACKET.
+    SeqPacket,
+}
 
 // ── Socket state ─────────────────────────────────────────────────────────────
 
@@ -35,12 +58,23 @@ pub enum UnixState {
 
 struct UnixSocket {
     state:       UnixState,
+    /// Socket type — `Stream` (byte-stream) or `SeqPacket` (boundary-preserving
+    /// datagrams).  Set at creation (socket(2)/socketpair(2)) and inherited by
+    /// peer sockets created by accept(2)/connect(2).
+    kind:        SockKind,
     path:        [u8; UNIX_PATH_MAX],
     path_len:    usize,
     peer_id:     u64,
     recv_buf:    [u8; RECV_BUF_CAP],
     recv_head:   usize,
     recv_tail:   usize,
+    /// SEQPACKET message-boundary queue: each entry records the length of
+    /// one outstanding sender-side message in `recv_buf`.  Unused for STREAM.
+    /// Implemented as a small ring; `seq_head` is dequeue, `seq_tail` is
+    /// enqueue.  Number of queued messages = `(tail - head) mod CAP`.
+    seq_lens:    [u32; SEQ_QUEUE_CAP],
+    seq_head:    usize,
+    seq_tail:    usize,
     backlog:     [u64; BACKLOG_CAP],
     backlog_len: usize,
     /// Per IEEE 1003.1 §shutdown.  `shut_rd` makes subsequent local reads
@@ -56,12 +90,16 @@ impl UnixSocket {
     const fn zeroed() -> Self {
         Self {
             state:       UnixState::Free,
+            kind:        SockKind::Stream,
             path:        [0u8; UNIX_PATH_MAX],
             path_len:    0,
             peer_id:     u64::MAX,
             recv_buf:    [0u8; RECV_BUF_CAP],
             recv_head:   0,
             recv_tail:   0,
+            seq_lens:    [0u32; SEQ_QUEUE_CAP],
+            seq_head:    0,
+            seq_tail:    0,
             backlog:     [u64::MAX; BACKLOG_CAP],
             backlog_len: 0,
             shut_rd:     false,
@@ -71,10 +109,13 @@ impl UnixSocket {
 
     fn reset(&mut self) {
         self.state       = UnixState::Free;
+        self.kind        = SockKind::Stream;
         self.path_len    = 0;
         self.peer_id     = u64::MAX;
         self.recv_head   = 0;
         self.recv_tail   = 0;
+        self.seq_head    = 0;
+        self.seq_tail    = 0;
         self.backlog_len = 0;
         self.shut_rd     = false;
         self.shut_wr     = false;
@@ -119,12 +160,13 @@ impl UnixSocket { const ZERO: Self = Self::zeroed(); }
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-pub fn create() -> u64 {
+pub fn create(kind: SockKind) -> u64 {
     let mut t = TABLE.lock();
     for (i, s) in t.0.iter_mut().enumerate() {
         if s.state == UnixState::Free {
             s.reset();
             s.state = UnixState::Unbound;
+            s.kind  = kind;
             return i as u64;
         }
     }
@@ -180,12 +222,21 @@ pub fn connect(id: u64, path: &[u8]) -> i64 {
         .unwrap_or(u64::MAX);
     if server_id == u64::MAX { return -111; }
 
+    // The accepted peer (server-side end of the new connection) inherits the
+    // server's socket type per `man 7 unix` — a SEQPACKET listener must yield
+    // SEQPACKET peers, never STREAM.
+    let server_kind = t.0[server_id as usize].kind;
+    let client_kind = t.0[id as usize].kind;
+    // POSIX: connect on a wrong-type socket fails (Linux returns EPROTOTYPE).
+    if client_kind != server_kind { return -91; } // EPROTOTYPE
+
     let peer_id = {
         let mut found = u64::MAX;
         for (i, s) in t.0.iter_mut().enumerate() {
             if i as u64 != id && s.state == UnixState::Free {
                 s.reset();
                 s.state   = UnixState::Connected;
+                s.kind    = server_kind;
                 s.peer_id = id;
                 found = i as u64;
                 break;
@@ -218,14 +269,24 @@ pub fn accept(id: u64) -> i64 {
     peer_id as i64
 }
 
-pub fn socketpair() -> (u64, u64) {
+pub fn socketpair(kind: SockKind) -> (u64, u64) {
     let mut t = TABLE.lock();
     let mut a = u64::MAX;
     let mut b = u64::MAX;
     for (i, s) in t.0.iter_mut().enumerate() {
         if s.state == UnixState::Free {
-            if a == u64::MAX { s.reset(); s.state = UnixState::Connected; a = i as u64; }
-            else             { s.reset(); s.state = UnixState::Connected; b = i as u64; break; }
+            if a == u64::MAX {
+                s.reset();
+                s.state = UnixState::Connected;
+                s.kind  = kind;
+                a = i as u64;
+            } else {
+                s.reset();
+                s.state = UnixState::Connected;
+                s.kind  = kind;
+                b = i as u64;
+                break;
+            }
         }
     }
     if b == u64::MAX {
@@ -240,28 +301,86 @@ pub fn socketpair() -> (u64, u64) {
 pub fn write(id: u64, data: &[u8]) -> i64 {
     if id as usize >= MAX_UNIX_SOCKETS { return -9; }
     let mut t = TABLE.lock();
-    let peer_id = {
+    let (peer_id, kind) = {
         let s = &t.0[id as usize];
         if s.state != UnixState::Connected { return -32; }
         // SHUT_WR locally → -EPIPE per IEEE 1003.1 §shutdown.
         if s.shut_wr { return -32; }
-        s.peer_id
+        (s.peer_id, s.kind)
     };
     if peer_id as usize >= MAX_UNIX_SOCKETS { return -32; }
+
+    if kind == SockKind::SeqPacket {
+        // SEQPACKET: an entire message must fit in the receiver's ring AND
+        // a free slot must exist in the message-length queue.  Per POSIX
+        // SOCK_SEQPACKET, a partial message is never delivered — either
+        // the whole datagram lands or the call returns -EAGAIN.
+        let peer = &mut t.0[peer_id as usize];
+        let queued = (peer.seq_tail + SEQ_QUEUE_CAP - peer.seq_head) % SEQ_QUEUE_CAP;
+        if queued >= SEQ_QUEUE_CAP - 1 { return -11; }   // EAGAIN — queue full
+        if data.len() > peer.recv_space() { return -11; } // EAGAIN — buffer full
+        let n = peer.push(data);
+        // n == data.len() because we checked space above.
+        peer.seq_lens[peer.seq_tail] = n as u32;
+        peer.seq_tail = (peer.seq_tail + 1) % SEQ_QUEUE_CAP;
+        return n as i64;
+    }
+
+    // STREAM: byte-stream, partial writes permitted.
     let n = t.0[peer_id as usize].push(data);
     if n == 0 { -11 } else { n as i64 }
 }
 
 pub fn read(id: u64, buf: &mut [u8]) -> i64 {
-    if id as usize >= MAX_UNIX_SOCKETS { return -9; }
+    let (n, _truncated) = match read_msg(id, buf) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    n as i64
+}
+
+/// Read one message from the socket.
+///
+/// Returns `Ok((bytes_copied, truncated_extra))` on success:
+///   * `bytes_copied`     — number of bytes actually placed in `buf`
+///   * `truncated_extra`  — bytes discarded from a SEQPACKET message that
+///     did not fit in `buf` (always 0 for STREAM, and 0 for SEQPACKET when
+///     the buffer was large enough).  Callers (recvmsg) should set the
+///     `MSG_TRUNC` flag when this is non-zero.
+///
+/// Returns `Err(errno)` for: -EBADF, -EAGAIN, and orderly EOF (0 from a
+/// shut-rd socket is signalled as `Ok((0, 0))` to keep the existing read()
+/// caller contract intact).
+pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
+    if id as usize >= MAX_UNIX_SOCKETS { return Err(-9); }
     let mut t = TABLE.lock();
     let s = &mut t.0[id as usize];
-    if s.state == UnixState::Free { return -9; }
+    if s.state == UnixState::Free { return Err(-9); }
     // SHUT_RD locally → return 0 (orderly EOF) regardless of any data
     // still queued in our recv_buf.  Matches Linux AF_UNIX behaviour.
-    if s.shut_rd { return 0; }
-    if s.recv_available() == 0 { return -11; }
-    s.pop(buf) as i64
+    if s.shut_rd { return Ok((0, 0)); }
+
+    if s.kind == SockKind::SeqPacket {
+        // SEQPACKET: dequeue exactly one message, truncating any tail that
+        // does not fit per `man 7 unix` §SOCK_SEQPACKET.
+        if s.seq_head == s.seq_tail { return Err(-11); } // EAGAIN — no message
+        let msg_len = s.seq_lens[s.seq_head] as usize;
+        s.seq_head = (s.seq_head + 1) % SEQ_QUEUE_CAP;
+
+        let want    = buf.len().min(msg_len);
+        let copied  = if want > 0 { s.pop(&mut buf[..want]) } else { 0 };
+        let discard = msg_len - copied;
+        // Drop the truncated tail from recv_buf so the next read sees the
+        // start of the following message.  (We pop into a black-hole slot.)
+        for _ in 0..discard {
+            s.recv_head = (s.recv_head + 1) % RECV_BUF_CAP;
+        }
+        return Ok((copied, discard));
+    }
+
+    // STREAM: byte-stream — copy as many bytes as fit, no boundaries.
+    if s.recv_available() == 0 { return Err(-11); }
+    Ok((s.pop(buf), 0))
 }
 
 /// Half-close per IEEE 1003.1 §shutdown.  `shut_rd_flag` / `shut_wr_flag`
@@ -298,12 +417,35 @@ pub fn close(id: u64) {
 
 pub fn has_data(id: u64) -> bool {
     if id as usize >= MAX_UNIX_SOCKETS { return false; }
-    TABLE.lock().0[id as usize].recv_available() > 0
+    let t = TABLE.lock();
+    let s = &t.0[id as usize];
+    if s.kind == SockKind::SeqPacket {
+        s.seq_head != s.seq_tail
+    } else {
+        s.recv_available() > 0
+    }
 }
 
 pub fn bytes_available(id: u64) -> usize {
     if id as usize >= MAX_UNIX_SOCKETS { return 0; }
-    TABLE.lock().0[id as usize].recv_available()
+    let t = TABLE.lock();
+    let s = &t.0[id as usize];
+    if s.kind == SockKind::SeqPacket {
+        // For SEQPACKET, ioctl(FIONREAD) and friends should report the size
+        // of the *next* message, not the cumulative buffer fill.  Linux
+        // returns 0 when no message is pending.
+        if s.seq_head == s.seq_tail { 0 }
+        else { s.seq_lens[s.seq_head] as usize }
+    } else {
+        s.recv_available()
+    }
+}
+
+/// Return the socket type (`Stream` or `SeqPacket`) for an open socket id.
+/// Returns `Stream` for an out-of-range id (matching the default).
+pub fn kind(id: u64) -> SockKind {
+    if id as usize >= MAX_UNIX_SOCKETS { return SockKind::Stream; }
+    TABLE.lock().0[id as usize].kind
 }
 
 pub fn has_pending(id: u64) -> bool {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -619,12 +619,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         41 => {
             let domain = arg1 as u32;  // AF_INET=2, AF_UNIX=1, AF_INET6=10
             let sock_type = arg2 & 0xFF; // strip SOCK_NONBLOCK/SOCK_CLOEXEC
+            // Per `man 2 socket`: SOCK_CLOEXEC = 0o2000000 = 0x80000,
+            // SOCK_NONBLOCK = 0o4000 = 0x800.  Both are ORed into the
+            // type argument and must be honoured on the resulting fd.
+            let cloexec  = (arg2 & 0x80000) != 0;
+            let nonblock = (arg2 & 0x00800) != 0;
             let pid = crate::proc::current_pid();
             if domain == 1 {
-                // AF_UNIX: use net::unix module
-                let unix_id = crate::net::unix::create();
+                // AF_UNIX: use net::unix module.
+                // SOCK_STREAM=1, SOCK_DGRAM=2, SOCK_SEQPACKET=5.
+                let kind = match sock_type {
+                    1 => crate::net::unix::SockKind::Stream,
+                    5 => crate::net::unix::SockKind::SeqPacket,
+                    // SOCK_DGRAM and other AF_UNIX types are not yet
+                    // supported — return -EPROTONOSUPPORT per POSIX.
+                    _ => return -93,
+                };
+                let unix_id = crate::net::unix::create(kind);
                 if unix_id == u64::MAX { return -24; } // EMFILE
-                crate::syscall::alloc_unix_socket_fd(pid, unix_id)
+                crate::syscall::alloc_unix_socket_fd(pid, unix_id, cloexec, nonblock)
             } else if domain == 2 || domain == 10 {
                 // AF_INET / AF_INET6
                 let net_type = match sock_type {
@@ -704,16 +717,21 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 }
             }
         }
-        // 43: accept(sockfd, addr, addrlen) — AF_UNIX real; AF_INET stub
+        // 43: accept(sockfd, addr, addrlen) — AF_UNIX real; AF_INET stub.
+        // arg4 carries `flags` for accept4(2): SOCK_CLOEXEC | SOCK_NONBLOCK.
+        // Plain accept(2) (#43) leaves arg4 = 0; accept4(2) (#288) forwards it.
         43 => {
             let pid = crate::proc::current_pid();
             let fd = arg1 as usize;
+            // accept4 flag bits: SOCK_CLOEXEC = 0x80000, SOCK_NONBLOCK = 0x800.
+            let cloexec  = (arg4 & 0x80000) != 0;
+            let nonblock = (arg4 & 0x00800) != 0;
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 match crate::net::unix::accept(unix_id) {
                     peer_id if peer_id >= 0 => {
                         // Allocate an fd for the accepted connected socket.
-                        crate::syscall::alloc_unix_socket_fd(pid, peer_id as u64)
+                        crate::syscall::alloc_unix_socket_fd(pid, peer_id as u64, cloexec, nonblock)
                     }
                     e => e, // EAGAIN or error
                 }
@@ -893,7 +911,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 let buf = unsafe { core::slice::from_raw_parts_mut(dst, cap) };
-                bytes_read = crate::net::unix::read(unix_id, buf);
+                // Use read_msg so SOCK_SEQPACKET callers see one message per
+                // recvmsg and can observe MSG_TRUNC (msghdr.msg_flags bit 0x20)
+                // when the receiver buffer was shorter than the sender message.
+                // msghdr.msg_flags lives at byte-offset 48 (i32) per the Linux
+                // x86_64 ABI for `struct msghdr`.
+                const MSG_TRUNC: u32 = 0x20;
+                bytes_read = match crate::net::unix::read_msg(unix_id, buf) {
+                    Ok((n, discarded)) => {
+                        if discarded > 0 {
+                            unsafe {
+                                let flags_ptr = (arg2 + 48) as *mut u32;
+                                let cur = core::ptr::read_unaligned(flags_ptr);
+                                core::ptr::write_unaligned(flags_ptr, cur | MSG_TRUNC);
+                            }
+                        }
+                        n as i64
+                    }
+                    Err(e) => e,
+                };
                 // Deliver pending SCM_RIGHTS fds into receiver's fd table.
                 if bytes_read >= 0 {
                     if let Some(scm_fds) = crate::syscall::scm_dequeue(unix_id) {
@@ -1098,37 +1134,76 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 None => -107, // ENOTCONN
             }
         }
-        // 53: socketpair(domain, type, protocol, sv[2]) — AF_UNIX loopback pair
+        // 53: socketpair(domain, type, protocol, sv[2]) — AF_UNIX loopback pair.
+        //
+        // Per `man 2 socketpair` / `man 7 unix`:
+        //   `type` is `sock_type | flags`.
+        //     - sock_type & 0xff selects the kind: SOCK_STREAM=1,
+        //       SOCK_SEQPACKET=5 (others currently rejected).
+        //     - SOCK_CLOEXEC  (0o2000000 = 0x80000) sets FD_CLOEXEC on both fds.
+        //     - SOCK_NONBLOCK (0o4000    = 0x800)   sets O_NONBLOCK on both fds.
+        //   Unknown sock_type → -EPROTONOSUPPORT (-93).
+        //
+        // SEQPACKET preserves message boundaries: a recv of N bytes returns at
+        // most one full sender-side message and discards any tail that does
+        // not fit (the in-kernel net::unix layer enforces this via per-message
+        // length records).
         53 => {
-            let domain = arg1 as u32;
-            let sv_ptr = arg4 as *mut u32;
+            let domain      = arg1 as u32;
+            let type_arg    = arg2;
+            let sock_type   = type_arg & 0xff;
+            let cloexec     = (type_arg & 0x80000) != 0;
+            let nonblock    = (type_arg & 0x00800) != 0;
+            let sv_ptr      = arg4 as *mut u32;
             if sv_ptr.is_null() { return -22; }
-            if domain == 1 {
-                // AF_UNIX socketpair
-                let pid = crate::proc::current_pid();
-                let (a, b) = crate::net::unix::socketpair();
-                if a == u64::MAX { return -24; }
-                let fd_a = crate::syscall::alloc_unix_socket_fd(pid, a);
-                if fd_a < 0 {
-                    crate::net::unix::close(a);
-                    crate::net::unix::close(b);
-                    return fd_a;
-                }
-                let fd_b = crate::syscall::alloc_unix_socket_fd(pid, b);
-                if fd_b < 0 {
-                    // Clean up fd_a: close the fd and the unix socket
-                    crate::net::unix::close(a);
-                    crate::net::unix::close(b);
-                    return fd_b;
-                }
-                unsafe {
-                    core::ptr::write(sv_ptr,       fd_a as u32);
-                    core::ptr::write(sv_ptr.add(1), fd_b as u32);
-                }
-                0
-            } else {
-                -38 // ENOSYS for non-UNIX socketpair
+            if domain != 1 {
+                // Only AF_UNIX socketpair is implemented.  POSIX permits
+                // -EAFNOSUPPORT for unknown families; -EOPNOTSUPP for
+                // unsupported family/type combinations.  Mozilla expects an
+                // unsupported-domain error; return -EAFNOSUPPORT (-97).
+                return -97;
             }
+            // Validate sock_type.  Reject everything but STREAM and SEQPACKET
+            // for now — DGRAM, RAW, RDM are not implemented for AF_UNIX.
+            let kind = match sock_type {
+                1 => crate::net::unix::SockKind::Stream,
+                5 => crate::net::unix::SockKind::SeqPacket,
+                _ => return -93, // EPROTONOSUPPORT
+            };
+            // Reject any unknown bits in `type` (Linux ignores them, but
+            // surfacing rather than silently dropping aids debugging; the
+            // common known bits are SOCK_CLOEXEC and SOCK_NONBLOCK only).
+            // We accept those plus the type field; anything else passes
+            // through silently to match Linux leniency.
+            let pid = crate::proc::current_pid();
+            let (a, b) = crate::net::unix::socketpair(kind);
+            if a == u64::MAX { return -24; }
+            let fd_a = crate::syscall::alloc_unix_socket_fd(pid, a, cloexec, nonblock);
+            if fd_a < 0 {
+                crate::net::unix::close(a);
+                crate::net::unix::close(b);
+                return fd_a;
+            }
+            let fd_b = crate::syscall::alloc_unix_socket_fd(pid, b, cloexec, nonblock);
+            if fd_b < 0 {
+                // Best-effort cleanup of fd_a's slot before propagating EMFILE.
+                {
+                    let mut procs = crate::proc::PROCESS_TABLE.lock();
+                    if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+                        if let Some(slot) = p.file_descriptors.get_mut(fd_a as usize) {
+                            *slot = None;
+                        }
+                    }
+                }
+                crate::net::unix::close(a);
+                crate::net::unix::close(b);
+                return fd_b;
+            }
+            unsafe {
+                core::ptr::write(sv_ptr,       fd_a as u32);
+                core::ptr::write(sv_ptr.add(1), fd_b as u32);
+            }
+            0
         }
         // 54: setsockopt(sockfd, level, optname, optval, optlen)
         54 => {
@@ -2124,8 +2199,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         286 => sys_timerfd_settime(arg1, arg2 as u32, arg3, arg4),
         // 287: timerfd_gettime(fd, curr_value)
         287 => sys_timerfd_gettime(arg1, arg2),
-        // 288: accept4(sockfd, addr, addrlen, flags) — delegate to accept(43)
-        288 => dispatch(43, arg1, arg2, arg3, 0, 0, 0),
+        // 288: accept4(sockfd, addr, addrlen, flags) — delegate to accept(43),
+        // forwarding the SOCK_CLOEXEC / SOCK_NONBLOCK flags via arg4 so the
+        // returned fd carries them (per `man 2 accept4`).
+        288 => dispatch(43, arg1, arg2, arg3, arg4, 0, 0),
         // 289: signalfd4(fd, mask, sizemask, flags)
         289 => sys_signalfd4(arg1, arg2, arg3, arg4 as u32),
         // 253: inotify_add_watch(fd, pathname, mask)

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2473,14 +2473,24 @@ pub(crate) fn get_unix_socket_id(pid: u64, fd_num: usize) -> u64 {
 }
 
 /// Allocate a new AF_UNIX socket fd, returning the fd number or negative errno.
-pub(crate) fn alloc_unix_socket_fd(pid: u64, unix_id: u64) -> i64 {
+///
+/// `cloexec` sets `FD_CLOEXEC` on the new fd (per `socket(2)` `SOCK_CLOEXEC`).
+/// `nonblock` sets `O_NONBLOCK` in the fd's status flags so subsequent
+/// read/write calls return -EAGAIN instead of blocking (per `socket(2)`
+/// `SOCK_NONBLOCK`).
+pub(crate) fn alloc_unix_socket_fd(pid: u64, unix_id: u64, cloexec: bool, nonblock: bool) -> i64 {
+    // O_NONBLOCK = 0x800 (Linux ABI).  Stored in the lower 12 bits of
+    // `flags` so fcntl(F_GETFL/F_SETFL) round-trips and read/write paths
+    // can branch on it.
+    let mut flag_bits: u32 = 0x4000_0000 | UNIX_SOCKET_FLAG; // SOCKET_FD | UNIX_FLAG
+    if nonblock { flag_bits |= 0x0800; }
     let fd = crate::vfs::FileDescriptor {
         mount_idx: usize::MAX,
         inode: unix_id,
         offset: 0,
-        flags: 0x4000_0000 | UNIX_SOCKET_FLAG, // SOCKET_FD | UNIX_FLAG
+        flags: flag_bits,
         is_console: false,
-        cloexec: false,
+        cloexec,
         file_type: crate::vfs::FileType::Socket,
         open_path: alloc::string::String::new(),
     };

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -623,6 +623,11 @@ pub fn run() -> ! {
     total += 1;
     if test_clock_realtime_futex_parity() { passed += 1; }
 
+    // ── Test 80d: socketpair(2) — type / SOCK_CLOEXEC / SOCK_NONBLOCK + SEQPACKET
+
+    total += 1;
+    if test_socketpair_type_flags() { passed += 1; }
+
     // ── Test 81: mlock/execveat/copy_file_range stubs ────────────────────────
 
     total += 1;
@@ -11159,7 +11164,7 @@ fn test_x11_hello() -> bool {
     // Init the X11 server here (not at boot) so Firefox doesn't block on it.
     crate::x11::init();
 
-    let client = crate::net::unix::create();
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if client == u64::MAX {
         test_fail!("x11_hello", "unix::create() failed");
         return false;
@@ -11222,7 +11227,7 @@ fn test_x11_intern_atom() -> bool {
     test_header!("X11 server — InternAtom(WM_NAME)");
 
     // ── Connect + perform setup ───────────────────────────────────────────
-    let client = crate::net::unix::create();
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if client == u64::MAX {
         test_fail!("x11_intern", "unix::create() failed");
         return false;
@@ -11314,7 +11319,7 @@ fn test_x11_draw_cycle() -> bool {
     test_header!("X11 CreateWindow + MapWindow + Draw cycle");
 
     // ── Connect + setup ──────────────────────────────────────────────────────
-    let client = crate::net::unix::create();
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if client == u64::MAX {
         test_fail!("x11_draw", "unix::create() failed");
         return false;
@@ -11494,7 +11499,7 @@ fn test_x11_key_event() -> bool {
     test_header!("X11 key event injection + delivery");
 
     // ── Connect + setup ──────────────────────────────────────────────────────
-    let client = crate::net::unix::create();
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if client == u64::MAX {
         test_fail!("x11_key", "unix::create() failed");
         return false;
@@ -11611,7 +11616,7 @@ fn test_x11_render_query() -> bool {
     test_header!("X11 RENDER extension — QueryExtension + QueryVersion");
 
     // ── Connect + setup ──────────────────────────────────────────────────────
-    let client = crate::net::unix::create();
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if client == u64::MAX {
         test_fail!("x11_render_q", "unix::create() failed");
         return false;
@@ -11736,7 +11741,7 @@ fn test_x11_render_draw() -> bool {
     test_header!("X11 RENDER extension — CreatePixmap + Picture + FillRectangles");
 
     // ── Connect + setup ──────────────────────────────────────────────────────
-    let client = crate::net::unix::create();
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if client == u64::MAX {
         test_fail!("x11_render_d", "unix::create() failed");
         return false;
@@ -12661,7 +12666,7 @@ fn test_x11_extensions() -> bool {
 
     // X11 server is already running (initialised by test_x11_hello earlier).
     // Connect a fresh client.
-    let cfd = crate::net::unix::create();
+    let cfd = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if cfd == u64::MAX {
         test_fail!("x11_ext", "unix::create() failed");
         return false;
@@ -13464,6 +13469,192 @@ fn test_clock_realtime_futex_parity() -> bool {
     let _ = Ordering::Relaxed; // silence unused-import warning when conditions disable use sites
 
     test_pass!("clock_gettime CLOCK_REALTIME — vDSO/syscall formula parity");
+    true
+}
+
+// ── Test 80d: socketpair(2) — type / SOCK_CLOEXEC / SOCK_NONBLOCK + SEQPACKET ─
+//
+// Asserts the Linux ABI for `socketpair(domain, type, protocol, sv[2])`:
+//
+//   * `type & 0xff` selects the socket kind (SOCK_STREAM=1, SOCK_SEQPACKET=5).
+//   * `type & SOCK_CLOEXEC`  (0x80000) sets FD_CLOEXEC on both fds.
+//   * `type & SOCK_NONBLOCK` (0x800)   sets O_NONBLOCK on both fds.
+//   * Unknown sock_type → -EPROTONOSUPPORT (-93).
+//   * SOCK_SEQPACKET preserves message boundaries: a `read` of N bytes
+//     returns at most one full sender-side message; the truncated tail is
+//     discarded and the next `read` returns the next message intact.
+//
+// Pre-fix bug: dispatch ignored `arg2` entirely, so `socketpair(AF_UNIX,
+// SOCK_SEQPACKET | SOCK_CLOEXEC, ...)` silently returned a STREAM pair with
+// no FD_CLOEXEC, no per-message framing, and no error for unknown types.
+// Mozilla's `LaunchProcess` requires SEQPACKET + CLOEXEC for parent/child
+// IPC; without these semantics it would silently corrupt the framing of
+// content-process IPDL messages.
+fn test_socketpair_type_flags() -> bool {
+    test_header!("socketpair(2) — type / SOCK_CLOEXEC / SOCK_NONBLOCK / SEQPACKET");
+
+    const AF_UNIX: u64        = 1;
+    const SOCK_STREAM: u64    = 1;
+    const SOCK_SEQPACKET: u64 = 5;
+    const SOCK_CLOEXEC: u64   = 0x80000;
+    const SOCK_NONBLOCK: u64  = 0x00800;
+    const F_GETFD: u64        = 1;
+    const F_GETFL: u64        = 3;
+    const FD_CLOEXEC: i64     = 1;
+    const O_NONBLOCK: i64     = 0x800;
+    const EPROTONOSUPPORT: i64 = -93;
+
+    let sp = |type_arg: u64, sv: &mut [u32; 2]| -> i64 {
+        crate::syscall::dispatch_linux(53, AF_UNIX, type_arg, 0, sv.as_mut_ptr() as u64, 0, 0)
+    };
+
+    // ── Sub-case 1: STREAM, no flags ────────────────────────────────────────
+    let mut sv = [0xFFFF_FFFFu32; 2];
+    let r = sp(SOCK_STREAM, &mut sv);
+    if r != 0 || sv[0] == 0xFFFF_FFFF || sv[1] == 0xFFFF_FFFF {
+        test_fail!("socketpair", "STREAM: rc={} sv=[{},{}]", r, sv[0] as i32, sv[1] as i32);
+        return false;
+    }
+    test_println!("  STREAM            → fds=[{},{}] ✓", sv[0], sv[1]);
+    // Cleanup.
+    let _ = crate::syscall::dispatch_linux(3, sv[0] as u64, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux(3, sv[1] as u64, 0, 0, 0, 0, 0);
+
+    // ── Sub-case 2: SEQPACKET, no flags ─────────────────────────────────────
+    let mut sv = [0xFFFF_FFFFu32; 2];
+    let r = sp(SOCK_SEQPACKET, &mut sv);
+    if r != 0 || sv[0] == 0xFFFF_FFFF || sv[1] == 0xFFFF_FFFF {
+        test_fail!("socketpair", "SEQPACKET: rc={} sv=[{},{}]", r, sv[0] as i32, sv[1] as i32);
+        return false;
+    }
+    test_println!("  SEQPACKET         → fds=[{},{}] ✓", sv[0], sv[1]);
+    // Sub-case 6 tests the underlying unix socket layer directly via
+    // `net::unix::write/read`, which takes unix-socket IDs (table indices),
+    // not process fds.  Resolve the IDs once here so the fds can later be
+    // closed via dispatch_linux(close).
+    let seq_fd_a = sv[0] as u64;
+    let seq_fd_b = sv[1] as u64;
+    let pid_for_lookup = crate::proc::current_pid();
+    let seq_a = crate::syscall::get_unix_socket_id(pid_for_lookup, seq_fd_a as usize);
+    let seq_b = crate::syscall::get_unix_socket_id(pid_for_lookup, seq_fd_b as usize);
+    if seq_a == u64::MAX || seq_b == u64::MAX {
+        test_fail!("socketpair",
+                   "SEQPACKET: get_unix_socket_id failed for fds=[{},{}]", seq_fd_a, seq_fd_b);
+        return false;
+    }
+
+    // ── Sub-case 3: STREAM | SOCK_CLOEXEC ───────────────────────────────────
+    let mut sv = [0u32; 2];
+    let r = sp(SOCK_STREAM | SOCK_CLOEXEC, &mut sv);
+    if r != 0 {
+        test_fail!("socketpair", "STREAM|CLOEXEC: rc={}", r);
+        return false;
+    }
+    let g0 = crate::syscall::dispatch_linux(72, sv[0] as u64, F_GETFD, 0, 0, 0, 0);
+    let g1 = crate::syscall::dispatch_linux(72, sv[1] as u64, F_GETFD, 0, 0, 0, 0);
+    if g0 != FD_CLOEXEC || g1 != FD_CLOEXEC {
+        test_fail!("socketpair",
+                   "SOCK_CLOEXEC not propagated: F_GETFD on fd[0]={}, fd[1]={} (want {})",
+                   g0, g1, FD_CLOEXEC);
+        return false;
+    }
+    test_println!("  STREAM|CLOEXEC    → F_GETFD={},{} (FD_CLOEXEC) ✓", g0, g1);
+    let _ = crate::syscall::dispatch_linux(3, sv[0] as u64, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux(3, sv[1] as u64, 0, 0, 0, 0, 0);
+
+    // ── Sub-case 4: STREAM | SOCK_NONBLOCK ──────────────────────────────────
+    let mut sv = [0u32; 2];
+    let r = sp(SOCK_STREAM | SOCK_NONBLOCK, &mut sv);
+    if r != 0 {
+        test_fail!("socketpair", "STREAM|NONBLOCK: rc={}", r);
+        return false;
+    }
+    let f0 = crate::syscall::dispatch_linux(72, sv[0] as u64, F_GETFL, 0, 0, 0, 0);
+    let f1 = crate::syscall::dispatch_linux(72, sv[1] as u64, F_GETFL, 0, 0, 0, 0);
+    if (f0 & O_NONBLOCK) == 0 || (f1 & O_NONBLOCK) == 0 {
+        test_fail!("socketpair",
+                   "SOCK_NONBLOCK not propagated: F_GETFL on fd[0]={:#x}, fd[1]={:#x}",
+                   f0, f1);
+        return false;
+    }
+    test_println!("  STREAM|NONBLOCK   → F_GETFL={:#x},{:#x} (O_NONBLOCK) ✓", f0, f1);
+    let _ = crate::syscall::dispatch_linux(3, sv[0] as u64, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux(3, sv[1] as u64, 0, 0, 0, 0, 0);
+
+    // ── Sub-case 5: unknown sock_type → -EPROTONOSUPPORT ───────────────────
+    let mut sv = [0u32; 2];
+    let r = sp(99, &mut sv);
+    if r != EPROTONOSUPPORT {
+        test_fail!("socketpair", "unknown type=99: rc={} (want {})", r, EPROTONOSUPPORT);
+        return false;
+    }
+    test_println!("  type=99 (unknown) → -EPROTONOSUPPORT ✓");
+
+    // ── Sub-case 6: SEQPACKET preserves message boundaries ─────────────────
+    //
+    // Two writes of 64 bytes each on seq_a; one read of up to 128 bytes on
+    // seq_b must return exactly 64 (one message) — not 128.  The next read
+    // must return the second 64-byte message intact.  This catches the
+    // type-blind regression where SEQPACKET silently degraded to STREAM.
+    let mut msg1 = [0u8; 64];
+    for (i, b) in msg1.iter_mut().enumerate() { *b = i as u8; }
+    let mut msg2 = [0u8; 64];
+    for (i, b) in msg2.iter_mut().enumerate() { *b = (0x80 + i) as u8; }
+    let w1 = crate::net::unix::write(seq_a, &msg1);
+    let w2 = crate::net::unix::write(seq_a, &msg2);
+    if w1 != 64 || w2 != 64 {
+        test_fail!("socketpair", "SEQPACKET write: w1={} w2={} (want 64,64)", w1, w2);
+        return false;
+    }
+    let mut rxbuf = [0u8; 128];
+    let r1 = crate::net::unix::read(seq_b, &mut rxbuf);
+    if r1 != 64 {
+        test_fail!("socketpair",
+                   "SEQPACKET read with buf=128 returned {} bytes — STREAM-style coalescing! \
+                    SEQPACKET must return one message at a time.", r1);
+        return false;
+    }
+    if &rxbuf[..64] != &msg1[..] {
+        test_fail!("socketpair", "SEQPACKET msg1 contents mismatch after first read");
+        return false;
+    }
+    let mut rxbuf2 = [0u8; 128];
+    let r2 = crate::net::unix::read(seq_b, &mut rxbuf2);
+    if r2 != 64 {
+        test_fail!("socketpair", "SEQPACKET second read: rc={} (want 64)", r2);
+        return false;
+    }
+    if &rxbuf2[..64] != &msg2[..] {
+        test_fail!("socketpair", "SEQPACKET msg2 contents mismatch after second read");
+        return false;
+    }
+    test_println!("  SEQPACKET boundary: read 128-byte buf got {}+{} (boundary preserved) ✓", r1, r2);
+
+    // Sub-case 6b: SEQPACKET truncation — write 100, read 32 → return 32, drop 68.
+    let mut big = [0u8; 100];
+    for (i, b) in big.iter_mut().enumerate() { *b = i as u8; }
+    let _ = crate::net::unix::write(seq_a, &big);
+    let mut small = [0u8; 32];
+    let n = crate::net::unix::read(seq_b, &mut small);
+    if n != 32 {
+        test_fail!("socketpair", "SEQPACKET truncation: read returned {} (want 32)", n);
+        return false;
+    }
+    // Next read must EAGAIN (no further messages), proving the 68-byte tail was discarded.
+    let mut tmp = [0u8; 100];
+    let n2 = crate::net::unix::read(seq_b, &mut tmp);
+    if n2 != -11 {
+        test_fail!("socketpair",
+                   "SEQPACKET truncation tail not dropped: next read returned {} (want -EAGAIN=-11)",
+                   n2);
+        return false;
+    }
+    test_println!("  SEQPACKET truncate: 100-byte msg → 32-byte read, tail discarded ✓");
+
+    let _ = crate::syscall::dispatch_linux(3, seq_fd_a, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux(3, seq_fd_b, 0, 0, 0, 0, 0);
+
+    test_pass!("socketpair(2) — type / SOCK_CLOEXEC / SOCK_NONBLOCK / SEQPACKET");
     true
 }
 
@@ -14392,7 +14583,7 @@ fn test_scm_rights() -> bool {
     test_header!("SCM_RIGHTS fd passing over Unix domain socket");
 
     // Create a socketpair.
-    let (id_a, id_b) = crate::net::unix::socketpair();
+    let (id_a, id_b) = crate::net::unix::socketpair(crate::net::unix::SockKind::Stream);
     if id_a == u64::MAX || id_b == u64::MAX {
         test_fail!("scm_rights", "socketpair() failed");
         return false;
@@ -14734,8 +14925,8 @@ fn test_x11_selection() -> bool {
     use crate::net::unix;
 
     // Connect client A (will own the selection).
-    let cfd_a = unix::create();
-    let cfd_b = unix::create();
+    let cfd_a = unix::create(unix::SockKind::Stream);
+    let cfd_b = unix::create(unix::SockKind::Stream);
     if cfd_a == u64::MAX || cfd_b == u64::MAX {
         test_fail!("x11_sel", "unix::create() failed");
         return false;
@@ -14848,7 +15039,7 @@ fn test_ewmh_net_supported() -> bool {
     use crate::x11::proto;
     use crate::net::unix;
 
-    let cfd = unix::create();
+    let cfd = unix::create(unix::SockKind::Stream);
     if cfd == u64::MAX { test_fail!("ewmh", "unix::create() failed"); return false; }
     if unix::connect(cfd, b"/tmp/.X11-unix/X0\0") < 0 {
         test_fail!("ewmh", "connect failed"); unix::close(cfd); return false;
@@ -17498,9 +17689,9 @@ fn test_elf_dt_gnu_hash_accepted() -> bool {
 // close on MAX).
 
 fn x11_connect_and_setup(tag: &str) -> u64 {
-    let fd = crate::net::unix::create();
+    let fd = crate::net::unix::create(crate::net::unix::SockKind::Stream);
     if fd == u64::MAX {
-        test_println!("  [{}] unix::create() failed", tag);
+        test_println!("  [{}] unix::create(unix::SockKind::Stream) failed", tag);
         return u64::MAX;
     }
     if crate::net::unix::connect(fd, b"/tmp/.X11-unix/X0\0") < 0 {

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -210,7 +210,7 @@ fn prop_arr_del(arr: &mut [Option<resource::PropertyEntry>; resource::MAX_PROPER
 /// Bind and listen on `/tmp/.X11-unix/X0`.
 pub fn init() {
     let _ = crate::vfs::mkdir("/tmp/.X11-unix");
-    let fd = unix::create();
+    let fd = unix::create(unix::SockKind::Stream);
     let r  = unix::bind(fd, SOCKET_PATH);
     if r < 0 {
         crate::serial_println!("[X11] bind failed: {}", r);


### PR DESCRIPTION
## Summary

Fixes the AF_UNIX socketpair(2) syscall path to honour the `type` argument as
specified by `man 2 socketpair` / `man 7 unix`. Pre-fix dispatch silently
ignored `arg2`, returning a generic STREAM pair regardless of caller intent
(no FD_CLOEXEC, no O_NONBLOCK, no SEQPACKET framing, no error for unknown
sock_types).

- Parses `arg2 & 0xff` as sock_type; rejects unknowns with `-EPROTONOSUPPORT`.
- Honours `SOCK_CLOEXEC` (0x80000) and `SOCK_NONBLOCK` (0x800) on both fds.
- Implements SOCK_SEQPACKET with preserved message boundaries: a recv of N
  bytes returns at most one full sender-side message; the truncated tail is
  discarded and `MSG_TRUNC` is set in `msghdr.msg_flags`. Backed by a
  per-socket `seq_lens` ring of message-length records.
- Plumbs the same flag handling through `socket(2)` and `accept4(2)` (the
  former dropped CLOEXEC/NONBLOCK; the latter passed arg4=0 to accept).
- Adds `connect()` cross-type rejection (`-EPROTOTYPE` when a SEQPACKET
  client tries to connect to a STREAM listener, or vice versa).

## Test plan

- [x] New kernel-internal Test 80d (`test_socketpair_type_flags`) covers six
  required sub-cases: STREAM, SEQPACKET, STREAM|CLOEXEC (F_GETFD round-trip),
  STREAM|NONBLOCK (F_GETFL round-trip), unknown type → -EPROTONOSUPPORT,
  SEQPACKET boundary preservation (write 64+64, single read of buf=128 returns
  64), plus SEQPACKET truncation (write 100, read 32, tail discarded).
- [x] All six sub-cases pass under `qemu-harness.py start --features test-mode`.
- [x] Pre-existing AF_UNIX socketpair round-trip test (STREAM legacy path)
  continues to pass.
- [x] No regressions in the full headless suite — 99 tests pass; 7 pre-existing
  failures are unrelated (data.img-not-present per project notes).

## References

- POSIX.1-2017 §socketpair(), §SOCK_SEQPACKET
- `man 2 socketpair`, `man 7 unix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)