### PR TITLE
scripts/qemu-harness: --cpu MODEL override for start subcommand

### DIFF
--- a/scripts/astryx_qemu.py
+++ b/scripts/astryx_qemu.py
@@ -88,7 +88,7 @@ def _detect_kvm() -> bool:
 
 # ── Block assemblers ──────────────────────────────────────────────────────────
 
-def _cpu_args(mode: str, kvm: bool) -> list[str]:
+def _cpu_args(mode: str, kvm: bool, cpu_override: Optional[str] = None) -> list[str]:
     """
     CPU model. Under KVM we prefer `host` because that matches what a
     real-hardware boot would encounter — critical for Firefox and any
@@ -102,7 +102,13 @@ def _cpu_args(mode: str, kvm: bool) -> list[str]:
     firefox-test forces `-cpu host` because its perf target is
     unreachable under TCG; if KVM is absent the run will be slow but
     correct.
+
+    `cpu_override` (if set) bypasses every other rule and passes
+    `-cpu <value>` verbatim. Used by perf investigations that need to
+    sweep CPU models (e.g. `-cpu max`, `-cpu Cascadelake-Server`).
     """
+    if cpu_override:
+        return ["-cpu", cpu_override]
     if mode == "firefox-test":
         return ["-cpu", "host"]
     if kvm:
@@ -232,6 +238,7 @@ def build_qemu_cmd(
     kvm: Optional[bool] = None,
     show_window: bool = False,
     extra_args: Optional[list[str]] = None,
+    cpu_override: Optional[str] = None,
 ) -> list[str]:
     """
     Return the full argv for `qemu-system-x86_64` for an AstryxOS test run.
@@ -275,7 +282,7 @@ def build_qemu_cmd(
 
     cmd: list[str] = ["qemu-system-x86_64"]
     cmd += _machine_args()
-    cmd += _cpu_args(mode, kvm)
+    cmd += _cpu_args(mode, kvm, cpu_override)
     cmd += _memory_args(mode)
     cmd += _smp_args()
     cmd += _serial_args(serial_path)

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -769,7 +769,8 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
                           gdb_wait: bool = False,
                           kdb_host_port: int = 0,
                           kvm: Optional[bool] = None,
-                          smp: int = 2) -> subprocess.Popen:
+                          smp: int = 2,
+                          cpu_model: Optional[str] = None) -> subprocess.Popen:
     """
     Launch QEMU with a per-session serial log and QMP socket.
 
@@ -812,6 +813,7 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
         gdb_port=gdb_port if gdb_port and gdb_port > 0 else None,
         gdb_wait=gdb_wait,
         kvm=kvm,
+        cpu_override=cpu_model,
     )
 
     # Override -smp count if caller asked for non-default. astryx_qemu.py
@@ -887,11 +889,13 @@ def cmd_start(args):
     else:
         kvm_arg = None  # autodetect
     smp = int(getattr(args, "smp", 2) or 2)
+    cpu_model = getattr(args, "cpu_model", None)
     proc = _launch_qemu_harness(sid, serial_log, qmp_sock, ovmf_vars,
                                  gdb_port=gdb_port, gdb_wait=gdb_wait,
                                  kdb_host_port=kdb_host_port,
                                  kvm=kvm_arg,
-                                 smp=smp)
+                                 smp=smp,
+                                 cpu_model=cpu_model)
 
     session = {
         "sid":        sid,
@@ -905,6 +909,7 @@ def cmd_start(args):
         "gdb_wait":   gdb_wait,
         "kdb_host_port": kdb_host_port,
         "smp":         smp,
+        "cpu_model":   cpu_model or "default",
         "breakpoints": [],
     }
     _save_session(session)
@@ -4153,6 +4158,13 @@ def main():
                           help="Number of QEMU vCPUs (default 2). Plan-C "
                                "experiment uses 16 to test Mozilla "
                                "nsThreadPool sizing under wider _SC_NPROCESSORS_ONLN.")
+    p_start.add_argument("--cpu", dest="cpu_model", default=None, metavar="MODEL",
+                          help="Override QEMU -cpu model verbatim (e.g. 'host', "
+                               "'max', 'Cascadelake-Server', 'EPYC-Genoa-v1', "
+                               "'qemu64'). When unset, astryx_qemu.py picks: "
+                               "'host' under KVM, otherwise "
+                               "'qemu64,+rdtscp,+ssse3,+sse4_1,+sse4_2'. Used "
+                               "by perf sweeps to vary VMEXIT surface.")
 
     # stop
     p_stop = sub.add_parser("stop", help="Kill a QEMU session")


### PR DESCRIPTION
## Summary

Adds `--cpu MODEL` to the `start` subcommand of `scripts/qemu-harness.py`. When set, passes `-cpu <model>` verbatim to QEMU, bypassing the existing KVM/build-mode heuristics.

## Motivation

Used during the Window 6 W1 libxul-perf investigation to sweep across `-cpu host`, `-cpu max`, and `-cpu Cascadelake-Server` while measuring Firefox plateau wall-time. Useful for any future kernel perf sweep across QEMU CPU models without changing the build mode or KVM setting.

## Changes

- `scripts/astryx_qemu.py`: `_cpu_args()` gains `cpu_override` kwarg; `build_qemu_cmd()` threads it through.
- `scripts/qemu-harness.py`: `start` subcommand accepts `--cpu` argparse flag; session state captures `cpu_model` for replay.

## Test plan

- [x] `python3 scripts/qemu-harness.py start --cpu host --features test-mode,kdb,ci-skip-test-104` boots correctly.
- [x] Same with `--cpu max` and `--cpu Cascadelake-Server`.
- [x] Default behaviour (no `--cpu` arg) unchanged.