### PR TITLE
demo/native: phase NRS-2 — base64 PNG extraction to host (read-png harness subcommand)

### DIFF
--- a/kernel/src/gdi/mod.rs
+++ b/kernel/src/gdi/mod.rs
@@ -16,6 +16,7 @@ pub mod primitives;
 pub mod text;
 pub mod bitblt;
 pub mod region;
+pub mod png;
 
 pub use surface::Surface;
 pub use dc::{DeviceContext, Pen, Brush, PenStyle, BrushStyle, Rop2, BgMode, Rect};

--- a/kernel/src/gdi/png.rs
+++ b/kernel/src/gdi/png.rs
@@ -1,0 +1,246 @@
+//! Minimal PNG encoder for AstryxOS GDI surfaces.
+//!
+//! Encodes a [`Surface`] (32-bpp ARGB pixel buffer) into a valid PNG byte stream.
+//!
+//! ## Format overview
+//!
+//! Per the PNG specification (W3C PNG Third Edition, ISO/IEC 15948:2024):
+//! - 8-byte PNG signature
+//! - IHDR chunk  (13 bytes of image metadata)
+//! - IDAT chunk  (compressed image data)
+//! - IEND chunk  (zero-length end marker)
+//!
+//! ## Compression
+//!
+//! The image data is compressed using zlib format (RFC 1950) with a deflate
+//! (RFC 1951) payload composed entirely of stored (non-compressed) blocks.
+//! Stored blocks are valid per RFC 1951 §3.2.4 and are accepted by every
+//! standards-conforming PNG decoder. This avoids a Huffman / LZ77 implementation
+//! while keeping the output a spec-valid, widely-readable PNG file.
+//!
+//! ## Pixel format conversion
+//!
+//! The surface stores pixels as 32-bit `0xAARRGGBB`. The encoder converts each
+//! pixel to an 8-bit RGBA byte tuple (R, G, B, A) and prepends each scanline
+//! with a PNG filter byte of 0 (None). Alpha is preserved.
+
+extern crate alloc;
+use alloc::vec::Vec;
+use super::surface::Surface;
+
+// ── CRC-32 ──────────────────────────────────────────────────────────────────
+
+/// Generate the standard CRC-32 table (ISO 3309 polynomial 0xEDB88320).
+///
+/// CRC-32 is used for PNG chunk integrity as required by the PNG specification.
+fn make_crc_table() -> [u32; 256] {
+    let mut table = [0u32; 256];
+    for n in 0..256usize {
+        let mut c = n as u32;
+        for _ in 0..8 {
+            if c & 1 != 0 {
+                c = 0xEDB88320 ^ (c >> 1);
+            } else {
+                c >>= 1;
+            }
+        }
+        table[n] = c;
+    }
+    table
+}
+
+/// Compute CRC-32 over `data`, seeded with `crc` (pass `0xFFFF_FFFF` initially,
+/// XOR the final result with `0xFFFF_FFFF`).
+fn update_crc(table: &[u32; 256], mut crc: u32, data: &[u8]) -> u32 {
+    for &b in data {
+        crc = table[((crc ^ b as u32) & 0xFF) as usize] ^ (crc >> 8);
+    }
+    crc
+}
+
+/// Compute the complete CRC-32 for a block of data.
+fn crc32(table: &[u32; 256], data: &[u8]) -> u32 {
+    update_crc(table, 0xFFFF_FFFF, data) ^ 0xFFFF_FFFF
+}
+
+// ── Chunk helpers ────────────────────────────────────────────────────────────
+
+/// Append a big-endian u32 to `buf`.
+#[inline]
+fn push_u32_be(buf: &mut Vec<u8>, v: u32) {
+    buf.push((v >> 24) as u8);
+    buf.push((v >> 16) as u8);
+    buf.push((v >>  8) as u8);
+    buf.push( v        as u8);
+}
+
+/// Write a PNG chunk: `length(4) + type(4) + data(length) + crc32(4)`.
+///
+/// `chunk_type` must be exactly 4 ASCII bytes.
+fn write_chunk(buf: &mut Vec<u8>, table: &[u32; 256], chunk_type: &[u8; 4], data: &[u8]) {
+    push_u32_be(buf, data.len() as u32);
+    buf.extend_from_slice(chunk_type);
+    buf.extend_from_slice(data);
+    // CRC covers chunk-type + chunk-data (not the length field).
+    let mut crc_input = [0u8; 4];
+    crc_input.copy_from_slice(chunk_type);
+    let crc = update_crc(table, 0xFFFF_FFFF, &crc_input);
+    let crc = update_crc(table, crc, data) ^ 0xFFFF_FFFF;
+    push_u32_be(buf, crc);
+}
+
+// ── Stored-block deflate / zlib ──────────────────────────────────────────────
+
+/// Wrap `raw_data` in a zlib envelope (RFC 1950) containing stored deflate blocks
+/// (RFC 1951 §3.2.4, BTYPE=00).
+///
+/// Structure:
+/// ```text
+/// zlib header  (2 bytes):  CMF=0x78 (deflate, window=32K), FLG (computed for FCHECK)
+/// for each stored block:
+///   BFINAL (1 bit) | BTYPE=00 (2 bits) | padding (5 bits)  -> 1 byte
+///   LEN   (2 bytes, little-endian)
+///   NLEN  (2 bytes, one's complement of LEN, little-endian)
+///   data  (LEN bytes)
+/// Adler-32 checksum (4 bytes, big-endian)
+/// ```
+///
+/// Maximum stored block payload is 65535 bytes. Long inputs are split.
+fn zlib_stored(data: &[u8]) -> Vec<u8> {
+    // Capacity estimate: header(2) + ceil(len/65535)*(5+65535) + trailer(4)
+    let n_blocks = if data.is_empty() { 1 } else { (data.len() + 65534) / 65535 };
+    let mut out = Vec::with_capacity(2 + n_blocks * 5 + data.len() + 4);
+
+    // zlib header: CMF = 0x78 (CM=8 deflate, CINFO=7 -> 32K window)
+    // FLG must make (CMF*256 + FLG) divisible by 31.
+    // 0x78 * 256 = 0x7800 = 30720.  30720 % 31 = 30720 - 991*31 = 30720-30721 < 0 → try 1
+    // 30720 + FLG ≡ 0 (mod 31) → FLG ≡ -30720 (mod 31) ≡ -(30720 % 31) (mod 31)
+    // 30720 / 31 = 991 rem 30720 - 991*31 = 30720 - 30721 … let's just compute.
+    // 30721 % 31 = 30721 - 991*31 = 30721 - 30721 = 0.  So CMF=0x78, FLG=0x01.
+    // Verify: (0x78<<8 | 0x01) = 0x7801 = 30721. 30721 / 31 = 991. ✓
+    out.push(0x78); // CMF
+    out.push(0x01); // FLG  (no dict, FCHECK=1)
+
+    // Adler-32 running state (RFC 1950 §2.2).
+    let mut s1: u32 = 1;
+    let mut s2: u32 = 0;
+
+    let mut offset = 0usize;
+    while offset < data.len() || data.is_empty() {
+        let end = (offset + 65535).min(data.len());
+        let block = &data[offset..end];
+        let bfinal: u8 = if end == data.len() { 1 } else { 0 };
+
+        // BFINAL + BTYPE=00 (stored).  The remaining 5 bits of the byte are 0.
+        out.push(bfinal); // BFINAL=bfinal, BTYPE=00
+
+        let len = block.len() as u16;
+        let nlen = !len;
+        out.push( len        as u8);
+        out.push((len >> 8)  as u8);
+        out.push( nlen       as u8);
+        out.push((nlen >> 8) as u8);
+
+        out.extend_from_slice(block);
+
+        // Update Adler-32 (mod 65521).
+        for &b in block {
+            s1 = (s1 + b as u32) % 65521;
+            s2 = (s2 + s1)       % 65521;
+        }
+
+        if data.is_empty() {
+            break;
+        }
+        offset = end;
+        if offset >= data.len() {
+            break;
+        }
+    }
+
+    // Handle truly empty input: one zero-length stored block was written above.
+    // Adler-32 of empty string = (s2<<16)|s1 = (0<<16)|1 = 1.
+
+    // Adler-32 trailer — big-endian.
+    let adler = (s2 << 16) | s1;
+    push_u32_be(&mut out, adler);
+
+    out
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Encode a [`Surface`] as a PNG byte stream.
+///
+/// The surface's pixels (32-bpp `0xAARRGGBB`) are converted to 8-bit RGBA
+/// tuples. Each scanline is preceded by a filter byte of 0 (None) as required
+/// by the PNG specification. The IDAT payload is zlib-wrapped with stored
+/// deflate blocks.
+///
+/// Returns the complete PNG file as a `Vec<u8>`.
+pub fn encode_surface_to_png(surface: &Surface) -> Vec<u8> {
+    let w = surface.width;
+    let h = surface.height;
+
+    let crc_table = make_crc_table();
+
+    // ── Build raw IDAT payload: filter(1) + RGBA(4) per pixel, per row ──────
+    // Each scanline: 1 filter byte + 4 bytes per pixel.
+    let row_stride = 1 + (w as usize) * 4;
+    let mut raw = Vec::with_capacity(row_stride * h as usize);
+
+    for y in 0..h {
+        raw.push(0u8); // PNG filter type 0 (None)
+        for x in 0..w {
+            let argb = surface.pixels[(y as usize) * (w as usize) + (x as usize)];
+            let r = ((argb >> 16) & 0xFF) as u8;
+            let g = ((argb >>  8) & 0xFF) as u8;
+            let b = ( argb        & 0xFF) as u8;
+            let a = ((argb >> 24) & 0xFF) as u8;
+            raw.push(r);
+            raw.push(g);
+            raw.push(b);
+            raw.push(a);
+        }
+    }
+
+    // ── Compress with stored deflate / zlib ──────────────────────────────────
+    let idat_data = zlib_stored(&raw);
+
+    // ── Assemble PNG ─────────────────────────────────────────────────────────
+    // Capacity estimate: sig(8) + IHDR(25) + IDAT(12+len) + IEND(12)
+    let mut png = Vec::with_capacity(8 + 25 + 12 + idat_data.len() + 12);
+
+    // PNG signature (fixed 8-byte magic, per PNG spec §5.2).
+    png.extend_from_slice(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+
+    // IHDR chunk (13 bytes of data):
+    //   width(4) height(4) bit_depth(1) color_type(1) compression(1) filter(1) interlace(1)
+    // color_type=6: RGBA (truecolour with alpha).
+    let mut ihdr = [0u8; 13];
+    ihdr[0] = (w >> 24) as u8;
+    ihdr[1] = (w >> 16) as u8;
+    ihdr[2] = (w >>  8) as u8;
+    ihdr[3] =  w        as u8;
+    ihdr[4] = (h >> 24) as u8;
+    ihdr[5] = (h >> 16) as u8;
+    ihdr[6] = (h >>  8) as u8;
+    ihdr[7] =  h        as u8;
+    ihdr[8]  = 8;  // bit depth
+    ihdr[9]  = 6;  // color type: RGBA
+    ihdr[10] = 0;  // compression method: deflate (only defined value)
+    ihdr[11] = 0;  // filter method: adaptive (only defined value)
+    ihdr[12] = 0;  // interlace method: none
+    write_chunk(&mut png, &crc_table, b"IHDR", &ihdr);
+
+    // IDAT chunk
+    write_chunk(&mut png, &crc_table, b"IDAT", &idat_data);
+
+    // IEND chunk (zero-length)
+    write_chunk(&mut png, &crc_table, b"IEND", &[]);
+
+    png
+}
+
+/// The 8-byte PNG signature that every valid PNG file begins with (PNG spec §5.2).
+pub const PNG_SIGNATURE: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];

--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -237,8 +237,8 @@ pub fn dispatch(
             crate::syscall::sys_unlink(arg1 as *const u8, arg2 as usize)
         }
         SYS_GETRANDOM => {
-            // getrandom(buf, count) -> count or -errno
-            crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize)
+            // getrandom(buf, count, flags) -> count or -errno
+            crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize, arg3 as u32)
         }
         SYS_KILL => {
             // kill(pid, sig) -> 0 or -errno

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1900,7 +1900,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             0
         }
         // 318: getrandom(buf, buflen, flags)
-        318 => crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize),
+        318 => crate::syscall::sys_getrandom(arg1 as *mut u8, arg2 as usize, arg3 as u32),
         // 324: membarrier(cmd, flags, cpu_id)
         // Used by glibc's rseq fallback path and by jemalloc.
         // MEMBARRIER_CMD_QUERY (0)             — return supported command bitmask

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2735,19 +2735,31 @@ pub(crate) fn sys_sigreturn() -> i64 {
 
 /// getrandom — Fill a buffer with pseudo-random bytes.
 ///
-/// Uses RDRAND if available, otherwise a simple xorshift PRNG seeded from
-/// the TSC.
-pub(crate) fn sys_getrandom(buf: *mut u8, count: usize) -> i64 {
+/// Per getrandom(2): on success returns the number of bytes filled, which
+/// equals `count` when called without GRND_NONBLOCK and no signal interrupts.
+///
+/// Flags:
+///   GRND_NONBLOCK (0x01) — return EAGAIN if the entropy pool is not ready.
+///                          We treat our PRNG as always ready, so this flag
+///                          is accepted but never causes EAGAIN.
+///   GRND_RANDOM   (0x02) — draw from /dev/random pool (legacy). We have one
+///                          pool, so this is accepted and ignored.
+///
+/// Implementation: attempt RDRAND up to 10 retries per 8-byte word; if
+/// RDRAND is unavailable or consistently fails (CF=0), fall back to a
+/// xorshift64 PRNG seeded from the TSC.  Either path fills exactly `count`
+/// bytes and returns `count`.
+pub(crate) fn sys_getrandom(buf: *mut u8, count: usize, _flags: u32) -> i64 {
     if buf.is_null() || count == 0 {
-        return -22;
+        return -22; // EINVAL
     }
 
     let out = unsafe { core::slice::from_raw_parts_mut(buf, count) };
 
-    // Try RDRAND first
+    // Detect RDRAND support via CPUID leaf 1, ECX bit 30.
     let has_rdrand = unsafe {
         let mut ecx: u32;
-        // rbx is reserved by LLVM, so save/restore it manually.
+        // rbx is reserved by LLVM as the PIC base; save/restore manually.
         core::arch::asm!(
             "push rbx",
             "cpuid",
@@ -2759,34 +2771,56 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize) -> i64 {
         ecx & (1 << 30) != 0
     };
 
+    // Try RDRAND with a bounded retry budget.  Intel recommends up to 10
+    // retries; if all fail the hardware RNG is busy or absent.  Fall back to
+    // the TSC-seeded xorshift rather than spinning forever.
+    let mut rdrand_succeeded = false;
     if has_rdrand {
         let mut i = 0;
-        while i < count {
-            let mut val: u64;
-            let ok: u8;
-            unsafe {
-                core::arch::asm!(
-                    "rdrand {val}",
-                    "setc {ok}",
-                    val = out(reg) val,
-                    ok = out(reg_byte) ok,
-                );
+        'fill: while i < count {
+            let mut filled = false;
+            for _ in 0..10 {
+                let mut val: u64;
+                let ok: u8;
+                unsafe {
+                    core::arch::asm!(
+                        "rdrand {val}",
+                        "setc {ok}",
+                        val = out(reg) val,
+                        ok = out(reg_byte) ok,
+                    );
+                }
+                if ok != 0 {
+                    let bytes = val.to_le_bytes();
+                    let n = (count - i).min(8);
+                    out[i..i + n].copy_from_slice(&bytes[..n]);
+                    i += n;
+                    filled = true;
+                    break;
+                }
             }
-            if ok != 0 {
-                let bytes = val.to_le_bytes();
-                let n = (count - i).min(8);
-                out[i..i + n].copy_from_slice(&bytes[..n]);
-                i += n;
+            if !filled {
+                // RDRAND exhausted retries — abandon and fall back.
+                break 'fill;
             }
         }
-    } else {
-        // Fallback: xorshift64 seeded from TSC
+        if i >= count {
+            rdrand_succeeded = true;
+        }
+    }
+
+    if !rdrand_succeeded {
+        // xorshift64 seeded from the TSC.  Mix in a pointer address for
+        // additional entropy across calls in the same TSC window.
         let mut state: u64 = unsafe {
             let lo: u32;
             let hi: u32;
             core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi);
             ((hi as u64) << 32) | lo as u64
         };
+        // XOR with the output buffer address to differentiate concurrent
+        // callers that happen to read the TSC at the same tick.
+        state ^= buf as u64;
         if state == 0 {
             state = 0xDEAD_BEEF_CAFE_BABE;
         }
@@ -2798,6 +2832,7 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize) -> i64 {
         }
     }
 
+    // Per getrandom(2): return the number of bytes filled on success.
     count as i64
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -878,6 +878,12 @@ pub fn run() -> ! {
     total += 1;
     if test_umount_removes_mount() { passed += 1; }
 
+    // ── Test 198: GDI PNG screenshot — render shapes + encode PNG headlessly
+    // Runs here (before userspace ELF tests) because it only needs GDI + VFS.
+
+    total += 1;
+    if test_gdi_png_screenshot() { passed += 1; }
+
     // ── Test 120: glibc hello — oracle test for glibc dynamic linker ───────
 
     total += 1;
@@ -23128,6 +23134,163 @@ fn test_dup_clears_cloexec() -> bool {
     crate::subsys::linux::syscall::sys_close_test(orig_fd as u64);
 
     test_pass!("dup/dup2 clear FD_CLOEXEC on duplicate");
+    true
+}
+
+// ── Test 198: GDI PNG screenshot ─────────────────────────────────────────────
+//
+// Exercises the full headless rendering pipeline:
+//   1. Allocate a 160×120 Surface using the kernel GDI Surface type.
+//   2. Draw a scene: gradient background, filled rectangles, filled ellipse,
+//      bitmap text — using existing GDI primitives and the 8×16 VGA font.
+//   3. Encode the surface to PNG using `gdi::png::encode_surface_to_png`.
+//      The encoder uses zlib with stored (non-compressed) deflate blocks
+//      (RFC 1951 §3.2.4), producing a spec-valid PNG without requiring a
+//      Huffman implementation.
+//   4. Write the PNG bytes to `/tmp/screenshot.png` via the VFS.
+//   5. Verify the file can be read back and starts with the 8-byte PNG
+//      signature (0x89 'P' 'N' 'G' \r \n 0x1a \n).
+//   6. Emit a `[SCREENSHOT]` line to the serial console so the harness can
+//      grep for the result.
+//
+// Pass criterion: VFS write succeeds; read-back starts with PNG_SIGNATURE.
+fn test_gdi_png_screenshot() -> bool {
+    test_header!("GDI PNG screenshot — render shapes + encode PNG headlessly");
+
+    // ── 1. Allocate surface ──────────────────────────────────────────────────
+    let mut surface = crate::gdi::Surface::new(160, 120);
+
+    // ── 2. Draw a scene ──────────────────────────────────────────────────────
+    // Background: vertical gradient from deep blue to dark navy.
+    crate::gdi::primitives::gradient_fill_v(
+        &mut surface, 0, 0, 160, 120,
+        0xFF1A3A6A, // top: deep blue
+        0xFF0A1020, // bottom: near black
+    );
+
+    // Red filled rectangle (title bar analogue).
+    {
+        use crate::gdi::dc::{DeviceContext, Pen, Brush, PenStyle, BrushStyle};
+        let mut dc = DeviceContext::new(0);
+        dc.pen   = Pen   { style: PenStyle::Null,  width: 0, color: 0 };
+        dc.brush = Brush { style: BrushStyle::Solid, color: 0xFFCC2233 };
+        crate::gdi::primitives::fill_rectangle(&mut surface, &dc, 10, 10, 150, 30);
+    }
+
+    // White border around the red rectangle.
+    crate::gdi::primitives::frame_rect(&mut surface, 0xFFFFFFFF, 10, 10, 150, 30);
+
+    // Green filled ellipse (content indicator).
+    {
+        use crate::gdi::dc::{DeviceContext, Pen, Brush, PenStyle, BrushStyle};
+        let mut dc = DeviceContext::new(0);
+        dc.pen   = Pen   { style: PenStyle::Solid,  width: 1, color: 0xFF00FF00 };
+        dc.brush = Brush { style: BrushStyle::Solid, color: 0xFF22AA44 };
+        crate::gdi::primitives::fill_ellipse(&mut surface, &dc, 80, 75, 50, 30);
+    }
+
+    // Diagonal line (Bresenham).
+    {
+        use crate::gdi::dc::{DeviceContext, Pen, Brush, PenStyle, BrushStyle};
+        let mut dc = DeviceContext::new(0);
+        dc.pen   = Pen   { style: PenStyle::Solid, width: 1, color: 0xFFFFFF00 };
+        dc.brush = Brush { style: BrushStyle::Null, color: 0 };
+        crate::gdi::primitives::line(&mut surface, &dc, 10, 40, 150, 110);
+    }
+
+    // Text in the title bar.
+    {
+        use crate::gdi::dc::{DeviceContext, BgMode};
+        let mut dc = DeviceContext::new(0);
+        dc.text_color = 0xFFFFFFFF; // white text
+        dc.bg_mode    = BgMode::Transparent;
+        crate::gdi::text::text_out(&mut surface, &dc, 14, 14, "AstryxOS");
+    }
+
+    // Small label below the ellipse.
+    {
+        use crate::gdi::dc::{DeviceContext, BgMode};
+        let mut dc = DeviceContext::new(0);
+        dc.text_color = 0xFFCCCCCC;
+        dc.bg_mode    = BgMode::Transparent;
+        crate::gdi::text::text_out(&mut surface, &dc, 10, 105, "NRS-1");
+    }
+
+    // ── 3. Encode to PNG ─────────────────────────────────────────────────────
+    let png_bytes = crate::gdi::png::encode_surface_to_png(&surface);
+    let png_len = png_bytes.len();
+
+    // ── 4. Write to VFS ──────────────────────────────────────────────────────
+    let png_path = "/tmp/screenshot.png";
+    // Ensure /tmp exists (ramfs root already has /tmp in most builds, but
+    // create_dir is idempotent if it does exist).
+    let _ = crate::vfs::mkdir("/tmp");
+
+    match crate::vfs::create_file(png_path) {
+        Ok(()) => {}
+        Err(e) => {
+            test_fail!("gdi_png_screenshot", "create_file({}) failed: {:?}", png_path, e);
+            return false;
+        }
+    }
+
+    match crate::vfs::write_file(png_path, &png_bytes) {
+        Ok(n) => {
+            if n != png_bytes.len() {
+                test_fail!(
+                    "gdi_png_screenshot",
+                    "write_file({}) wrote {} of {} bytes",
+                    png_path, n, png_bytes.len()
+                );
+                return false;
+            }
+        }
+        Err(e) => {
+            test_fail!("gdi_png_screenshot", "write_file({}) failed: {:?}", png_path, e);
+            return false;
+        }
+    }
+
+    test_println!("  wrote {} bytes to '{}'", png_len, png_path);
+
+    // ── 5. Read back and verify PNG signature ─────────────────────────────────
+    let read_back = match crate::vfs::read_file(png_path) {
+        Ok(v) => v,
+        Err(e) => {
+            test_fail!("gdi_png_screenshot", "read_file({}) failed: {:?}", png_path, e);
+            return false;
+        }
+    };
+
+    if read_back.len() < 8 {
+        test_fail!(
+            "gdi_png_screenshot",
+            "read-back too short: {} bytes (expected ≥8)",
+            read_back.len()
+        );
+        return false;
+    }
+
+    let sig = &read_back[..8];
+    let expected = crate::gdi::png::PNG_SIGNATURE;
+    if sig != expected {
+        test_fail!(
+            "gdi_png_screenshot",
+            "PNG signature mismatch: got {:02X?}, expected {:02X?}",
+            sig, expected
+        );
+        return false;
+    }
+
+    test_println!("  PNG signature {:02X?} ✓", sig);
+
+    // ── 6. Emit harness-greppable summary line ────────────────────────────────
+    test_println!(
+        "[SCREENSHOT] path={} size={} signature_ok=true",
+        png_path, png_len
+    );
+
+    test_pass!("GDI PNG screenshot — render shapes + encode PNG headlessly");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -23290,6 +23290,76 @@ fn test_gdi_png_screenshot() -> bool {
         png_path, png_len
     );
 
+    // ── 7. Emit base64-encoded PNG over serial for host extraction ─────────────
+    //
+    // Protocol (RFC 4648 §4 base64):
+    //   [SCREENSHOT-B64:N/M] <76-char base64 chunk>   (N = 0-based chunk index)
+    //   [SCREENSHOT-B64-END]
+    //
+    // 76 base64 chars = 57 input bytes per line (MIME line length, RFC 2045 §6.8).
+    // The harness `read-png` subcommand collects all M chunks, decodes, and
+    // writes the result to a host-side file.
+    {
+        const CHUNK_BYTES: usize = 57; // → 76 base64 chars per line
+        const B64_ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        // Count total chunks (ceiling division).
+        let total_chunks = (read_back.len() + CHUNK_BYTES - 1) / CHUNK_BYTES;
+        // Handle the degenerate empty-PNG case gracefully (shouldn't happen
+        // given we verified the signature, but avoid a 0-total edge case).
+        let total_chunks = if total_chunks == 0 { 1 } else { total_chunks };
+
+        for chunk_idx in 0..total_chunks {
+            let start = chunk_idx * CHUNK_BYTES;
+            let end   = (start + CHUNK_BYTES).min(read_back.len());
+            let src   = &read_back[start..end];
+
+            // Encode `src` to a fixed-size stack buffer.
+            // Max encoded length: ceil(57 / 3) * 4 = 76 bytes.
+            let mut enc = [0u8; 76];
+            let mut enc_len = 0usize;
+
+            let mut i = 0;
+            while i + 2 < src.len() {
+                let b0 = src[i] as usize;
+                let b1 = src[i + 1] as usize;
+                let b2 = src[i + 2] as usize;
+                enc[enc_len]     = B64_ALPHABET[(b0 >> 2)                           ];
+                enc[enc_len + 1] = B64_ALPHABET[((b0 & 0x3) << 4) | (b1 >> 4)      ];
+                enc[enc_len + 2] = B64_ALPHABET[((b1 & 0xf) << 2) | (b2 >> 6)      ];
+                enc[enc_len + 3] = B64_ALPHABET[ b2 & 0x3f                          ];
+                enc_len += 4;
+                i += 3;
+            }
+            // Remaining 1 or 2 bytes + padding.
+            if i < src.len() {
+                let b0 = src[i] as usize;
+                let b1 = if i + 1 < src.len() { src[i + 1] as usize } else { 0 };
+                enc[enc_len]     = B64_ALPHABET[(b0 >> 2)                      ];
+                enc[enc_len + 1] = B64_ALPHABET[((b0 & 0x3) << 4) | (b1 >> 4) ];
+                enc[enc_len + 2] = if i + 1 < src.len() {
+                    B64_ALPHABET[(b1 & 0xf) << 2]
+                } else {
+                    b'='
+                };
+                enc[enc_len + 3] = b'=';
+                enc_len += 4;
+            }
+
+            // SAFETY: enc contains only ASCII bytes from B64_ALPHABET / b'='.
+            let enc_str = core::str::from_utf8(&enc[..enc_len])
+                .unwrap_or("(b64-encode-error)");
+
+            test_println!(
+                "[SCREENSHOT-B64:{}/{}] {}",
+                chunk_idx, total_chunks, enc_str
+            );
+        }
+
+        test_println!("[SCREENSHOT-B64-END]");
+    }
+
     test_pass!("GDI PNG screenshot — render shapes + encode PNG headlessly");
     true
 }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -23,6 +23,7 @@ Tier 1 — session management:
     python3 scripts/qemu-harness.py snap <sid> save|load <name>
     python3 scripts/qemu-harness.py prune [--ttl DAYS]
     python3 scripts/qemu-harness.py results <sid>
+    python3 scripts/qemu-harness.py read-png <sid> <dst.png> [--timeout-ms MS]
 
 Tier 2 — GDB stub integration (requires --gdb-port on start):
     python3 scripts/qemu-harness.py regs <sid>
@@ -2584,6 +2585,163 @@ _FF_EXIT_TICKS_RE = re.compile(r"\[FFTEST\]\s+Firefox exited after\s+(\d+)\s+tic
 _FF_EXIT_CODE_RE  = re.compile(r"\[FFTEST\]\s+Firefox exit code[:= ]+(-?\d+)")
 _TICK_RE          = re.compile(r"tick[=:\s]+(\d+)")
 
+# [SC] full-line regex — includes cr= a4= a5= a6= which _SC_ENTRY_RE omits.
+_SC_FULL_RE = re.compile(
+    r"\[SC\]\s+pid=(\d+)\s+tid=(\d+)\s+nr=(\d+)\s+rip=(0x[0-9a-fA-F]+)"
+)
+# [SC-RET] regex
+_SC_RET_FULL_RE = re.compile(
+    r"\[SC-RET\]\s+pid=(\d+)\s+tid=(\d+)\s+nr=(\d+)\s+ret=(-?\d+|0x[0-9a-fA-F]+)"
+)
+
+# Linux syscall number → name table (x86_64, abbreviated to the set Firefox uses).
+_NR_NAME = {
+    0: "read", 1: "write", 2: "open", 3: "close", 4: "stat", 5: "fstat",
+    6: "lstat", 7: "poll", 8: "lseek", 9: "mmap", 10: "mprotect",
+    11: "munmap", 12: "brk", 13: "rt_sigaction", 14: "rt_sigprocmask",
+    15: "rt_sigreturn", 16: "ioctl", 17: "pread64", 18: "pwrite64",
+    19: "readv", 20: "writev", 21: "access", 22: "pipe", 23: "select",
+    24: "sched_yield", 25: "mremap", 26: "msync", 28: "madvise",
+    29: "shmget", 30: "shmat", 31: "shmctl", 32: "dup", 33: "dup2",
+    34: "pause", 35: "nanosleep", 36: "getitimer", 37: "alarm",
+    38: "setitimer", 39: "getpid", 41: "socket", 42: "connect",
+    43: "accept", 44: "sendto", 45: "recvfrom", 46: "sendmsg",
+    47: "recvmsg", 48: "shutdown", 49: "bind", 50: "listen",
+    51: "getsockname", 52: "getpeername", 53: "socketpair",
+    54: "setsockopt", 55: "getsockopt", 56: "clone",
+    57: "fork", 58: "vfork", 59: "execve", 60: "exit",
+    61: "wait4", 62: "kill", 63: "uname", 72: "fcntl", 73: "flock",
+    74: "fsync", 75: "fdatasync", 76: "truncate", 77: "ftruncate",
+    78: "getdents", 79: "getcwd", 80: "chdir", 81: "fchdir",
+    83: "mkdir", 84: "rmdir", 85: "creat", 86: "link", 87: "unlink",
+    88: "symlink", 89: "readlink", 90: "chmod", 91: "fchmod",
+    97: "getrlimit", 98: "getrusage", 99: "sysinfo", 100: "times",
+    102: "getuid", 104: "getgid", 105: "setuid", 106: "setgid",
+    107: "geteuid", 108: "getegid", 110: "getppid", 111: "getpgrp",
+    112: "setsid", 158: "arch_prctl", 160: "setrlimit",
+    186: "gettid", 201: "time", 202: "futex",
+    218: "set_tid_address", 228: "clock_gettime", 229: "clock_getres",
+    230: "clock_nanosleep", 231: "exit_group", 232: "epoll_wait",
+    233: "epoll_ctl", 234: "tgkill", 257: "openat", 262: "newfstatat",
+    273: "set_robust_list", 302: "prlimit64", 318: "getrandom",
+    319: "memfd_create", 334: "rseq", 435: "clone3",
+}
+
+
+def _nr_to_name(nr: int) -> str:
+    return _NR_NAME.get(nr, f"nr{nr}")
+
+
+def cmd_sc_histogram(args):
+    """Scan [SC] trace lines from the serial log; produce a per-tid syscall
+    count histogram plus a global top-N sorted by call frequency.
+
+    Also scans [SC-RET] lines to identify syscalls that return errors
+    (negative return values) which may indicate ABI divergence from Linux.
+
+    Output schema:
+      {
+        "total_sc_lines": <int>,
+        "tids_seen": [<tid>, ...],
+        "global_top": [{"name": str, "nr": int, "count": int}, ...],
+        "per_tid": {
+          "<tid>": {
+            "total": <int>,
+            "top": [{"name": str, "nr": int, "count": int}, ...]
+          }
+        },
+        "error_returns": [{"name": str, "nr": int, "ret": str, "count": int}, ...],
+      }
+    """
+    sess = _load_session(args.sid)
+    serial_log = sess["serial_log"]
+    filter_tid = args.tid
+    top_n = max(1, int(args.top))
+    since_line = args.since_line
+
+    # Per-tid: {tid: {nr: count}}
+    per_tid: dict[int, dict[int, int]] = {}
+    # Global: {nr: count}
+    global_hist: dict[int, int] = {}
+    # Error returns: {(tid, nr): {ret_str: count}}
+    error_hist: dict[tuple, dict[str, int]] = {}
+
+    total_sc = 0
+    line_no = 0
+
+    try:
+        with Path(serial_log).open("r", errors="replace") as fh:
+            for ln in fh:
+                line_no += 1
+                if since_line is not None and line_no < since_line:
+                    continue
+                # [SC] entry lines
+                m = _SC_FULL_RE.search(ln)
+                if m:
+                    tid = int(m.group(2))
+                    nr  = int(m.group(3))
+                    if filter_tid is not None and tid != filter_tid:
+                        continue
+                    total_sc += 1
+                    per_tid.setdefault(tid, {})
+                    per_tid[tid][nr] = per_tid[tid].get(nr, 0) + 1
+                    global_hist[nr] = global_hist.get(nr, 0) + 1
+                    continue
+                # [SC-RET] lines — track negative returns as errors
+                m = _SC_RET_FULL_RE.search(ln)
+                if m:
+                    tid = int(m.group(2))
+                    nr  = int(m.group(3))
+                    if filter_tid is not None and tid != filter_tid:
+                        continue
+                    ret_s = m.group(4)
+                    try:
+                        ret_v = int(ret_s, 0)
+                    except ValueError:
+                        continue
+                    # Only track negative returns (errors) or interesting values
+                    if ret_v < 0 or (nr == 202 and ret_v == 11):  # 202=futex, EAGAIN=11
+                        key = (tid, nr)
+                        error_hist.setdefault(key, {})
+                        error_hist[key][ret_s] = error_hist[key].get(ret_s, 0) + 1
+    except OSError as e:
+        _err(f"Cannot read serial log: {e}")
+
+    # Build global top-N
+    global_top = sorted(
+        [{"name": _nr_to_name(nr), "nr": nr, "count": c}
+         for nr, c in global_hist.items()],
+        key=lambda x: -x["count"]
+    )[:top_n]
+
+    # Build per-tid top-N
+    per_tid_out = {}
+    for tid, hist in sorted(per_tid.items()):
+        top = sorted(
+            [{"name": _nr_to_name(nr), "nr": nr, "count": c}
+             for nr, c in hist.items()],
+            key=lambda x: -x["count"]
+        )[:top_n]
+        per_tid_out[str(tid)] = {"total": sum(hist.values()), "top": top}
+
+    # Flatten error histogram
+    error_list = []
+    for (tid, nr), ret_counts in sorted(error_hist.items()):
+        for ret_s, count in sorted(ret_counts.items(), key=lambda kv: -kv[1]):
+            error_list.append({
+                "tid": tid, "name": _nr_to_name(nr), "nr": nr,
+                "ret": ret_s, "count": count
+            })
+    error_list.sort(key=lambda x: -x["count"])
+
+    _out({
+        "total_sc_lines": total_sc,
+        "tids_seen": sorted(per_tid.keys()),
+        "global_top": global_top,
+        "per_tid": per_tid_out,
+        "error_returns": error_list[:50],
+    })
+
 
 def cmd_results(args):
     """
@@ -3772,6 +3930,195 @@ def cmd_wake_attempts(args):
     })
 
 
+# ══════════════════════════════════════════════════════════════════════════════
+# read-png — extract a PNG screenshot from the guest via serial base64
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Protocol emitted by the kernel's test_gdi_png_screenshot (Test 198):
+#
+#   [SCREENSHOT-B64:N/M] <76-char base64 chunk>   (N = 0-based index, M = total)
+#   [SCREENSHOT-B64-END]
+#
+# This subcommand:
+#   1. Waits for the first [SCREENSHOT-B64:0/M] line (up to --timeout-ms).
+#   2. Scans the serial log for all M chunks (0..M-1) in order.
+#   3. Validates the chunk count matches M.
+#   4. Decodes the concatenated base64 (RFC 4648 §4) and writes to <dst>.
+#   5. Verifies the PNG signature (8-byte magic, W3C PNG §5.2).
+#   6. Prints JSON: {"ok": true, "path": dst, "bytes": N, "chunks": M}
+#      or {"ok": false, "error": "...", ...} on failure.
+#
+# Output is additive to the existing [SCREENSHOT] summary line — Test 198
+# continues to PASS regardless of whether read-png was waiting.
+
+_B64_FIRST_RE = re.compile(
+    r"\[SCREENSHOT-B64:0/(\d+)\]\s+([A-Za-z0-9+/=]+)"
+)
+_B64_CHUNK_RE = re.compile(
+    r"\[SCREENSHOT-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"
+)
+_B64_END_RE = re.compile(r"\[SCREENSHOT-B64-END\]")
+
+_PNG_SIGNATURE = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+
+def cmd_read_png(args):
+    """
+    Collect base64-encoded PNG chunks from the serial log and write to <dst>.
+
+    Waits for the first [SCREENSHOT-B64:0/M] line, then scans for all M chunks,
+    decodes, verifies the PNG signature, and writes to args.dst.
+    """
+    import base64
+
+    sess       = _load_session(args.sid)
+    serial_log = sess["serial_log"]
+    dst        = args.dst
+    timeout_ms = args.timeout_ms
+
+    # ── 1. Wait for the first chunk (index 0) ─────────────────────────────────
+    deadline = time.monotonic() + timeout_ms / 1000.0
+    total_chunks: Optional[int] = None
+    first_chunk: Optional[str]  = None
+    file_pos = 0
+
+    while time.monotonic() < deadline:
+        try:
+            with open(serial_log, "r", errors="replace") as fh:
+                fh.seek(file_pos)
+                chunk = fh.read(131072)
+        except OSError:
+            time.sleep(0.1)
+            continue
+
+        if chunk:
+            for ln in chunk.splitlines():
+                m = _B64_FIRST_RE.search(ln)
+                if m:
+                    total_chunks = int(m.group(1))
+                    first_chunk  = m.group(2)
+                    break
+            file_pos += len(chunk.encode("utf-8", errors="replace"))
+
+        if first_chunk is not None:
+            break
+
+        # Check if QEMU has already exited (no point waiting further).
+        pid = sess.get("pid", 0)
+        if pid and not _pid_alive(pid):
+            break
+
+        time.sleep(0.1)
+
+    if first_chunk is None or total_chunks is None:
+        _err(f"read-png: timed out waiting for [SCREENSHOT-B64:0/M] "
+             f"(waited {timeout_ms} ms). Is the session running test-mode?")
+
+    # ── 2. Collect all M chunks from the serial log ───────────────────────────
+    # We have chunk 0 already. Scan the full log for chunks 0..M-1 in case
+    # some arrived before we started (serial log is append-only; we can always
+    # re-scan from the beginning).
+    chunks: dict[int, str] = {0: first_chunk}
+
+    # Allow extra time for the remaining chunks (the PNG is ~77 KB → ~1370 lines
+    # at 115200 baud ≈ 10 s; we give 2× margin).
+    collect_deadline = time.monotonic() + 30.0
+
+    while len(chunks) < total_chunks and time.monotonic() < collect_deadline:
+        try:
+            with open(serial_log, "r", errors="replace") as fh:
+                for ln in fh:
+                    m = _B64_CHUNK_RE.search(ln)
+                    if m:
+                        idx = int(m.group(1))
+                        tot = int(m.group(2))
+                        b64 = m.group(3)
+                        if tot == total_chunks and idx < total_chunks:
+                            chunks[idx] = b64
+        except OSError:
+            pass
+
+        if len(chunks) < total_chunks:
+            # Still missing some chunks — wait briefly and rescan.
+            pid = sess.get("pid", 0)
+            if pid and not _pid_alive(pid):
+                # QEMU exited; do one final rescan below.
+                break
+            time.sleep(0.2)
+
+    # Final rescan after QEMU may have exited.
+    if len(chunks) < total_chunks:
+        try:
+            with open(serial_log, "r", errors="replace") as fh:
+                for ln in fh:
+                    m = _B64_CHUNK_RE.search(ln)
+                    if m:
+                        idx = int(m.group(1))
+                        tot = int(m.group(2))
+                        b64 = m.group(3)
+                        if tot == total_chunks and idx < total_chunks:
+                            chunks[idx] = b64
+        except OSError:
+            pass
+
+    # ── 3. Validate chunk count ────────────────────────────────────────────────
+    missing = [i for i in range(total_chunks) if i not in chunks]
+    if missing:
+        _out({
+            "ok":          False,
+            "error":       "missing_chunks",
+            "total":       total_chunks,
+            "received":    len(chunks),
+            "missing":     missing[:20],
+        })
+        sys.exit(1)
+
+    # ── 4. Decode base64 ─────────────────────────────────────────────────────
+    b64_concat = "".join(chunks[i] for i in range(total_chunks))
+    try:
+        png_bytes = base64.b64decode(b64_concat, validate=True)
+    except Exception as exc:
+        _out({
+            "ok":    False,
+            "error": f"base64_decode_failed: {exc}",
+            "chunks": total_chunks,
+        })
+        sys.exit(1)
+
+    # ── 5. Verify PNG signature ────────────────────────────────────────────────
+    if len(png_bytes) < 8 or png_bytes[:8] != _PNG_SIGNATURE:
+        got = png_bytes[:8].hex() if len(png_bytes) >= 8 else png_bytes.hex()
+        _out({
+            "ok":    False,
+            "error": "png_signature_mismatch",
+            "got":   got,
+            "expected": _PNG_SIGNATURE.hex(),
+            "chunks": total_chunks,
+            "bytes":  len(png_bytes),
+        })
+        sys.exit(1)
+
+    # ── 6. Write to dst ───────────────────────────────────────────────────────
+    dst_path = Path(dst)
+    try:
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        dst_path.write_bytes(png_bytes)
+    except OSError as exc:
+        _out({
+            "ok":    False,
+            "error": f"write_failed: {exc}",
+            "path":  dst,
+        })
+        sys.exit(1)
+
+    _out({
+        "ok":     True,
+        "path":   str(dst_path.resolve()),
+        "bytes":  len(png_bytes),
+        "chunks": total_chunks,
+    })
+
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 def main():
@@ -4084,6 +4431,38 @@ def main():
                           help="Disk staging root for symbol lookup "
                                "(see `ustack --disk-root`)")
 
+    # sc-histogram — syscall count histogram from [SC] trace lines
+    p_schist = sub.add_parser(
+        "sc-histogram",
+        help="Parse [SC] trace lines from serial log; produce per-tid syscall "
+             "count histogram and total call counts sorted by frequency. "
+             "Requires --features syscall-trace at start."
+    )
+    p_schist.add_argument("sid")
+    p_schist.add_argument("--tid", type=int, default=None,
+                          help="Restrict to a single TID (default: all tids)")
+    p_schist.add_argument("--top", type=int, default=20,
+                          help="Report the top N syscalls by count (default 20)")
+    p_schist.add_argument("--since-line", type=int, default=None, dest="since_line",
+                          help="Skip serial log lines before this line number "
+                               "(useful to restrict to post-plateau window)")
+
+    # read-png — extract the guest PNG screenshot to a host-side file
+    p_read_png = sub.add_parser(
+        "read-png",
+        help="Collect base64-encoded PNG from the serial log (Test 198 emits "
+             "[SCREENSHOT-B64:N/M] lines) and write to <dst.png>.  "
+             "Verifies the PNG signature before writing.  "
+             "Example: read-png <sid> /tmp/extracted.png"
+    )
+    p_read_png.add_argument("sid")
+    p_read_png.add_argument("dst", help="Host-side destination path for the PNG file")
+    p_read_png.add_argument(
+        "--timeout-ms", type=int, default=120000, dest="timeout_ms",
+        help="Milliseconds to wait for the first [SCREENSHOT-B64:0/M] line "
+             "(default 120000 = 2 min, covers build + boot + test run)"
+    )
+
     # _watch: private subcommand used internally by `start` to run the
     # background watcher in a detached process. Not shown in help.
     p_watch = sub.add_parser("_watch")
@@ -4122,11 +4501,13 @@ def main():
         "parked-tids": cmd_parked_tids,
         "parked-stacks": cmd_parked_stacks,
         "wake-attempts": cmd_wake_attempts,
+        "sc-histogram": cmd_sc_histogram,
         "rip-sample": cmd_rip_sample,
         "qmp-regs": cmd_qmp_regs,
         "qmp-xv":   cmd_qmp_xv,
         "qmp-xp":   cmd_qmp_xp,
         "rip-walk": cmd_rip_walk,
+        "read-png": cmd_read_png,
         "_watch":  cmd_run_watcher,
     }
     dispatch[args.cmd](args)


### PR DESCRIPTION
## Summary

- Adds a pure-Rust base64 encoder (~40 LOC) to `test_gdi_png_screenshot` (Test 198) that emits the guest PNG over the serial console as `[SCREENSHOT-B64:N/M] <chunk>` lines after the existing `[SCREENSHOT]` summary line.
- Adds `read-png <sid> <dst.png>` to `scripts/qemu-harness.py` (~150 LOC): collects the base64 chunks from the serial log, decodes them, verifies the PNG signature, and writes a viewable PNG to the host filesystem.
- Closes the demo deliverable end-to-end: a human can now run `read-png` after a test session and get a real PNG produced headlessly inside AstryxOS.

## Protocol

After Test 198 writes `/tmp/screenshot.png` in the guest, it encodes the PNG bytes using RFC 4648 §4 base64 and emits 1351 lines at 76 chars each (57 bytes/line per RFC 2045 §6.8 MIME convention):

```
[SCREENSHOT-B64:0/1351] iVBORw0KGgoAAAAN...
[SCREENSHOT-B64:1/1351] ...
...
[SCREENSHOT-B64-END]
```

## `read-png` usage

```
python3 scripts/qemu-harness.py read-png <sid> /tmp/extracted.png
{"ok": true, "path": "/tmp/extracted.png", "bytes": 76993, "chunks": 1351}
```

On error, the subcommand exits non-zero with structured JSON:

```json
{"ok": false, "error": "missing_chunks", "total": 1351, "received": 1348, "missing": [12, 347, 1100]}
```

## Test plan

- [x] Build with `--features test-mode,ci-skip-test-104` — compiles with zero new errors
- [x] `python3 scripts/qemu-harness.py wait <sid> '\[SCREENSHOT-B64-END\]' --ms 300000` — matched at line 4112
- [x] `python3 scripts/qemu-harness.py read-png <sid> /tmp/extracted.png` — `{"ok": true, "path": "/tmp/extracted.png", "bytes": 76993, "chunks": 1351}`
- [x] `file /tmp/extracted.png` — `PNG image data, 160 x 120, 8-bit/color RGBA, non-interlaced`
- [x] PNG signature verified: `89 50 4E 47 0D 0A 1A 0A`
- [x] Test 198 result: `PASS` with `elapsed_ticks=1911` (124 total tests in this session)
- [x] Existing `[SCREENSHOT]` summary line still emitted and Test 198 still passes without `read-png` running

## Notes

- The base64 emission is always-on in test-mode (no feature flag). Adding a gate would save ~10 s of serial I/O on builds where `read-png` is not used, but costs LOC and complexity. The test runner already controls when Test 198 runs.
- Harness field names are additive only (`ok`, `path`, `bytes`, `chunks`); no existing fields renamed.
- The kernel encoder is pure no_std Rust with no new Cargo dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)