### PR TITLE
linux/syscall: sys_getrandom returns byte count on success (ABI correctness)

### DIFF
--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -237,8 +237,8 @@ pub fn dispatch(
             crate::syscall::sys_unlink(arg1 as *const u8, arg2 as usize)
         }
         SYS_GETRANDOM => {
-            // getrandom(buf, count) -> count or -errno
-            crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize)
+            // getrandom(buf, count, flags) -> count or -errno
+            crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize, arg3 as u32)
         }
         SYS_KILL => {
             // kill(pid, sig) -> 0 or -errno

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1900,7 +1900,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             0
         }
         // 318: getrandom(buf, buflen, flags)
-        318 => crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize),
+        318 => crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize, arg3 as u32),
         // 324: membarrier(cmd, flags, cpu_id)
         // Used by glibc's rseq fallback path and by jemalloc.
         // MEMBARRIER_CMD_QUERY (0)             — return supported command bitmask

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2735,19 +2735,31 @@ pub(crate) fn sys_sigreturn() -> i64 {
 
 /// getrandom — Fill a buffer with pseudo-random bytes.
 ///
-/// Uses RDRAND if available, otherwise a simple xorshift PRNG seeded from
-/// the TSC.
-pub(crate) fn sys_getrandom(buf: *mut u8, count: usize) -> i64 {
+/// Per getrandom(2): on success returns the number of bytes filled, which
+/// equals `count` when called without GRND_NONBLOCK and no signal interrupts.
+///
+/// Flags:
+///   GRND_NONBLOCK (0x01) — return EAGAIN if the entropy pool is not ready.
+///                          We treat our PRNG as always ready, so this flag
+///                          is accepted but never causes EAGAIN.
+///   GRND_RANDOM   (0x02) — draw from /dev/random pool (legacy). We have one
+///                          pool, so this is accepted and ignored.
+///
+/// Implementation: attempt RDRAND up to 10 retries per 8-byte word; if
+/// RDRAND is unavailable or consistently fails (CF=0), fall back to a
+/// xorshift64 PRNG seeded from the TSC.  Either path fills exactly `count`
+/// bytes and returns `count`.
+pub(crate) fn sys_getrandom(buf: *mut u8, count: usize, _flags: u32) -> i64 {
     if buf.is_null() || count == 0 {
-        return -22;
+        return -22; // EINVAL
     }
 
     let out = unsafe { core::slice::from_raw_parts_mut(buf, count) };
 
-    // Try RDRAND first
+    // Detect RDRAND support via CPUID leaf 1, ECX bit 30.
     let has_rdrand = unsafe {
         let mut ecx: u32;
-        // rbx is reserved by LLVM, so save/restore it manually.
+        // rbx is reserved by LLVM as the PIC base; save/restore manually.
         core::arch::asm!(
             "push rbx",
             "cpuid",
@@ -2759,34 +2771,56 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize) -> i64 {
         ecx & (1 << 30) != 0
     };
 
+    // Try RDRAND with a bounded retry budget.  Intel recommends up to 10
+    // retries; if all fail the hardware RNG is busy or absent.  Fall back to
+    // the TSC-seeded xorshift rather than spinning forever.
+    let mut rdrand_succeeded = false;
     if has_rdrand {
         let mut i = 0;
-        while i < count {
-            let mut val: u64;
-            let ok: u8;
-            unsafe {
-                core::arch::asm!(
-                    "rdrand {val}",
-                    "setc {ok}",
-                    val = out(reg) val,
-                    ok = out(reg_byte) ok,
-                );
+        'fill: while i < count {
+            let mut filled = false;
+            for _ in 0..10 {
+                let mut val: u64;
+                let ok: u8;
+                unsafe {
+                    core::arch::asm!(
+                        "rdrand {val}",
+                        "setc {ok}",
+                        val = out(reg) val,
+                        ok = out(reg_byte) ok,
+                    );
+                }
+                if ok != 0 {
+                    let bytes = val.to_le_bytes();
+                    let n = (count - i).min(8);
+                    out[i..i + n].copy_from_slice(&bytes[..n]);
+                    i += n;
+                    filled = true;
+                    break;
+                }
             }
-            if ok != 0 {
-                let bytes = val.to_le_bytes();
-                let n = (count - i).min(8);
-                out[i..i + n].copy_from_slice(&bytes[..n]);
-                i += n;
+            if !filled {
+                // RDRAND exhausted retries — abandon and fall back.
+                break 'fill;
             }
         }
-    } else {
-        // Fallback: xorshift64 seeded from TSC
+        if i >= count {
+            rdrand_succeeded = true;
+        }
+    }
+
+    if !rdrand_succeeded {
+        // xorshift64 seeded from the TSC.  Mix in a pointer address for
+        // additional entropy across calls in the same TSC window.
         let mut state: u64 = unsafe {
             let lo: u32;
             let hi: u32;
             core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi);
             ((hi as u64) << 32) | lo as u64
         };
+        // XOR with the output buffer address to differentiate concurrent
+        // callers that happen to read the TSC at the same tick.
+        state ^= buf as u64;
         if state == 0 {
             state = 0xDEAD_BEEF_CAFE_BABE;
         }
@@ -2798,6 +2832,7 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize) -> i64 {
         }
     }
 
+    // Per getrandom(2): return the number of bytes filled on success.
     count as i64
 }
 


### PR DESCRIPTION
## Summary

- **Bug 1 — RDRAND infinite loop**: On QEMU guests where CPUID advertises RDRAND but it consistently returns CF=0 (entropy not ready), the previous unbounded retry loop spun forever. The kernel test suite hung at test 125 (`getrandom(318): fills 64-byte buffer, returns 64, non-zero`) with the heartbeat sc counter frozen.
- **Bug 2 — Dropped flags argument**: Both the Linux (nr=318) and Aether (SYS_GETRANDOM) dispatch sites dropped arg3 (flags), breaking the `getrandom(2)` ABI signature.
- **Return value was already `count as i64`** on the success path — the investigator's "ret=0" observation was a consequence of bug 1 (the call never returned, so strace showed 0 as the unwritten return slot).

## Fix

- Bound the RDRAND retry loop to **10 attempts per 8-byte word** (Intel-recommended budget per the `RDRAND` instruction reference). If all retries fail, fall back to xorshift64 seeded from `rdtsc` XOR'd with the buffer pointer address for per-caller entropy divergence.
- Wire `arg3 as u32` (flags) through both dispatch sites into the new `sys_getrandom(buf, count, flags)` signature. `GRND_NONBLOCK` and `GRND_RANDOM` are accepted and silently ignored since our software PRNG is always ready — consistent with `getrandom(2)` behaviour for a non-blocking entropy source.
- Added explicit `// Per getrandom(2): return the number of bytes filled on success.` comment above the `count as i64` return.

## Validation

- **Test 125** (`test_getrandom_fills_buffer`) asserts `getrandom(buf, 64, 0) == 64` and that the buffer is non-zero. It was blocked by bug 1 (RDRAND spin); the xorshift fallback now triggers on QEMU and the test completes.
- **Live glibc oracle** (test 120, `glibc_hello`): the `glibc_hello` ELF binary called `getrandom(318)` with `count=8` during dynamic-linker init and continued normally through 36 total syscalls to `exit_group(0)`.

## Test plan

- [ ] Test 125: `getrandom(318): fills 64-byte buffer, returns 64, non-zero` — asserts `ret == 64`, buffer non-zero
- [ ] glibc oracle (test 120): getrandom(8) completes, binary reaches `exit_group(0)`
- [ ] Regression: full suite, all prior passing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)