### PR TITLE
linux/syscall: poll_revents POLLHUP for pipe read-end EOF (Mozilla glxtest unblock)

### DIFF
--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -237,6 +237,20 @@ pub fn pipe_is_eof(pipe_id: u64) -> bool {
         .unwrap_or(true)
 }
 
+/// Check if every write end has been closed, regardless of whether the
+/// ring buffer still has unread data.  POSIX `poll(2)` requires `POLLHUP`
+/// on a pipe read-end whose writer has hung up; if data is still buffered
+/// the kernel must report `POLLIN | POLLHUP` so userspace can drain the
+/// remainder before observing EOF.  `pipe_is_eof` only fires once the
+/// buffer is also empty, so it cannot drive the `POLLIN | POLLHUP`
+/// composition on its own.
+pub fn pipe_writer_closed(pipe_id: u64) -> bool {
+    let pipes = PIPE_TABLE.lock();
+    pipes.iter().find(|p| p.id == pipe_id)
+        .map(|p| p.writer_closed())
+        .unwrap_or(true)
+}
+
 // ── Wait / wake hooks ─────────────────────────────────────────────────────────
 
 /// Atomic check-then-park for a reader on `pipe_id`.

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2868,7 +2868,13 @@ fn sys_select_linux(
         } else if crate::syscall::is_eventfd_fd(pid, fd) {
             crate::ipc::eventfd::is_readable(crate::syscall::get_eventfd_id(pid, fd))
         } else if crate::syscall::is_pipe_fd(pid, fd) {
-            crate::ipc::pipe::pipe_has_data(crate::syscall::get_pipe_id(pid, fd))
+            // Per POSIX `select(2)`: a pipe read-end whose writer has
+            // closed must be reported readable so the userspace `read()`
+            // can return 0 (EOF).  Otherwise glibc / Firefox would block
+            // forever waiting for data that can never arrive.
+            let pid_id = crate::syscall::get_pipe_id(pid, fd);
+            crate::ipc::pipe::pipe_has_data(pid_id)
+                || crate::ipc::pipe::pipe_writer_closed(pid_id)
         } else if crate::syscall::is_unix_socket_fd(pid, fd) {
             let uid = crate::syscall::get_unix_socket_id(pid, fd);
             crate::net::unix::has_data(uid) || crate::net::unix::has_pending(uid)
@@ -2913,7 +2919,12 @@ fn sys_select_linux(
                 && unsafe { *((writefds + byte_off) as *const u8) & bit != 0 };
             if !r_req && !w_req { continue; }
             let revents = crate::syscall::poll_revents(pid, fd, if r_req { 0x0001 } else { 0x0004 });
-            if r_req && revents & 0x0001 != 0 { *ready += 1; }
+            // Per POSIX `select(2)`: a hung-up pipe read-end is reported
+            // readable so the userspace `read()` returns 0 (EOF).  POLLHUP
+            // (0x0010) here therefore counts as a readable signal in
+            // addition to POLLIN (0x0001).
+            const READABLE_MASK: u16 = 0x0001 | 0x0010;
+            if r_req && revents & READABLE_MASK != 0 { *ready += 1; }
             else if r_req { unsafe { *((readfds + byte_off) as *mut u8) &= !bit; } }
             if w_req && revents & 0x0004 != 0 { *ready += 1; }
             else if w_req { unsafe { *((writefds + byte_off) as *mut u8) &= !bit; } }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2448,9 +2448,16 @@ pub(crate) fn get_inotify_id(pid: u64, fd_num: usize) -> u64 {
 
 /// Compute revents for a single fd given the requested events mask.
 /// Returns 0 if fd is not ready for any of the requested events.
+///
+/// `POLLHUP` is *unconditional* per POSIX `poll(2)` — it is reported
+/// regardless of whether the caller requested it in `events`.  On a pipe
+/// read-end whose every writer has closed, the kernel must set
+/// `POLLHUP`; if data is still buffered it must coexist with `POLLIN`
+/// so userspace can drain the remainder before observing EOF.
 pub(crate) fn poll_revents(pid: u64, fd: usize, events: u16) -> u16 {
     const POLLIN:  u16 = 0x0001;
     const POLLOUT: u16 = 0x0004;
+    const POLLHUP: u16 = 0x0010;
     if fd <= 2 {
         if fd == 0 { events & POLLIN } else { events & POLLOUT }
     } else if is_eventfd_fd(pid, fd) {
@@ -2486,7 +2493,21 @@ pub(crate) fn poll_revents(pid: u64, fd: usize, events: u16) -> u16 {
                 .unwrap_or(false)
         };
         if is_read_end {
-            if crate::ipc::pipe::pipe_has_data(pipe_id) { events & POLLIN } else { 0 }
+            // Per POSIX `poll(2)`:
+            //   * `POLLIN`  — data is available to read.
+            //   * `POLLHUP` — the peer (writer) has closed; reported even
+            //                 when the caller did not request it.  When
+            //                 buffered data remains, `POLLHUP` is set
+            //                 alongside `POLLIN` so a draining reader can
+            //                 consume the tail before observing EOF.
+            let mut rev = 0u16;
+            if crate::ipc::pipe::pipe_has_data(pipe_id) {
+                rev |= events & POLLIN;
+            }
+            if crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+                rev |= POLLHUP;
+            }
+            rev
         } else {
             events & POLLOUT
         }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -177,6 +177,10 @@ pub fn run() -> ! {
     total += 1;
     if test_poll_bell_source_attribution() { passed += 1; }
 
+    // ── Test 0bc: POLLHUP on pipe read-end after writer close ─────────────
+    total += 1;
+    if test_pipe_pollhup_on_writer_close() { passed += 1; }
+
     // ── Test 0bb: SERIAL per-CPU re-entry guard ──────────────────────────
     total += 1;
     if test_serial_reentry_guard() { passed += 1; }
@@ -23223,6 +23227,118 @@ fn test_poll_bell_source_attribution() -> bool {
     }
     test_println!("  all 8 tagged sources bumped their own slot; `other` unchanged ✓");
     test_pass!("poll-bell per-source attribution counters");
+    true
+}
+
+// ── Test 0bc: POLLHUP on pipe read-end after writer close ───────────────────
+//
+// Verifies the helper state that `poll_revents` consumes per POSIX
+// `poll(2)`: a pipe whose every writer has closed must drive `POLLHUP`
+// regardless of whether unread data remains in the buffer.  When buffered
+// data is still present the kernel reports `POLLIN | POLLHUP` so a
+// draining reader can consume the tail before observing EOF; once the
+// buffer empties only `POLLHUP` (plus the EOF condition that drives
+// `read(2)` to return 0) remains.
+fn test_pipe_pollhup_on_writer_close() -> bool {
+    test_header!("pipe POLLHUP — writer close drives POLLHUP regardless of buffered data");
+
+    let pipe_id = crate::ipc::pipe::create_pipe();
+    test_println!("  created pipe id={} ✓", pipe_id);
+
+    // Initial state: no writer has closed, no data.
+    if crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_pollhup", "fresh pipe reports writer_closed = true");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if crate::ipc::pipe::pipe_has_data(pipe_id) {
+        test_fail!("pipe_pollhup", "fresh pipe reports pipe_has_data = true");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if crate::ipc::pipe::pipe_is_eof(pipe_id) {
+        test_fail!("pipe_pollhup", "fresh pipe reports pipe_is_eof = true");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  initial: !writer_closed, !has_data, !is_eof ✓");
+
+    // Write payload — pipe has data but writer is still open.
+    let n = crate::ipc::pipe::pipe_write(pipe_id, b"glxtest").unwrap_or(0);
+    if n != 7 {
+        test_fail!("pipe_pollhup", "pipe_write returned {} (expected 7)", n);
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if !crate::ipc::pipe::pipe_has_data(pipe_id) {
+        test_fail!("pipe_pollhup", "after write, pipe_has_data is false");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_pollhup", "after write (writer still open), writer_closed is true");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  wrote 7B, writer still open: has_data && !writer_closed ✓");
+
+    // Close writer.  This is the Mozilla glxtest scenario: helper child
+    // exits, parent's poll(read_end) must see POLLHUP even though there
+    // is still data to drain.
+    crate::ipc::pipe::pipe_close_writer(pipe_id);
+    if !crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_pollhup", "after pipe_close_writer, writer_closed is false");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if !crate::ipc::pipe::pipe_has_data(pipe_id) {
+        test_fail!("pipe_pollhup", "after writer close (data still buffered), pipe_has_data is false");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if crate::ipc::pipe::pipe_is_eof(pipe_id) {
+        test_fail!("pipe_pollhup", "after writer close with data still buffered, pipe_is_eof is true (should be false until drained)");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  writer closed, data still buffered: writer_closed && has_data && !is_eof ✓");
+    test_println!("  → poll(read_end) would return POLLIN | POLLHUP (Mozilla glxtest unblock path)");
+
+    // Drain.  Now both writer is closed AND buffer is empty.
+    let mut drain = [0u8; 7];
+    let r = crate::ipc::pipe::pipe_read(pipe_id, &mut drain).unwrap_or(0);
+    if r != 7 || &drain != b"glxtest" {
+        test_fail!("pipe_pollhup", "drain returned {} bytes (expected 7) or wrong content", r);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if crate::ipc::pipe::pipe_has_data(pipe_id) {
+        test_fail!("pipe_pollhup", "after drain, pipe_has_data is true");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if !crate::ipc::pipe::pipe_is_eof(pipe_id) {
+        test_fail!("pipe_pollhup", "after drain + writer closed, pipe_is_eof is false");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if !crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_pollhup", "after drain, writer_closed is false (regressed)");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  drained: !has_data && writer_closed && is_eof ✓");
+    test_println!("  → poll(read_end) would return POLLHUP only (writer hung up, no data left)");
+
+    crate::ipc::pipe::pipe_close_reader(pipe_id);
+
+    test_pass!("pipe POLLHUP — writer close drives POLLHUP regardless of buffered data");
     true
 }
 


### PR DESCRIPTION
## Summary

Brings `poll_revents` and `sys_select_linux` to POSIX parity with `epoll_wait` for the "pipe writer has hung up" case.  Pre-fix the pipe branch returned `revents = 0` when the buffer was empty *and* the writer was closed, so `poll(2)` timed out instead of reporting `POLLHUP`.  This is the immediate kernel-visible cause of Mozilla's `[GFX1-]: ManageChildProcess(glxtest): poll failed: Success` diagnostic followed by a NULL-deref in the no-GPU fallback path.

Per POSIX.1-2017 `poll(2)` the kernel must surface `POLLHUP` regardless of the requested `events` mask, and must compose `POLLIN | POLLHUP` when buffered data still needs to be drained before EOF is observed.

## Root cause

```
Mozilla parent              kernel                     Mozilla glxtest child
┌──────────────────┐                                   ┌──────────────────┐
│ fork glxtest     │──── clone3 / spawn ──────────────▶│ try to open      │
│ poll(read_end,   │                                   │ /dev/dri/card0   │
│      4000ms)     │                                   │   → ENOENT       │
│                  │                                   │ write status to  │
│                  │◀─── pipe data + writer close ─────│ pipe, exit       │
│                  │                                   └──────────────────┘
│ kernel wakes us  │
│ poll_revents     │  ◀── pre-fix: returns 0 ─── ❌
│ select_revents   │      because buffer empty
│                  │      and POLLHUP semantic
│                  │      was missing
│ ret = 0          │
│ "poll failed:    │
│  Success"        │
│ no-GPU fallback  │  ◀── NULL-deref @ RIP=
│ SIGSEGV          │       0x7efffa0307c1
│ exit_group(11)   │
└──────────────────┘
```

Post-fix, the kernel reports `POLLHUP` on the pipe read-end as soon as every writer has closed, so `poll(2)` / `select(2)` return ret > 0 and Mozilla's `read()` observes orderly EOF instead of timing out.  The no-GPU fallback then runs to completion without dereferencing the unset error-path pointer.

## Code delta

| file | +/- | what |
|------|-----|------|
| `kernel/src/ipc/pipe.rs` | +14 | new `pipe_writer_closed(pipe_id)` helper — wraps the existing `writer_closed()` accessor under `PIPE_TABLE`.  No new locks, no new lock-order edges. |
| `kernel/src/syscall/mod.rs` | +22/-1 | `poll_revents` pipe branch: `POLLIN` if data, `POLLHUP` if writer closed, composable.  POLLHUP unconditional per POSIX. |
| `kernel/src/subsys/linux/syscall.rs` | +13/-2 | `sys_select_linux`: hung-up pipe is reported readable so `read()` returns 0 (EOF); post-poll classification counts POLLHUP as a readable signal. |
| `kernel/src/test_runner.rs` | +116 | Test 0bc `test_pipe_pollhup_on_writer_close` — walks the four state transitions including the `POLLIN|POLLHUP` composition path. |

Mirrors the existing `pipe_is_eof` pattern already wired into `sys_epoll_wait` at `kernel/src/subsys/linux/syscall.rs:5899`, bringing `poll`, `ppoll`, and `select` to parity with `epoll_wait` for the EOF case.

## Test 0bc result

```
[PASS] pipe POLLHUP — writer close drives POLLHUP regardless of buffered data
[TEST-JSON] {"name":"pipe POLLHUP — writer close drives POLLHUP regardless of buffered data","result":"pass","elapsed_ticks":8}

Test Results: 218/225 passed
```

Pre-fix baseline 217/225 → post-fix 218/225 (the seven remaining failures are missing `/disk/bin/*` user binaries — pre-existing `data.img` artifact issue, unrelated to this change).

## firefox-test progression

|                     | pre-fix (sc=5213 plateau) | post-fix |
|---------------------|---------------------------|----------|
| `[Page Fault]`      | yes — RIP=0x7efffa0307c1  | **none** |
| SIGSEGV             | yes                       | **none** |
| `tgkill` / `exit_group(11)` | yes                       | **none** |
| `PROC.*memory freed` | yes (pid 1)               | **none** |
| sc count at 7 min   | 5213 (terminal)           | **5767 and climbing** |
| clone3 count        | 53                        | 53 (Mozilla in the next phase — sem_t plateau, see project memory) |
| Mozilla diagnostic  | `poll failed: Success`<br>followed by NULL-deref + crash | `poll failed: Success` logged by glxtest helper, parent then runs no-GPU fallback to completion: `No GPUs detected via PCI` → `Failed to initialize shared font list, falling back to in-process list` |

The Mozilla SIGSEGV is gone.  54 TIDs remain parked on futexes in worker-pool steady-state, which is the next-phase plateau — separate gate, separate fix.

## Validation

- [x] Rebased onto current master (`2b41c9a` PR #159) cleanly — only `test_runner.rs` had a conflict (both Test 0bx and Test 0bc registrations now coexist); pipe.rs / syscall.rs auto-merged.
- [x] Test 0bc passes
- [x] Suite goes from 217/225 to 218/225 (no regressions; 7 failures are missing data.img user binaries)
- [x] Kernel builds clean with `test-mode,kdb` and `firefox-test,kdb,syscall-trace` feature sets
- [x] firefox-test boots past the pre-fix plateau without SIGSEGV
- [x] sc count progresses beyond 5213 (now 5767 and climbing)
- [x] Mozilla `[Page Fault]` / SIGSEGV / `exit_group` / `PROC memory freed` are all absent from the post-fix serial log

## References

- POSIX.1-2017 §poll, §select, §ppoll, §pselect
- `man 2 poll`, `man 2 select`, `man 7 pipe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)