### PR TITLE
sched/proc: 'pick: loop is_active recheck after hlt + bootstrap cr3 defense

### DIFF
--- a/kernel/src/proc/usermode.rs
+++ b/kernel/src/proc/usermode.rs
@@ -221,7 +221,7 @@ pub fn user_mode_bootstrap() {
         }
     }
 
-    let (entry_rip, entry_rsp, entry_rdx, entry_r8, kernel_stack_top, user_cr3, tls_base, gs_base) = {
+    let (entry_rip, entry_rsp, entry_rdx, entry_r8, kernel_stack_top, mut user_cr3, tls_base, gs_base, pid) = {
         let tid = proc::current_tid();
         let threads = THREAD_TABLE.lock();
         let thread = match threads.iter().find(|t| t.tid == tid) {
@@ -242,8 +242,36 @@ pub fn user_mode_bootstrap() {
             thread.context.cr3,
             thread.tls_base,
             thread.gs_base,
+            thread.pid,
         )
     };
+
+    // Defensive: if the thread's context.cr3 was never propagated by the
+    // creator (e.g. a future code path creates the thread before the
+    // owning process's cr3 is known, or a fork/clone helper forgets to
+    // copy it), fall back to the owning process's cr3.  Without this
+    // recovery user_mode_bootstrap would IRETQ with stale-or-zero CR3
+    // and #PF immediately on the first user instruction.  Persist the
+    // value back to the thread so any subsequent re-entry into bootstrap
+    // (or schedule()'s CR3 switch) sees a consistent non-zero cr3.
+    if user_cr3 == 0 {
+        let p_cr3 = {
+            let procs = PROCESS_TABLE.lock();
+            procs.iter().find(|p| p.pid == pid).map(|p| p.cr3).unwrap_or(0)
+        };
+        if p_cr3 != 0 {
+            crate::serial_println!(
+                "[BOOT] tid={} pid={}: context.cr3 was 0, propagating from process cr3={:#x}",
+                proc::current_tid(), pid, p_cr3
+            );
+            user_cr3 = p_cr3;
+            let tid = proc::current_tid();
+            let mut threads = THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                t.context.cr3 = p_cr3;
+            }
+        }
+    }
 
     crate::serial_println!(
         "[USER] Bootstrap tid={}: Ring 3 at RIP={:#x} RSP={:#x} CR3={:#x} RDX={:#x} R8={:#x}",

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -333,6 +333,18 @@ pub fn schedule() {
                     unsafe {
                         core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
                     }
+                    // Re-check SCHEDULER_ACTIVE after waking from hlt.
+                    // If another CPU called sched::disable() while we were
+                    // halted, timer_tick_schedule() now short-circuits and
+                    // will never flip a peer to Ready or set NEED_RESCHEDULE
+                    // — `continue 'pick` would loop forever in sti;hlt;cli.
+                    // Treat disable as "drop out of the picker"; the caller's
+                    // schedule() prologue already returns when is_active() is
+                    // false, so unwinding to it preserves existing semantics.
+                    if !is_active() {
+                        crate::hal::enable_interrupts();
+                        return;
+                    }
                     continue 'pick;
                 }
                 _ => {
@@ -351,6 +363,11 @@ pub fn schedule() {
                     crate::perf::record_idle_tick();
                     unsafe {
                         core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
+                    }
+                    // See is_active() recheck rationale above.
+                    if !is_active() {
+                        crate::hal::enable_interrupts();
+                        return;
                     }
                     continue 'pick;
                 }
@@ -500,6 +517,14 @@ pub fn schedule() {
                         unsafe {
                             core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
                         }
+                        // Re-check SCHEDULER_ACTIVE after waking from hlt.
+                        // sched::disable() on another CPU silently disarms
+                        // timer_tick_schedule()'s wake hooks, so without
+                        // this guard the loop would spin sti;hlt;cli forever.
+                        if !is_active() {
+                            crate::hal::enable_interrupts();
+                            return;
+                        }
                         continue 'pick;
                     }
                     _ => {
@@ -509,6 +534,11 @@ pub fn schedule() {
                         crate::perf::record_idle_tick();
                         unsafe {
                             core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
+                        }
+                        // See is_active() recheck rationale above.
+                        if !is_active() {
+                            crate::hal::enable_interrupts();
+                            return;
                         }
                         continue 'pick;
                     }


### PR DESCRIPTION
## Summary

- Picker's `'pick:` loop re-checks `SCHEDULER_ACTIVE` after every `sti;hlt;cli`. A sibling-CPU `sched::disable()` racing with a halted picker iteration would otherwise leave the loop spinning forever, because `timer_tick_schedule()` short-circuits when the scheduler is disarmed and so no wake hook fires.
- `user_mode_bootstrap` falls back to the owning process's `cr3` when the thread's `context.cr3 == 0`, and persists the recovered value back to the thread. Defensive backstop against any future creation path that forgets to propagate cr3 — without this, bootstrap would IRETQ to Ring 3 with CR3=0 and #PF immediately.

Both fixes are scoped, localised, and required by the long-standing investigation of the Test 104 / Test 120 wedge. The picker recheck closes the `sched::disable()`-mid-`'pick:`-loop race the previous investigator identified at four hlt sites.

## What this does NOT fix

This is **not sufficient** to remove the `ci-skip-test-104` gate. With the gate removed, the suite no longer wedges in the picker — but CPU 0 then livelocks inside `ipc::inotify::notify_event` iterating a watch slot whose `watches` Vec is not converging during repeated `free_vm_space()` teardowns. That is a separate VFS/inotify livelock owned by a follow-up investigation; this PR lands the picker / bootstrap invariants cleanly so they are not entangled with the inotify fix when it comes.

The `Cargo.toml` feature `ci-skip-test-104` and the `#[cfg(not(feature = \"ci-skip-test-104\"))]` gate around `test_execve_no_pmm_leak()` are kept as-is.

## Test plan

- [x] `qemu-harness.py start --features test-mode,kdb,ci-skip-test-104` — 119 / 125 tests pass (six pre-existing failures unchanged: musl hello, pie_elf, TCC compile, busybox basic, sigchld, ascension).
- [x] Build succeeds on master without warnings new to this branch.
- [x] No new test failures introduced by either fix.
- [ ] Follow-up: investigate `inotify::notify_event` livelock during repeated `free_vm_space()` (next blocker for removing `ci-skip-test-104`).

## References

- Intel SDM Vol. 3A §6.8.5 — `STI; HLT` shadow & interruptibility window
- Intel SDM Vol. 3A §4.10.4 — INVLPG / CR3 reload requirements

(Re-pushed from PR #148 to land cleanly on current origin/master without a stale qemu-harness.py merge conflict.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)