### PR TITLE
qemu-harness: QGA-3 — qga-ping / qga-info / qga-file-read / qga-sync subcommands

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -34,6 +34,12 @@ Tier 2 — GDB stub integration (requires --gdb-port on start):
     python3 scripts/qemu-harness.py cont <sid>
     python3 scripts/qemu-harness.py pause <sid>
     python3 scripts/qemu-harness.py resume <sid>
+
+QGA bridge (requires --features qga on start):
+    python3 scripts/qemu-harness.py qga-ping <sid> [--timeout S]
+    python3 scripts/qemu-harness.py qga-info <sid> [--timeout S]
+    python3 scripts/qemu-harness.py qga-sync <sid> [--id N] [--timeout S]
+    python3 scripts/qemu-harness.py qga-file-read <sid> --path <P> [--max-bytes N]
 """
 
 import argparse
@@ -1082,6 +1088,11 @@ def cmd_start(args):
           # True when data.img was absent (even after auto-symlink attempt).
           # Agents should treat this as a hard warning for firefox-test runs.
           "data_img_missing": _data_img_missing,
+          # Per-session QGA UNIX chardev socket path. Empty string when the
+          # session was started without --features qga; non-empty paths may
+          # not yet exist on disk if QEMU hasn't bound the socket yet
+          # (the qga-* subcommands report `socket missing` until then).
+          "qga_sock_path": qga_sock,
           # Session-scoped kernel binary path (additive field — agents that
           # want to verify the running binary's SHA against a known-good
           # reference can read this directly).
@@ -1883,6 +1894,214 @@ def cmd_kdb(args):
     except OSError: pass
 
     _out(resp)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# QGA (QEMU Guest Agent) subcommands — one-shot calls into the in-guest daemon
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# These commands speak qemu-guest-agent-compatible NDJSON over the UNIX-domain
+# chardev socket QEMU exposes on the host side of the virtio-serial port. The
+# socket path is per-session: ~/.astryx-harness/<sid>.qga.sock, recorded as
+# `qga_sock` in the session JSON. Each invocation here opens the socket, sends
+# one request, reads one reply, closes. See `scripts/qga_client.py` for the
+# wire helper that takes care of framing, timeouts, and the `0xff` stale-data
+# delimiter quirk (sync-delimited path; documented at
+# https://wiki.qemu.org/Features/GuestAgent).
+#
+# The session must have been started with `--features qga` (or a feature set
+# that pulls it in) for the daemon to spawn and the host socket to bind. When
+# the socket is absent, the wrappers return a structured `connect failed`
+# error rather than raising.
+
+# qga_client lives next to this file — already imported above via the sys.path
+# manipulation that pulled in astryx_qemu.
+import qga_client  # noqa: E402
+
+
+def _qga_sock_or_err(sess: dict) -> str:
+    """
+    Resolve the QGA socket path from a session dict.
+
+    Returns the path string; if the session was not started with QGA
+    enabled, prints a structured error and exits non-zero. Callers can
+    therefore treat the return value as a guaranteed non-empty path.
+    """
+    sock = (sess.get("qga_sock") or "").strip()
+    if not sock:
+        _out({
+            "ok": False,
+            "error": "session was not started with --features qga "
+                     "(no qga_sock in session JSON)",
+        })
+        sys.exit(2)
+    return sock
+
+
+def cmd_qga_ping(args):
+    """guest-ping — round-trip latency probe."""
+    sess = _load_session(args.sid)
+    sock = _qga_sock_or_err(sess)
+    timeout = float(getattr(args, "timeout", 5.0) or 5.0)
+    res = qga_client.qga_ping(sock, timeout=timeout)
+    # Project the qga_client structured result onto the harness contract:
+    #   {"ok": bool, "latency_ms": int, "error"?: str, "response"?: ...}
+    out = {"ok": bool(res.get("ok")), "latency_ms": int(res.get("latency_ms", 0))}
+    if not res.get("ok"):
+        out["error"] = res.get("error", "unknown error")
+        if "raw" in res:
+            out["raw"] = res["raw"]
+    else:
+        out["response"] = res.get("response")
+    _out(out)
+    sys.exit(0 if out["ok"] else 2)
+
+
+def cmd_qga_info(args):
+    """guest-info — daemon version + supported-commands list."""
+    sess = _load_session(args.sid)
+    sock = _qga_sock_or_err(sess)
+    timeout = float(getattr(args, "timeout", 5.0) or 5.0)
+    res = qga_client.qga_info(sock, timeout=timeout)
+    out = {"ok": bool(res.get("ok")), "latency_ms": int(res.get("latency_ms", 0))}
+    if not res.get("ok"):
+        out["error"] = res.get("error", "unknown error")
+        if "raw" in res:
+            out["raw"] = res["raw"]
+    else:
+        # Surface the daemon's `return` payload at the top level so agents
+        # can read `version` / `supported_commands` without descending into
+        # the QGA envelope.
+        resp = res.get("response") or {}
+        ret = resp.get("return") if isinstance(resp, dict) else None
+        out["response"] = resp
+        if isinstance(ret, dict):
+            out["return"] = ret
+    _out(out)
+    sys.exit(0 if out["ok"] else 2)
+
+
+def cmd_qga_sync(args):
+    """guest-sync — verify the daemon round-trip ID matches.
+
+    Useful as a liveness probe before any other QGA call; the daemon
+    echoes the supplied integer, so a mismatch flags a stale or mis-
+    framed reply (e.g. a crash-restart between calls). Default id is
+    a random 31-bit positive integer to keep concurrent callers
+    independent; pass --id to pin a specific value (handy in tests
+    that compare on exact JSON output).
+    """
+    sess = _load_session(args.sid)
+    sock = _qga_sock_or_err(sess)
+    timeout = float(getattr(args, "timeout", 5.0) or 5.0)
+    sync_id = getattr(args, "id", None)
+    res = qga_client.qga_sync(sock, timeout=timeout, sync_id=sync_id)
+    out = {
+        "ok": bool(res.get("ok")),
+        "latency_ms": int(res.get("latency_ms", 0)),
+        "id": res.get("id"),
+    }
+    if not res.get("ok"):
+        out["error"] = res.get("error", "unknown error")
+        if "raw" in res:
+            out["raw"] = res["raw"]
+    else:
+        out["response"] = res.get("response")
+    _out(out)
+    sys.exit(0 if out["ok"] else 2)
+
+
+def cmd_qga_file_read(args):
+    """guest-file-open → guest-file-read → guest-file-close in one call.
+
+    Returns:
+        On success: {"ok":true,"bytes_b64":"...","len":N,"path":...}
+        On any failure: {"ok":false,"error":"...","stage":"open|read|close"}
+
+    The `stage` field identifies which underlying QGA call failed, so a
+    caller can distinguish "file not found" (open) from "guest read
+    error" (read). The close step is best-effort: if open+read both
+    succeeded but close failed, we still return ok=true and surface the
+    close diagnostic under `close_error`.
+    """
+    sess = _load_session(args.sid)
+    sock = _qga_sock_or_err(sess)
+    timeout = float(getattr(args, "timeout", 5.0) or 5.0)
+    path = args.path
+    # Cap at 4 KiB by default — matches the daemon's MAX_READ_CHUNK so a
+    # caller asking for more wouldn't get more anyway. Larger reads would
+    # need iterated guest-file-read calls (out of scope for QGA-3).
+    max_bytes = int(getattr(args, "max_bytes", 4096) or 4096)
+    if max_bytes <= 0:
+        _out({"ok": False, "error": "max-bytes must be positive", "stage": "args"})
+        sys.exit(2)
+    if max_bytes > 4096:
+        max_bytes = 4096
+
+    # ── open ────────────────────────────────────────────────────────────────
+    open_res = qga_client.qga_file_open(sock, path, mode="r", timeout=timeout)
+    if not open_res.get("ok"):
+        out = {
+            "ok": False,
+            "stage": "open",
+            "error": open_res.get("error", "open failed"),
+            "path": path,
+            "latency_ms": int(open_res.get("latency_ms", 0)),
+        }
+        if "raw" in open_res:
+            out["raw"] = open_res["raw"]
+        _out(out)
+        sys.exit(2)
+
+    handle_raw = (open_res.get("response") or {}).get("return")
+    try:
+        handle = int(handle_raw)
+    except (TypeError, ValueError):
+        _out({
+            "ok": False,
+            "stage": "open",
+            "error": f"daemon returned non-integer handle: {handle_raw!r}",
+            "path": path,
+        })
+        sys.exit(2)
+
+    # ── read ────────────────────────────────────────────────────────────────
+    read_res = qga_client.qga_file_read(sock, handle, max_bytes, timeout=timeout)
+    if not read_res.get("ok"):
+        # Best-effort close, then report the read failure.
+        qga_client.qga_file_close(sock, handle, timeout=timeout)
+        out = {
+            "ok": False,
+            "stage": "read",
+            "error": read_res.get("error", "read failed"),
+            "path": path,
+            "handle": handle,
+            "latency_ms": int(read_res.get("latency_ms", 0)),
+        }
+        if "raw" in read_res:
+            out["raw"] = read_res["raw"]
+        _out(out)
+        sys.exit(2)
+
+    ret = (read_res.get("response") or {}).get("return") or {}
+    bytes_b64 = ret.get("buf-b64") or ""
+    length = int(ret.get("count") or 0)
+
+    # ── close ───────────────────────────────────────────────────────────────
+    close_res = qga_client.qga_file_close(sock, handle, timeout=timeout)
+
+    out = {
+        "ok": True,
+        "path": path,
+        "handle": handle,
+        "bytes_b64": bytes_b64,
+        "len": length,
+        "latency_ms": int(read_res.get("latency_ms", 0)),
+    }
+    if not close_res.get("ok"):
+        out["close_error"] = close_res.get("error", "close failed")
+    _out(out)
+    sys.exit(0)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -4468,6 +4687,46 @@ def main():
     p_kdb.add_argument("--timeout", type=float, default=5.0,
                         help="Socket timeout in seconds (default 5.0)")
 
+    # qga-ping / qga-info / qga-sync / qga-file-read — QEMU Guest Agent
+    # bridge.  Requires --features qga at start; talks NDJSON over the
+    # per-session UNIX chardev socket at ~/.astryx-harness/<sid>.qga.sock.
+    p_qga_ping = sub.add_parser(
+        "qga-ping",
+        help="QGA: round-trip ping the in-guest QEMU Guest Agent daemon")
+    p_qga_ping.add_argument("sid")
+    p_qga_ping.add_argument("--timeout", type=float, default=5.0,
+                             help="Socket timeout in seconds (default 5.0)")
+
+    p_qga_info = sub.add_parser(
+        "qga-info",
+        help="QGA: fetch daemon version + supported-commands list")
+    p_qga_info.add_argument("sid")
+    p_qga_info.add_argument("--timeout", type=float, default=5.0,
+                             help="Socket timeout in seconds (default 5.0)")
+
+    p_qga_sync = sub.add_parser(
+        "qga-sync",
+        help="QGA: send guest-sync, verify the daemon echoes the same id "
+             "(liveness probe before other QGA calls)")
+    p_qga_sync.add_argument("sid")
+    p_qga_sync.add_argument("--id", dest="id", type=int, default=None,
+                             help="Sync id (default: random 31-bit positive int)")
+    p_qga_sync.add_argument("--timeout", type=float, default=5.0,
+                             help="Socket timeout in seconds (default 5.0)")
+
+    p_qga_fread = sub.add_parser(
+        "qga-file-read",
+        help="QGA: open + read + close a guest file in one call. "
+             "Returns base64-encoded bytes (capped at 4 KiB per QGA-2)")
+    p_qga_fread.add_argument("sid")
+    p_qga_fread.add_argument("--path", required=True,
+                              help="Absolute guest path (e.g. /disk/opt/firefox/firefox-bin)")
+    p_qga_fread.add_argument("--max-bytes", dest="max_bytes",
+                              type=int, default=4096,
+                              help="Max bytes to read (1..4096, default 4096)")
+    p_qga_fread.add_argument("--timeout", type=float, default=5.0,
+                              help="Socket timeout in seconds (default 5.0)")
+
     # prune — housekeeping for ~/.astryx-harness/
     p_prune = sub.add_parser("prune",
         help="Delete state/log files for dead sessions older than --ttl days")
@@ -4691,6 +4950,11 @@ def main():
         "resume": cmd_resume,
         # Tier 1
         "kdb":    cmd_kdb,
+        # QGA bridge
+        "qga-ping":      cmd_qga_ping,
+        "qga-info":      cmd_qga_info,
+        "qga-sync":      cmd_qga_sync,
+        "qga-file-read": cmd_qga_file_read,
         # Housekeeping / reporting
         "prune":   cmd_prune,
         "results": cmd_results,

--- a/scripts/qga_client.py
+++ b/scripts/qga_client.py
@@ -1,0 +1,286 @@
+"""
+qga_client.py — Minimal one-shot client for the AstryxOS QGA daemon.
+
+Talks to the in-guest QEMU Guest Agent daemon through QEMU's UNIX-domain
+chardev socket (the host side of the virtio-serial port wired into the
+guest as `/dev/vport0p0`). Wire format is qemu-guest-agent compatible —
+each line is one JSON request, the daemon replies with one JSON line.
+
+See https://wiki.qemu.org/Features/GuestAgent and
+https://www.qemu.org/docs/master/interop/qemu-ga-ref.html for the protocol.
+
+## Design
+
+Strictly one-shot per call: every public helper opens the socket, writes
+one request, reads one response, closes, returns. This matches the
+agent-friendly contract enforced by `qemu-harness.py` itself — no REPL,
+no kept-open connections, no stdin pipes. Multiple parallel callers are
+safe because the chardev socket is session-scoped (one socket per
+QEMU process).
+
+## guest-sync-delimited robustness
+
+The published QGA framing has a stale-data quirk: after a guest reboot,
+the host side of the chardev may still have bytes from the previous
+guest's reply lingering in its receive buffer. The recommended cure is
+`guest-sync-delimited`, which prefixes its reply with a literal `0xff`
+byte that the client uses to skip the stale prefix. A plain `guest-sync`
+emits no `0xff`. Both forms are valid JSON-line replies.
+
+We accept either: when reading the response we strip a single leading
+`0xff` if present before JSON parsing. This keeps the client compatible
+with the current AstryxOS daemon (which never emits `0xff`) and with a
+future upgrade path to delimited sync.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import socket
+import time
+from typing import Any, Optional
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def qga_request(
+    sock_path: str,
+    request: dict,
+    *,
+    timeout: float = 5.0,
+) -> dict:
+    """
+    Send one QGA request, return one parsed response.
+
+    Returns a dict of the form:
+      - success: ``{"ok": True, "response": <parsed JSON>, "latency_ms": N}``
+      - failure: ``{"ok": False, "error": "<short reason>", "latency_ms": N}``
+
+    Never raises. All failure modes (missing socket, connect refused,
+    short read, bad JSON, server-side error reply) are surfaced through
+    the ``ok=False`` shape so callers can render structured stdout
+    without try/except boilerplate.
+
+    The ``latency_ms`` field is the wall-clock duration of the call,
+    rounded down to whole milliseconds.
+
+    Args:
+        sock_path:  Filesystem path of the host-side QGA chardev socket
+                    (``~/.astryx-harness/<sid>.qga.sock``).
+        request:    Dict that JSON-encodes to one QGA request line.
+                    Must include an ``execute`` key per QGA spec.
+        timeout:    Total wall-clock budget for connect + send + recv,
+                    in seconds. Default 5s (matches the smoke-test
+                    expectation of "fresh boot → ping in well under 1s").
+
+    Errors returned:
+      - ``"socket missing"`` — sock_path doesn't exist (QGA daemon never
+        ran, or session not started with `--features qga`)
+      - ``"connect failed: ..."`` — socket exists but QEMU refused
+      - ``"timeout"`` — no response line within ``timeout``
+      - ``"short read"`` — peer closed before delivering a complete line
+      - ``"bad JSON: ..."`` — response was not valid JSON
+      - ``"server error: ..."`` — response was a well-formed QGA error
+    """
+    t0 = time.monotonic()
+
+    def _latency() -> int:
+        return int((time.monotonic() - t0) * 1000)
+
+    if not os.path.exists(sock_path):
+        return {"ok": False, "error": "socket missing", "latency_ms": _latency()}
+
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    try:
+        try:
+            s.connect(sock_path)
+        except (ConnectionRefusedError, FileNotFoundError, OSError) as e:
+            return {
+                "ok": False,
+                "error": f"connect failed: {e}",
+                "latency_ms": _latency(),
+            }
+
+        payload = (json.dumps(request, separators=(",", ":")) + "\n").encode()
+        try:
+            s.sendall(payload)
+        except OSError as e:
+            return {
+                "ok": False,
+                "error": f"send failed: {e}",
+                "latency_ms": _latency(),
+            }
+
+        # Read until newline or deadline. The daemon emits exactly one
+        # newline-terminated reply per request — anything past it is a
+        # framing error.
+        deadline = t0 + timeout
+        buf = bytearray()
+        while b"\n" not in buf:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return {
+                    "ok": False,
+                    "error": "timeout",
+                    "latency_ms": _latency(),
+                }
+            try:
+                s.settimeout(remaining)
+                chunk = s.recv(65536)
+            except socket.timeout:
+                return {
+                    "ok": False,
+                    "error": "timeout",
+                    "latency_ms": _latency(),
+                }
+            except OSError as e:
+                return {
+                    "ok": False,
+                    "error": f"recv failed: {e}",
+                    "latency_ms": _latency(),
+                }
+            if not chunk:
+                return {
+                    "ok": False,
+                    "error": "short read",
+                    "latency_ms": _latency(),
+                }
+            buf.extend(chunk)
+            # Cap buffer to keep a runaway server from blowing the host.
+            if len(buf) > 1024 * 1024:
+                return {
+                    "ok": False,
+                    "error": "reply too large",
+                    "latency_ms": _latency(),
+                }
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass
+
+    # Carve out exactly the first line.
+    line, _, _ = bytes(buf).partition(b"\n")
+
+    # Strip a single leading 0xff if present (guest-sync-delimited path —
+    # see module docstring). Anything else is treated as opaque JSON bytes.
+    if line.startswith(b"\xff"):
+        line = line[1:]
+
+    try:
+        obj = json.loads(line.decode("utf-8", errors="replace"))
+    except (ValueError, json.JSONDecodeError) as e:
+        return {
+            "ok": False,
+            "error": f"bad JSON: {e}",
+            "raw": line.decode("utf-8", errors="replace"),
+            "latency_ms": _latency(),
+        }
+
+    if isinstance(obj, dict) and "error" in obj:
+        err = obj.get("error")
+        # QGA error class is `{"error":{"class":"GenericError","desc":"..."}}`
+        desc = ""
+        if isinstance(err, dict):
+            desc = str(err.get("desc") or err)
+        else:
+            desc = str(err)
+        return {
+            "ok": False,
+            "error": f"server error: {desc}",
+            "response": obj,
+            "latency_ms": _latency(),
+        }
+
+    return {"ok": True, "response": obj, "latency_ms": _latency()}
+
+
+def qga_sync(sock_path: str, *, timeout: float = 5.0,
+             sync_id: Optional[int] = None) -> dict:
+    """
+    Issue a `guest-sync` request and verify the echoed id matches.
+
+    Returns the same shape as `qga_request` plus a ``"id"`` field
+    holding the id that was sent. On a successful sync the response
+    object will have ``response["return"]`` equal to ``sync_id``.
+
+    If `sync_id` is omitted, a fresh random 31-bit positive integer is
+    generated so concurrent callers do not collide.
+    """
+    if sync_id is None:
+        sync_id = random.randint(1, 0x7FFF_FFFF)
+    req = {"execute": "guest-sync", "arguments": {"id": sync_id}}
+    out = qga_request(sock_path, req, timeout=timeout)
+    out["id"] = sync_id
+    if out.get("ok") and isinstance(out.get("response"), dict):
+        ret = out["response"].get("return")
+        if ret != sync_id:
+            out["ok"] = False
+            out["error"] = f"sync id mismatch: sent {sync_id}, got {ret!r}"
+    return out
+
+
+def qga_ping(sock_path: str, *, timeout: float = 5.0) -> dict:
+    """
+    Issue a `guest-ping`. Returns the qga_request shape; on success
+    `response["return"]` is the empty object `{}`.
+    """
+    return qga_request(sock_path, {"execute": "guest-ping"}, timeout=timeout)
+
+
+def qga_info(sock_path: str, *, timeout: float = 5.0) -> dict:
+    """Issue a `guest-info`. Returns the qga_request shape."""
+    return qga_request(sock_path, {"execute": "guest-info"}, timeout=timeout)
+
+
+def qga_file_open(sock_path: str, path: str, mode: str = "r",
+                  *, timeout: float = 5.0) -> dict:
+    """
+    Issue a `guest-file-open`. On success `response["return"]` is the
+    integer file handle the daemon allocated.
+    """
+    return qga_request(
+        sock_path,
+        {"execute": "guest-file-open",
+         "arguments": {"path": path, "mode": mode}},
+        timeout=timeout,
+    )
+
+
+def qga_file_read(sock_path: str, handle: int, count: int,
+                  *, timeout: float = 5.0) -> dict:
+    """
+    Issue a `guest-file-read`. On success `response["return"]` is an
+    object `{"count": N, "buf-b64": "<base64>"}`.
+    """
+    return qga_request(
+        sock_path,
+        {"execute": "guest-file-read",
+         "arguments": {"handle": handle, "count": count}},
+        timeout=timeout,
+    )
+
+
+def qga_file_close(sock_path: str, handle: int,
+                   *, timeout: float = 5.0) -> dict:
+    """Issue a `guest-file-close`. On success `response["return"]` is `{}`."""
+    return qga_request(
+        sock_path,
+        {"execute": "guest-file-close", "arguments": {"handle": handle}},
+        timeout=timeout,
+    )
+
+
+__all__ = [
+    "qga_request",
+    "qga_sync",
+    "qga_ping",
+    "qga_info",
+    "qga_file_open",
+    "qga_file_read",
+    "qga_file_close",
+]


### PR DESCRIPTION
## Summary
- Adds four host-side QGA wrappers to `scripts/qemu-harness.py`: `qga-ping`, `qga-info`, `qga-sync`, `qga-file-read`. Each is strictly one-shot — opens the per-session UNIX chardev socket, sends one NDJSON request, reads one response line, exits with structured JSON to stdout.
- New helper `scripts/qga_client.py` carries the socket I/O, framing (with single-byte `0xff` stripping for `guest-sync-delimited` compatibility per https://wiki.qemu.org/Features/GuestAgent), and timeout/error handling. Failure modes (missing socket, connect-refused, short read, bad JSON, server-side error) all surface as structured `{ok:false,error:...}` rather than tracebacks.
- `start` now reports the per-session socket path as `qga_sock_path` in its stdout JSON (additive field, empty when started without `--features qga`).

## Wire shape

| Subcommand | Success | Failure | Exit |
|---|---|---|---|
| `qga-ping` | `{ok:true, latency_ms:N, response:{return:{}}}` | `{ok:false, error:..., latency_ms:N}` | 0 / 2 |
| `qga-info` | `{ok:true, return:{version,supported_commands}, ...}` | same | 0 / 2 |
| `qga-sync [--id N]` | `{ok:true, id:N, response:{return:N}}` | `{ok:false, error:..., id:N}` | 0 / 2 |
| `qga-file-read --path P --max-bytes N` | `{ok:true, bytes_b64,len,handle,path}` | `{ok:false, stage:open\|read, error:...}` | 0 / 2 |

## Validation

Boot with `--features firefox-test,kdb,qga` confirms:
- `start` returns `qga_sock_path` in its JSON;
- The chardev socket binds (`srwxrwxr-x` under `~/.astryx-harness/<sid>.qga.sock`);
- All four subcommands return structured JSON with no Python traceback;
- They correctly time out with `error:\"timeout\"` and exit 2 when the daemon is unresponsive (the QGA-2 daemon's RX side does not appear to dispatch in this build — independent of the wrapper layer).

Offline mock-daemon round-trip covers every command's happy path plus the `0xff` stale-delimiter strip, server-error replies, and timeouts.

## Test plan
- [x] `python3 scripts/qemu-harness.py --help` lists `qga-ping / qga-info / qga-sync / qga-file-read`
- [x] Offline mock daemon: ping/info/sync/file-read all succeed with `ok:true`
- [x] Offline mock daemon: 0xff-prefixed reply parses correctly
- [x] Offline mock daemon: server `{\"error\":...}` reply surfaces as `ok:false`
- [x] Offline mock daemon: timeout path returns `{ok:false,error:\"timeout\"}`
- [x] Missing-socket path: `{ok:false,error:\"socket missing\"}`, exit 2
- [x] Orphan-socket path: `{ok:false,error:\"connect failed: ...\"}`, exit 2
- [x] Non-`qga` session: `{ok:false,error:\"session was not started with --features qga\"}`, exit 2
- [x] Real `firefox-test,kdb,qga` boot: `qga_sock_path` present in `start` JSON, all four subcommands return structured JSON