### PR TITLE
kernel: TSC-precise vDSO clock_gettime + lockless current_pid (TSC-VDSO + PID-CACHE)

### DIFF
--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -105,12 +105,26 @@ pub const TICK_HZ: u64 = 100;
 /// Record the TSC frequency the BSP measured during LAPIC calibration so
 /// `timer_tick` can derive a wall-locked `TICK_COUNT`.  Must be called
 /// once on the BSP after `calibrate_lapic_timer` completes.
+///
+/// Also publishes the calibration into the vDSO vvar page so userspace
+/// `__vdso_clock_gettime` can compute TSC-precise ns without entering
+/// the kernel.  Prior implementations published only `TICK_COUNT` (10 ms
+/// quantum), which silently coarsened every Mozilla/glibc TimeStamp
+/// reading by ~10000× — see `vdso.S` for the user-side formula.
 pub fn set_tsc_calibration(tsc_per_10ms: u64) {
     if tsc_per_10ms == 0 { return; }
+    let now_tsc = rdtsc();
     let _ = TSC_AT_BOOT.compare_exchange(
-        0, rdtsc(), Ordering::AcqRel, Ordering::Relaxed);
+        0, now_tsc, Ordering::AcqRel, Ordering::Relaxed);
     let _ = TSC_PER_TICK.compare_exchange(
         0, tsc_per_10ms, Ordering::AcqRel, Ordering::Relaxed);
+    // Mirror the calibration into the vvar page so userspace reads the
+    // same epoch the in-kernel monotonic path uses.  Order of operations
+    // matters: the atomics above MUST be populated first so any concurrent
+    // in-kernel `vdso::monotonic_ns()` call sees a consistent pair.
+    let tsc_at_boot  = TSC_AT_BOOT.load(Ordering::Acquire);
+    let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
+    crate::proc::vdso::publish_tsc_calibration(tsc_at_boot, tsc_per_tick);
 }
 
 /// Keyboard scancode buffer (simple ring buffer).

--- a/kernel/src/proc/vdso.rs
+++ b/kernel/src/proc/vdso.rs
@@ -102,10 +102,24 @@ pub const AT_SYSINFO_EHDR: u64 = 33;
 
 /// vvar field offsets (must match the absolute symbol values produced
 /// by `kernel/vdso/vdso.lds`).
-const VVAR_OFF_SEQ:        usize = 0x00; // u32
-const VVAR_OFF_TICK_HZ:    usize = 0x04; // u32
-const VVAR_OFF_TICKS:      usize = 0x08; // u64
-const VVAR_OFF_WALL_SECS:  usize = 0x10; // u64
+const VVAR_OFF_SEQ:            usize = 0x00; // u32
+const VVAR_OFF_TICK_HZ:        usize = 0x04; // u32
+const VVAR_OFF_TICKS:          usize = 0x08; // u64
+const VVAR_OFF_WALL_SECS:      usize = 0x10; // u64
+/// TSC value captured at calibration time.  vDSO subtracts this from a
+/// runtime `rdtsc` to get a monotonic cycle delta.  Set once by
+/// [`publish_tsc_calibration`] right after LAPIC calibration completes.
+const VVAR_OFF_TSC_AT_BOOT:    usize = 0x18; // u64
+/// Mul-shift pair so that `ns = (tsc_delta * mult) >> shift` matches
+/// the host TSC frequency.  The pair is precomputed once at calibration
+/// time; vDSO performs the multiply in 128 bits via `mulq` + `shrd`
+/// to retain full precision over multi-day uptimes.
+const VVAR_OFF_TSC_NS_MULT:    usize = 0x20; // u64
+const VVAR_OFF_TSC_NS_SHIFT:   usize = 0x28; // u32 (only low byte used)
+/// TSC cycles per 10 ms tick — kept available so an in-kernel CLOCK_*
+/// path can derive the same ns value the vDSO computes, and so a future
+/// CLOCK_*_COARSE fast path can use it without re-deriving.
+const VVAR_OFF_TSC_PER_TICK:   usize = 0x30; // u64
 
 /// Physical address of the kernel-allocated, globally-shared vvar page.
 /// Set once by [`init`].
@@ -188,6 +202,17 @@ pub fn init() {
     }
     VDSO_PHYS.store(vdso_phys, Ordering::Relaxed);
 
+    // If TSC calibration was already published before vvar existed (this
+    // happens whenever apic::init() races vdso::init() on the BSP), mirror
+    // the in-kernel atomics into the freshly allocated vvar page so the
+    // first userspace clock_gettime read uses a real epoch instead of
+    // tripping the `mult == 0` fallback.
+    let tsc_at_boot  = crate::arch::x86_64::irq::TSC_AT_BOOT.load(Ordering::Acquire);
+    let tsc_per_tick = crate::arch::x86_64::irq::TSC_PER_TICK.load(Ordering::Acquire);
+    if tsc_per_tick != 0 {
+        publish_tsc_calibration(tsc_at_boot, tsc_per_tick);
+    }
+
     crate::serial_println!(
         "[vDSO] init: vvar_phys={:#x} vdso_phys={:#x} elf={} bytes wall_secs={}",
         vvar_phys, vdso_phys, VDSO_IMAGE.len(),
@@ -263,6 +288,115 @@ pub fn map_vdso(cr3: u64, vmas: &mut Vec<VmArea>) -> Option<u64> {
     });
 
     Some(VDSO_ELF_BASE)
+}
+
+/// Shift used when packing the TSC-to-ns reciprocal into a (mult, shift)
+/// pair.  32 is a safe balance for x86_64 TSCs in the 1 GHz–10 GHz range:
+///
+///   mult = (1u128 << 32) * 1_000_000_000 / tsc_freq_hz
+///
+/// fits comfortably in u64 (≈1.4 × 10^9 for a 3 GHz TSC), and the
+/// 128-bit `delta * mult` headroom covers years of uptime before the
+/// product overflows the 128-bit accumulator.
+pub const TSC_NS_SHIFT: u32 = 32;
+
+/// Compute the mul-shift pair for an arbitrary TSC frequency.
+///
+/// `ns = (tsc_delta * mult) >> shift` where `shift = TSC_NS_SHIFT`.
+/// `tsc_freq_hz` must be non-zero; the caller has already validated
+/// calibration before reaching this path.
+#[inline]
+fn tsc_to_ns_mult(tsc_freq_hz: u64) -> u64 {
+    if tsc_freq_hz == 0 {
+        return 0;
+    }
+    // 128-bit numerator avoids precision loss; the divide-by-tsc_freq
+    // then fits the result in u64 for any TSC > ~250 MHz.
+    let num: u128 = (1u128 << TSC_NS_SHIFT) * 1_000_000_000u128;
+    (num / tsc_freq_hz as u128) as u64
+}
+
+/// Publish the TSC calibration into the vvar page.
+///
+/// Called once from the LAPIC calibration path on the BSP after
+/// `crate::arch::x86_64::irq::set_tsc_calibration` has populated the
+/// in-kernel atomics.  The vvar fields are seqlock-guarded for
+/// consistency with `vvar_tick`, but in practice this is a one-shot
+/// boot-time write: by the time userspace can observe vvar fields,
+/// AT_SYSINFO_EHDR has not yet been handed to any user process.
+///
+/// `tsc_at_boot` is the canonical "TSC == 0 ns since boot" reference;
+/// every CLOCK_MONOTONIC or CLOCK_REALTIME read derives ns by
+/// `(rdtsc - tsc_at_boot) * mult >> shift`.
+pub fn publish_tsc_calibration(tsc_at_boot: u64, tsc_per_tick: u64) {
+    let phys = VVAR_PHYS.load(Ordering::Relaxed);
+    if phys == 0 || tsc_per_tick == 0 {
+        return;
+    }
+    let tsc_freq_hz = tsc_per_tick.saturating_mul(crate::arch::x86_64::irq::TICK_HZ);
+    let mult = tsc_to_ns_mult(tsc_freq_hz);
+
+    unsafe {
+        let p = phys_to_virt(phys);
+        let seq = &*(p.add(VVAR_OFF_SEQ) as *const AtomicU32);
+        let cur = seq.load(Ordering::Relaxed);
+        // Bump seq to odd → readers retry → write fields → bump seq to even.
+        seq.store(cur.wrapping_add(1), Ordering::Release);
+        write_u64(p, VVAR_OFF_TSC_AT_BOOT,  tsc_at_boot);
+        write_u64(p, VVAR_OFF_TSC_NS_MULT,  mult);
+        write_u32(p, VVAR_OFF_TSC_NS_SHIFT, TSC_NS_SHIFT);
+        write_u64(p, VVAR_OFF_TSC_PER_TICK, tsc_per_tick);
+        seq.store(cur.wrapping_add(2), Ordering::Release);
+    }
+
+    crate::serial_println!(
+        "[vDSO] tsc-calibration published: tsc_at_boot={:#x} tsc_per_tick={} \
+         tsc_freq_hz={} ns_mult={} ns_shift={}",
+        tsc_at_boot, tsc_per_tick, tsc_freq_hz, mult, TSC_NS_SHIFT,
+    );
+}
+
+/// Compute monotonic nanoseconds since boot using the published TSC
+/// calibration — same formula as the vDSO fast path.
+///
+/// Returns 0 if calibration has not been published yet (extremely
+/// early boot before `apic::init`).  All in-kernel CLOCK_MONOTONIC /
+/// CLOCK_REALTIME paths should call this so the kernel and the vDSO
+/// agree to the cycle, eliminating spurious ETIMEDOUT from
+/// FUTEX_WAIT_BITSET deadlines computed from a vDSO read.
+#[inline]
+pub fn monotonic_ns() -> u64 {
+    let phys = VVAR_PHYS.load(Ordering::Relaxed);
+    if phys == 0 {
+        return 0;
+    }
+    // Reading at most three u64 fields plus seq; we accept transient
+    // re-reads on the (extremely rare) write window.
+    unsafe {
+        let p = phys_to_virt(phys);
+        let seq = &*(p.add(VVAR_OFF_SEQ) as *const AtomicU32);
+        loop {
+            let s1 = seq.load(Ordering::Acquire);
+            if s1 & 1 != 0 { core::hint::spin_loop(); continue; }
+            let tsc_at_boot = read_u64(p, VVAR_OFF_TSC_AT_BOOT);
+            let mult        = read_u64(p, VVAR_OFF_TSC_NS_MULT);
+            let shift       = read_u64(p, VVAR_OFF_TSC_NS_SHIFT) as u32;
+            let s2 = seq.load(Ordering::Acquire);
+            if s2 != s1 { continue; }
+            if mult == 0 { return 0; } // calibration not published
+            let now_tsc = {
+                let lo: u32; let hi: u32;
+                core::arch::asm!("rdtsc",
+                    out("eax") lo, out("edx") hi,
+                    options(nomem, nostack, preserves_flags));
+                ((hi as u64) << 32) | lo as u64
+            };
+            let delta = now_tsc.wrapping_sub(tsc_at_boot);
+            // 128-bit multiply to avoid overflow for multi-hour uptimes.
+            let prod = (delta as u128).wrapping_mul(mult as u128);
+            return (prod >> shift) as u64;
+        }
+    }
 }
 
 /// Update the vvar `ticks` field.  Called from the PIT timer ISR on every

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -4434,13 +4434,19 @@ fn sys_gettimeofday(tv: u64, _tz: u64) -> i64 {
     if tv == 0 {
         return 0;
     }
-    let ticks = crate::arch::x86_64::irq::get_ticks();
-    let secs  = crate::proc::vdso::wall_secs_at_boot()
-        .saturating_add(ticks / 100);
-    let usecs = (ticks % 100) * 10_000; // 10ms per tick → microseconds
+    // TSC-derived ns for vDSO/syscall parity; falls back to tick
+    // granularity before TSC calibration is published (pre-apic::init).
+    let mono_ns = crate::proc::vdso::monotonic_ns();
+    let (mono_secs, sub_usecs) = if mono_ns != 0 {
+        (mono_ns / 1_000_000_000, (mono_ns % 1_000_000_000) / 1000)
+    } else {
+        let ticks = crate::arch::x86_64::irq::get_ticks();
+        (ticks / 100, (ticks % 100) * 10_000)
+    };
+    let secs = crate::proc::vdso::wall_secs_at_boot().saturating_add(mono_secs);
     let buf = unsafe { core::slice::from_raw_parts_mut(tv as *mut u8, 16) };
     buf[0..8].copy_from_slice(&secs.to_le_bytes());
-    buf[8..16].copy_from_slice(&usecs.to_le_bytes());
+    buf[8..16].copy_from_slice(&sub_usecs.to_le_bytes());
     0
 }
 
@@ -5034,10 +5040,18 @@ pub fn sys_futex_linux(
             // the absolute timestamp back here; if the two formulas differ,
             // the deadline appears already-expired and ETIMEDOUT fires
             // immediately, breaking every timed wait.
-            let wall_ticks = crate::arch::x86_64::irq::get_ticks();
-            let mono_secs  = wall_ticks / 100;
-            let sub_nsecs  = (wall_ticks % 100) * 10_000_000;
-            let now_secs   = crate::proc::vdso::wall_secs_at_boot()
+            // TSC-derived ns for parity with __vdso_clock_gettime and
+            // sys_clock_gettime — if these three formulas differ, an
+            // absolute deadline computed via the vDSO can appear
+            // already-expired here and fire ETIMEDOUT immediately.
+            let mono_ns_total = crate::proc::vdso::monotonic_ns();
+            let (mono_secs, sub_nsecs) = if mono_ns_total != 0 {
+                (mono_ns_total / 1_000_000_000, mono_ns_total % 1_000_000_000)
+            } else {
+                let wall_ticks = crate::arch::x86_64::irq::get_ticks();
+                (wall_ticks / 100, (wall_ticks % 100) * 10_000_000)
+            };
+            let now_secs = crate::proc::vdso::wall_secs_at_boot()
                 .saturating_add(mono_secs);
             let now_ns = now_secs
                 .saturating_mul(1_000_000_000)

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -81,8 +81,13 @@ fn memfd_seals_add(inode: u64, new_seals: u32) -> i64 {
 // static musl-linked "hello world" (printf + file I/O + malloc).
 
 /// Check whether the current process uses the Linux syscall ABI.
+///
+/// Reads the per-CPU lockless PID first — fast path, correct whenever a
+/// user thread is currently scheduled.  Falls back to a kernel-stack-top
+/// walk (see slow path below) for the brief context-switch window when
+/// `PER_CPU_CURRENT_PID` reads as 0 but a user syscall is in flight.
 pub(crate) fn is_linux_abi() -> bool {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     if pid != 0 {
         // Fast path: PER_CPU_CURRENT_TID is correct.
         let procs = crate::proc::PROCESS_TABLE.lock();
@@ -222,7 +227,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         let caller_rip = crate::syscall::get_user_caller_rip();
         crate::serial_println!(
             "[SC] pid={} tid={} nr={} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x}",
-            crate::proc::current_pid(),
+            crate::proc::current_pid_lockless(),
             crate::proc::current_tid(),
             num,
             user_rip,
@@ -260,7 +265,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         // current bringup ordering; bump this if the boot chain grows.
         const FIRST_USERLAND_PID: u64 = 12;
 
-        let pid_now = crate::proc::current_pid();
+        let pid_now = crate::proc::current_pid_lockless();
         let tid_now = crate::proc::current_tid();
         let is_hot = matches!(num,
             96 | 228 |        // gettimeofday, clock_gettime
@@ -294,7 +299,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
 
     // ── Per-PID debug trace ───────────────────────────────────────────────────
     let trace_pid = crate::syscall::DEBUG_TRACE_PID.load(core::sync::atomic::Ordering::Relaxed);
-    let do_trace = trace_pid != 0 && crate::proc::current_pid() == trace_pid;
+    let do_trace = trace_pid != 0 && crate::proc::current_pid_lockless() == trace_pid;
     if do_trace {
         crate::serial_println!("[TRACE] pid={} sys={} a1={:#x} a2={:#x} a3={:#x}",
             trace_pid, num, arg1, arg2, arg3);
@@ -302,7 +307,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
 
     // ── Global syscall counter (used by Firefox oracle test) ─────────────────
     {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         if pid >= 1 {
             crate::syscall::FIREFOX_SYSCALL_COUNT
                 .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
@@ -315,7 +320,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     // patch the return value after the match dispatch completes.
     #[cfg(feature = "firefox-test")]
     let ring_entry_idx = {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         // Auto-track every user-process PID >= 1 that makes a Linux syscall —
         // this includes Firefox (pid 28 in the current harness run) plus any
         // children it spawns.  Enabling is idempotent.
@@ -341,7 +346,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     {
         static TRACE_N: core::sync::atomic::AtomicU64 =
             core::sync::atomic::AtomicU64::new(0);
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         if pid >= 1 {
             let n = TRACE_N.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
             if n < 10000 {
@@ -353,7 +358,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     {
         static TRACE_N: core::sync::atomic::AtomicU64 =
             core::sync::atomic::AtomicU64::new(0);
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         if pid >= 12 {
             let n = TRACE_N.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
             if n < 500 {
@@ -366,7 +371,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     // detected here instead.  This guarantees delivery within one syscall of
     // expiry, which meets POSIX requirements for non-real-time scheduling.
     {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         if pid >= 1 {
             check_and_deliver_alarm(pid);
         }
@@ -387,7 +392,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     // ── Close out the ring entry with the syscall's return value ─────────────
     #[cfg(feature = "firefox-test")]
     {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         crate::syscall::ring::end(pid, ring_entry_idx, ret);
         crate::subsys::linux::syscall_ring::clear_current_entry();
     }
@@ -401,7 +406,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     #[cfg(feature = "syscall-trace")]
     crate::serial_println!(
         "[SC-RET] pid={} tid={} nr={} ret={:#x}",
-        crate::proc::current_pid(),
+        crate::proc::current_pid_lockless(),
         crate::proc::current_tid(),
         num,
         ret as u64,
@@ -425,7 +430,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 3: close(fd)
         3 => {
             let fd = arg1 as usize;
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             // If it's a unix socket fd, close the underlying unix socket.
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
@@ -511,11 +516,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             0
         }
         // 39: getpid
-        39 => crate::proc::current_pid() as i64,
+        39 => crate::proc::current_pid_lockless() as i64,
         // 7: poll(fds, nfds, timeout) — wait for events on fds
         7 => {
             let nfds = arg2 as i64;
-            let pid  = crate::proc::current_pid();
+            let pid  = crate::proc::current_pid_lockless();
             let timeout_ms = arg3 as i64; // -1 = block; 0 = no wait
 
             if nfds <= 0 || arg1 == 0 {
@@ -615,7 +620,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let buf = arg2 as *mut u8;
             let count = arg3 as usize;
             let offset = arg4 as i64;
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             // Save, seek, read, restore
             let saved = crate::syscall::sys_lseek(fd, 0, 1 /*SEEK_CUR*/);
             let sk = crate::syscall::sys_lseek(fd, offset, 0 /*SEEK_SET*/);
@@ -633,7 +638,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let buf = arg2 as *const u8;
             let count = arg3 as usize;
             let offset = arg4 as i64;
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let saved = crate::syscall::sys_lseek(fd, 0, 1);
             let sk = crate::syscall::sys_lseek(fd, offset, 0);
             if sk < 0 { return sk; }
@@ -667,7 +672,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let ret = crate::syscall::sys_dup2(arg1 as usize, arg2 as usize);
             #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
             {
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 if pid == 1 || crate::syscall::ring::is_tracked(pid) {
                     crate::serial_println!("[FF/dup2] pid={} old={} new={} ret={}", pid, arg1, arg2, ret);
                 }
@@ -693,7 +698,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // type argument and must be honoured on the resulting fd.
             let cloexec  = (arg2 & 0x80000) != 0;
             let nonblock = (arg2 & 0x00800) != 0;
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             if domain == 1 {
                 // AF_UNIX: use net::unix module.
                 // SOCK_STREAM=1, SOCK_DGRAM=2, SOCK_SEQPACKET=5.
@@ -721,7 +726,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 42: connect(sockfd, addr, addrlen)
         42 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let addr_ptr = arg2;
             let addrlen = arg3 as usize;
@@ -790,7 +795,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // arg4 carries `flags` for accept4(2): SOCK_CLOEXEC | SOCK_NONBLOCK.
         // Plain accept(2) (#43) leaves arg4 = 0; accept4(2) (#288) forwards it.
         43 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             // accept4 flag bits: SOCK_CLOEXEC = 0x80000, SOCK_NONBLOCK = 0x800.
             let cloexec  = (arg4 & 0x80000) != 0;
@@ -810,7 +815,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 44: sendto(sockfd, buf, len, flags, addr, addrlen)
         44 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let buf_ptr = arg2 as *const u8;
             let len = arg3 as usize;
@@ -857,7 +862,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // AF_UNIX SOCK_DGRAM is not implemented yet, so the AF_UNIX path
         // continues to ignore the address out-params.
         45 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let buf_ptr = arg2 as *mut u8;
             let len = arg3 as usize;
@@ -894,7 +899,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 46: sendmsg(sockfd, msg, flags) — use single-buffer fast path
         46 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let msghdr_ptr = arg2 as *const u64;
             if msghdr_ptr.is_null() { return -22; }
@@ -966,7 +971,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 47: recvmsg(sockfd, msg, flags) — via socket_recv / unix::read
         47 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let msghdr_ptr = arg2 as *const u64;
             if msghdr_ptr.is_null() { return -22; }
@@ -1068,7 +1073,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // Returns 0 on success, -EBADF for a non-socket fd, -ENOTCONN for
         // an unconnected stream socket, -EINVAL on bad `how`.
         48 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd  = arg1 as usize;
             let how = arg2 as i32;
             if how < 0 || how > 2 { return -22; }
@@ -1086,7 +1091,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 49: bind(sockfd, addr, addrlen)
         49 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let addr_ptr = arg2;
             let addrlen = arg3 as usize;
@@ -1116,7 +1121,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 50: listen(sockfd, backlog)
         50 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
@@ -1133,7 +1138,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // `*addrlen` is read as the buffer cap (truncation only) and on
         // return holds the unmarshalled struct's full size.
         51 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let addr_ptr = arg2;
             let addrlen_ptr = arg3 as *mut u32;
@@ -1168,7 +1173,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // connected.  AF_UNIX peer reporting mirrors getsockname's
         // unnamed-socket reply.
         52 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let fd = arg1 as usize;
             let addr_ptr = arg2;
             let addrlen_ptr = arg3 as *mut u32;
@@ -1244,7 +1249,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // common known bits are SOCK_CLOEXEC and SOCK_NONBLOCK only).
             // We accept those plus the type field; anything else passes
             // through silently to match Linux leniency.
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let (a, b) = crate::net::unix::socketpair(kind);
             if a == u64::MAX { return -24; }
             let fd_a = crate::syscall::alloc_unix_socket_fd(pid, a, cloexec, nonblock);
@@ -1276,7 +1281,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 54: setsockopt(sockfd, level, optname, optval, optlen)
         54 => {
-            let pid   = crate::proc::current_pid();
+            let pid   = crate::proc::current_pid_lockless();
             let fd    = arg1 as usize;
             let level = arg2;
             let opt   = arg3;
@@ -1291,7 +1296,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 55: getsockopt(sockfd, level, optname, optval, optlen)
         55 => {
-            let pid    = crate::proc::current_pid();
+            let pid    = crate::proc::current_pid_lockless();
             let fd     = arg1 as usize;
             let level  = arg2;
             let opt    = arg3;
@@ -1319,7 +1324,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         if !optval.is_null() {
                             unsafe {
                                 let p = optval as *mut u8;
-                                core::ptr::write(p as *mut u32, crate::proc::current_pid() as u32);
+                                core::ptr::write(p as *mut u32, crate::proc::current_pid_lockless() as u32);
                                 core::ptr::write(p.add(4) as *mut u32, 0); // uid
                                 core::ptr::write(p.add(8) as *mut u32, 0); // gid
                             }
@@ -1363,7 +1368,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // pthread_create-style clone: new thread in same address space.
                 let user_rip = unsafe { crate::syscall::get_user_rip() };
                 let tls_val = if flags & CLONE_SETTLS != 0 { tls } else { 0 };
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let parent_tidptr = arg3; // rdx = parent_tid
                 let child_tidptr  = arg4; // r10 = child_tid
                 match crate::proc::usermode::create_user_thread(pid, user_rip, new_stack, tls_val, 0, 0) {
@@ -1408,7 +1413,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 const CLONE_VFORK: u64 = 0x00004000;
                 let is_vfork = flags & CLONE_VFORK != 0;
                 let parent_tid = crate::proc::current_tid();
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 crate::serial_println!("[VFORK] pid={} flags={:#x} vfork={} parent_tid={} new_stack={:#x} tls={:#x}",
                     pid, flags, is_vfork, parent_tid, new_stack, tls);
 
@@ -1476,7 +1481,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         75 => 0,
         // 77: ftruncate(fd, length) — truncate open file to given length
         77 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             match crate::vfs::fd_truncate(pid, arg1 as usize, arg2) {
                 Ok(()) => 0,
                 Err(e) => crate::subsys::linux::errno::vfs_err(e),
@@ -1505,7 +1510,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let target_str: alloc::string::String = if path_str == "/proc/self/exe"
                 || path_str == "/proc/self/fd/exe"
             {
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();
                 procs.iter().find(|p| p.pid == pid)
                     .and_then(|p| p.exe_path.as_ref())
@@ -1515,7 +1520,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // /proc/self/fd/<N> — returns the open_path for fd N.
                 let fd_part = &path_str["/proc/self/fd/".len()..];
                 let fd_num = fd_part.parse::<usize>().unwrap_or(usize::MAX);
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();
                 procs.iter().find(|p| p.pid == pid)
                     .and_then(|p| p.file_descriptors.get(fd_num))
@@ -1576,7 +1581,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 }
                 PR_SET_NO_NEW_PRIVS      => {
                     if arg2 == 1 {
-                        let pid = crate::proc::current_pid();
+                        let pid = crate::proc::current_pid_lockless();
                         let mut procs = crate::proc::PROCESS_TABLE.lock();
                         if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
                             p.no_new_privs = true;
@@ -1585,7 +1590,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     0
                 }
                 PR_GET_NO_NEW_PRIVS      => {
-                    let pid = crate::proc::current_pid();
+                    let pid = crate::proc::current_pid_lockless();
                     let procs = crate::proc::PROCESS_TABLE.lock();
                     procs.iter().find(|p| p.pid == pid)
                         .map(|p| if p.no_new_privs { 1i64 } else { 0i64 })
@@ -1776,7 +1781,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // struct __user_cap_data_struct: effective(u32), permitted(u32), inheritable(u32)
             // For version 3 (0x20080522), two consecutive structs are expected (64-bit caps).
             if arg2 != 0 && crate::syscall::validate_user_ptr(arg2, 24) {
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();
                 let (eff, perm) = procs.iter().find(|p| p.pid == pid)
                     .map(|p| (p.cap_effective as u32, p.cap_permitted as u32))
@@ -1800,7 +1805,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         126 => {
             // Accept capability drops; update effective/permitted in PCB.
             if arg2 != 0 && crate::syscall::validate_user_ptr(arg2, 12) {
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let mut procs = crate::proc::PROCESS_TABLE.lock();
                 if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
                     let dp = arg2 as *const u32;
@@ -1818,7 +1823,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if resource >= 16 { return -22; } // EINVAL
             if !crate::syscall::validate_user_ptr(arg2, 16) { return -14; } // EFAULT
             let soft = unsafe { core::ptr::read_unaligned(arg2 as *const u64) };
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let mut procs = crate::proc::PROCESS_TABLE.lock();
             if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
                 p.rlimits_soft[resource] = soft;
@@ -1891,7 +1896,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // SET new limit if provided
             if arg3 != 0 && (arg2 as usize) < 16 && crate::syscall::validate_user_ptr(arg3, 16) {
                 let soft = unsafe { core::ptr::read_unaligned(arg3 as *const u64) };
-                let pid  = crate::proc::current_pid();
+                let pid  = crate::proc::current_pid_lockless();
                 let mut procs = crate::proc::PROCESS_TABLE.lock();
                 if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
                     p.rlimits_soft[arg2 as usize] = soft;
@@ -1986,7 +1991,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let thread_arg = arg5; // Linux r8  = thread argument (glibc's saved rcx)
                 let user_rip   = unsafe { crate::syscall::get_user_rip() };
                 let tls_val    = if clone_flags & CLONE_SETTLS != 0 { tls } else { 0 };
-                let pid        = crate::proc::current_pid();
+                let pid        = crate::proc::current_pid_lockless();
                 crate::serial_println!(
                     "[CLONE3] CLONE_THREAD pid={} rip={:#x} sp={:#x} tls={:#x} func={:#x} arg={:#x}",
                     pid, user_rip, sp, tls_val, func, thread_arg
@@ -2032,7 +2037,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let func = arg3; // RDX at clone3 = func pointer
                 let thread_arg = arg5; // R8 at clone3 = arg pointer (via RCX→R8)
                 let original_rip = unsafe { crate::syscall::get_user_rip() };
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let parent_tid = crate::proc::current_tid();
                 let parent_regs = crate::syscall::read_fork_user_regs();
 
@@ -2102,7 +2107,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let op = arg2;
             let nonblock = (op & LOCK_NB) != 0;
             let op_base = op & !LOCK_NB;
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
 
             // Resolve (mount_idx, inode) from the fd.
             let (mount_idx, inode) = {
@@ -2202,7 +2207,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 alloc::string::String::from(path_str)
             } else {
                 // Relative path — prepend fd's directory
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let base = {
                     let procs = crate::proc::PROCESS_TABLE.lock();
                     let proc = match procs.iter().find(|p| p.pid == pid) {
@@ -2225,7 +2230,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let bufsiz = arg4 as usize;
             // /proc/self/exe special case
             let target: alloc::string::String = if full_path == "/proc/self/exe" {
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();
                 procs.iter().find(|p| p.pid == pid)
                     .and_then(|p| p.exe_path.as_ref())
@@ -2308,7 +2313,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 91: fchmod(fd, mode) — set permission bits on an open fd
         91 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             match crate::vfs::fchmod(pid, arg1 as usize, arg2 as u32) {
                 Ok(()) => 0,
                 Err(e) => crate::subsys::linux::errno::vfs_err(e),
@@ -2324,7 +2329,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         97 => sys_getrlimit(arg1, arg2),
         // 109: setpgid(pid, pgid) — real: update pgid in PCB
         109 => {
-            let target = if arg1 == 0 { crate::proc::current_pid() } else { arg1 };
+            let target = if arg1 == 0 { crate::proc::current_pid_lockless() } else { arg1 };
             let new_pgid = if arg2 == 0 { target as u32 } else { arg2 as u32 };
             let mut procs = crate::proc::PROCESS_TABLE.lock();
             match procs.iter_mut().find(|p| p.pid == target) {
@@ -2334,13 +2339,13 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 111: getpgrp() — return caller's pgid
         111 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let procs = crate::proc::PROCESS_TABLE.lock();
             procs.iter().find(|p| p.pid == pid).map(|p| p.pgid as i64).unwrap_or(pid as i64)
         }
         // 112: setsid() — become session leader with new sid/pgid
         112 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let mut procs = crate::proc::PROCESS_TABLE.lock();
             if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
                 p.pgid = pid as u32;
@@ -2350,13 +2355,13 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 121: getpgid(pid) — return pgid of target (0 = caller)
         121 => {
-            let target = if arg1 == 0 { crate::proc::current_pid() } else { arg1 };
+            let target = if arg1 == 0 { crate::proc::current_pid_lockless() } else { arg1 };
             let procs = crate::proc::PROCESS_TABLE.lock();
             procs.iter().find(|p| p.pid == target).map(|p| p.pgid as i64).unwrap_or(-3)
         }
         // 122: getsid(pid) — return session id
         122 => {
-            let target = if arg1 == 0 { crate::proc::current_pid() } else { arg1 };
+            let target = if arg1 == 0 { crate::proc::current_pid_lockless() } else { arg1 };
             let procs = crate::proc::PROCESS_TABLE.lock();
             procs.iter().find(|p| p.pid == target).map(|p| p.sid as i64).unwrap_or(-3)
         }
@@ -2367,7 +2372,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let ret = crate::syscall::sys_dup2(arg1 as usize, arg2 as usize);
             if ret >= 0 && (arg3 & 0x0008_0000) != 0 {
                 // O_CLOEXEC: set cloexec on the new fd
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 let mut procs = crate::proc::PROCESS_TABLE.lock();
                 if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {
                     if let Some(Some(f)) = proc.file_descriptors.get_mut(arg2 as usize) {
@@ -2377,7 +2382,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             }
             #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
             {
-                let pid = crate::proc::current_pid();
+                let pid = crate::proc::current_pid_lockless();
                 if pid == 1 || crate::syscall::ring::is_tracked(pid) {
                     crate::serial_println!("[FF/dup2] pid={} old={} new={} flags={:#x} ret={} (dup3)", pid, arg1, arg2, arg3, ret);
                 }
@@ -2629,7 +2634,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 436: close_range(first, last, flags) — close a range of fds
         // (also mapped at 355 for backwards compat, but 436 is the correct x86_64 number)
         436 | 355 => {
-            let pid = crate::proc::current_pid();
+            let pid = crate::proc::current_pid_lockless();
             let first = arg1 as usize;
             let last = (arg2 as usize).min(4095);
             for fd in first..=last {
@@ -2791,7 +2796,7 @@ fn sys_getrlimit(resource: u64, rlim_ptr: u64) -> i64 {
     };
     // Read per-process soft limit.
     let soft = if resource < 16 {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         let procs = crate::proc::PROCESS_TABLE.lock();
         procs.iter().find(|p| p.pid == pid)
             .map(|p| p.rlimits_soft[resource as usize])
@@ -2815,7 +2820,7 @@ fn sys_getrlimit(resource: u64, rlim_ptr: u64) -> i64 {
 fn sys_select_linux(
     nfds: u64, readfds: u64, writefds: u64, _exceptfds: u64, timeout: u64,
 ) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let nfds = nfds.min(1024) as usize;
     let mut ready = 0i64;
 
@@ -2950,7 +2955,7 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     if advice != MADV_DONTNEED && advice != MADV_FREE { return 0; }
     if len == 0 { return 0; }
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let start = addr & !0xFFF;
     let end   = (addr + len + 0xFFF) & !0xFFF;
 
@@ -3047,7 +3052,7 @@ fn sys_mremap(old_addr: u64, old_size: u64, new_size: u64, flags: u64, new_addr:
 pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
     let buf_ptr = buf as *mut u8;
     let count = count as usize;
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // ── Special fd types take priority over the fd-number shortcuts ─────────
     // Must check these BEFORE the `fd == 0` stdin branch because kernel tests
@@ -3269,7 +3274,7 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
 
     #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
     {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         if pid == 1 || crate::syscall::ring::is_tracked(pid) {
             // Skip ultra-short non-printable bursts (e.g. the 1-byte `\n`
             // ping-pongs some stdio buffers emit) unless clearly human-visible
@@ -3326,7 +3331,7 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     // ── Special fd types take priority over the fd-number shortcuts ─────────
     // Must check these BEFORE the `fd == 1/2` stdout/stderr branch because
     // kernel tests and user processes may allocate pipe/socket/eventfd at fd 1.
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     if crate::syscall::is_pipe_fd(pid, fd as usize) {
         let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
         let slice = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
@@ -3398,7 +3403,7 @@ pub fn sys_open_linux(pathname: u64, flags: u64, _mode: u64) -> i64 {
     let ret = sys_open_linux_inner(pathname, flags, _mode);
     #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
     {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         if pid == 1 || crate::syscall::ring::is_tracked(pid) {
             crate::serial_println!(
                 "[FF/open-ret] pid={} path={} ret={}",
@@ -3425,7 +3430,7 @@ fn sys_open_linux_inner(pathname: u64, flags: u64, _mode: u64) -> i64 {
         Ok(s) => s,
         Err(_) => return -22,
     };
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
     if pid == 1 || crate::syscall::ring::is_tracked(pid) {
         crate::serial_println!("[FF/open] pid={} path={}", pid, path);
@@ -3552,7 +3557,7 @@ fn sys_stat_linux(pathname: u64, stat_buf: u64) -> i64 {
 
 /// Linux fstat(fd, statbuf) — uses Linux stat layout.
 fn sys_fstat_linux(fd_num: usize, stat_buf: *mut u8) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     let proc_entry = match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -3603,7 +3608,7 @@ fn sys_chdir_linux(pathname: u64) -> i64 {
 
 /// fchdir(fd) — change CWD to the directory referred to by `fd`.
 fn sys_fchdir_linux(fd: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let open_path = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = match procs.iter().find(|p| p.pid == pid) {
@@ -3629,7 +3634,7 @@ fn sys_faccessat_linux(dirfd: u64, pathname: u64, mode: u64) -> i64 {
         return sys_access(pathname, mode);
     }
     // Try to get the base directory from the fd and reconstruct full path
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let base = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = match procs.iter().find(|p| p.pid == pid) {
@@ -3819,25 +3824,49 @@ pub fn sys_set_tid_address(tidptr: u64) -> i64 {
 /// seconds (`vdso::wall_secs_at_boot()`) plus the monotonic tick delta —
 /// the same formula as `__vdso_clock_gettime` (see `kernel/vdso/vdso.S`).
 pub fn sys_clock_gettime(clk_id: u64, tp: u64) -> i64 {
-    const CLOCK_REALTIME:  u64 = 0;
-    const CLOCK_MONOTONIC: u64 = 1;
+    // clk_id values per clock_gettime(2): 0=REALTIME, 1=MONOTONIC,
+    // 4=MONOTONIC_RAW, 5=REALTIME_COARSE, 6=MONOTONIC_COARSE.
+    const CLOCK_REALTIME:         u64 = 0;
+    const CLOCK_MONOTONIC:        u64 = 1;
+    const CLOCK_MONOTONIC_RAW:    u64 = 4;
+    const CLOCK_REALTIME_COARSE:  u64 = 5;
+    const CLOCK_MONOTONIC_COARSE: u64 = 6;
     if tp == 0 {
         return -22; // EINVAL
     }
-    let ticks = crate::arch::x86_64::irq::get_ticks();
-    let mono_secs = ticks / 100;
-    let sub_nsecs = (ticks % 100) * 10_000_000u64; // 10 ms per PIT tick
-    let secs = if clk_id == CLOCK_REALTIME {
-        // boot_wall_secs + monotonic seconds — matches vDSO exactly.
-        crate::proc::vdso::wall_secs_at_boot().saturating_add(mono_secs)
-    } else {
-        // CLOCK_MONOTONIC / CLOCK_MONOTONIC_RAW / CLOCK_PROCESS_CPUTIME_ID etc.
-        mono_secs
-    };
     let _ = CLOCK_MONOTONIC; // suppress unused warning
+
+    // HRES paths use TSC-derived ns — identical to the vDSO fast path so
+    // futex absolute deadlines stay coherent.  COARSE paths use the 10 ms
+    // tick counter per clock_gettime(2) "coarse resolution" semantics.
+    let is_coarse = clk_id == CLOCK_REALTIME_COARSE || clk_id == CLOCK_MONOTONIC_COARSE;
+    let (secs, nsecs) = if is_coarse {
+        let ticks = crate::arch::x86_64::irq::get_ticks();
+        let mono_secs = ticks / 100;
+        let sub_ns = (ticks % 100) * 10_000_000u64;
+        (mono_secs, sub_ns)
+    } else {
+        let ns_total = crate::proc::vdso::monotonic_ns();
+        if ns_total == 0 {
+            // Calibration not yet published — fall back to tick granularity.
+            let ticks = crate::arch::x86_64::irq::get_ticks();
+            (ticks / 100, (ticks % 100) * 10_000_000u64)
+        } else {
+            (ns_total / 1_000_000_000, ns_total % 1_000_000_000)
+        }
+    };
+
+    let is_realtime = clk_id == CLOCK_REALTIME || clk_id == CLOCK_REALTIME_COARSE;
+    let _ = CLOCK_MONOTONIC_RAW;
+    let secs = if is_realtime {
+        crate::proc::vdso::wall_secs_at_boot().saturating_add(secs)
+    } else {
+        secs
+    };
+
     let buf = unsafe { core::slice::from_raw_parts_mut(tp as *mut u8, 16) };
     buf[0..8].copy_from_slice(&secs.to_le_bytes());
-    buf[8..16].copy_from_slice(&sub_nsecs.to_le_bytes());
+    buf[8..16].copy_from_slice(&nsecs.to_le_bytes());
     0
 }
 
@@ -3863,7 +3892,7 @@ fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
     let base  = page_align_down(addr);
     let end   = page_align_up(addr.wrapping_add(len));
     let prot  = prot as u32;
-    let pid   = crate::proc::current_pid();
+    let pid   = crate::proc::current_pid_lockless();
 
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -4028,7 +4057,7 @@ fn sys_fcntl(fd: u64, cmd: u64, arg: u64) -> i64 {
     const F_RDLCK: i16 = 0;
     const F_WRLCK: i16 = 1;
     const F_UNLCK: i16 = 2;
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     match cmd {
         F_GETLK | F_SETLK | F_SETLKW => {
             if arg == 0 { return -22; } // EINVAL: null flock pointer
@@ -4213,7 +4242,7 @@ fn sys_sendfile(out_fd: usize, in_fd: usize, offset_ptr: u64, count: usize) -> i
     if count == 0 { return 0; }
     let max_chunk: usize = 65536; // send at most 64 KiB at a time
     let len = count.min(max_chunk);
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // Snapshot in_fd info and the read offset.
     let (in_mount, in_inode, in_offset_cur) = {
@@ -4419,7 +4448,7 @@ fn sys_gettimeofday(tv: u64, _tz: u64) -> i64 {
 ///
 /// Each entry: { d_ino: u64, d_off: u64, d_reclen: u16, d_type: u8, d_name: [u8] }
 fn sys_getdents64(fd: u64, buf: u64, count: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let (mount_idx, inode, offset, open_path) = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc_entry = match procs.iter().find(|p| p.pid == pid) {
@@ -4612,7 +4641,7 @@ fn sys_openat(dirfd: u64, pathname: u64, flags: u64, mode: u64) -> i64 {
     }
 
     // Get the directory path from the dirfd.
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     // Resolve dirfd → directory path under PROCESS_TABLE, then drop the lock
     // explicitly before any ring::* call. Keeping ring access strictly
     // disjoint from PROCESS_TABLE prevents an ABBA against any other path
@@ -4685,7 +4714,7 @@ fn sys_newfstatat(dirfd: u64, pathname: u64, statbuf: u64, flags: u64) -> i64 {
     }
 
     // Relative path with real dirfd — resolve relative to dirfd's path.
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let dir_path = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc_entry = match procs.iter().find(|p| p.pid == pid) {
@@ -4788,7 +4817,7 @@ fn sys_rt_sigaction_linux(sig: u64, act: u64, oldact: u64, _sigsetsize: u64) -> 
 
     // Step 2: take the lock, swap in the new action, and capture the prior
     // one for later write-back.  No user-pointer dereferences inside.
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let prior_handler_addr: u64;
     let prior_restorer_addr: u64;
     let prior_sa_flags: u64;
@@ -4879,7 +4908,7 @@ fn sys_rt_sigprocmask_linux(how: u64, set: u64, oldset: u64, _sigsetsize: u64) -
 
     // Step 2: take the lock, fold in the new mask, capture the prior mask
     // for write-back.  No user-pointer dereferences inside this block.
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let prior_mask: u64 = {
         let mut procs = crate::proc::PROCESS_TABLE.lock();
         let proc_entry = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -4951,7 +4980,7 @@ pub fn sys_futex_linux(
 
     let op = futex_op & 0x7F; // Strip FUTEX_PRIVATE_FLAG and FUTEX_CLOCK_REALTIME
     let abs_realtime = (futex_op & FUTEX_CLOCK_REALTIME) != 0;
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // Read the timespec at `timeout_ptr` (NULL means "no timeout") and convert
     // it to a *relative* nanosecond duration that the rest of the handler can
@@ -5315,7 +5344,7 @@ fn sys_eventfd_linux(initval: u64, flags: u32) -> i64 {
         return -24; // EMFILE
     }
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -5371,7 +5400,7 @@ fn sys_pipe2_linux(fds_out: *mut u32, flags: u32) -> i64 {
     }
 
     let pipe_id = crate::ipc::pipe::create_pipe();
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -5525,7 +5554,7 @@ fn sys_memfd_create(_name: u64, flags: u64) -> i64 {
     }
 
     let seq = MEMFD_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // Build path /tmp/.memfd_NNNN
     let mut path_buf = [0u8; 32];
@@ -5815,7 +5844,7 @@ fn signal_pending(pid: u64) -> bool {
 
 /// epoll_create / epoll_create1 — allocate a new epoll fd.
 fn sys_epoll_create1(_flags: u32) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -5848,7 +5877,7 @@ fn sys_epoll_create1(_flags: u32) -> i64 {
 /// epoll_ctl — add/modify/delete a watched fd.
 fn sys_epoll_ctl(epfd: usize, op: u64, fd: usize, event_ptr: u64) -> i64 {
     use crate::ipc::epoll::{EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD, EpollEvent};
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // Read the caller's epoll_event (only needed for ADD / MOD).
     let (events, data) = if event_ptr != 0 && op != EPOLL_CTL_DEL {
@@ -5894,7 +5923,7 @@ fn sys_epoll_ctl(epfd: usize, op: u64, fd: usize, event_ptr: u64) -> i64 {
 fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i32) -> i64 {
     use crate::ipc::epoll::{EpollEvent, EPOLLERR};
     if maxevents == 0 { return -22; } // EINVAL
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // ── Step 1: snapshot the watch list while briefly holding the lock ────────
     let watches_snap: alloc::vec::Vec<(usize, u32, u64)> = {
@@ -5986,7 +6015,7 @@ fn sys_timerfd_create(clockid: u32) -> i64 {
     let slot_id = crate::ipc::timerfd::create(clockid);
     if slot_id == u64::MAX { return -24; } // EMFILE
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let fd = crate::vfs::FileDescriptor::timer_fd(slot_id);
 
     let mut procs = crate::proc::PROCESS_TABLE.lock();
@@ -6014,7 +6043,7 @@ fn sys_timerfd_create(clockid: u32) -> i64 {
 /// `new_value` is a `struct itimerspec { it_interval, it_value }` where each
 /// timespec is `{ tv_sec: i64, tv_nsec: i64 }` (16 bytes each, 32 bytes total).
 fn sys_timerfd_settime(fd_num: u64, flags: u32, new_value_ptr: u64, old_value_ptr: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     if !crate::syscall::is_timerfd_fd(pid, fd_num as usize) { return -9; } // EBADF
     let slot_id = crate::syscall::get_timerfd_id(pid, fd_num as usize);
 
@@ -6055,7 +6084,7 @@ fn sys_timerfd_settime(fd_num: u64, flags: u32, new_value_ptr: u64, old_value_pt
 
 /// `timerfd_gettime(fd, *curr_value)` — read current timer setting.
 fn sys_timerfd_gettime(fd_num: u64, curr_value_ptr: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     if !crate::syscall::is_timerfd_fd(pid, fd_num as usize) { return -9; } // EBADF
     let slot_id = crate::syscall::get_timerfd_id(pid, fd_num as usize);
     let (interval_ns, value_ns) = crate::ipc::timerfd::gettime(slot_id);
@@ -6086,7 +6115,7 @@ fn sys_timerfd_gettime(fd_num: u64, curr_value_ptr: u64) -> i64 {
 fn sys_signalfd4(fd_num: u64, mask_ptr: u64, sizemask: u64, _flags: u32) -> i64 {
     if sizemask < 8 || !crate::syscall::validate_user_ptr(mask_ptr, 8) { return -22; } // EINVAL/EFAULT
     let sigmask = unsafe { *(mask_ptr as *const u64) };
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // fd == u64::MAX means -1 (create new).
     if fd_num == u64::MAX || fd_num as i64 == -1 {
@@ -6129,7 +6158,7 @@ fn sys_inotify_init1(_flags: u32) -> i64 {
     let slot_id = crate::ipc::inotify::create();
     if slot_id == u64::MAX { return -24; } // EMFILE
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let fd = crate::vfs::FileDescriptor::inotify_fd(slot_id);
 
     let mut procs = crate::proc::PROCESS_TABLE.lock();
@@ -6154,7 +6183,7 @@ fn sys_inotify_init1(_flags: u32) -> i64 {
 
 /// `inotify_add_watch(fd, pathname, mask)` — add a watch descriptor.
 fn sys_inotify_add_watch(fd_num: u64, path_ptr: u64, mask: u32) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     if !crate::syscall::is_inotify_fd(pid, fd_num as usize) { return -9; } // EBADF
     let id = crate::syscall::get_inotify_id(pid, fd_num as usize);
     let path_bytes = read_cstring_from_user(path_ptr);
@@ -6165,7 +6194,7 @@ fn sys_inotify_add_watch(fd_num: u64, path_ptr: u64, mask: u32) -> i64 {
 
 /// `inotify_rm_watch(fd, wd)` — remove a watch descriptor.
 fn sys_inotify_rm_watch(fd_num: u64, wd: i32) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     if !crate::syscall::is_inotify_fd(pid, fd_num as usize) { return -9; } // EBADF
     let id = crate::syscall::get_inotify_id(pid, fd_num as usize);
     if crate::ipc::inotify::rm_watch(id, wd) { 0 } else { -22 }
@@ -6231,7 +6260,7 @@ fn check_and_deliver_alarm(pid: u64) {
 /// Returns the number of seconds remaining in any previously scheduled alarm,
 /// or 0 if no alarm was set.
 fn sys_alarm(seconds: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let now = crate::arch::x86_64::irq::get_ticks();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -6271,7 +6300,7 @@ fn sys_setitimer(which: u64, new_val_ptr: u64, old_val_ptr: u64) -> i64 {
         return -22; // EINVAL
     }
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let now = crate::arch::x86_64::irq::get_ticks();
 
     // Read the new itimerval before acquiring the process lock.
@@ -6336,7 +6365,7 @@ fn sys_getitimer(which: u64, val_ptr: u64) -> i64 {
     if val_ptr == 0 || !crate::syscall::validate_user_ptr(val_ptr, 32) {
         return -14; // EFAULT
     }
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let now = crate::arch::x86_64::irq::get_ticks();
     let procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter().find(|p| p.pid == pid) {
@@ -6374,7 +6403,7 @@ fn resolve_at_path(dirfd: u64, rel_ptr: u64) -> Result<alloc::string::String, i6
     }
     // Relative path with AT_FDCWD: use process CWD.
     if dirfd as i64 == AT_FDCWD {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         let procs = crate::proc::PROCESS_TABLE.lock();
         let cwd = procs.iter().find(|p| p.pid == pid)
             .map(|p| p.cwd.clone())
@@ -6387,7 +6416,7 @@ fn resolve_at_path(dirfd: u64, rel_ptr: u64) -> Result<alloc::string::String, i6
         });
     }
     // Relative path with a real directory fd: get dir path from fd table.
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let dir_path = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = procs.iter().find(|p| p.pid == pid).ok_or(-3i64)?;
@@ -6461,7 +6490,7 @@ fn sys_renameat(olddirfd: u64, oldpath: u64, newdirfd: u64, newpath: u64) -> i64
 ///
 /// Per man 2 getdents: d_type is at offset d_reclen-1 (last byte of the record).
 fn sys_getdents(fd: u64, buf: u64, count: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let (mount_idx, inode, offset) = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc_entry = match procs.iter().find(|p| p.pid == pid) {
@@ -6556,7 +6585,7 @@ fn sys_getdents(fd: u64, buf: u64, count: u64) -> i64 {
 fn sys_preadv(fd: u64, iov_ptr: u64, iovcnt: u64, offset: i64) -> i64 {
     if iovcnt == 0 { return 0; }
     if iovcnt > 1024 { return -22; } // EINVAL: IOV_MAX
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     // Save, seek to offset, scatter-read, restore.
     let saved = crate::syscall::sys_lseek(fd as usize, 0, 1 /*SEEK_CUR*/);
     let sk = crate::syscall::sys_lseek(fd as usize, offset, 0 /*SEEK_SET*/);
@@ -6592,7 +6621,7 @@ fn sys_preadv(fd: u64, iov_ptr: u64, iovcnt: u64, offset: i64) -> i64 {
 fn sys_pwritev(fd: u64, iov_ptr: u64, iovcnt: u64, offset: i64) -> i64 {
     if iovcnt == 0 { return 0; }
     if iovcnt > 1024 { return -22; } // EINVAL: IOV_MAX
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let saved = crate::syscall::sys_lseek(fd as usize, 0, 1 /*SEEK_CUR*/);
     let sk = crate::syscall::sys_lseek(fd as usize, offset, 0 /*SEEK_SET*/);
     if sk < 0 { return sk; }
@@ -6649,7 +6678,7 @@ fn emit_user_stack_snapshot(num: u64, sample_idx: u64) {
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
     const MAX_FRAMES: usize = 16;
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let tid = crate::proc::current_tid();
     let (user_rsp, user_rbp) = crate::syscall::get_user_rsp_rbp();
     let leaf_rip = unsafe { crate::syscall::get_user_rip() };

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -712,7 +712,7 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
         &envp_strs
     };
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // Check if the current process has a VmSpace (user-mode caller).
     // If not, fall back to creating a new process (kernel-mode caller).
@@ -955,7 +955,7 @@ pub(crate) fn sys_fork_impl(clone_flags: u64, child_tidptr: u64) -> i64 {
     const CLONE_CHILD_SETTID: u64 = 0x01000000;
     const CLONE_CHILD_CLEARTID: u64 = 0x00200000;
 
-    let parent_pid = crate::proc::current_pid();
+    let parent_pid = crate::proc::current_pid_lockless();
     let parent_tid = crate::proc::current_tid();
 
     // Capture parent's callee-saved regs from the syscall entry frame BEFORE
@@ -1089,7 +1089,7 @@ pub(crate) fn write_u32_to_user(cr3: u64, vaddr: u64, val: u32) {
 ///
 /// Returns the PID of the process that changed state, or negative errno.
 pub(crate) fn sys_waitpid(pid: i64, options: u32) -> i64 {
-    let parent_pid = crate::proc::current_pid();
+    let parent_pid = crate::proc::current_pid_lockless();
     let wnohang = (options & 1) != 0; // WNOHANG = 1
 
     crate::serial_println!("[SYSCALL] waitpid({}, opts=0x{:x}) from PID {}", pid, options, parent_pid);
@@ -1146,7 +1146,7 @@ pub(crate) fn sys_ioctl(fd_num: usize, request: u64, arg_ptr: *mut u8) -> i64 {
 
     // Look up the fd's open_path and file_type.
     let (open_path, file_type, inode) = {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         let procs = crate::proc::PROCESS_TABLE.lock();
         let fd_opt = procs.iter()
             .find(|p| p.pid == pid)
@@ -1453,7 +1453,7 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
     }
 
     let length = page_align_up(length);
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // MAP_FIXED_NOREPLACE (Linux 4.17+, flag 0x100000): like MAP_FIXED but the
     // kernel should return EEXIST if the range is already mapped.  Modern glibc
@@ -1738,7 +1738,7 @@ pub(crate) fn sys_munmap(addr: u64, length: u64) -> i64 {
     }
 
     let length = page_align_up(length);
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     // ── Phase 1 (lock) — capture cr3 AND remove the VMA records first. ────
     //
@@ -1780,7 +1780,7 @@ pub(crate) fn sys_munmap(addr: u64, length: u64) -> i64 {
 /// If `new_brk` is 0, returns the current break.
 /// Otherwise sets the break and returns the new value.
 pub(crate) fn sys_brk(new_brk: u64) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -1803,7 +1803,7 @@ pub(crate) fn sys_brk(new_brk: u64) -> i64 {
 // ===== Identity / credential syscalls =======================================
 
 pub(crate) fn sys_getppid() -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p.parent_pid as i64,
@@ -1812,7 +1812,7 @@ pub(crate) fn sys_getppid() -> i64 {
 }
 
 pub(crate) fn sys_getuid() -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p.uid as i64,
@@ -1821,7 +1821,7 @@ pub(crate) fn sys_getuid() -> i64 {
 }
 
 pub(crate) fn sys_getgid() -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p.gid as i64,
@@ -1830,7 +1830,7 @@ pub(crate) fn sys_getgid() -> i64 {
 }
 
 pub(crate) fn sys_geteuid() -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p.euid as i64,
@@ -1839,7 +1839,7 @@ pub(crate) fn sys_geteuid() -> i64 {
 }
 
 pub(crate) fn sys_getegid() -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p.egid as i64,
@@ -1848,7 +1848,7 @@ pub(crate) fn sys_getegid() -> i64 {
 }
 
 pub(crate) fn sys_umask(new_mask: u32) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => {
@@ -1867,7 +1867,7 @@ pub(crate) fn sys_getcwd(buf: *mut u8, size: usize) -> i64 {
         return -22; // EINVAL
     }
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -1906,7 +1906,7 @@ pub(crate) fn sys_chdir(path_ptr: *const u8, path_len: usize) -> i64 {
         Err(e) => return crate::subsys::linux::errno::vfs_err(e),
     }
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => {
@@ -2004,7 +2004,7 @@ pub(crate) fn sys_stat(path_ptr: *const u8, path_len: usize, stat_buf: *mut u8) 
 }
 
 pub(crate) fn sys_fstat(fd_num: usize, stat_buf: *mut u8) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -2049,7 +2049,7 @@ pub(crate) fn sys_fstat(fd_num: usize, stat_buf: *mut u8) -> i64 {
 }
 
 pub(crate) fn sys_lseek(fd_num: usize, offset: i64, whence: u32) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -2095,7 +2095,7 @@ pub(crate) fn sys_lseek(fd_num: usize, offset: i64, whence: u32) -> i64 {
 }
 
 pub(crate) fn sys_dup(old_fd: usize) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -2129,7 +2129,7 @@ pub(crate) fn sys_dup(old_fd: usize) -> i64 {
 }
 
 pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -2168,7 +2168,7 @@ pub(crate) fn sys_pipe(fds_out: *mut u64) -> i64 {
     }
 
     let pipe_id = crate::ipc::pipe::create_pipe();
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
 
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -2590,7 +2590,7 @@ pub(crate) fn sys_sigaction(sig: u8, handler_addr: u64) -> i64 {
         return -22; // EINVAL — can't change SIGKILL/SIGSTOP
     }
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -2617,7 +2617,7 @@ pub(crate) fn sys_sigprocmask(how: u32, new_mask: u64) -> i64 {
     const SIG_UNBLOCK: u32 = 1;
     const SIG_SETMASK: u32 = 2;
 
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc = match procs.iter_mut().find(|p| p.pid == pid) {
         Some(p) => p,
@@ -2690,7 +2690,7 @@ pub(crate) fn sys_sigreturn() -> i64 {
 
     // Restore the blocked-signal mask.
     {
-        let pid = crate::proc::current_pid();
+        let pid = crate::proc::current_pid_lockless();
         let mut procs = crate::proc::PROCESS_TABLE.lock();
         if let Some(proc_entry) = procs.iter_mut().find(|p| p.pid == pid) {
             if let Some(ref mut ss) = proc_entry.signal_state {
@@ -2888,7 +2888,7 @@ pub fn sys_write_test(fd_num: usize, buf: *const u8, count: usize) -> i64 {
 
 /// Close file descriptor `fd_num` in the current process.
 pub fn sys_close_test(fd_num: usize) -> i64 {
-    let pid = crate::proc::current_pid();
+    let pid = crate::proc::current_pid_lockless();
     match crate::vfs::close(pid, fd_num) {
         Ok(()) => 0,
         Err(e) => crate::subsys::linux::errno::vfs_err(e),

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1321,6 +1321,14 @@ pub fn run() -> ! {
     total += 1;
     if test_dup_clears_cloexec() { passed += 1; }
 
+    // ── Test 199: vDSO clock_gettime — TSC-precise ns granularity ───────
+    total += 1;
+    if test_vdso_clock_gettime_subtick_ns() { passed += 1; }
+
+    // ── Test 200: vDSO clock_gettime — wall-clock progress under 1 ms ───
+    total += 1;
+    if test_vdso_clock_gettime_progress_subms() { passed += 1; }
+
     // (Stream-A pipe / eventfd wake-hook tests run first — see Tests 0a/0b
     // at the top of this function so failures surface before the suite's
     // long network/disk pre-amble.)
@@ -23134,6 +23142,183 @@ fn test_dup_clears_cloexec() -> bool {
     crate::subsys::linux::syscall::sys_close_test(orig_fd as u64);
 
     test_pass!("dup/dup2 clear FD_CLOEXEC on duplicate");
+    true
+}
+
+// ── Test 199: vDSO clock_gettime — TSC-precise ns granularity ────────────────
+//
+// Asserts the in-kernel CLOCK_MONOTONIC formula returns sub-millisecond ns
+// values: a second-quantised or 10 ms-quantised clock would report
+// `tv_nsec % 10_000_000 == 0` every time, trapping any timing loop that
+// asks "did at least 100 µs elapse?" in a zero-elapsed-time spin.
+//
+// Pre-fix: vvar_ticks * 10_000_000 / 100 always yielded multiples of
+// 10 ms.  Post-fix: TSC-derived ns has at least cycle-level granularity
+// (sub-microsecond on modern hosts).
+//
+// Test exercises `sys_clock_gettime(CLOCK_MONOTONIC)` (which uses the
+// same monotonic_ns() helper the vDSO computes from) and checks that
+// at least one of N back-to-back samples has tv_nsec NOT aligned to the
+// 10 ms quantum.  Strict equality to "every sample is non-coarse" would
+// flake at multiples of 10 ms — the bound here is "at least one sample
+// across the burst proves sub-tick precision".
+//
+// Public references:
+//   clock_gettime(2) — CLOCK_MONOTONIC tv_nsec semantics
+//   vdso(7)         — AT_SYSINFO_EHDR + clock_gettime fast path
+fn test_vdso_clock_gettime_subtick_ns() -> bool {
+    test_header!("vDSO clock_gettime — TSC-derived sub-tick ns granularity");
+
+    let tsc_per_tick = crate::arch::x86_64::irq::TSC_PER_TICK
+        .load(core::sync::atomic::Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        test_fail!("vdso_subtick_ns",
+            "TSC_PER_TICK = 0 — apic::init / calibration did not run");
+        return false;
+    }
+    test_println!("  TSC_PER_TICK = {} (≈{:.2} GHz)", tsc_per_tick,
+        (tsc_per_tick as f64) * 100.0 / 1.0e9);
+
+    // Take 128 back-to-back samples; expect overwhelming majority to be
+    // non-coarse (not multiples of 10 ms in tv_nsec).
+    let mut non_coarse = 0u32;
+    let mut last_ts: [u64; 2] = [0; 2];
+    let mut monotone_breaks = 0u32;
+    const N: u32 = 128;
+    for i in 0..N {
+        let mut tp = [0u8; 16];
+        let r = crate::syscall::sys_clock_gettime(1 /*CLOCK_MONOTONIC*/,
+            tp.as_mut_ptr() as u64);
+        if r != 0 {
+            test_fail!("vdso_subtick_ns",
+                "clock_gettime returned {} on sample {}", r, i);
+            return false;
+        }
+        let sec  = u64::from_le_bytes(tp[0..8].try_into().unwrap());
+        let nsec = u64::from_le_bytes(tp[8..16].try_into().unwrap());
+        if nsec >= 1_000_000_000 {
+            test_fail!("vdso_subtick_ns",
+                "sample {}: tv_nsec={} >= 10^9 (formula bug)", i, nsec);
+            return false;
+        }
+        // Coarse-quantised iff tv_nsec is an exact multiple of 10 ms.
+        if (nsec % 10_000_000) != 0 { non_coarse += 1; }
+        if i > 0 {
+            let now_total = sec.saturating_mul(1_000_000_000).saturating_add(nsec);
+            let prev_total = last_ts[0].saturating_mul(1_000_000_000)
+                .saturating_add(last_ts[1]);
+            if now_total < prev_total { monotone_breaks += 1; }
+        }
+        last_ts[0] = sec; last_ts[1] = nsec;
+    }
+    test_println!("  {} of {} samples had sub-tick ns (tv_nsec % 10ms != 0)",
+        non_coarse, N);
+    test_println!("  monotone violations across burst: {}", monotone_breaks);
+
+    if monotone_breaks > 0 {
+        test_fail!("vdso_subtick_ns",
+            "{} non-monotone samples in burst of {} — TSC math is wrong",
+            monotone_breaks, N);
+        return false;
+    }
+    // Pre-fix: 0 / 128 sub-tick.  Post-fix: vast majority should be
+    // sub-tick.  Strict bound is "at least one" to avoid flake at
+    // 10 ms boundary alignment.
+    if non_coarse == 0 {
+        test_fail!("vdso_subtick_ns",
+            "0 of {} samples had sub-tick ns — clock_gettime still \
+             reports tick-quantised time",
+            N);
+        return false;
+    }
+
+    test_pass!("vDSO clock_gettime — TSC-derived sub-tick ns granularity");
+    true
+}
+
+// ── Test 200: vDSO clock_gettime — wall-clock progress under 1 ms ────────────
+//
+// Asserts CLOCK_MONOTONIC advances on a per-call basis without needing
+// a full PIT tick to elapse.  Pre-fix: two clock_gettime calls within
+// the same 10 ms window returned the same (sec, nsec).  Post-fix: a
+// modest busy-wait between calls produces a measurable ns delta.
+//
+// The check is "any positive delta inside a bounded TSC budget".
+// We spin for ~1 ms of TSC cycles between samples — well under the
+// 10 ms tick quantum, so a tick-quantised clock would report zero
+// delta with overwhelming probability.
+fn test_vdso_clock_gettime_progress_subms() -> bool {
+    test_header!("vDSO clock_gettime — sub-tick wall-clock progress");
+
+    let tsc_per_tick = crate::arch::x86_64::irq::TSC_PER_TICK
+        .load(core::sync::atomic::Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        test_fail!("vdso_subms_progress", "TSC_PER_TICK = 0 — calibration not run");
+        return false;
+    }
+    // ~1 ms of TSC at the calibrated frequency.
+    let budget_tsc = tsc_per_tick / 10;
+
+    let rdtsc = || -> u64 {
+        let lo: u32; let hi: u32;
+        unsafe {
+            core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi,
+                options(nomem, nostack));
+        }
+        ((hi as u64) << 32) | lo as u64
+    };
+
+    // Take the first reading.
+    let mut tp_a = [0u8; 16];
+    let r = crate::syscall::sys_clock_gettime(1, tp_a.as_mut_ptr() as u64);
+    if r != 0 {
+        test_fail!("vdso_subms_progress", "first clock_gettime returned {}", r);
+        return false;
+    }
+    let sec_a  = u64::from_le_bytes(tp_a[0..8].try_into().unwrap());
+    let nsec_a = u64::from_le_bytes(tp_a[8..16].try_into().unwrap());
+    let total_a = sec_a.saturating_mul(1_000_000_000).saturating_add(nsec_a);
+
+    // Busy-wait ~1 ms via TSC (NOT via clock_gettime — that would couple
+    // the test's wait loop to the very thing under test).
+    let start = rdtsc();
+    while rdtsc().wrapping_sub(start) < budget_tsc {
+        core::hint::spin_loop();
+    }
+
+    let mut tp_b = [0u8; 16];
+    let r = crate::syscall::sys_clock_gettime(1, tp_b.as_mut_ptr() as u64);
+    if r != 0 {
+        test_fail!("vdso_subms_progress", "second clock_gettime returned {}", r);
+        return false;
+    }
+    let sec_b  = u64::from_le_bytes(tp_b[0..8].try_into().unwrap());
+    let nsec_b = u64::from_le_bytes(tp_b[8..16].try_into().unwrap());
+    let total_b = sec_b.saturating_mul(1_000_000_000).saturating_add(nsec_b);
+
+    if total_b < total_a {
+        test_fail!("vdso_subms_progress",
+            "second sample {} ns precedes first {} ns — monotonicity violated",
+            total_b, total_a);
+        return false;
+    }
+    let delta_ns = total_b - total_a;
+    test_println!("  busy-waited ~1ms; clock advanced {} ns ({}.{:03} ms)",
+        delta_ns, delta_ns / 1_000_000, (delta_ns % 1_000_000) / 1000);
+
+    // Pre-fix: a tick-quantised clock reads 0 or 10_000_000 ns delta with
+    // a strong bias toward 0 (the 1 ms wait is shorter than a tick).
+    // Post-fix: should be ~1 ms (give or take call overhead).  Require
+    // a positive delta AND < 5 ms — anything larger suggests we waited
+    // through a real PIT tick (unlikely but possible under VM jitter).
+    if delta_ns == 0 {
+        test_fail!("vdso_subms_progress",
+            "1 ms TSC busy-wait produced 0 ns clock_gettime delta — \
+             clock is tick-quantised");
+        return false;
+    }
+
+    test_pass!("vDSO clock_gettime — sub-tick wall-clock progress");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -633,6 +633,14 @@ pub fn run() -> ! {
     total += 1;
     if test_clock_realtime_futex_parity() { passed += 1; }
 
+    // ── Test 199: vDSO clock_gettime — TSC-derived sub-tick ns granularity ────
+    total += 1;
+    if test_vdso_clock_gettime_subtick_ns() { passed += 1; }
+
+    // ── Test 200: vDSO clock_gettime — sub-tick wall-clock progress ───────────
+    total += 1;
+    if test_vdso_clock_gettime_progress_subms() { passed += 1; }
+
     // ── Test 80d: socketpair(2) — type / SOCK_CLOEXEC / SOCK_NONBLOCK + SEQPACKET
 
     total += 1;
@@ -1321,17 +1329,11 @@ pub fn run() -> ! {
     total += 1;
     if test_dup_clears_cloexec() { passed += 1; }
 
-    // ── Test 199: vDSO clock_gettime — TSC-precise ns granularity ───────
-    total += 1;
-    if test_vdso_clock_gettime_subtick_ns() { passed += 1; }
-
-    // ── Test 200: vDSO clock_gettime — wall-clock progress under 1 ms ───
-    total += 1;
-    if test_vdso_clock_gettime_progress_subms() { passed += 1; }
-
-    // (Stream-A pipe / eventfd wake-hook tests run first — see Tests 0a/0b
-    // at the top of this function so failures surface before the suite's
-    // long network/disk pre-amble.)
+    // (Tests 199/200 run earlier — right after Test 80c — so the vDSO
+    // TSC fast path is verified before the slow PNG screenshot test.
+    // Stream-A pipe / eventfd wake-hook tests run first — see Tests
+    // 0a/0b at the top of this function so failures surface before the
+    // suite's long network/disk pre-amble.)
 
     // ── Summary ─────────────────────────────────────────────────────────
 

--- a/kernel/vdso/vdso.S
+++ b/kernel/vdso/vdso.S
@@ -10,11 +10,28 @@
  *     read a kernel-maintained "vvar" page mapped at a FIXED OFFSET
  *     relative to the vDSO ELF base.  The seqlock pattern (read seq → read
  *     fields → reread seq → retry on change) guards against torn reads
- *     while the timer ISR is updating ticks.
+ *     while the kernel is updating fields.
  *
- *   - getcpu reads IA32_TSC_AUX via RDTSCP.  The kernel writes the logical
- *     CPU index into IA32_TSC_AUX during AP startup, so userspace recovers
- *     it locklessly with no syscall.
+ *   - High-resolution clocks compute nanoseconds from the host TSC:
+ *
+ *         ns = (rdtsc - tsc_at_boot) * tsc_ns_mult >> tsc_ns_shift
+ *
+ *     The (mult, shift) pair is computed once at boot by the kernel
+ *     (kernel/src/proc/vdso.rs::publish_tsc_calibration) to match the
+ *     measured TSC frequency, giving nanosecond resolution without
+ *     entering the kernel.  Mozilla `mozilla::TimeStamp::Now()` and glibc
+ *     `clock_gettime(CLOCK_MONOTONIC)` therefore see a real ns-precision
+ *     clock — earlier tick-quantised implementations returned the same
+ *     value for ~10 ms of wall time, which trapped libxul timing loops
+ *     in zero-elapsed-time busy spins.
+ *
+ *   - CLOCK_*_COARSE callers explicitly trade precision for speed
+ *     (per clock_gettime(2)).  The COARSE path uses the cheaper tick
+ *     counter (10 ms granularity) since precision is not required.
+ *
+ *   - getcpu reads IA32_TSC_AUX via RDTSCP.  The kernel writes the
+ *     logical CPU index into IA32_TSC_AUX during AP startup, so
+ *     userspace recovers it locklessly with no syscall.
  *
  *   - Unsupported clock ids fall through to a raw syscall.
  *
@@ -43,6 +60,7 @@
  *   getcpu(2)           — *cpu / *node / *unused argument convention
  *   System V ABI x86-64 — calling convention, RDI/RSI/RDX/RCX/R8/R9
  *   ELF-64 spec         — DT_VERSYM / GNU version symbol table
+ *   Intel SDM Vol 2, RDTSC / RDTSCP / MUL / SHRD — instruction semantics
  */
 
 	.text
@@ -59,12 +77,10 @@
  * Linux UAPI:  REALTIME=0, MONOTONIC=1, MONOTONIC_RAW=4,
  *              REALTIME_COARSE=5, MONOTONIC_COARSE=6, BOOTTIME=7
  *
- * The COARSE variants explicitly trade precision for speed (man page
- * recommends them for callers that don't need nanosecond accuracy).
- * Our PIT tick base is already 10 ms so CLOCK_*_COARSE and CLOCK_*
- * return identical values; we accept all five fast-path ids.  BOOTTIME
- * (7) falls through to the syscall (it includes time spent suspended,
- * which we don't track here).
+ * BOOTTIME (7) includes time spent suspended which we don't track, so it
+ * falls through to the syscall.  All five other IDs are served from
+ * userspace — the HRES family uses the TSC fast path; COARSE uses the
+ * tick counter directly.
  */
 	.equ CLOCK_REALTIME,         0
 	.equ CLOCK_MONOTONIC,        1
@@ -72,25 +88,22 @@
 	.equ CLOCK_REALTIME_COARSE,  5
 	.equ CLOCK_MONOTONIC_COARSE, 6
 
-/* ── Constants for tick-rate arithmetic ─────────────────────────────── */
+/* ── Numeric constants ─────────────────────────────────────────────── */
 	.equ TICK_HZ,           100      /* PIT programmed at 100 Hz */
 	.equ NS_PER_TICK,       10000000 /* 10 ms */
 	.equ US_PER_TICK,       10000    /* 10 ms in microseconds */
+	.equ NS_PER_SEC,        1000000000
 
 /* ── vvar layout ────────────────────────────────────────────────────
  *
- * The four vvar fields are declared as ordinary symbols in the .vvar
- * section below.  The linker script vdso.lds places .vvar at virtual
- * address 0 and .text at virtual address 0x1000, with .vvar marked
- * NOLOAD so it occupies no bytes in the loadable image.
+ * The vvar field symbols are PROVIDE()'d in vdso.lds at virtual addresses
+ * below 0 so RIP-relative references in .text resolve to fixed negative
+ * 32-bit displacements at link time.  At runtime, the kernel maps a real
+ * page one page below the vDSO ELF so each rip-relative reference reaches
+ * the corresponding kernel-maintained field.
  *
- * RIP-relative references "field(%rip)" inside .text resolve at link
- * time to (field_vaddr - (rip_of_next_insn)), giving a constant negative
- * 32-bit displacement.  At runtime, since the kernel maps a real page
- * at user_base + 0 (the vvar page) and the vDSO ELF at user_base + 0x1000,
- * the same displacement reaches the vvar page from any runtime RIP.
- *
- * KEEP IN SYNC with `struct VvarPage` in kernel/src/proc/vdso.rs.
+ * KEEP IN SYNC with `struct VvarPage` in kernel/src/proc/vdso.rs
+ * (VVAR_OFF_*) and the field layout in kernel/vdso/vdso.lds.
  */
 
 
@@ -109,42 +122,122 @@ __vdso_clock_gettime:
 	jz      .Lcg_einval
 
 	cmp     $CLOCK_REALTIME,         %edi
-	je      .Lcg_realtime
+	je      .Lcg_realtime_hres
 	cmp     $CLOCK_REALTIME_COARSE,  %edi
-	je      .Lcg_realtime
+	je      .Lcg_realtime_coarse
 	cmp     $CLOCK_MONOTONIC,        %edi
-	je      .Lcg_monotonic
+	je      .Lcg_monotonic_hres
 	cmp     $CLOCK_MONOTONIC_RAW,    %edi
-	je      .Lcg_monotonic
+	je      .Lcg_monotonic_hres
 	cmp     $CLOCK_MONOTONIC_COARSE, %edi
-	je      .Lcg_monotonic
+	je      .Lcg_monotonic_coarse
 	jmp     .Lcg_syscall            /* unsupported id → kernel */
 
-.Lcg_realtime:
+/*
+ * High-resolution monotonic: ns = (rdtsc - tsc_at_boot) * mult >> shift.
+ *
+ * Register layout during the seqlock-guarded read window:
+ *
+ *   r8d = seq snapshot
+ *   r10 = tsc_at_boot
+ *   r11 = ns_mult
+ *   ecx = ns_shift (only low byte used by `shrd`)
+ *   r12 = wall_secs (realtime path only — saved/restored on entry/exit)
+ *
+ * The TSC read happens INSIDE the seqlock window so writers that change
+ * tsc_at_boot mid-read force a retry — without this, a rare but real
+ * race could see a delta computed against the old anchor while the new
+ * one was already in mult/shift, producing a wildly wrong ns.
+ */
+.Lcg_monotonic_hres:
 1:	movl    vvar_seq(%rip), %r8d
 	testl   $1, %r8d
-	jnz     1b                      /* writer in progress → spin */
-	movq    vvar_ticks(%rip),     %rax     /* rax = ticks */
-	movq    vvar_wall_secs(%rip), %rcx     /* rcx = wall_secs at boot */
-	lfence
+	jnz     1b                              /* writer in progress */
+	movq    vvar_tsc_at_boot(%rip), %r10
+	movq    vvar_tsc_ns_mult(%rip),  %r11
+	movl    vvar_tsc_ns_shift(%rip), %ecx
+	test    %r11, %r11                       /* calibration ready? */
+	jz      .Lcg_mono_coarse_from_hres       /* fall back to tick */
+	rdtsc                                    /* edx:eax = current TSC */
+	shlq    $32, %rdx
+	orq     %rdx, %rax                       /* rax = full 64-bit TSC */
+	lfence                                   /* serialise vs. retry */
 	movl    vvar_seq(%rip), %r9d
 	cmpl    %r8d, %r9d
-	jne     1b                      /* seq changed → retry */
+	jne     1b
 
-	/* tv_sec  = wall_secs + ticks / 100 */
-	movq    $TICK_HZ, %r11
+	subq    %r10, %rax                       /* rax = tsc - tsc_at_boot */
+	mulq    %r11                             /* rdx:rax = delta * mult */
+	shrdq   %cl, %rdx, %rax                  /* rax = low 64 of (>> cl) */
+	/* rax = ns since boot.  Split into sec / nsec. */
+	movq    %rax, %r8                        /* preserve ns */
+	movq    $NS_PER_SEC, %r11
 	xorq    %rdx, %rdx
-	divq    %r11                    /* rax = ticks/100, rdx = ticks%100 */
-	addq    %rcx, %rax
-	movq    %rax, 0(%rsi)           /* tp->tv_sec */
-	/* tv_nsec = (ticks % 100) * 10_000_000 */
-	movq    %rdx, %rax
-	imulq   $NS_PER_TICK, %rax
-	movq    %rax, 8(%rsi)           /* tp->tv_nsec */
+	divq    %r11                             /* rax = sec, rdx = nsec */
+	movq    %rax, 0(%rsi)
+	movq    %rdx, 8(%rsi)
 	xorl    %eax, %eax
 	ret
 
-.Lcg_monotonic:
+.Lcg_realtime_hres:
+1:	movl    vvar_seq(%rip), %r8d
+	testl   $1, %r8d
+	jnz     1b
+	movq    vvar_tsc_at_boot(%rip),  %r10
+	movq    vvar_tsc_ns_mult(%rip),  %r11
+	movl    vvar_tsc_ns_shift(%rip), %ecx
+	movq    vvar_wall_secs(%rip),    %r9
+	test    %r11, %r11
+	jz      .Lcg_real_coarse_from_hres
+	rdtsc
+	shlq    $32, %rdx
+	orq     %rdx, %rax
+	lfence
+	movl    vvar_seq(%rip), %edi
+	cmpl    %r8d, %edi
+	jne     1b
+
+	subq    %r10, %rax
+	mulq    %r11
+	shrdq   %cl, %rdx, %rax                  /* rax = ns since boot */
+	movq    $NS_PER_SEC, %r11
+	xorq    %rdx, %rdx
+	divq    %r11                             /* rax = sec, rdx = nsec */
+	addq    %r9,  %rax                       /* + wall_secs */
+	movq    %rax, 0(%rsi)
+	movq    %rdx, 8(%rsi)
+	xorl    %eax, %eax
+	ret
+
+/*
+ * COARSE paths (and the calibration-not-ready fallback) use the 10 ms
+ * tick counter directly — same precision as Linux's CLOCK_*_COARSE.
+ */
+.Lcg_realtime_coarse:
+.Lcg_real_coarse_from_hres:
+1:	movl    vvar_seq(%rip), %r8d
+	testl   $1, %r8d
+	jnz     1b
+	movq    vvar_ticks(%rip),     %rax
+	movq    vvar_wall_secs(%rip), %rcx
+	lfence
+	movl    vvar_seq(%rip), %r9d
+	cmpl    %r8d, %r9d
+	jne     1b
+
+	movq    $TICK_HZ, %r11
+	xorq    %rdx, %rdx
+	divq    %r11
+	addq    %rcx, %rax
+	movq    %rax, 0(%rsi)
+	movq    %rdx, %rax
+	imulq   $NS_PER_TICK, %rax
+	movq    %rax, 8(%rsi)
+	xorl    %eax, %eax
+	ret
+
+.Lcg_monotonic_coarse:
+.Lcg_mono_coarse_from_hres:
 1:	movl    vvar_seq(%rip), %r8d
 	testl   $1, %r8d
 	jnz     1b
@@ -198,6 +291,40 @@ __vdso_gettimeofday:
 1:	movl    vvar_seq(%rip), %r8d
 	testl   $1, %r8d
 	jnz     1b
+	movq    vvar_tsc_at_boot(%rip),  %r10
+	movq    vvar_tsc_ns_mult(%rip),  %r11
+	movl    vvar_tsc_ns_shift(%rip), %ecx
+	movq    vvar_wall_secs(%rip),    %r9
+	test    %r11, %r11
+	jz      .Lgtod_from_ticks
+	rdtsc
+	shlq    $32, %rdx
+	orq     %rdx, %rax
+	lfence
+	movl    vvar_seq(%rip), %edx
+	cmpl    %r8d, %edx
+	jne     1b
+
+	subq    %r10, %rax
+	mulq    %r11
+	shrdq   %cl, %rdx, %rax                  /* rax = ns since boot */
+	movq    $NS_PER_SEC, %r11
+	xorq    %rdx, %rdx
+	divq    %r11                             /* rax = sec, rdx = nsec */
+	addq    %r9, %rax                        /* + wall_secs */
+	movq    %rax, 0(%rdi)
+	movq    %rdx, %rax
+	movq    $1000, %r11
+	xorq    %rdx, %rdx
+	divq    %r11                             /* rax = nsec/1000 = usec */
+	movq    %rax, 8(%rdi)
+	jmp     .Lgtod_zero_tz_only
+
+/* Calibration not yet published — fall back to 10 ms tick. */
+.Lgtod_from_ticks:
+1:	movl    vvar_seq(%rip), %r8d
+	testl   $1, %r8d
+	jnz     1b
 	movq    vvar_ticks(%rip),     %rax
 	movq    vvar_wall_secs(%rip), %rcx
 	lfence
@@ -205,13 +332,11 @@ __vdso_gettimeofday:
 	cmpl    %r8d, %r9d
 	jne     1b
 
-	/* tv_sec = wall_secs + ticks / 100 */
 	movq    $TICK_HZ, %r11
 	xorq    %rdx, %rdx
 	divq    %r11
 	addq    %rcx, %rax
 	movq    %rax, 0(%rdi)
-	/* tv_usec = (ticks % 100) * 10_000 */
 	movq    %rdx, %rax
 	imulq   $US_PER_TICK, %rax
 	movq    %rax, 8(%rdi)
@@ -233,7 +358,8 @@ __vdso_gettimeofday:
  * time_t __vdso_time(time_t *tloc)
  *
  * Returns seconds since the UNIX epoch and writes the same value to *tloc
- * if non-NULL.
+ * if non-NULL.  Second-granularity, so the cheap tick-counter path is
+ * sufficient — no TSC reading.
  *
  * Args:    rdi = tloc
  * Return:  rax = seconds since epoch.

--- a/kernel/vdso/vdso.lds
+++ b/kernel/vdso/vdso.lds
@@ -48,10 +48,14 @@ SECTIONS {
 	 */
 	. = -0x1000;
 
-	vvar_seq       = . + 0x00;   /* u32 — sequence counter        */
-	vvar_tick_hz   = . + 0x04;   /* u32 — PIT frequency           */
-	vvar_ticks     = . + 0x08;   /* u64 — monotonic PIT ticks     */
-	vvar_wall_secs = . + 0x10;   /* u64 — UNIX seconds at boot    */
+	vvar_seq            = . + 0x00; /* u32 — sequence counter           */
+	vvar_tick_hz        = . + 0x04; /* u32 — PIT frequency              */
+	vvar_ticks          = . + 0x08; /* u64 — monotonic PIT ticks        */
+	vvar_wall_secs      = . + 0x10; /* u64 — UNIX seconds at boot       */
+	vvar_tsc_at_boot    = . + 0x18; /* u64 — TSC reading at boot epoch  */
+	vvar_tsc_ns_mult    = . + 0x20; /* u64 — ns = (tsc_delta * mult)    */
+	vvar_tsc_ns_shift   = . + 0x28; /* u32 —          >> shift          */
+	vvar_tsc_per_tick   = . + 0x30; /* u64 — TSC cycles per 10 ms tick  */
 
 	/*
 	 * Place ELF header + program headers + dynamic info at vaddr 0


### PR DESCRIPTION
## Summary

Phase TSC-VDSO + PID-CACHE — two bundled fixes targeting the Firefox parent
process timing wedge.  Together they remove ~10,000× over-quantisation from
every Mozilla `TimeStamp::Now()` read and ~2-5× lock-thrash from every Linux
syscall.

### Fix 1 — vDSO `clock_gettime` uses TSC-derived ns (not tick-quantised)

The vDSO fast path previously computed time from a 100 Hz tick counter:

    ts.tv_sec  = vvar_wall_secs + vvar_ticks / TICK_HZ
    ts.tv_nsec = (vvar_ticks % TICK_HZ) * NS_PER_TICK     # 10 ms steps

`TICK_HZ` is 100, so every `clock_gettime(CLOCK_MONOTONIC)` read returned the
same value for ~10 ms of wall time.  Mozilla's `mozilla::TimeStamp::Now()`
calls this directly, and any libxul timing loop using `TimeStamp` /
`TimeDuration` observed "0 ns elapsed" within a 10 ms window — trapping
the JS event-pump and worker-coordination loops in zero-elapsed-time spins.

This PR publishes the host TSC calibration into the vvar page

    vvar_tsc_at_boot   = rdtsc() at calibration time
    vvar_tsc_ns_mult   = (1 << 32) * 1e9 / tsc_freq_hz
    vvar_tsc_ns_shift  = 32
    vvar_tsc_per_tick  = TSC cycles per 10 ms tick

and rewrites `__vdso_clock_gettime` so the HRES clock IDs (`REALTIME`,
`MONOTONIC`, `MONOTONIC_RAW`) compute

    ns = (rdtsc - tsc_at_boot) * mult >> shift

using `mulq` + `shrd` for full 128-bit-multiply precision.  The `COARSE`
clock IDs keep the cheap tick path, matching `clock_gettime(2)`'s
"coarse resolution" semantics.

The kernel-side `sys_clock_gettime` is updated to use the same TSC formula
via a new `vdso::monotonic_ns()` helper, so kernel-side futex
absolute-deadline conversion stays coherent with what userspace reads.
Without this, a thread reading the vDSO ns then asking the kernel to wait
until that absolute deadline could see `ETIMEDOUT` immediately if the two
formulas disagreed by more than the elapsed time.

### Fix 2 — `current_pid_lockless()` in syscall hot paths

`current_pid()` previously took `THREAD_TABLE.lock()` and did an O(n) linear
scan of every thread to find the owning PID.  Each Linux syscall handler
calls it 2-5×.

A per-CPU `PER_CPU_CURRENT_PID` atomic was already maintained by the
scheduler for ISR-context lookups in the page-fault handler.  This PR
routes every syscall-handler call site (124 sites across
`kernel/src/subsys/linux/syscall.rs` + `kernel/src/syscall/mod.rs`)
through the lockless variant — a single relaxed atomic load.

The locking variant is retained only where the slow path matters:

- `is_linux_abi()` keeps its existing slow-path recovery
  (`THREAD_TABLE` walk by kernel-stack-top) for the rare
  `PER_CPU_CURRENT_PID`-is-stale window when the timer ISR preempted a
  user thread mid-`set_current_tid`.
- Non-syscall-handler call sites (PF handler, signal delivery,
  sysv_shm, NT dispatch, etc.) are left untouched.

`PER_CPU_CURRENT_PID` is set by the scheduler on every context switch
(`kernel/src/sched/mod.rs::set_current_pid`) and matches what
`THREAD_TABLE.iter().find()` would return for the running thread, so the
lockless read is exact in syscall handler context.

### Public references

- `clock_gettime(2)` — clock_id semantics, struct timespec layout
- `vdso(7)` — AT_SYSINFO_EHDR, symbol versioning, fast-path strategy
- Intel SDM Vol 2 — `RDTSC`, `MUL`, `SHRD`, `LFENCE` instruction semantics
- Intel SDM Vol 3, Time-Stamp Counter — invariant TSC, frequency scaling

## Test plan

- [x] Build: `cargo +nightly build ... --features test-mode`
- [x] Boot: `[vDSO] tsc-calibration published: tsc_at_boot=0x... tsc_per_tick=... tsc_freq_hz=... ns_mult=... ns_shift=32` emitted right after APIC init
- [x] vDSO disasm: HRES path emits `rdtsc` + `mulq` + `shrd` (verified via `objdump -d vdso.so` at `__vdso_clock_gettime+0x60`)
- [ ] Test 199 — sub-tick ns granularity: 128 `clock_gettime(CLOCK_MONOTONIC)` reads, at least one with `tv_nsec % 10_000_000 != 0`
- [ ] Test 200 — sub-tick wall-clock progress: 1 ms TSC busy-wait between two `clock_gettime` calls yields a positive ns delta
- [ ] All existing CLOCK_REALTIME / CLOCK_MONOTONIC / futex-parity tests (80a/80b/80c) pass