### PR TITLE
ipc: pipe/eventfd wake hooks (Stream A) — close epoll/poll/select wake gap

### DIFF
--- a/kernel/src/ipc/eventfd.rs
+++ b/kernel/src/ipc/eventfd.rs
@@ -11,15 +11,33 @@
 //!
 //! The blocking decision is made at the syscall layer (which knows the
 //! per-fd O_NONBLOCK status).  This module provides a non-blocking
-//! `try_read` primitive plus a helper to inspect the EFD_NONBLOCK creation
-//! flag so the caller can decide.
+//! `try_read` primitive plus the wait/wake hooks the syscall layer uses
+//! to park a caller atomically without busy-spinning.
+//!
+//! ## Wake hooks
+//!
+//! `wait_readable(efd_id, wake_tick)` performs an atomic check-then-park
+//! against the per-eventfd wait list (`EVENTFD_READ_WAITERS`).  The
+//! `write` helper drains the wait list after bumping the counter so a
+//! peer parked in `wait_readable` (or `poll`/`epoll_wait` registered
+//! against this fd) is woken on the same code path.
+//!
+//! Lock order:
+//!     `EVENTFD_READ_WAITERS` -> `TABLE` (waiter side)
+//!     `TABLE` -> drop -> `EVENTFD_READ_WAITERS` (writer side)
+//! Same shape as the pipe wake hooks; matches the futex
+//! `FUTEX_WAITERS` -> `THREAD_TABLE` ordering.
 //!
 //! This implementation stores counters in a fixed-size global table.
 
 extern crate alloc;
 
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
+
+use crate::ipc::waitlist::{ring_poll_bell, wake_tids, WaitList};
 
 /// Maximum number of concurrent eventfds.
 const MAX_EVENTFDS: usize = 64;
@@ -49,6 +67,22 @@ impl EventFdEntry {
 static TABLE: Mutex<[EventFdEntry; MAX_EVENTFDS]> =
     Mutex::new([EventFdEntry::empty(); MAX_EVENTFDS]);
 
+/// Per-eventfd reader wait queue, keyed by slot id.  Entries are removed
+/// when the last waiter is drained.
+static EVENTFD_READ_WAITERS: Mutex<BTreeMap<u64, WaitList>> = Mutex::new(BTreeMap::new());
+
+/// Outcome of `wait_readable`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WaitOutcome {
+    /// Counter was non-zero at the recheck — caller may retry the read.
+    Ready,
+    /// Caller is now parked; the calling site MUST invoke
+    /// `crate::sched::schedule()` after this returns.
+    Enqueued,
+    /// `efd_id` does not refer to a live slot; treat as EBADF.
+    Gone,
+}
+
 /// Allocate a new eventfd slot.  Returns the slot index (as the `inode`
 /// value stored in the FileDescriptor) or `u64::MAX` on failure.
 pub fn create(initval: u64, flags: u32) -> u64 {
@@ -71,7 +105,7 @@ pub fn create(initval: u64, flags: u32) -> u64 {
 ///
 /// The blocking-vs-non-blocking decision lives at the syscall layer; this
 /// primitive never blocks.  See `is_efd_nonblock` to query the
-/// EFD_NONBLOCK creation flag.
+/// EFD_NONBLOCK creation flag and `wait_readable` for the parking helper.
 pub fn try_read(id: u64) -> Result<u64, i64> {
     let mut table = TABLE.lock();
     let slot = match table.get_mut(id as usize) {
@@ -113,6 +147,12 @@ pub fn is_efd_nonblock(id: u64) -> bool {
 
 /// Write to eventfd — add `val` to the counter.  Returns 0 on success or
 /// `Err(-27)` (EFBIG) if the counter would overflow u64::MAX - 1.
+///
+/// On success the caller should invoke `wake_readers(id)` after dropping
+/// any unrelated locks so a peer parked in `wait_readable` (or registered
+/// on this fd via poll/epoll) is woken promptly.  The wake is NOT issued
+/// from inside this helper because callers in the syscall layer keep
+/// `TABLE` and `EVENTFD_READ_WAITERS` strictly disjoint.
 pub fn write(id: u64, val: u64) -> Result<(), i64> {
     let mut table = TABLE.lock();
     let slot = match table.get_mut(id as usize) {
@@ -127,16 +167,103 @@ pub fn write(id: u64, val: u64) -> Result<(), i64> {
     Ok(())
 }
 
-/// Free an eventfd slot.
+/// Free an eventfd slot.  Wakes every reader parked on the slot so they
+/// observe EBADF on the next try_read call rather than blocking
+/// indefinitely against a counter that nobody can ever post to.
 pub fn close(id: u64) {
-    let mut table = TABLE.lock();
-    if let Some(slot) = table.get_mut(id as usize) {
-        *slot = EventFdEntry::empty();
+    {
+        let mut table = TABLE.lock();
+        if let Some(slot) = table.get_mut(id as usize) {
+            *slot = EventFdEntry::empty();
+        }
     }
+    wake_readers_all(id);
 }
 
 /// Check if counter > 0 (used by `poll` / `select`).
 pub fn is_readable(id: u64) -> bool {
     let table = TABLE.lock();
     table.get(id as usize).map(|s| s.in_use && s.counter > 0).unwrap_or(false)
+}
+
+// ── Wait / wake hooks ─────────────────────────────────────────────────────────
+
+/// Atomic check-then-park for a reader on `efd_id`.
+///
+/// Holds `EVENTFD_READ_WAITERS` across a brief `TABLE` re-check so the
+/// "counter still zero?" decision and the "enqueue self" step are one
+/// critical section.  See `crate::ipc::pipe::wait_readable` for the
+/// wider rationale; the futex check-then-queue helper documents the
+/// lost-wakeup race this discipline closes.
+///
+/// `wake_tick` is the absolute tick at which the kernel timer auto-wakes
+/// a Blocked thread; pass `u64::MAX` for an indefinite block.
+pub fn wait_readable(efd_id: u64, wake_tick: u64) -> WaitOutcome {
+    let tid = crate::proc::current_tid();
+    let mut waiters = EVENTFD_READ_WAITERS.lock();
+
+    // Brief re-check under the wait-list lock.  Lock order is
+    // EVENTFD_READ_WAITERS -> TABLE on the waiter side; the writer side
+    // drops TABLE before taking the wait-list, so the orders agree.
+    let outcome = {
+        let table = TABLE.lock();
+        match table.get(efd_id as usize) {
+            None => WaitOutcome::Gone,
+            Some(slot) if !slot.in_use => WaitOutcome::Gone,
+            Some(slot) if slot.counter > 0 => WaitOutcome::Ready,
+            Some(_) => WaitOutcome::Enqueued,
+        }
+    };
+    if matches!(outcome, WaitOutcome::Ready | WaitOutcome::Gone) {
+        return outcome;
+    }
+
+    let entry = waiters.entry(efd_id).or_insert_with(WaitList::new);
+    entry.enqueue_self_blocked(tid, wake_tick);
+    drop(waiters);
+    WaitOutcome::Enqueued
+}
+
+/// Wake every reader parked on `efd_id`.  Idempotent — a no-op when no
+/// waiters are registered.  For semaphore-mode eventfds (EFD_SEMAPHORE)
+/// only one reader will successfully decrement on the first try_read;
+/// any extras simply re-park on the next pass.  Waking all matches
+/// pipe-EOF semantics and avoids a thundering-herd-vs-stranded-waiter
+/// trade-off in the common single-waiter case.
+pub fn wake_readers_all(efd_id: u64) {
+    let drained = {
+        let mut waiters = EVENTFD_READ_WAITERS.lock();
+        match waiters.get_mut(&efd_id) {
+            Some(list) => {
+                let v = list.drain_all();
+                if list.is_empty() { waiters.remove(&efd_id); }
+                v
+            }
+            None => Vec::new(),
+        }
+    };
+    wake_tids(&drained);
+    // Also kick the global poll bell so a poll/epoll/select caller
+    // watching this eventfd re-evaluates immediately.
+    ring_poll_bell();
+}
+
+/// Best-effort cleanup: remove `tid` from this eventfd's wait list.
+/// Called by callers that returned from `schedule()` having timed out or
+/// been interrupted, so they do not leak a stale entry.
+pub fn waiter_cleanup(efd_id: u64, tid: u64) {
+    let mut waiters = EVENTFD_READ_WAITERS.lock();
+    if let Some(list) = waiters.get_mut(&efd_id) {
+        list.remove_tid(tid);
+        if list.is_empty() {
+            waiters.remove(&efd_id);
+        }
+    }
+}
+
+/// Test-only diagnostic: returns the number of reader TIDs currently
+/// parked on `efd_id`.
+pub fn debug_reader_waiter_count(efd_id: u64) -> usize {
+    let waiters = EVENTFD_READ_WAITERS.lock();
+    waiters.get(&efd_id).map(|l| l.len()).unwrap_or(0)
 }

--- a/kernel/src/ipc/mod.rs
+++ b/kernel/src/ipc/mod.rs
@@ -9,6 +9,7 @@ pub mod timerfd;
 pub mod signalfd;
 pub mod inotify;
 pub mod sysv_shm;
+pub mod waitlist;
 
 /// Initialize the IPC subsystem.
 pub fn init() {

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -2,12 +2,30 @@
 //!
 //! Provides an in-kernel pipe mechanism for data transfer between threads/processes.
 //! Used for shell pipelines and general IPC.
+//!
+//! ## Wake hooks (per `man 7 pipe`, `man 2 read`, `man 2 write`)
+//!
+//! When a reader finds an empty blocking pipe, it must park itself until
+//! either data arrives or the write end is closed (EOF -> `read` returns 0).
+//! Symmetrically, a writer that finds a full pipe parks until space is
+//! available or the read end is closed (in which case `write` raises
+//! `SIGPIPE` / returns `EPIPE`).
+//!
+//! Wait lists live OUTSIDE `PIPE_TABLE` so `PIPE_TABLE` is never held
+//! across `schedule()`.  Lock order:
+//!     `PIPE_*_WAITERS` -> `PIPE_TABLE` (waiter side)
+//!     `PIPE_TABLE` -> drop -> `PIPE_*_WAITERS` (writer/closer side)
+//! Both orders agree because no path holds both locks at once.  Identical
+//! pattern to `crate::syscall::FUTEX_WAITERS` -> `THREAD_TABLE`.
 
 extern crate alloc;
 
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
+
+use crate::ipc::waitlist::{ring_poll_bell, wake_tids, WaitList};
 
 /// Pipe buffer size (4 KiB).
 const PIPE_BUF_SIZE: usize = 4096;
@@ -76,13 +94,45 @@ impl Pipe {
         self.writers == 0 && self.count == 0
     }
 
+    /// Check if write end is closed (regardless of buffered data).  Used
+    /// by the wait helper to short-circuit a parked reader when there is
+    /// no possibility of more data ever arriving.
+    pub fn writer_closed(&self) -> bool {
+        self.writers == 0
+    }
+
+    /// Available bytes (count of unread data).
     pub fn available(&self) -> usize {
         self.count
+    }
+
+    /// Free space remaining in the ring buffer.
+    pub fn space(&self) -> usize {
+        PIPE_BUF_SIZE - self.count
     }
 }
 
 /// Global pipe table.
 static PIPE_TABLE: Mutex<Vec<Pipe>> = Mutex::new(Vec::new());
+
+/// Per-pipe reader wait queue.  Keyed by pipe id; the entry is dropped
+/// when the last waiter departs to keep the map small in the steady state.
+static PIPE_READ_WAITERS: Mutex<BTreeMap<u64, WaitList>> = Mutex::new(BTreeMap::new());
+
+/// Per-pipe writer wait queue (used when `write()` would block on a full
+/// buffer).  Same shape as `PIPE_READ_WAITERS`.
+static PIPE_WRITE_WAITERS: Mutex<BTreeMap<u64, WaitList>> = Mutex::new(BTreeMap::new());
+
+/// Outcome of a check-then-park call.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WaitOutcome {
+    /// Condition was already satisfied — caller may proceed without parking.
+    Ready,
+    /// Caller is now parked; the calling site MUST invoke `schedule()`.
+    Enqueued,
+    /// Pipe id no longer exists (e.g. both ends closed).  Treat as EBADF.
+    Gone,
+}
 
 /// Create a new pipe. Returns the pipe ID.
 pub fn create_pipe() -> u64 {
@@ -99,6 +149,14 @@ pub fn pipe_read(pipe_id: u64, buf: &mut [u8]) -> Option<usize> {
 }
 
 /// Write to a pipe by ID.
+///
+/// On a successful write of one or more bytes the caller should invoke
+/// `wake_readers(pipe_id)` after dropping any unrelated locks, so a peer
+/// thread blocked in `pipe_read` (or `poll`/`epoll_wait`) is woken
+/// promptly.  The wake is NOT issued from inside the write helper itself
+/// because callers in the syscall layer already separate "advance pipe
+/// state" from "notify waiters" to keep `PIPE_TABLE` strictly disjoint
+/// from `PIPE_*_WAITERS`.
 pub fn pipe_write(pipe_id: u64, data: &[u8]) -> Option<usize> {
     let mut pipes = PIPE_TABLE.lock();
     let pipe = pipes.iter_mut().find(|p| p.id == pipe_id)?;
@@ -113,22 +171,54 @@ pub fn pipe_add_writer(pipe_id: u64) {
     }
 }
 
-/// Close the write end of a pipe.
+/// Close the write end of a pipe.  When the writer count reaches zero,
+/// every reader parked on `PIPE_READ_WAITERS` for this pipe id is woken
+/// so it observes EOF (per `man 7 pipe`: "If all file descriptors
+/// referring to the write end of a pipe have been closed, then an attempt
+/// to read(2) from the pipe will see end-of-file (read(2) will return 0)").
 pub fn pipe_close_writer(pipe_id: u64) {
-    let mut pipes = PIPE_TABLE.lock();
-    if let Some(pipe) = pipes.iter_mut().find(|p| p.id == pipe_id) {
-        pipe.writers = pipe.writers.saturating_sub(1);
+    let became_eof = {
+        let mut pipes = PIPE_TABLE.lock();
+        match pipes.iter_mut().find(|p| p.id == pipe_id) {
+            Some(pipe) => {
+                pipe.writers = pipe.writers.saturating_sub(1);
+                pipe.writers == 0
+            }
+            None => false,
+        }
+    };
+    if became_eof {
+        // Wake every reader waiting on this pipe — they must see EOF.
+        wake_readers_all(pipe_id);
+        // Also wake any writers parked for buffer space; without a peer
+        // reader they would otherwise stall forever (in practice a SIGPIPE
+        // path, but the wake still has to fire so the syscall returns).
+        wake_writers_all(pipe_id);
     }
 }
 
-/// Close the read end of a pipe.
+/// Close the read end of a pipe.  When the reader count reaches zero,
+/// any writer parked waiting for buffer space must be woken so it can
+/// observe `EPIPE` rather than block forever.
 pub fn pipe_close_reader(pipe_id: u64) {
-    let mut pipes = PIPE_TABLE.lock();
-    if let Some(pipe) = pipes.iter_mut().find(|p| p.id == pipe_id) {
-        pipe.readers = pipe.readers.saturating_sub(1);
+    let no_readers = {
+        let mut pipes = PIPE_TABLE.lock();
+        let result = if let Some(pipe) = pipes.iter_mut().find(|p| p.id == pipe_id) {
+            pipe.readers = pipe.readers.saturating_sub(1);
+            pipe.readers == 0
+        } else {
+            false
+        };
+        // Clean up pipes with no readers and no writers.
+        pipes.retain(|p| p.readers > 0 || p.writers > 0);
+        result
+    };
+    if no_readers {
+        wake_writers_all(pipe_id);
+        // Drop any reader waitlist that lingered (the pipe may have been
+        // dropped by `retain` above).
+        wake_readers_all(pipe_id);
     }
-    // Clean up pipes with no readers and no writers.
-    pipes.retain(|p| p.readers > 0 || p.writers > 0);
 }
 
 /// Check if a pipe has data.
@@ -145,4 +235,167 @@ pub fn pipe_is_eof(pipe_id: u64) -> bool {
     pipes.iter().find(|p| p.id == pipe_id)
         .map(|p| p.is_eof())
         .unwrap_or(true)
+}
+
+// ── Wait / wake hooks ─────────────────────────────────────────────────────────
+
+/// Atomic check-then-park for a reader on `pipe_id`.
+///
+/// Holds `PIPE_READ_WAITERS` across a brief `PIPE_TABLE` re-check so the
+/// "pipe still empty?" decision and the "enqueue self as a waiter" step
+/// happen under one critical section, mirroring the futex
+/// `check-then-queue` pattern documented at
+/// `crate::syscall::futex_wait_check_and_enqueue`.  Without that
+/// discipline, a writer that fires its `wake_readers` between our check
+/// and our enqueue would slip past us and we would park with no wake on
+/// the way.
+///
+/// `wake_tick` is the absolute scheduler tick at which the kernel timer
+/// auto-wakes a Blocked thread; pass `u64::MAX` for an indefinite block,
+/// or a finite tick to honor a `poll` / `select` timeout.
+///
+/// Returns:
+///   * `Ready`    — pipe already has data (or EOF).  Caller may retry the
+///                  read without parking.
+///   * `Enqueued` — caller is now in `Blocked`; caller MUST call
+///                  `crate::sched::schedule()` after this returns.
+///   * `Gone`     — pipe id no longer exists (caller treats as EBADF).
+pub fn wait_readable(pipe_id: u64, wake_tick: u64) -> WaitOutcome {
+    let tid = crate::proc::current_tid();
+    let mut waiters = PIPE_READ_WAITERS.lock();
+
+    // Brief re-check under the wait-list lock — see the doc-comment for
+    // why this MUST be inside the critical section.  We take and drop
+    // PIPE_TABLE while still holding PIPE_READ_WAITERS.  Lock order:
+    // PIPE_READ_WAITERS -> PIPE_TABLE.  No path goes the other direction
+    // (the writer/closer drop PIPE_TABLE before taking the wait-list).
+    let outcome = {
+        let pipes = PIPE_TABLE.lock();
+        match pipes.iter().find(|p| p.id == pipe_id) {
+            None => WaitOutcome::Gone,
+            // Either data is buffered or the writer has closed and we
+            // would observe EOF — in both cases the caller can return
+            // immediately without parking.
+            Some(p) if p.has_data() || p.writer_closed() => WaitOutcome::Ready,
+            Some(_) => WaitOutcome::Enqueued,
+        }
+    };
+    if matches!(outcome, WaitOutcome::Ready | WaitOutcome::Gone) {
+        return outcome;
+    }
+
+    // Park the caller while still holding PIPE_READ_WAITERS.
+    let entry = waiters.entry(pipe_id).or_insert_with(WaitList::new);
+    entry.enqueue_self_blocked(tid, wake_tick);
+    drop(waiters);
+    WaitOutcome::Enqueued
+}
+
+/// Atomic check-then-park for a writer on `pipe_id`.  Symmetric with
+/// `wait_readable`; a writer parks when the pipe is full unless the
+/// reader has gone away (in which case the caller will return EPIPE).
+pub fn wait_writable(pipe_id: u64, wake_tick: u64) -> WaitOutcome {
+    let tid = crate::proc::current_tid();
+    let mut waiters = PIPE_WRITE_WAITERS.lock();
+
+    let outcome = {
+        let pipes = PIPE_TABLE.lock();
+        match pipes.iter().find(|p| p.id == pipe_id) {
+            None => WaitOutcome::Gone,
+            Some(p) if p.space() > 0 || p.readers == 0 => WaitOutcome::Ready,
+            Some(_) => WaitOutcome::Enqueued,
+        }
+    };
+    if matches!(outcome, WaitOutcome::Ready | WaitOutcome::Gone) {
+        return outcome;
+    }
+
+    let entry = waiters.entry(pipe_id).or_insert_with(WaitList::new);
+    entry.enqueue_self_blocked(tid, wake_tick);
+    drop(waiters);
+    WaitOutcome::Enqueued
+}
+
+/// Wake every reader parked on `pipe_id`.  Idempotent — a no-op when no
+/// waiters are registered.  The split between draining TIDs (under
+/// `PIPE_READ_WAITERS`) and flipping thread state (under `THREAD_TABLE`)
+/// avoids holding two locks simultaneously, identical to FUTEX_WAKE.
+///
+/// Bounded variant `wake_readers(pipe_id, n)` is intentionally not
+/// exposed: pipe data is universally consumable so waking one reader vs.
+/// many makes no spec-visible difference and the all-wake path matches
+/// `wake_up_interruptible_all` in mainline pipe-EOF semantics.
+pub fn wake_readers_all(pipe_id: u64) {
+    let drained = {
+        let mut waiters = PIPE_READ_WAITERS.lock();
+        match waiters.get_mut(&pipe_id) {
+            Some(list) => {
+                let v = list.drain_all();
+                if list.is_empty() { waiters.remove(&pipe_id); }
+                v
+            }
+            None => Vec::new(),
+        }
+    };
+    wake_tids(&drained);
+    // Also kick the global poll bell so any poll/epoll/select caller
+    // watching this pipe re-evaluates immediately rather than waiting
+    // for its 10 ms tick.
+    ring_poll_bell();
+}
+
+/// Wake every writer parked on `pipe_id`.
+pub fn wake_writers_all(pipe_id: u64) {
+    let drained = {
+        let mut waiters = PIPE_WRITE_WAITERS.lock();
+        match waiters.get_mut(&pipe_id) {
+            Some(list) => {
+                let v = list.drain_all();
+                if list.is_empty() { waiters.remove(&pipe_id); }
+                v
+            }
+            None => Vec::new(),
+        }
+    };
+    wake_tids(&drained);
+    ring_poll_bell();
+}
+
+/// Best-effort cleanup: remove `tid` from this pipe's reader wait list.
+/// Called by callers that returned from `schedule()` having timed out or
+/// been interrupted, to ensure they do not leak a stale entry.
+pub fn waiter_cleanup_reader(pipe_id: u64, tid: u64) {
+    let mut waiters = PIPE_READ_WAITERS.lock();
+    if let Some(list) = waiters.get_mut(&pipe_id) {
+        list.remove_tid(tid);
+        if list.is_empty() {
+            waiters.remove(&pipe_id);
+        }
+    }
+}
+
+/// Best-effort cleanup for a writer that was parked on `pipe_id`.
+pub fn waiter_cleanup_writer(pipe_id: u64, tid: u64) {
+    let mut waiters = PIPE_WRITE_WAITERS.lock();
+    if let Some(list) = waiters.get_mut(&pipe_id) {
+        list.remove_tid(tid);
+        if list.is_empty() {
+            waiters.remove(&pipe_id);
+        }
+    }
+}
+
+/// Test-only diagnostic: returns the number of reader TIDs currently
+/// parked on `pipe_id`.  Exposed to the in-kernel test runner so wake-up
+/// invariants ("0 waiters after wake_readers_all") can be asserted.
+pub fn debug_reader_waiter_count(pipe_id: u64) -> usize {
+    let waiters = PIPE_READ_WAITERS.lock();
+    waiters.get(&pipe_id).map(|l| l.len()).unwrap_or(0)
+}
+
+/// Test-only diagnostic: returns the number of writer TIDs currently
+/// parked on `pipe_id`.
+pub fn debug_writer_waiter_count(pipe_id: u64) -> usize {
+    let waiters = PIPE_WRITE_WAITERS.lock();
+    waiters.get(&pipe_id).map(|l| l.len()).unwrap_or(0)
 }

--- a/kernel/src/ipc/waitlist.rs
+++ b/kernel/src/ipc/waitlist.rs
@@ -1,0 +1,220 @@
+//! Per-fd wait list primitive for pipe / eventfd / poll wake hooks.
+//!
+//! A `WaitList` is a list of TIDs that have parked themselves on a single
+//! condition (e.g. "this pipe has data" or "this eventfd's counter is
+//! non-zero").  Wake-ups walk the list and flip every parked thread back
+//! from `ThreadState::Blocked` to `ThreadState::Ready` so the scheduler
+//! picks them up on the next tick.
+//!
+//! The shape mirrors the futex wait queue (`crate::syscall::FUTEX_WAITERS`)
+//! and the same lost-wakeup discipline applies: any condition that depends
+//! on a "is there data?" check followed by a "park if not" decision MUST
+//! perform both steps under the same `WaitList` lock.  See
+//! `wait_check_and_enqueue` for the canonical pattern.
+//!
+//! Per `man 7 pipe`, `man 2 eventfd`, and `man 2 poll`: a reader that finds
+//! a pipe / eventfd unready must block (when the fd is in blocking mode)
+//! until either data arrives, the peer closes the write end, or a signal
+//! is delivered.  Pre-fix, both subsystems returned "no data" without
+//! parking, leaving callers to busy-spin via the syscall layer.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+/// A list of thread IDs parked on a single wake condition.
+///
+/// `WaitList` is meant to live inside an outer `Mutex<...>` (typically the
+/// `Mutex<BTreeMap<key, WaitList>>` keyed by pipe id, eventfd id, etc).
+/// All operations therefore assume exclusive access via the outer lock and
+/// do not synchronise internally.
+pub struct WaitList {
+    tids: Vec<u64>,
+}
+
+impl WaitList {
+    /// Construct an empty wait list.  `const fn` so it can be used in
+    /// `static` initialisers (e.g. inside a `Mutex<BTreeMap<u64, WaitList>>`
+    /// allocated lazily on first use).
+    pub const fn new() -> Self {
+        Self { tids: Vec::new() }
+    }
+
+    /// True if no threads are parked on this list.  Used by wake helpers
+    /// to short-circuit work when there is nothing to do.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.tids.is_empty()
+    }
+
+    /// Number of TIDs currently parked.  Diagnostic-only — wake paths use
+    /// `drain` / `drain_all` which return the TID list directly.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.tids.len()
+    }
+
+    /// Enqueue `tid` on the wait list, then mark the matching thread
+    /// `Blocked` with the supplied `wake_tick` deadline (use `u64::MAX`
+    /// for an indefinite block).  The caller MUST hold the outer wait-list
+    /// lock for the duration of this call; this function additionally
+    /// acquires `proc::THREAD_TABLE` while still holding it (lock order:
+    /// `WaitList parent` -> `THREAD_TABLE`, identical to the futex
+    /// `FUTEX_WAITERS -> THREAD_TABLE` order documented in
+    /// `crate::syscall::futex_wait_check_and_enqueue`).
+    ///
+    /// The caller invokes `crate::sched::schedule()` after the outer lock
+    /// has been dropped.
+    pub fn enqueue_self_blocked(&mut self, tid: u64, wake_tick: u64) {
+        self.tids.push(tid);
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+            // Mirror the SMP context-switch invariant from `sleep_ticks`:
+            // release-store ctx_rsp_valid=false BEFORE transitioning out
+            // of `Running`, so a peer CPU that sees the wake (via the
+            // scheduler tick or an explicit `wake_all`) cannot load a
+            // stale RSP between the state write and our schedule().
+            t.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
+            t.state = crate::proc::ThreadState::Blocked;
+            t.wake_tick = wake_tick;
+        }
+    }
+
+    /// Drain up to `max` parked TIDs and return them to the caller, who is
+    /// expected to call `wake_tids` *after* dropping the outer wait-list
+    /// lock.  Splitting drain-from-list and flip-thread-state into two
+    /// phases keeps the wait-list lock and `THREAD_TABLE` from being
+    /// nested in the wake path (the matching pattern used by FUTEX_WAKE).
+    pub fn drain(&mut self, max: usize) -> Vec<u64> {
+        if self.tids.is_empty() || max == 0 {
+            return Vec::new();
+        }
+        let n = self.tids.len().min(max);
+        self.tids.drain(..n).collect()
+    }
+
+    /// Drain every parked TID — used by close-end wakes (EOF) where every
+    /// blocked reader must be released.
+    pub fn drain_all(&mut self) -> Vec<u64> {
+        if self.tids.is_empty() {
+            return Vec::new();
+        }
+        let n = self.tids.len();
+        self.tids.drain(..n).collect()
+    }
+
+    /// Remove `tid` from the list if present.  Returns `true` if the TID
+    /// was found.  Used by post-wake cleanup paths to detect whether a
+    /// timed-out / signalled waiter raced with a wake (still on the list
+    /// -> we own the dequeue and treat as timeout; no longer on the list
+    /// -> a wake removed us already, treat as success).
+    pub fn remove_tid(&mut self, tid: u64) -> bool {
+        let before = self.tids.len();
+        self.tids.retain(|&t| t != tid);
+        self.tids.len() < before
+    }
+}
+
+/// Flip a batch of TIDs from `Blocked` to `Ready` under a single
+/// `THREAD_TABLE` acquisition.  Matches the FUTEX_WAKE post-drain pattern
+/// (see `subsys/linux/syscall.rs` op == 1 / 10): drain TIDs from the
+/// keyed wait list, drop that lock, then take `THREAD_TABLE` once and
+/// flip every drained TID.  Threads that have already transitioned out
+/// of `Blocked` (e.g. timed out via the scheduler tick at
+/// `sched/mod.rs:104`) are left alone.
+pub fn wake_tids(tids: &[u64]) {
+    if tids.is_empty() {
+        return;
+    }
+    let mut threads = crate::proc::THREAD_TABLE.lock();
+    for &t in tids {
+        if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
+            if th.state == crate::proc::ThreadState::Blocked {
+                th.state = crate::proc::ThreadState::Ready;
+                th.wake_tick = 0;
+            }
+        }
+    }
+}
+
+// ── Global poll/select/epoll wake-bell ────────────────────────────────────────
+//
+// `poll(2)`, `select(2)`, and `epoll_wait(2)` block on a set of fds.
+// Maintaining per-(fd, poller) registration lists is the optimal
+// solution but requires invasive cleanup on every wake, signal, or
+// timeout path.  As a tractable middle ground we expose a global
+// "poll bell" — a single wait list that every IPC state-change writer
+// rings via `ring_poll_bell()`.  Any thread blocked in
+// `wait_poll_event` is woken; it then re-evaluates its fd set and
+// either returns ready or re-parks.
+//
+// Per `man 2 select`: "If the call is interrupted by a signal handler
+// or a fd becomes ready, select() returns".  The bell is correct so
+// long as every state change that could affect fd readiness rings it;
+// false wakeups (writer rings the bell for an fd we are not watching)
+// are harmless — the poller re-checks and re-parks.
+//
+// The bell uses the same `Blocked + wake_tick` discipline as the
+// per-fd wait lists: parking is `Blocked`, the scheduler tick auto-
+// wakes on `wake_tick` (poll timeout), and `ring_poll_bell` flips us
+// back to `Ready` immediately when a writer fires.
+
+static POLL_BELL: spin::Mutex<WaitList> = spin::Mutex::new(WaitList::new());
+
+/// Park the caller on the global poll bell.  Returns once any IPC
+/// writer has rung the bell, the bounded resync interval elapses, or
+/// the caller is woken for another reason (e.g. signal injection
+/// flips us to Ready).  Callers MUST treat the wake as advisory — re-
+/// evaluate fd readiness before returning to userspace.
+///
+/// `caller_deadline` is the absolute scheduler tick at which the
+/// caller's own timeout expires (`u64::MAX` for infinite waits, per
+/// `poll(2)` `timeout=-1` and `epoll_wait(2)` `timeout=-1`).  The
+/// helper deliberately parks for at most `RESYNC_INTERVAL_TICKS`
+/// before falling back through so the caller's outer rescan loop
+/// observes any fd state that did not ring the bell — TCP socket
+/// data, X11 reply bytes, signal injection mid-park, and any future
+/// readiness source not yet wired into `ring_poll_bell` are all
+/// covered by the next periodic recheck.  Without this floor an
+/// `epoll_wait(timeout=-1)` watching only TCP fds would park
+/// indefinitely (the bell only fires on pipe / eventfd / unix-socket
+/// writes), reproducing the pre-fix busy-poll wedge in inverse.
+pub fn wait_poll_event(caller_deadline: u64) {
+    /// Maximum ticks to park before the outer loop rescans.  10 ticks
+    /// = 100 ms at TICK_HZ=100 — coarse enough to be a low-CPU floor
+    /// for genuinely-quiescent fd sets, fine enough that polling
+    /// interactive workloads (X11, etc.) stay responsive.  The bell
+    /// path returns much sooner in the common case.
+    const RESYNC_INTERVAL_TICKS: u64 = 10;
+    let tid = crate::proc::current_tid();
+    let now = crate::arch::x86_64::irq::get_ticks();
+    let resync_tick = now.saturating_add(RESYNC_INTERVAL_TICKS);
+    // Honor whichever deadline arrives first — the caller's, or our
+    // periodic resync.  Saturating arithmetic on u64::MAX yields the
+    // resync floor (correct: the caller wants infinity, we want to
+    // floor at resync).
+    let wake_tick = caller_deadline.min(resync_tick);
+
+    let mut bell = POLL_BELL.lock();
+    bell.enqueue_self_blocked(tid, wake_tick);
+    drop(bell);
+    crate::sched::schedule();
+    // Drop any stale entry — we may have woken via the scheduler tick
+    // (deadline elapsed) rather than via `ring_poll_bell`, in which
+    // case our TID is still on the list.
+    POLL_BELL.lock().remove_tid(tid);
+}
+
+/// Ring the poll bell — wake every thread parked in `wait_poll_event`.
+/// Called by IPC writers (pipe write, eventfd post, unix socket write,
+/// X11 server reply, etc.) after the data side has been updated.
+pub fn ring_poll_bell() {
+    let drained = POLL_BELL.lock().drain_all();
+    wake_tids(&drained);
+}
+
+/// Diagnostic hook — number of threads currently parked on the global
+/// poll bell.  Used by the test runner to assert wake-up correctness.
+pub fn poll_bell_waiter_count() -> usize {
+    POLL_BELL.lock().len()
+}

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -323,11 +323,24 @@ pub fn write(id: u64, data: &[u8]) -> i64 {
         // n == data.len() because we checked space above.
         peer.seq_lens[peer.seq_tail] = n as u32;
         peer.seq_tail = (peer.seq_tail + 1) % SEQ_QUEUE_CAP;
+        // Drop the table lock before ringing the global poll bell so a
+        // poller waking on the bell does not contend on TABLE on its
+        // re-evaluation pass.
+        drop(t);
+        crate::ipc::waitlist::ring_poll_bell();
         return n as i64;
     }
 
     // STREAM: byte-stream, partial writes permitted.
     let n = t.0[peer_id as usize].push(data);
+    drop(t);
+    if n > 0 {
+        // Wake any poll/epoll/select caller watching the peer fd.  The
+        // pre-existing read path returns -EAGAIN when the buffer is empty,
+        // so without this kick the caller would wait for the next 10 ms
+        // tick to discover the new bytes.
+        crate::ipc::waitlist::ring_poll_bell();
+    }
     if n == 0 { -11 } else { n as i64 }
 }
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -519,7 +519,17 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     now + ((timeout_ms as u64) / 10).max(1)
                 };
                 loop {
-                    crate::proc::sleep_ticks(1); // sleep 1 tick (10ms)
+                    // Park on the global IPC poll bell rather than spin-
+                    // sleeping at 100 Hz.  Any pipe write / eventfd post /
+                    // unix-socket message rings the bell (see
+                    // `crate::ipc::waitlist::ring_poll_bell`), waking us
+                    // promptly to re-evaluate the fd set.  The scheduler
+                    // tick wakes us anyway when `wake_tick == deadline`,
+                    // so a missed bell is bounded by the timeout (with
+                    // `u64::MAX` for infinite waits, the bell is the only
+                    // wake mechanism — its single firing point is every
+                    // pipe/eventfd write).
+                    crate::ipc::waitlist::wait_poll_event(deadline_tick);
                     // Pump X11 so replies appear in socket buffers.
                     crate::x11::poll();
                     let r = do_check(true, true);
@@ -528,6 +538,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         if pid >= 1 { crate::serial_println!("[POLL_RET] pid={} ret={} (woke)", pid, r); }
                         return r;
                     }
+                    if signal_pending(pid) { return -4; } // EINTR
                     let now = crate::arch::x86_64::irq::get_ticks();
                     if now >= deadline_tick { break; }
                 }
@@ -2853,7 +2864,12 @@ fn sys_select_linux(
                 now.saturating_add(((timeout_ms as u64) / 10).max(1))
             };
             loop {
-                crate::proc::sleep_ticks(1); // 10ms
+                // Park on the global poll bell — see the matching change
+                // in sys_poll for why this replaces the prior 10 ms tick
+                // sleep.  The bell wakes us when any pipe/eventfd state
+                // change occurs; the scheduler tick wakes us at the
+                // deadline.  Either path drops back into the rescan.
+                crate::ipc::waitlist::wait_poll_event(deadline_tick);
                 crate::x11::poll();
                 do_rescan(&mut ready);
                 if ready > 0 { break; }
@@ -2981,10 +2997,49 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
     if crate::syscall::is_pipe_fd(pid, fd as usize) {
         let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
         let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr, count) };
-        return match crate::ipc::pipe::pipe_read(pipe_id, buf) {
-            Some(n) => n as i64,
-            None => -9,
+        // Per `man 7 pipe` and `man 2 read`: a read on an empty pipe with the
+        // write end still open blocks until data arrives (or a signal fires)
+        // unless O_NONBLOCK is set.  EOF (write end closed) returns 0.  Pre-
+        // fix this branch returned `Some(0)` immediately, leaving callers to
+        // busy-spin via repeated read+poll cycles in user space.
+        let nonblock = {
+            let procs = crate::proc::PROCESS_TABLE.lock();
+            procs.iter().find(|p| p.pid == pid)
+                .and_then(|p| p.file_descriptors.get(fd as usize).and_then(|f| f.as_ref()))
+                .map(|f| (f.flags & 0x0800) != 0)
+                .unwrap_or(false)
         };
+        loop {
+            match crate::ipc::pipe::pipe_read(pipe_id, buf) {
+                None => return -9, // EBADF — pipe vanished (both ends closed).
+                Some(n) if n > 0 => return n as i64,
+                Some(_) => {
+                    // 0 bytes returned: either EOF or empty-but-open.
+                    if crate::ipc::pipe::pipe_is_eof(pipe_id) {
+                        return 0; // EOF — peer closed the write end.
+                    }
+                    if nonblock {
+                        return -11; // EAGAIN
+                    }
+                    if signal_pending(pid) {
+                        return -4; // EINTR
+                    }
+                    // Park the caller atomically against pipe_write's wake.
+                    let tid = crate::proc::current_tid();
+                    match crate::ipc::pipe::wait_readable(pipe_id, u64::MAX) {
+                        crate::ipc::pipe::WaitOutcome::Ready => continue,
+                        crate::ipc::pipe::WaitOutcome::Gone  => return -9, // EBADF
+                        crate::ipc::pipe::WaitOutcome::Enqueued => {
+                            crate::sched::schedule();
+                            // Cleanup any stale entry (e.g. timeout path) so
+                            // we never leak a dead waiter on the per-pipe
+                            // wait list.
+                            crate::ipc::pipe::waiter_cleanup_reader(pipe_id, tid);
+                        }
+                    }
+                }
+            }
+        }
     } else if crate::syscall::is_unix_socket_fd(pid, fd as usize) {
         let unix_id = crate::syscall::get_unix_socket_id(pid, fd as usize);
         let avail = crate::net::unix::bytes_available(unix_id);
@@ -3029,11 +3084,20 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
                 }
                 Err(-11) if nonblock => return -11, // EAGAIN
                 Err(-11) => {
-                    // Block: yield until counter becomes non-zero or a
-                    // signal interrupts us.  10 ms tick polling matches the
-                    // shape used by sys_select/poll above.
+                    // Atomic check-then-park against the per-eventfd wait
+                    // list.  Replaces the prior `sleep_ticks(1)` busy-poll
+                    // (10 ms latency, full CPU budget) with a real block
+                    // that wakes promptly when `eventfd::write` posts.
                     if signal_pending(pid) { return -4; } // EINTR
-                    crate::proc::sleep_ticks(1);
+                    let tid = crate::proc::current_tid();
+                    match crate::ipc::eventfd::wait_readable(efd_id, u64::MAX) {
+                        crate::ipc::eventfd::WaitOutcome::Ready => continue,
+                        crate::ipc::eventfd::WaitOutcome::Gone  => return -9, // EBADF
+                        crate::ipc::eventfd::WaitOutcome::Enqueued => {
+                            crate::sched::schedule();
+                            crate::ipc::eventfd::waiter_cleanup(efd_id, tid);
+                        }
+                    }
                 }
                 Err(e) => return e,
             }
@@ -3209,7 +3273,16 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
         let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
         let slice = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
         return match crate::ipc::pipe::pipe_write(pipe_id, slice) {
-            Some(n) => n as i64,
+            Some(n) => {
+                // Per `man 7 pipe`: writes that deposit data MUST wake any
+                // readers parked on this pipe (the matching wait list lives
+                // in `crate::ipc::pipe::PIPE_READ_WAITERS`).  Skip the wake
+                // on a zero-byte write — the buffer state did not change.
+                if n > 0 {
+                    crate::ipc::pipe::wake_readers_all(pipe_id);
+                }
+                n as i64
+            }
             None => -9,
         };
     } else if crate::syscall::is_unix_socket_fd(pid, fd as usize) {
@@ -3229,7 +3302,13 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
         let efd_id = crate::syscall::get_eventfd_id(pid, fd as usize);
         let val = unsafe { core::ptr::read_unaligned(buf_ptr as *const u64) };
         return match crate::ipc::eventfd::write(efd_id, u64::from_le(val)) {
-            Ok(()) => 8,
+            Ok(()) => {
+                // Per `man 2 eventfd`: a write that bumps the counter must
+                // wake any reader parked on a zero counter (see the per-
+                // eventfd wait list in `crate::ipc::eventfd`).
+                crate::ipc::eventfd::wake_readers_all(efd_id);
+                8
+            }
             Err(e) => e,
         };
     }
@@ -5721,7 +5800,12 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
             now.saturating_add(((timeout_ms as u64) / 10).max(1))
         };
         loop {
-            crate::proc::sleep_ticks(1); // 10ms granularity
+            // Park on the global poll bell.  Pipe/eventfd writes ring it
+            // (see `crate::ipc::waitlist::ring_poll_bell`); the scheduler
+            // tick wakes us at the deadline.  Replaces the prior
+            // 10 ms-tick sleep loop and is the change responsible for
+            // closing the post-PR-#119 epoll-spin plateau.
+            crate::ipc::waitlist::wait_poll_event(deadline_tick);
             do_poll(&mut fired);
             if !fired.is_empty() { break; }
             // Signal pending → return -EINTR per spec.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -163,6 +163,16 @@ pub fn run() -> ! {
     let mut total = 0u32;
     let mut passed = 0u32;
 
+    // ── Test 0a: pipe wake hook (Stream A) ───────────────────────────────
+    // Run before any network/disk tests so a regression here surfaces
+    // immediately rather than after the long pre-amble.
+    total += 1;
+    if test_pipe_wake_hook() { passed += 1; }
+
+    // ── Test 0b: eventfd wake hook (Stream A) ────────────────────────────
+    total += 1;
+    if test_eventfd_wake_hook() { passed += 1; }
+
     // ── Test 1: Network Configuration ───────────────────────────────────
 
     total += 1;
@@ -1296,6 +1306,10 @@ pub fn run() -> ! {
     // ── Test 195: FUTEX_WAIT atomic check-then-queue (lost-wakeup race) ──
     total += 1;
     if test_futex_wait_atomic_check_then_queue() { passed += 1; }
+
+    // (Stream-A pipe / eventfd wake-hook tests run first — see Tests 0a/0b
+    // at the top of this function so failures surface before the suite's
+    // long network/disk pre-amble.)
 
     // ── Summary ─────────────────────────────────────────────────────────
 
@@ -22590,6 +22604,255 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
 
     test_println!("  all {} waiters drained, no leaked queue entries ✓", N_WAITERS);
     test_pass!("FUTEX_WAIT atomic check-then-queue (lost-wakeup race)");
+    true
+}
+
+// ── Test 196: pipe wake hook — reader parks, writer wakes ────────────────────
+//
+// Verifies the per-pipe wait list integration introduced for Stream A.
+// A reader thread enters `wait_readable` against an empty pipe, parks
+// itself in `Blocked`, and is woken when a peer thread calls
+// `pipe_write` followed by `wake_readers_all`.  Pre-fix the pipe layer
+// had no wait list and the syscall layer's pipe_read returned 0 bytes
+// immediately, so blocked-pipe semantics from `man 7 pipe` were
+// unsatisfiable in-kernel.
+//
+// The test deliberately exercises the kernel-level primitives (not the
+// syscall surface) so it does not depend on per-process file descriptor
+// table state — same shape as the futex check-then-queue test above.
+fn test_pipe_wake_hook() -> bool {
+    use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+    test_header!("pipe wake hook — reader parks, writer wakes");
+
+    let pipe_id = crate::ipc::pipe::create_pipe();
+    test_println!("  created pipe id={} ✓", pipe_id);
+
+    static READER_DONE: AtomicU32 = AtomicU32::new(0);
+    static READER_OUTCOME: AtomicU32 = AtomicU32::new(0); // 1 = Ready, 2 = Enqueued+woken, 3 = Gone
+    static PIPE_ID_SLOT: AtomicU64 = AtomicU64::new(0);
+    READER_DONE.store(0, Ordering::SeqCst);
+    READER_OUTCOME.store(0, Ordering::SeqCst);
+    PIPE_ID_SLOT.store(pipe_id, Ordering::SeqCst);
+
+    fn reader_entry() {
+        crate::hal::enable_interrupts();
+        let pid = PIPE_ID_SLOT.load(Ordering::SeqCst);
+        let tid = crate::proc::current_tid();
+        // Park indefinitely on the pipe's reader wait list.
+        match crate::ipc::pipe::wait_readable(pid, u64::MAX) {
+            crate::ipc::pipe::WaitOutcome::Ready => {
+                READER_OUTCOME.store(1, Ordering::SeqCst);
+            }
+            crate::ipc::pipe::WaitOutcome::Enqueued => {
+                crate::sched::schedule();
+                crate::ipc::pipe::waiter_cleanup_reader(pid, tid);
+                READER_OUTCOME.store(2, Ordering::SeqCst);
+            }
+            crate::ipc::pipe::WaitOutcome::Gone => {
+                READER_OUTCOME.store(3, Ordering::SeqCst);
+            }
+        }
+        READER_DONE.store(1, Ordering::SeqCst);
+        crate::proc::exit_thread(0);
+    }
+
+    let was_active = crate::sched::is_active();
+    if !was_active { crate::sched::enable(); }
+
+    let reader_pid = crate::proc::create_kernel_process(
+        "pipe_wake_reader", reader_entry as *const () as u64);
+    test_println!("  spawned reader pid={} ✓", reader_pid);
+
+    // Yield enough times for the reader to reach `wait_readable` and park.
+    for _ in 0..32u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..400u32 { core::hint::spin_loop(); }
+    }
+
+    let parked = crate::ipc::pipe::debug_reader_waiter_count(pipe_id);
+    if parked != 1 {
+        test_fail!("pipe_wake_hook",
+            "expected 1 parked reader, found {} (reader did not enter wait_readable)",
+            parked);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    test_println!("  reader parked on pipe.read_waiters (count={}) ✓", parked);
+
+    // Write to the pipe and wake.  Use the kernel-level helpers so the
+    // test does not depend on a per-process fd table.
+    let n = crate::ipc::pipe::pipe_write(pipe_id, b"hello").unwrap_or(0);
+    if n != 5 {
+        test_fail!("pipe_wake_hook", "pipe_write returned {} (expected 5)", n);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    crate::ipc::pipe::wake_readers_all(pipe_id);
+    test_println!("  wrote 5 bytes + wake_readers_all ✓");
+
+    // Wait for reader to re-run and exit.  Bounded loop so we report
+    // hang rather than freezing the suite.
+    let mut woke = false;
+    for _ in 0..512u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..200u32 { core::hint::spin_loop(); }
+        if READER_DONE.load(Ordering::SeqCst) == 1 {
+            woke = true;
+            break;
+        }
+    }
+
+    let outcome = READER_OUTCOME.load(Ordering::SeqCst);
+    let leaked = crate::ipc::pipe::debug_reader_waiter_count(pipe_id);
+
+    // Cleanup: drain the pipe so the close path is clean.
+    let mut drain = [0u8; 5];
+    let _ = crate::ipc::pipe::pipe_read(pipe_id, &mut drain);
+    crate::ipc::pipe::pipe_close_writer(pipe_id);
+    crate::ipc::pipe::pipe_close_reader(pipe_id);
+
+    if !was_active { crate::sched::disable(); }
+
+    if !woke {
+        test_fail!("pipe_wake_hook",
+            "reader did not exit after wake_readers_all (lost wakeup; outcome={})", outcome);
+        return false;
+    }
+    if outcome != 2 {
+        test_fail!("pipe_wake_hook",
+            "reader outcome {} (expected 2 = Enqueued+woken)", outcome);
+        return false;
+    }
+    if leaked != 0 {
+        test_fail!("pipe_wake_hook",
+            "{} stale waiter(s) on PIPE_READ_WAITERS after wake (leaked entry)", leaked);
+        return false;
+    }
+    test_println!("  reader woke promptly (outcome={}, no leaked waiters) ✓", outcome);
+    test_pass!("pipe wake hook — reader parks, writer wakes");
+    true
+}
+
+// ── Test 197: eventfd wake hook — reader parks, write wakes ──────────────────
+//
+// Symmetric to the pipe test: a reader parks via `wait_readable` on a
+// zero-counter eventfd; a peer thread calls `eventfd::write` (which
+// internally invokes `wake_readers_all` via the syscall write hook —
+// here we drive the kernel helper directly), and the reader wakes.
+fn test_eventfd_wake_hook() -> bool {
+    use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+    test_header!("eventfd wake hook — reader parks, writer wakes");
+
+    let efd_id = crate::ipc::eventfd::create(0, 0);
+    if efd_id == u64::MAX {
+        test_fail!("eventfd_wake_hook", "eventfd create returned u64::MAX");
+        return false;
+    }
+    test_println!("  created eventfd id={} (counter=0) ✓", efd_id);
+
+    static READER_DONE: AtomicU32 = AtomicU32::new(0);
+    static READER_OUTCOME: AtomicU32 = AtomicU32::new(0);
+    static EFD_SLOT: AtomicU64 = AtomicU64::new(0);
+    READER_DONE.store(0, Ordering::SeqCst);
+    READER_OUTCOME.store(0, Ordering::SeqCst);
+    EFD_SLOT.store(efd_id, Ordering::SeqCst);
+
+    fn reader_entry() {
+        crate::hal::enable_interrupts();
+        let id = EFD_SLOT.load(Ordering::SeqCst);
+        let tid = crate::proc::current_tid();
+        match crate::ipc::eventfd::wait_readable(id, u64::MAX) {
+            crate::ipc::eventfd::WaitOutcome::Ready => {
+                READER_OUTCOME.store(1, Ordering::SeqCst);
+            }
+            crate::ipc::eventfd::WaitOutcome::Enqueued => {
+                crate::sched::schedule();
+                crate::ipc::eventfd::waiter_cleanup(id, tid);
+                READER_OUTCOME.store(2, Ordering::SeqCst);
+            }
+            crate::ipc::eventfd::WaitOutcome::Gone => {
+                READER_OUTCOME.store(3, Ordering::SeqCst);
+            }
+        }
+        READER_DONE.store(1, Ordering::SeqCst);
+        crate::proc::exit_thread(0);
+    }
+
+    let was_active = crate::sched::is_active();
+    if !was_active { crate::sched::enable(); }
+
+    let reader_pid = crate::proc::create_kernel_process(
+        "evfd_wake_reader", reader_entry as *const () as u64);
+    test_println!("  spawned reader pid={} ✓", reader_pid);
+
+    for _ in 0..32u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..400u32 { core::hint::spin_loop(); }
+    }
+
+    let parked = crate::ipc::eventfd::debug_reader_waiter_count(efd_id);
+    if parked != 1 {
+        test_fail!("eventfd_wake_hook",
+            "expected 1 parked reader, found {} (reader did not enter wait_readable)",
+            parked);
+        crate::ipc::eventfd::close(efd_id);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    test_println!("  reader parked on eventfd.read_waiters (count={}) ✓", parked);
+
+    // Bump counter and wake.
+    if let Err(e) = crate::ipc::eventfd::write(efd_id, 1) {
+        test_fail!("eventfd_wake_hook", "eventfd write returned {}", e);
+        crate::ipc::eventfd::close(efd_id);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    crate::ipc::eventfd::wake_readers_all(efd_id);
+    test_println!("  posted counter += 1 + wake_readers_all ✓");
+
+    let mut woke = false;
+    for _ in 0..512u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..200u32 { core::hint::spin_loop(); }
+        if READER_DONE.load(Ordering::SeqCst) == 1 {
+            woke = true;
+            break;
+        }
+    }
+
+    let outcome = READER_OUTCOME.load(Ordering::SeqCst);
+    let leaked = crate::ipc::eventfd::debug_reader_waiter_count(efd_id);
+
+    // Drain counter + free slot.
+    let _ = crate::ipc::eventfd::try_read(efd_id);
+    crate::ipc::eventfd::close(efd_id);
+
+    if !was_active { crate::sched::disable(); }
+
+    if !woke {
+        test_fail!("eventfd_wake_hook",
+            "reader did not exit after wake_readers_all (lost wakeup; outcome={})", outcome);
+        return false;
+    }
+    if outcome != 2 {
+        test_fail!("eventfd_wake_hook",
+            "reader outcome {} (expected 2 = Enqueued+woken)", outcome);
+        return false;
+    }
+    if leaked != 0 {
+        test_fail!("eventfd_wake_hook",
+            "{} stale waiter(s) on EVENTFD_READ_WAITERS after wake (leaked entry)", leaked);
+        return false;
+    }
+    test_println!("  reader woke promptly (outcome={}, no leaked waiters) ✓", outcome);
+    test_pass!("eventfd wake hook — reader parks, writer wakes");
     true
 }
 


### PR DESCRIPTION
## Summary

- Pipes and eventfds now have per-fd wait lists; readers park on `wait_readable` instead of returning 0/EAGAIN, and writers wake every parked reader on the same syscall path.  Per `man 7 pipe`, `man 2 eventfd`.
- A global "poll bell" gives `poll(2)` / `select(2)` / `epoll_wait(2)` a wake source so they leave the 100 Hz sleep_ticks loop the moment any pipe/eventfd/unix-socket write changes readiness.  10-tick (100 ms) resync floor preserves correctness for fds the bell does not directly cover.
- New atomic check-then-park primitive (`waitlist::WaitList`) mirrors the futex `FUTEX_WAITERS -> THREAD_TABLE` lock-order discipline introduced in #126; lock orders documented in module-level prose.
- Closes the post-PR-#119 epoll-spin plateau identified by the native-kernel audit (Stream A) as the credible Firefox demo-gate fix.

## Test plan

- [x] `cargo +nightly check --features test-mode` clean.
- [x] In-kernel Tests 0a/0b (added at the very top of the suite so they run before the network/disk pre-amble): both PASS via `qemu-harness.py start --features test-mode,kdb,ci-skip-test-104`.
  - Test 0a: spawn reader → park on pipe wait list (assert count==1) → write 5 bytes + wake_readers_all → reader exits with outcome=Enqueued+woken; no leaked waiters.
  - Test 0b: same shape against a fresh eventfd slot.
- [ ] Firefox demo verification deferred to next-wave verifier (per dispatch instructions — sc-past-2232 / parked-tids drop is for that agent to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)