### PR TITLE
drivers/virtio-serial: IRQ-driven RX + QGA daemon wedge fix

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -337,6 +337,16 @@ pub fn ioapic_route_irq(irq: u8, vector: u8, dest_apic_id: u8) {
     ioapic_write(redtbl_offset, lo);
 }
 
+/// Read back a (lo, hi) IO-APIC redirect entry for diagnostics.  Used by
+/// driver `arm_irq()` paths to confirm that the route they programmed
+/// actually landed (shared-IRQ debugging is otherwise blind).
+pub fn ioapic_read_entry(irq: u8) -> (u32, u32) {
+    let redtbl_offset = IOAPIC_REDTBL + irq * 2;
+    let lo = ioapic_read(redtbl_offset);
+    let hi = ioapic_read(redtbl_offset + 1);
+    (lo, hi)
+}
+
 /// Route a PCI IRQ through the I/O APIC (level-triggered, active-low — for PCI INTx).
 pub fn ioapic_route_irq_level(irq: u8, vector: u8, dest_apic_id: u8) {
     let redtbl_offset = IOAPIC_REDTBL + irq * 2;

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -154,6 +154,7 @@ pub fn init() {
             IDT[43].set_handler(fix(super::irq::irq_e1000_handler as *const () as u64), kernel_cs, 0, 0);
             IDT[44].set_handler(fix(super::irq::irq_mouse_handler as *const () as u64), kernel_cs, 0, 0);
             IDT[45].set_handler(fix(super::irq::irq_virtio_blk_handler as *const () as u64), kernel_cs, 0, 0);
+            IDT[46].set_handler(fix(super::irq::irq_virtio_serial_handler as *const () as u64), kernel_cs, 0, 0);
 
             // Syscall interrupt (vector 0x80) — for int 0x80 style syscalls
             IDT[0x80].set_handler(fix(isr_syscall_int80 as *const () as u64), kernel_cs, 0, 3);

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -461,6 +461,7 @@ extern "C" fn timer_tick() {
 irq_stub!(irq_mouse_handler, mouse_interrupt);
 irq_stub!(irq_e1000_handler, e1000_interrupt);
 irq_stub!(irq_virtio_blk_handler, virtio_blk_interrupt);
+irq_stub!(irq_virtio_serial_handler, virtio_serial_interrupt);
 
 /// Virtio-blk PCI INTx interrupt logic.
 ///
@@ -474,6 +475,16 @@ extern "C" fn virtio_blk_interrupt() {
     // EOI is sent by handle_irq itself (LAPIC) — keep this stub narrow so
     // the ack-then-EOI ordering matches the rest of the device's spec
     // contract (read ISR before EOI for level-triggered PCI INTx).
+}
+
+/// Virtio-serial PCI INTx interrupt logic.  Same contract as virtio-blk —
+/// ack via ISR_STATUS read, walk used ring for received bytes, deposit
+/// into the driver's rx ring buffer, wake any thread parked in
+/// `read_blocking()`, then LAPIC EOI.  The driver implements the entire
+/// sequence; this stub exists purely to route the IDT vector.
+extern "C" fn virtio_serial_interrupt() {
+    crate::perf::record_interrupt(crate::drivers::virtio_serial::VIRTIO_SERIAL_IRQ_VECTOR);
+    crate::drivers::virtio_serial::handle_irq();
 }
 
 /// E1000 NIC interrupt logic.

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -483,8 +483,17 @@ extern "C" fn virtio_blk_interrupt() {
 /// `read_blocking()`, then LAPIC EOI.  The driver implements the entire
 /// sequence; this stub exists purely to route the IDT vector.
 extern "C" fn virtio_serial_interrupt() {
-    crate::perf::record_interrupt(crate::drivers::virtio_serial::VIRTIO_SERIAL_IRQ_VECTOR);
-    crate::drivers::virtio_serial::handle_irq();
+    // The virtio_serial driver module is only compiled with `--features qga`;
+    // when absent, IDT[46] is still wired (idt.rs) so the stub stays present,
+    // but it must not reference the missing module.  No-op in that build —
+    // QEMU only fires this vector when a virtio-serial device is exposed,
+    // which is itself gated by the host launching with `-device virtio-serial`
+    // (QGA feature only).
+    #[cfg(feature = "qga")]
+    {
+        crate::perf::record_interrupt(crate::drivers::virtio_serial::VIRTIO_SERIAL_IRQ_VECTOR);
+        crate::drivers::virtio_serial::handle_irq();
+    }
 }
 
 /// E1000 NIC interrupt logic.

--- a/kernel/src/drivers/virtio_serial.rs
+++ b/kernel/src/drivers/virtio_serial.rs
@@ -1,39 +1,65 @@
-//! Virtio-serial PCI Driver (Legacy Interface) — Phase QGA-1
+//! Virtio-serial PCI Driver (Legacy Interface) — Multiport + IRQ-driven RX
 //!
 //! Exposes a single byte-stream character device at `/dev/vport0p0` backed by
 //! a virtio-serial (virtio-console) port.  This is the kernel half of the
-//! QEMU Guest Agent (QGA) transport: a userspace daemon (Phase QGA-2) will
-//! open the device node and run the QGA JSON-RPC loop against the host.
+//! QEMU Guest Agent (QGA) transport: a userspace daemon (`userspace/qga/`)
+//! opens the device node and runs the QGA JSON-RPC loop against the host.
 //!
-//! # Scope (QGA-1 only)
+//! # Multiport (PORT_OPEN handshake)
 //!
-//! * Legacy PCI virtio (vendor `0x1AF4`, device `0x1003`, subsystem id `3`).
-//! * Two virtqueues:
-//!   - vq0 (port 0 receive — host → guest writes data here).
-//!   - vq1 (port 0 transmit — guest → host).
-//! * Feature negotiation accepts **no** features.  In particular we do NOT
-//!   negotiate `VIRTIO_CONSOLE_F_MULTIPORT`, so the device skips the control
-//!   queue handshake entirely and port 0 is the only port that ever carries
-//!   data.  QEMU still routes a single `virtserialport,name=org.qemu.guest_agent.0`
-//!   to that port regardless of the name string — naming only matters once
-//!   multiport is on.
-//! * Polling-mode I/O.  The byte path is exercised by a userspace daemon at
-//!   human timescales (QGA frames arrive at request/response cadence, not at
-//!   block-I/O throughput), so the spin cost is acceptable until Phase QGA-4
-//!   promotes the rx path to interrupt-driven completion.
+//! QEMU's `-device virtserialport,nr=1,name=org.qemu.guest_agent.0` wires
+//! the QGA chardev to **port 1**, not port 0.  Port 0 is permanently
+//! reserved for the legacy console pair (vq0/vq1).  To route data through
+//! port 1 we must negotiate `VIRTIO_CONSOLE_F_MULTIPORT` and perform the
+//! control-queue handshake from virtio 1.2 §5.3.6: send `DEVICE_READY(1)`
+//! and `PORT_OPEN(port=1, value=1)` on the control TX queue, then receive
+//! and ack the host's `PORT_ADD` / `PORT_NAME` / `PORT_OPEN` events on the
+//! control RX queue.  Without this, QEMU keeps `host_connected = false`
+//! for port 1 and silently swallows incoming chardev bytes — the wedge
+//! that PR #158's QGA-3 harness surfaced.
+//!
+//! # Virtqueue layout (per §5.3.2)
+//!
+//! * vq0 — port 0 receiveq      (allocated for DRIVER_OK; never used).
+//! * vq1 — port 0 transmitq     (same).
+//! * vq2 — control receiveq     (host → guest control events).
+//! * vq3 — control transmitq    (guest → host control events).
+//! * vq4 — port 1 (QGA) rx      (the data RX queue).
+//! * vq5 — port 1 (QGA) tx      (the data TX queue).
+//!
+//! # RX path (poll + IRQ)
+//!
+//! Two delivery paths cooperate:
+//!
+//! 1. **Polling** — `read()` always walks the rx used ring directly.  This
+//!    is the only path active before `arm_irq()` registers the IO-APIC
+//!    route (early-boot test runner, QGA-1 smoke).
+//! 2. **IRQ-driven** — after `arm_irq()` flips `IRQS_ARMED`, the device's
+//!    `virtio_notify` on used.idx advance fires the IO-APIC line through
+//!    vector `VIRTIO_SERIAL_IRQ_VECTOR`.  `handle_irq` drains the used
+//!    ring into `rx_ring`, re-publishes the rx descriptor, and wakes any
+//!    thread parked in `read_blocking` via the global `WaitList`.
+//!
+//! `read_blocking` is the VFS entry point for blocking reads (default for
+//! `/dev/vport0p0` opens without `O_NONBLOCK`).  It loop-yields when IRQs
+//! have never fired (test-mode synthetic injection bypasses the host) and
+//! parks on the WaitList once a real IRQ has been observed.
 //!
 //! # References
 //!
 //! * Virtio 1.2 spec, §5.3 (Console Device).
 //! * Virtio 1.0 legacy PCI device init: §4.1.4.
+//! * Virtio 1.0 ISR-status read-to-clear: §4.1.4.5.
 //! * Virtqueue split-ring layout: §2.6.
 
 extern crate alloc;
 
-use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use alloc::collections::VecDeque;
+use core::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use spin::Mutex;
 
 use crate::hal;
+use crate::ipc::waitlist::{ring_poll_bell, wake_tids, WaitList};
 use crate::mm::pmm;
 
 // ── Virtio PCI Constants ────────────────────────────────────────────────────
@@ -62,6 +88,66 @@ const VIRTIO_REG_ISR_STATUS:      u16 = 0x13; // u8  RO (read-to-clear; QGA-1b)
 const VIRTIO_STATUS_ACKNOWLEDGE: u8 = 1;
 const VIRTIO_STATUS_DRIVER:      u8 = 2;
 const VIRTIO_STATUS_DRIVER_OK:   u8 = 4;
+
+// ── Virtio-Console Feature Bits ─────────────────────────────────────────────
+//
+// Per virtio 1.2 §5.3.3:
+//   VIRTIO_CONSOLE_F_SIZE      (bit 0) — host carries console window-size info.
+//   VIRTIO_CONSOLE_F_MULTIPORT (bit 1) — device supports multiple ports.
+//
+// QEMU's virtio-serial-pci offers MULTIPORT unconditionally.  We must
+// accept it: the QGA chardev is wired to port 1 (port 0 is reserved for
+// the legacy console pair), and QEMU only routes data to port 1 when
+// the driver has acknowledged MULTIPORT, processed the control-queue
+// PORT_ADD handshake, and sent PORT_OPEN.  Without this, QEMU keeps
+// `host_connected = false` for port 1 and silently swallows host writes
+// to the chardev socket (the QGA-3 wedge surfaced by PR #158).
+const VIRTIO_CONSOLE_F_MULTIPORT: u32 = 1 << 1;
+
+// ── Control-Queue Message Layout & Events ───────────────────────────────────
+//
+// Per virtio 1.2 §5.3.6.7.  Every control message is a 4-byte header:
+//   u32 id     — target port id (0xFFFFFFFF / "bad id" for device-wide messages)
+//   u16 event  — event code, table below
+//   u16 value  — event payload (boolean flag for OPEN/READY/etc.)
+//
+// We send DEVICE_READY + PORT_OPEN; we consume PORT_ADD, PORT_NAME, and
+// PORT_OPEN (host-initiated) from the device.  Other event types are
+// processed by replenishing the rx buffer and silently dropping the
+// payload.
+const VIRTIO_CONSOLE_DEVICE_READY: u16 = 0;
+#[allow(dead_code)]
+const VIRTIO_CONSOLE_DEVICE_ADD:   u16 = 1;
+#[allow(dead_code)]
+const VIRTIO_CONSOLE_DEVICE_REMOVE:u16 = 2;
+const VIRTIO_CONSOLE_PORT_READY:   u16 = 3;
+#[allow(dead_code)]
+const VIRTIO_CONSOLE_CONSOLE_PORT: u16 = 4;
+#[allow(dead_code)]
+const VIRTIO_CONSOLE_RESIZE:       u16 = 5;
+const VIRTIO_CONSOLE_PORT_OPEN:    u16 = 6;
+#[allow(dead_code)]
+const VIRTIO_CONSOLE_PORT_NAME:    u16 = 7;
+
+/// Port id of the QGA chardev, derived from the `-device virtserialport,nr=1`
+/// QEMU CLI.  Port 0 is reserved for the console pair (vq0 / vq1) so the
+/// first user-visible port is always 1, regardless of multiport count.
+const QGA_PORT_ID: u32 = 1;
+
+/// "Bad" port id used for device-wide control messages (DEVICE_READY,
+/// DEVICE_ADD/REMOVE).
+const CTRL_BAD_PORT_ID: u32 = 0xFFFF_FFFF;
+
+/// Number of control-rx buffers we keep parked.  The host issues one
+/// control event per port at init (PORT_ADD, PORT_NAME, PORT_OPEN — three
+/// events for our single QGA port) plus an indefinite trickle of
+/// connect/disconnect notifications; a small ring is enough.
+const CTRL_RX_BUFS: u16 = 8;
+
+/// Size of one control-rx scratch slot.  Control messages are at most a
+/// 4-byte header + a small payload (port name string for PORT_NAME), all
+/// well under 256 B.  Round to one cache line for hygiene.
+const CTRL_BUF_LEN: usize = 64;
 
 // ── Virtqueue Descriptor Flags ──────────────────────────────────────────────
 
@@ -160,7 +246,15 @@ impl VirtQueue {
     /// Write descriptor 0 with `(addr, len, flags)` — no next link.
     /// SAFETY: caller must hold the device mutex.
     unsafe fn fill_desc0(&self, addr: u64, len: u32, flags: u16) {
-        let d = self.desc();
+        self.fill_desc(0, addr, len, flags);
+    }
+
+    /// Write descriptor `idx` with `(addr, len, flags)` — no next link.
+    /// `idx` must be < `queue_size`.  Used for control-queue rings where we
+    /// want multiple parked buffers, one per descriptor index.
+    /// SAFETY: caller must hold the device mutex.
+    unsafe fn fill_desc(&self, idx: u16, addr: u64, len: u32, flags: u16) {
+        let d = self.desc().add((idx as usize) * 16);
         (d as *mut u64).write_volatile(addr);
         (d.add(8) as *mut u32).write_volatile(len);
         (d.add(12) as *mut u16).write_volatile(flags & !VRING_DESC_F_NEXT);
@@ -170,13 +264,30 @@ impl VirtQueue {
     /// Publish descriptor 0 into the available ring.
     /// SAFETY: caller must hold the device mutex.
     unsafe fn publish_desc0(&mut self) {
+        self.publish_desc(0);
+    }
+
+    /// Publish descriptor `idx` into the available ring.  Bumps
+    /// `next_avail` and writes the new value into `avail.idx` per virtio
+    /// 1.2 §2.6.6.
+    /// SAFETY: caller must hold the device mutex.
+    unsafe fn publish_desc(&mut self, idx: u16) {
         let avail = self.avail();
-        let entry = avail.add(4 + ((self.next_avail % self.queue_size) as usize) * 2) as *mut u16;
-        entry.write_volatile(0);
+        let slot = avail.add(4 + ((self.next_avail % self.queue_size) as usize) * 2) as *mut u16;
+        slot.write_volatile(idx);
         core::sync::atomic::fence(Ordering::SeqCst);
         self.next_avail = self.next_avail.wrapping_add(1);
         let avail_idx = avail.add(2) as *mut u16;
         avail_idx.write_volatile(self.next_avail);
+    }
+
+    /// Read the descriptor id of the entry at `used.ring[(used_idx-1) % qs].id`.
+    /// Counterpart to `used_len`.  Needed for control-queue replenish so we
+    /// can re-publish the slot the device just returned.
+    /// SAFETY: caller must hold the device mutex.
+    unsafe fn used_id(&self, used_idx: u16) -> u32 {
+        let slot = self.used().add(4 + ((used_idx.wrapping_sub(1) % self.queue_size) as usize) * 8);
+        (slot as *const u32).read_volatile()
     }
 
     /// SAFETY: caller must hold the device mutex (or be the ISR).
@@ -195,16 +306,73 @@ impl VirtQueue {
 
 struct VirtioSerialDevice {
     io_base: u16,
+    /// Port 1 (QGA) data RX queue — virtqueue index 4.
     rxq: VirtQueue,
+    /// Port 1 (QGA) data TX queue — virtqueue index 5.
     txq: VirtQueue,
+    /// Control RX queue (host → guest control messages) — virtqueue index 2.
+    /// Populated with `CTRL_RX_BUFS` slots in `init()`; replenished by the
+    /// ISR each time the host pushes a control event.
+    cq_rx: VirtQueue,
+    /// Control TX queue (guest → host control messages) — virtqueue index 3.
+    /// Used to send DEVICE_READY, PORT_READY, and PORT_OPEN.
+    cq_tx: VirtQueue,
     /// Bytes already consumed from the currently active rx descriptor.
     rx_consumed: u32,
     /// Total bytes available in the currently active rx descriptor.
     rx_avail: u32,
+    /// PCI bus/device/function and INTx line, cached for `arm_irq()`.
+    pci_bus: u8,
+    pci_dev: u8,
+    pci_func: u8,
+    pci_irq_line: u8,
+    /// Bytes copied out of the rx virtqueue by the ISR but not yet drained
+    /// by a userspace `read()`.  The ring is short-lived in steady state —
+    /// host writes one QGA frame, daemon `read()`s it within a tick.  The
+    /// 16 KiB cap matches the maximum-burst case (four 4 KiB descriptors
+    /// landing back-to-back before the daemon catches up).
+    rx_ring: VecDeque<u8>,
+    /// True once we have replied PORT_OPEN(1) for the QGA port, which
+    /// flips QEMU's `host_connected` flag for the chardev backend and
+    /// authorises data delivery.  Diagnostic — also surfaces in `stats()`.
+    port_opened: bool,
 }
+
+/// Maximum bytes held in `rx_ring` before the ISR starts dropping data.
+/// The QGA frame upper bound is ~5.5 KiB (base64 of a 4 KiB file read);
+/// 16 KiB gives ~3 frames of headroom which is enough for any burst the
+/// host can produce between two scheduler ticks.
+const RX_RING_CAP: usize = 16 * 1024;
 
 static VIRTIO_SERIAL: Mutex<Option<VirtioSerialDevice>> = Mutex::new(None);
 static VIRTIO_SERIAL_AVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// Whether `arm_irq()` has registered the IO-APIC route.  Until this flips
+/// true the driver uses pure polling (the boot path runs before APIC init
+/// on the BSP, so the polling fallback covers early callers).
+static IRQS_ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Wait list of threads parked in `read_blocking()` waiting for the ISR
+/// to deposit bytes into `rx_ring`.  Woken via `wake_tids` from the IRQ
+/// path; the global poll bell is also rung so any `poll`/`epoll_wait`
+/// caller watching the vport re-evaluates.
+static RX_WAITERS: Mutex<WaitList> = Mutex::new(WaitList::new());
+
+/// Lock-free snapshot of the device's I/O base for the ISR.  The ISR
+/// reads `ISR_STATUS` (read-to-clear) without taking [`VIRTIO_SERIAL`] —
+/// a `read_blocking()` caller may have just parked while still holding
+/// the device mutex's spinlock briefly, and we want the IRQ to be
+/// serviceable immediately regardless.
+static IRQ_IO_BASE: AtomicU16 = AtomicU16::new(0);
+/// Total ISR entries.  Diagnostic counter.
+static TOTAL_IRQS: AtomicU64 = AtomicU64::new(0);
+/// ISR entries that found no new used-ring progress.  Non-zero in steady
+/// state indicates shared-IRQ routing or a stale ack.
+static SPURIOUS_IRQS: AtomicU64 = AtomicU64::new(0);
+/// Bytes the ISR had to drop because `rx_ring` was full.  Should stay 0
+/// for QGA workloads; rising values mean the daemon is not draining fast
+/// enough or the ring cap is too small.
+static RX_DROPPED_BYTES: AtomicU64 = AtomicU64::new(0);
 
 /// Mutex-free snapshot of the virtqueue physical/runtime addresses used by
 /// the loopback test helpers (`test_inject_rx` / `test_drain_tx`).  These are
@@ -223,10 +391,9 @@ struct LoopbackHandles {
 #[cfg(feature = "qga")]
 static LOOPBACK: Mutex<Option<LoopbackHandles>> = Mutex::new(None);
 
-/// IRQ vector reserved for Phase QGA-1b.  Vectors 32-45 are taken by timer,
-/// keyboard, e1000, mouse, virtio-blk; pick the next free slot.
-#[allow(dead_code)]
-pub const VIRTIO_SERIAL_IRQ_VECTOR: u8 = 46;
+// VIRTIO_SERIAL_IRQ_VECTOR is defined further down inside the IRQ wiring
+// block, alongside `arm_irq()` and `handle_irq()`.  Vectors 32-45 are
+// taken by timer, keyboard, e1000, mouse, virtio-blk; we use 46.
 
 // ── PCI Discovery ───────────────────────────────────────────────────────────
 
@@ -284,6 +451,40 @@ unsafe fn replenish_rx(rxq: &mut VirtQueue) {
 /// Probe PCI for a virtio-serial device and bring it up.  Returns `true` on
 /// success, `false` when no device was found or init failed.  Safe to call
 /// multiple times — the global state will only be populated once.
+///
+/// # MULTIPORT init sequence
+///
+/// QEMU's `-device virtserialport,nr=1,name=org.qemu.guest_agent.0` exposes
+/// the QGA chardev on **port 1**, not port 0.  Port 0 is permanently
+/// reserved for the legacy console pair (vq0/vq1).  Routing data through
+/// port 1 requires `VIRTIO_CONSOLE_F_MULTIPORT` and the control-queue
+/// handshake from virtio 1.2 §5.3.6.  Without MULTIPORT the host treats
+/// port 1 as `host_connected = false` and silently swallows incoming
+/// chardev bytes — the wedge that PR #158's QGA-3 harness surfaced.
+///
+/// Steps performed here:
+///   1. PCI probe + reset → ACK → DRIVER.
+///   2. Negotiate features: accept `VIRTIO_CONSOLE_F_MULTIPORT`, refuse
+///      every other offered bit.
+///   3. Set up six virtqueues:
+///         vq0 — port 0 receiveq      (allocated but unused; QEMU still
+///                                     enumerates port 0 in non-console
+///                                     mode and rejects DRIVER_OK if the
+///                                     queue PFNs are zero).
+///         vq1 — port 0 transmitq     (same — allocated, never published to).
+///         vq2 — control receiveq     (filled with `CTRL_RX_BUFS` buffers).
+///         vq3 — control transmitq    (used for DEVICE_READY / PORT_OPEN).
+///         vq4 — port 1 (QGA) rx      (the only RX queue we actually consume).
+///         vq5 — port 1 (QGA) tx      (the only TX queue we ever write to).
+///   4. Mark DRIVER_OK.
+///   5. Replenish the QGA rx queue with one scratch buffer.
+///   6. Send `VIRTIO_CONSOLE_DEVICE_READY(value=1)` via vq3.  The host
+///      responds with a stream of control events on vq2 (PORT_ADD,
+///      PORT_NAME, PORT_OPEN) which we consume + reply to in the IRQ
+///      handler.
+///   7. Send `VIRTIO_CONSOLE_PORT_OPEN(port=1, value=1)` via vq3.  This
+///      flips `host_connected = true` on the QEMU side and unblocks
+///      `virtio_serial_write()` so chardev data starts flowing to vq4.
 pub fn init() -> bool {
     if VIRTIO_SERIAL_AVAILABLE.load(Ordering::Acquire) {
         return true;
@@ -316,7 +517,7 @@ pub fn init() -> bool {
     super::pci::pci_config_write32(pci_dev.bus, pci_dev.device, pci_dev.function, 0x04, cmd | 0x01);
 
     // SAFETY: writing to the discovered virtio device's own I/O ports.
-    let (rxq, txq) = unsafe {
+    let (port0_rx, port0_tx, cq_rx, cq_tx, rxq, txq) = unsafe {
         // Reset → ACK → DRIVER per §4.1.4.1.
         hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0);
         hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, VIRTIO_STATUS_ACKNOWLEDGE);
@@ -325,54 +526,122 @@ pub fn init() -> bool {
             VIRTIO_STATUS_ACKNOWLEDGE | VIRTIO_STATUS_DRIVER,
         );
 
-        // Read offered features, accept none.  We deliberately do NOT
-        // negotiate VIRTIO_CONSOLE_F_MULTIPORT (bit 1) — without it the
-        // device exposes only vq0 (port 0 rx) and vq1 (port 0 tx) and
-        // skips the control queue handshake entirely (§5.3.6).
-        let _offered = hal::inl(io_base + VIRTIO_REG_DEVICE_FEATURES);
-        hal::outl(io_base + VIRTIO_REG_GUEST_FEATURES, 0);
+        // Negotiate features.  Accept MULTIPORT; refuse the rest — we do
+        // not implement F_SIZE (console-mode window-size), and the
+        // device's advanced layout bits (event_idx, packed, etc.) are
+        // unconditionally legacy-off for a vendor 0x1003 device.
+        let offered = hal::inl(io_base + VIRTIO_REG_DEVICE_FEATURES);
+        let guest_feats = offered & VIRTIO_CONSOLE_F_MULTIPORT;
+        hal::outl(io_base + VIRTIO_REG_GUEST_FEATURES, guest_feats);
+        crate::serial_println!(
+            "[VIRTIO-SERIAL] features: offered={:#x} accepted={:#x} (multiport={})",
+            offered, guest_feats,
+            if guest_feats & VIRTIO_CONSOLE_F_MULTIPORT != 0 { "yes" } else { "NO" }
+        );
+        if guest_feats & VIRTIO_CONSOLE_F_MULTIPORT == 0 {
+            crate::serial_println!(
+                "[VIRTIO-SERIAL] host refused MULTIPORT — port 1 (QGA) cannot be reached, aborting"
+            );
+            hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0);
+            return false;
+        }
 
-        let rxq = match setup_queue(io_base, 0) {
+        // Per §5.3.2, multiport layout is vq0..vq5:
+        //   0/1 = port 0 (console pair),  2/3 = control rx/tx,
+        //   4/5 = port 1 (QGA) rx/tx.
+        // We allocate all six even though port 0 stays idle, because
+        // QEMU's `virtio-serial-bus.c::set_status` refuses DRIVER_OK
+        // unless every advertised queue has been programmed with a PFN.
+        let port0_rx = match setup_queue(io_base, 0) {
             Some(q) => q,
-            None => {
-                hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0);
-                return false;
-            }
+            None => { hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0); return false; }
         };
-        let txq = match setup_queue(io_base, 1) {
+        let port0_tx = match setup_queue(io_base, 1) {
             Some(q) => q,
-            None => {
-                hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0);
-                return false;
-            }
+            None => { hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0); return false; }
+        };
+        let cq_rx = match setup_queue(io_base, 2) {
+            Some(q) => q,
+            None => { hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0); return false; }
+        };
+        let cq_tx = match setup_queue(io_base, 3) {
+            Some(q) => q,
+            None => { hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0); return false; }
+        };
+        let rxq = match setup_queue(io_base, 4) {
+            Some(q) => q,
+            None => { hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0); return false; }
+        };
+        let txq = match setup_queue(io_base, 5) {
+            Some(q) => q,
+            None => { hal::outb(io_base + VIRTIO_REG_DEVICE_STATUS, 0); return false; }
         };
 
         hal::outb(
             io_base + VIRTIO_REG_DEVICE_STATUS,
             VIRTIO_STATUS_ACKNOWLEDGE | VIRTIO_STATUS_DRIVER | VIRTIO_STATUS_DRIVER_OK,
         );
-        (rxq, txq)
+        (port0_rx, port0_tx, cq_rx, cq_tx, rxq, txq)
     };
 
     crate::serial_println!(
-        "[VIRTIO-SERIAL] Initialized: io={:#06x}, rxq_size={}, txq_size={}, rxq_phys={:#x}, txq_phys={:#x}",
-        io_base, rxq.queue_size, txq.queue_size, rxq.phys, txq.phys
+        "[VIRTIO-SERIAL] queues: p0_rx={:#x} p0_tx={:#x} cq_rx={:#x} cq_tx={:#x} p1_rx={:#x} p1_tx={:#x}",
+        port0_rx.phys, port0_tx.phys, cq_rx.phys, cq_tx.phys, rxq.phys, txq.phys
     );
 
     let mut dev = VirtioSerialDevice {
         io_base,
         rxq,
         txq,
+        cq_rx,
+        cq_tx,
         rx_consumed: 0,
         rx_avail: 0,
+        pci_bus:  pci_dev.bus,
+        pci_dev:  pci_dev.device,
+        pci_func: pci_dev.function,
+        pci_irq_line: pci_dev.interrupt_line,
+        rx_ring: VecDeque::with_capacity(RX_RING_CAP),
+        port_opened: false,
     };
+    // Port 0's queues are bound to the device but never carry data on our
+    // QGA wiring; drop them on the floor.  Holding them in `dev` would
+    // confuse the loopback test which keys off (rxq, txq) addresses.
+    drop(port0_rx);
+    drop(port0_tx);
 
-    // Prime the rx ring with one empty buffer so the device has somewhere
-    // to write the first host-originated bytes.  Notify after publishing.
     // SAFETY: dev is locally owned at this point.
     unsafe {
+        // Replenish the QGA rx queue with one scratch buffer.  Notify
+        // after publishing so the host wakes up immediately.
         replenish_rx(&mut dev.rxq);
-        hal::outw(io_base + VIRTIO_REG_QUEUE_NOTIFY, 0);
+        hal::outw(io_base + VIRTIO_REG_QUEUE_NOTIFY, 4);
+
+        // Replenish the control rx queue with CTRL_RX_BUFS small slots,
+        // each living at scratch_phys + i*CTRL_BUF_LEN.  The slots fit
+        // inside the queue's 4 KiB scratch page (8 * 64 = 512 bytes).
+        let cq_rx_scratch = dev.cq_rx.scratch_phys();
+        for i in 0..CTRL_RX_BUFS {
+            let addr = cq_rx_scratch + (i as u64) * (CTRL_BUF_LEN as u64);
+            dev.cq_rx.fill_desc(i, addr, CTRL_BUF_LEN as u32, VRING_DESC_F_WRITE);
+            dev.cq_rx.publish_desc(i);
+        }
+        hal::outw(io_base + VIRTIO_REG_QUEUE_NOTIFY, 2);
+
+        // Step 6 — send DEVICE_READY(1) on the control TX queue.  Host
+        // responds with PORT_ADD / PORT_NAME control events for every
+        // configured port.  We don't have to wait for them in init;
+        // they will arrive on the cq_rx and be consumed by the ISR
+        // (or by `pump_control_rx` called from the polling path).
+        send_control_msg(&mut dev, CTRL_BAD_PORT_ID, VIRTIO_CONSOLE_DEVICE_READY, 1);
+
+        // Step 7 — send PORT_READY(1) + PORT_OPEN(1) for the QGA port.
+        // PORT_READY signals "I'm ready to receive PORT_ADD's friends
+        // (PORT_NAME, etc.)"; PORT_OPEN flips the host's
+        // `host_connected` flag for the chardev backend and authorises
+        // data delivery into vq4.
+        send_control_msg(&mut dev, QGA_PORT_ID, VIRTIO_CONSOLE_PORT_READY, 1);
+        send_control_msg(&mut dev, QGA_PORT_ID, VIRTIO_CONSOLE_PORT_OPEN,  1);
     }
 
     // Stash the queue physical addresses + sizes for mutex-free loopback
@@ -387,20 +656,371 @@ pub fn init() -> bool {
         });
     }
 
+    crate::serial_println!(
+        "[VIRTIO-SERIAL] Initialized: io={:#06x}, rxq_size={}, txq_size={}, rxq_phys={:#x}, txq_phys={:#x}",
+        io_base, dev.rxq.queue_size, dev.txq.queue_size, dev.rxq.phys, dev.txq.phys
+    );
+
     *VIRTIO_SERIAL.lock() = Some(dev);
+    IRQ_IO_BASE.store(io_base, Ordering::Release);
     VIRTIO_SERIAL_AVAILABLE.store(true, Ordering::Release);
     true
 }
 
+/// Send one virtio-console control message via the control TX queue
+/// (`cq_tx`).  The message is the canonical 8-byte header:
+///   u32 id, u16 event, u16 value
+/// per virtio 1.2 §5.3.6.7.  We reuse the queue's scratch buffer (each
+/// VirtQueue has one); the call is synchronous — descriptor 0 carries
+/// the message, we publish, notify, and spin briefly on the used ring.
+///
+/// SAFETY: caller must hold the device mutex (or be in `init()` which
+/// owns the device).  Bounded by a 1 M iteration budget so a wedged
+/// hypervisor cannot hang init.
+unsafe fn send_control_msg(dev: &mut VirtioSerialDevice, id: u32, event: u16, value: u16) {
+    let scratch = dev.cq_tx.scratch_virt();
+    (scratch as *mut u32).write_volatile(id);
+    (scratch.add(4) as *mut u16).write_volatile(event);
+    (scratch.add(6) as *mut u16).write_volatile(value);
+
+    let msg_len: u32 = 8;
+    dev.cq_tx.fill_desc0(dev.cq_tx.scratch_phys(), msg_len, 0); // device reads
+    dev.cq_tx.publish_desc0();
+    hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 3);
+
+    // Spin briefly on used.idx — the host retires the control message
+    // synchronously, so the wait is bounded.  At ~1 M iterations on
+    // typical KVM hardware this is well under a millisecond.
+    let mut budget: u32 = 1_000_000;
+    let expected = dev.cq_tx.next_avail;
+    loop {
+        let cur = dev.cq_tx.used_idx();
+        if cur == expected {
+            dev.cq_tx.last_used = cur;
+            break;
+        }
+        budget = match budget.checked_sub(1) {
+            Some(b) => b,
+            None => {
+                crate::serial_println!(
+                    "[VIRTIO-SERIAL] ctrl-tx wedged sending id={} event={} value={}",
+                    id, event, value
+                );
+                return;
+            }
+        };
+        core::hint::spin_loop();
+    }
+    // ctrl-tx happens exactly three times at init (DEVICE_READY,
+    // PORT_READY, PORT_OPEN) so we leave the trace in to make the
+    // multiport handshake observable; suppressing it would hide a
+    // regression where one of the three never goes out.
+    let ev_name = match event {
+        VIRTIO_CONSOLE_DEVICE_READY => "DEVICE_READY",
+        VIRTIO_CONSOLE_PORT_READY   => "PORT_READY",
+        VIRTIO_CONSOLE_PORT_OPEN    => "PORT_OPEN",
+        _ => "?",
+    };
+    crate::serial_println!(
+        "[VIRTIO-SERIAL] ctrl-tx {} value={} id={}",
+        ev_name, value, id as i32
+    );
+}
+
+/// Drain pending control RX messages from `cq_rx`, take any actions
+/// they imply (PORT_OPEN → flip `port_opened`), and re-publish the
+/// consumed descriptor.  Idempotent — returns the number of events
+/// drained.  Called both from the ISR and from the polling `read()`
+/// path so the handshake completes even before `arm_irq()` runs.
+///
+/// SAFETY: caller must hold the device mutex.
+unsafe fn pump_control_rx(dev: &mut VirtioSerialDevice) -> u32 {
+    let mut drained: u32 = 0;
+    loop {
+        let cur_used = dev.cq_rx.used_idx();
+        if cur_used == dev.cq_rx.last_used {
+            return drained;
+        }
+        let new_used = dev.cq_rx.last_used.wrapping_add(1);
+        let len = dev.cq_rx.used_len(new_used) as usize;
+        let id_desc = dev.cq_rx.used_id(new_used) as u16;
+        dev.cq_rx.last_used = new_used;
+
+        if len >= 8 {
+            let slot = dev.cq_rx.scratch_virt().add((id_desc as usize) * CTRL_BUF_LEN);
+            let port_id = (slot as *const u32).read_volatile();
+            let event   = (slot.add(4) as *const u16).read_volatile();
+            let value   = (slot.add(6) as *const u16).read_volatile();
+            // Only log PORT_OPEN transitions — every other event (PORT_ADD,
+            // PORT_NAME) fires exactly twice at init and is noise after that.
+            if event == VIRTIO_CONSOLE_PORT_OPEN {
+                crate::serial_println!(
+                    "[VIRTIO-SERIAL] port {} {}", port_id,
+                    if value != 0 { "opened (host connected)" } else { "closed (host disconnected)" }
+                );
+                if port_id == QGA_PORT_ID && value != 0 {
+                    dev.port_opened = true;
+                }
+            }
+        }
+
+        // Re-publish the descriptor for the next host control message.
+        let addr = dev.cq_rx.scratch_phys() + (id_desc as u64) * (CTRL_BUF_LEN as u64);
+        dev.cq_rx.fill_desc(id_desc, addr, CTRL_BUF_LEN as u32, VRING_DESC_F_WRITE);
+        dev.cq_rx.publish_desc(id_desc);
+        hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 2);
+        drained += 1;
+    }
+}
+
+// ── IRQ Wiring ──────────────────────────────────────────────────────────────
+
+/// IRQ vector reserved for virtio-serial in the IDT.  Allocated alongside
+/// the other PCI INTx vectors at the top of `irq.rs`; kept in sync with
+/// the `IDT[46].set_handler(...)` call in `arch/x86_64/idt.rs`.
+pub const VIRTIO_SERIAL_IRQ_VECTOR: u8 = 46;
+
+/// Route the virtio-serial legacy INTx line through the IO-APIC, disable
+/// any MSI-X capability the firmware may have left armed, and flip
+/// `IRQS_ARMED` so `read_blocking()` parks instead of busy-polling.
+///
+/// MUST be called after `apic::init()` has brought the IO-APIC up.  Safe
+/// to call when no device was discovered or when invoked twice — both
+/// become no-ops.  Mirrors `virtio_blk::arm_irq()` exactly so the two
+/// drivers share the same legacy-INTx contract.
+///
+/// Per virtio 1.0 §4.1.4.5 the driver enables interrupts simply by
+/// leaving the device's line unmasked at the IO-APIC; no register write
+/// to the device itself is required.  The device raises the line
+/// whenever it advances `used.idx`; we ack each entry by reading
+/// `ISR_STATUS` (read-to-clear) inside the ISR.
+pub fn arm_irq() {
+    if !VIRTIO_SERIAL_AVAILABLE.load(Ordering::Acquire) {
+        return;
+    }
+    if IRQS_ARMED.load(Ordering::Acquire) {
+        return;
+    }
+    let (irq_line, b, d, f) = {
+        let guard = VIRTIO_SERIAL.lock();
+        match guard.as_ref() {
+            Some(dev) => (dev.pci_irq_line, dev.pci_bus, dev.pci_dev, dev.pci_func),
+            None => return,
+        }
+    };
+    if irq_line == 0 || irq_line == 0xFF {
+        crate::serial_println!(
+            "[VIRTIO-SERIAL] No PCI interrupt line programmed (line={:#x}); staying on poll path",
+            irq_line
+        );
+        return;
+    }
+
+    // Clear PCI command-register bit 10 (Interrupt Disable) so the device
+    // can assert legacy INTx.  Some firmware leaves it set expecting an
+    // MSI/MSI-X path; we explicitly enable INTx for the legacy IO-APIC
+    // route below.  PCI Local Bus Specification 3.0, §6.2.2.
+    let cmd = super::pci::pci_config_read32(b, d, f, 0x04);
+    super::pci::pci_config_write32(b, d, f, 0x04, cmd & !(1u32 << 10));
+
+    // Walk the PCI capability list and disable MSI-X if present — when
+    // MSI-X enable=1 the device routes interrupts via MSI-X messages and
+    // ignores its INTx pin entirely (PCI 3.0 §6.8.2.3).  QEMU's
+    // `virtio-serial-pci` exposes MSI-X by default; forcing it off
+    // restores the legacy INTx path that this driver uses.
+    disable_msix(b, d, f);
+
+    // Route the GSI through the IO-APIC.  PCI INTx is level-triggered,
+    // active-low — use the level helper.
+    let bsp_id = crate::arch::x86_64::apic::bsp_apic_id();
+    crate::arch::x86_64::apic::ioapic_route_irq_level(irq_line, VIRTIO_SERIAL_IRQ_VECTOR, bsp_id);
+
+    // Drain any stale ISR bit so the first real completion isn't masked
+    // behind a left-over assertion from QEMU's device init.
+    let io_base_snap = IRQ_IO_BASE.load(Ordering::Acquire);
+    if io_base_snap != 0 {
+        // SAFETY: ISR status is read-to-clear; no side effects beyond
+        // clearing latched bits and de-asserting the level line.
+        unsafe {
+            let _ = crate::hal::inb(io_base_snap + VIRTIO_REG_ISR_STATUS);
+        }
+    }
+
+    IRQS_ARMED.store(true, Ordering::Release);
+    crate::serial_println!(
+        "[VIRTIO-SERIAL] IRQ armed: PCI {:02x}:{:02x}.{} line={} -> vector {} (BSP APIC {})",
+        b, d, f, irq_line, VIRTIO_SERIAL_IRQ_VECTOR, bsp_id
+    );
+
+    // Kick the QGA rx queue (vq4) once now that interrupts are live.
+    // QEMU's `handle_input` callback uses the kick to call
+    // `qemu_chr_fe_accept_input`, which is the only path that primes
+    // the chardev for the first read after a `host_connected` flip.
+    // Without this, host writes that arrive after init silently sit in
+    // the socket's kernel buffer until the next guest kick — the
+    // exact symptom observed on PR #158's QGA-3 wedge.  See virtio 1.2
+    // §5.3.7.3 for the rx-side delivery model.
+    if io_base_snap != 0 {
+        unsafe { crate::hal::outw(io_base_snap + VIRTIO_REG_QUEUE_NOTIFY, 4); }
+    }
+}
+
+/// Walk a device's PCI capability list and disable any MSI-X capability
+/// we find.  PCI 3.0 §6.7 (Capability Pointers): caps list starts at
+/// config offset 0x34 if Status register bit 4 is set; each cap header is
+/// two bytes — `cap_id` at +0, `next_ptr` at +1.  MSI-X cap_id = 0x11.
+/// The MSI-X Message Control register lives at cap_offset+2; bit 15 of
+/// that 16-bit field is "MSI-X Enable" — clear it to fall back to INTx.
+fn disable_msix(bus: u8, device: u8, function: u8) {
+    let status_reg = super::pci::pci_config_read32(bus, device, function, 0x04);
+    let status = (status_reg >> 16) as u16;
+    if status & (1 << 4) == 0 {
+        return;
+    }
+    let cap_ptr = super::pci::pci_config_read32(bus, device, function, 0x34) & 0xFF;
+    let mut off = (cap_ptr as u8) & 0xFC;
+    let mut hops = 0u8;
+    while off != 0 && hops < 48 {
+        let dw = super::pci::pci_config_read32(bus, device, function, off);
+        let cap_id = (dw & 0xFF) as u8;
+        let next = ((dw >> 8) & 0xFF) as u8;
+        if cap_id == 0x11 {
+            let msg_ctl = ((dw >> 16) & 0xFFFF) as u16;
+            if msg_ctl & (1 << 15) != 0 {
+                let new_ctl = (msg_ctl & !(1u16 << 15)) as u32;
+                let new_dw = (dw & 0x0000_FFFF) | (new_ctl << 16);
+                super::pci::pci_config_write32(bus, device, function, off, new_dw);
+                crate::serial_println!(
+                    "[VIRTIO-SERIAL] Disabled MSI-X (was enabled, cap@{:#x})", off
+                );
+            }
+            return;
+        }
+        off = next & 0xFC;
+        hops += 1;
+    }
+}
+
+/// Virtio-serial ISR.  Called from the IDT stub with interrupts disabled.
+///
+/// Per virtio 1.0 §4.1.4.5 the driver:
+///   1. Reads `ISR_STATUS` (read-to-clear) to ack the device's INTx
+///      assertion — required even on spurious entries to keep the level
+///      line from re-asserting after EOI.
+///   2. Drains every newly-completed rx descriptor into `rx_ring`,
+///      re-priming the descriptor and notifying the device so the next
+///      host write has somewhere to land.
+///   3. Wakes any thread parked in `read_blocking()`.
+///   4. Issues LAPIC EOI.
+///
+/// Lock discipline: tries `VIRTIO_SERIAL.try_lock()` — if the device
+/// mutex is held by a concurrent `read()` / `write()` on another CPU,
+/// the latched ISR_STATUS read still completes (so the line de-asserts)
+/// and the wake is deferred to the next ISR entry.  The bounded
+/// re-arm interval is one timer tick because `read_blocking()`'s wake
+/// fires whenever new bytes land — a single missed wake is harmless
+/// (the next host write or replenish kick re-fires the IRQ).
+pub(crate) fn handle_irq() {
+    TOTAL_IRQS.fetch_add(1, Ordering::Relaxed);
+    let io_base = IRQ_IO_BASE.load(Ordering::Acquire);
+
+    // 1. Acknowledge device — read ISR status (read-to-clear).
+    let isr_bits = if io_base != 0 {
+        // SAFETY: ISR status is a read-to-clear u8 register at +0x13.
+        unsafe { crate::hal::inb(io_base + VIRTIO_REG_ISR_STATUS) }
+    } else { 0 };
+
+    // 2. Drain newly-completed rx descriptors AND control-rx events.
+    let mut woke_any = false;
+    if let Some(guard) = VIRTIO_SERIAL.try_lock() {
+        let mut g = guard;
+        if let Some(dev) = g.as_mut() {
+            // Drain control-queue events first — PORT_OPEN handshake
+            // completion may flip `port_opened` which the data path
+            // queries.
+            // SAFETY: we hold the device mutex.
+            unsafe { pump_control_rx(dev); }
+            // SAFETY: walking our owned virtqueue memory.
+            loop {
+                let cur_used = unsafe { dev.rxq.used_idx() };
+                if cur_used == dev.rxq.last_used {
+                    break;
+                }
+                let new_used = dev.rxq.last_used.wrapping_add(1);
+                // SAFETY: device wrote this many bytes into our scratch.
+                let len = unsafe { dev.rxq.used_len(new_used) } as usize;
+                let len = len.min(SCRATCH_BUF_LEN);
+                // Copy into the ring; drop overflow (counted).
+                let room = RX_RING_CAP.saturating_sub(dev.rx_ring.len());
+                let take = len.min(room);
+                if take < len {
+                    RX_DROPPED_BYTES.fetch_add((len - take) as u64, Ordering::Relaxed);
+                }
+                // SAFETY: scratch_virt..+take is within our owned buffer.
+                unsafe {
+                    let src = dev.rxq.scratch_virt();
+                    for i in 0..take {
+                        dev.rx_ring.push_back(src.add(i).read_volatile());
+                    }
+                }
+                dev.rxq.last_used = new_used;
+                woke_any = true;
+                // Re-publish the descriptor for the next host write.
+                // SAFETY: we hold the device mutex.
+                unsafe {
+                    replenish_rx(&mut dev.rxq);
+                    crate::hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 4);
+                }
+            }
+        }
+    } else if isr_bits != 0 {
+        // Mutex contended — count and ack only.  The next read()/timer
+        // tick will catch the missed descriptor.
+        SPURIOUS_IRQS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    // 3. Wake parked readers if we deposited bytes.
+    if woke_any {
+        let drained = RX_WAITERS.lock().drain_all();
+        wake_tids(&drained);
+        ring_poll_bell();
+    }
+
+    // 4. EOI.
+    if crate::arch::x86_64::apic::is_enabled() {
+        crate::arch::x86_64::apic::lapic_eoi();
+    } else {
+        // SAFETY: PIC fallback path; we never see this on KVM but keep
+        // parity with the virtio-blk handler so a PIC-only smoke test
+        // doesn't surprise us.
+        unsafe {
+            crate::arch::x86_64::irq::send_eoi(
+                VIRTIO_SERIAL_IRQ_VECTOR.saturating_sub(32),
+            );
+        }
+    }
+}
+
 // ── Read / Write API ────────────────────────────────────────────────────────
 
-/// Read up to `out.len()` bytes from the rx queue.  Returns the number of
-/// bytes copied.  Zero on no data available (non-blocking semantics).
+/// Read up to `out.len()` bytes from the rx queue.  Non-blocking — returns
+/// zero immediately when no data is available.
 ///
-/// Bytes from a single device-written descriptor are streamed out across
-/// multiple `read()` calls — the driver remembers how many bytes have been
-/// consumed from the active rx descriptor and replenishes only once it is
-/// fully drained.
+/// In steady state (post-`arm_irq()`) bytes are deposited into `rx_ring`
+/// by the ISR and this call drains the ring under the device mutex.
+/// During early boot — before `arm_irq()` has registered the IO-APIC
+/// route — the call falls back to walking the virtqueue itself; that
+/// path matches the pre-IRQ behaviour required by the QGA-2 loopback
+/// test (`test_inject_rx` → `read`).
+///
+/// **Wedge fix (PR following #158)**: when the call would otherwise
+/// return 0, it issues a single `QUEUE_NOTIFY` to re-arm QEMU's chardev
+/// poll.  Per virtio-serial-bus semantics, QEMU only re-primes
+/// `qemu_chr_fe_accept_input` on a guest kick of vq0; host-side
+/// connections that arrive after init therefore stay invisible to the
+/// device until the first such kick.  Issuing the notify on every empty
+/// read is cheap (one I/O port write) and self-throttling — the daemon
+/// only polls when no data is in flight.
 pub fn read(out: &mut [u8]) -> usize {
     if !VIRTIO_SERIAL_AVAILABLE.load(Ordering::Acquire) || out.is_empty() {
         return 0;
@@ -411,10 +1031,33 @@ pub fn read(out: &mut [u8]) -> usize {
         None => return 0,
     };
 
+    // Drain any pending control-queue events first.  In test-mode boots
+    // `arm_irq()` is never called, so the ISR-driven pump never fires —
+    // doing it here on every read keeps the multiport handshake live
+    // for both the loopback test and the early-boot real-host path.
+    // SAFETY: we hold the device mutex.
+    unsafe { pump_control_rx(dev); }
+
+    // Fast path — ISR has already deposited bytes into the ring.
+    if !dev.rx_ring.is_empty() {
+        let n = drain_rx_ring(dev, out);
+        if n > 0 { return n; }
+    }
+
+    // Polling fallback — also taken in steady state if IRQs are armed.
+    // The ISR may have missed deposits if the device mutex was contended,
+    // and bytes that landed via the device's `virtio_notify` between two
+    // ISR entries are still recoverable by walking the used ring here.
+    // SAFETY: reading our owned virtqueue memory.
     if dev.rx_avail == 0 {
         // SAFETY: reading our owned virtqueue memory.
         let cur_used = unsafe { dev.rxq.used_idx() };
         if cur_used == dev.rxq.last_used {
+            // Same wedge fix on the polling path — many test boots run
+            // long before `arm_irq()` fires (test runner reads before
+            // APIC init); we want host writes to flush in either case.
+            // SAFETY: doorbell write to our device.
+            unsafe { hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 4); }
             return 0;
         }
         let new_used = dev.rxq.last_used.wrapping_add(1);
@@ -440,12 +1083,99 @@ pub fn read(out: &mut [u8]) -> usize {
         // SAFETY: replenish + notify; we hold the device mutex.
         unsafe {
             replenish_rx(&mut dev.rxq);
-            hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 0);
+            hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 4);
         }
     }
 
     n
 }
+
+/// Drain bytes from the ISR-filled ring into `out`.  Assumes the caller
+/// holds the device mutex.  Returns the number of bytes copied.
+fn drain_rx_ring(dev: &mut VirtioSerialDevice, out: &mut [u8]) -> usize {
+    let mut n = 0;
+    while n < out.len() {
+        match dev.rx_ring.pop_front() {
+            Some(b) => { out[n] = b; n += 1; }
+            None => break,
+        }
+    }
+    n
+}
+
+/// Blocking variant of [`read`].  Parks the caller on `RX_WAITERS` until
+/// the ISR deposits bytes, then returns the same way as `read`.  Used by
+/// the VFS layer for `/dev/vport0p0` opens that are NOT `O_NONBLOCK`.
+///
+/// Returns 0 only when the device is unavailable; otherwise blocks until
+/// at least one byte is delivered.  This is the semantics POSIX
+/// `read(2)` on a blocking fd specifies — no partial-success path is
+/// needed because the caller already framed the request.
+pub fn read_blocking(out: &mut [u8]) -> usize {
+    if !VIRTIO_SERIAL_AVAILABLE.load(Ordering::Acquire) || out.is_empty() {
+        return 0;
+    }
+    loop {
+        let n = read(out);
+        if n > 0 {
+            return n;
+        }
+        // Before parking, kick the QGA rx queue (vq4) once more so that
+        // any data that landed while we held the mutex during the prior
+        // read attempt is observed by the ISR before we go to sleep.
+        // This closes the lost-wakeup window between the ring-empty
+        // check and the enqueue; symmetric with the futex
+        // `check-then-enqueue-under-lock` pattern in
+        // `subsys/linux/syscall.rs::futex_wait_check_and_enqueue`.
+        {
+            let guard = VIRTIO_SERIAL.lock();
+            if let Some(dev) = guard.as_ref() {
+                // SAFETY: doorbell write to our device's notify port.
+                unsafe { hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 4); }
+            }
+        }
+        // Re-check after the kick; QEMU may have delivered bytes by the
+        // time we get the device mutex below.
+        let n = read(out);
+        if n > 0 {
+            return n;
+        }
+        // Decide whether to park or just yield-poll.  We park (block via
+        // WaitList) only when there is concrete evidence the ISR path is
+        // delivering wake-ups — i.e. `TOTAL_IRQS > 0`.  In test-mode
+        // boots `test_inject_rx` bumps `used.idx` synthetically without
+        // firing the IRQ, so a parked thread would never be woken until
+        // the 10-tick safety floor expires (which doesn't advance under
+        // a tight `yield_cpu` loop — yields don't tick the clock).  The
+        // yield path keeps the QGA-2 loopback test working without
+        // hurting the real-boot path: once a real IRQ has fired we
+        // commit to the WaitList wake source.
+        let irqs_seen = TOTAL_IRQS.load(Ordering::Relaxed);
+        if !IRQS_ARMED.load(Ordering::Acquire) || irqs_seen == 0 {
+            // Cooperative yield — gives the producer (host write,
+            // test_inject_rx caller) a quantum to make progress; we
+            // recheck on next loop iteration.
+            crate::sched::yield_cpu();
+            continue;
+        }
+        // Park ourselves on the wait list.  Wake source is the ISR's
+        // `wake_tids` call after it deposits into `rx_ring`; a 10-tick
+        // ceiling matches the global poll-bell resync interval so a
+        // hypothetical missed wake recovers within 100 ms.
+        let tid = crate::proc::current_tid();
+        let now = crate::arch::x86_64::irq::get_ticks();
+        let wake_tick = now.saturating_add(10);
+        {
+            let mut wl = RX_WAITERS.lock();
+            wl.enqueue_self_blocked(tid, wake_tick);
+        }
+        crate::sched::schedule();
+        // Drop any stale entry — we may have been woken via the
+        // scheduler tick rather than via the ISR's `wake_tids`.
+        RX_WAITERS.lock().remove_tid(tid);
+    }
+}
+
 
 /// Send up to `data.len()` bytes through the tx queue.  Returns the number
 /// of bytes accepted by the device; capped at the scratch buffer length
@@ -467,7 +1197,8 @@ pub fn write(data: &[u8]) -> usize {
         core::ptr::copy_nonoverlapping(data.as_ptr(), dev.txq.scratch_virt(), n);
         dev.txq.fill_desc0(dev.txq.scratch_phys(), n as u32, 0); // device reads
         dev.txq.publish_desc0();
-        hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 1);
+        // Notify vq5 — port 1's TX queue under MULTIPORT layout.
+        hal::outw(dev.io_base + VIRTIO_REG_QUEUE_NOTIFY, 5);
     }
 
     // Spin until the device retires our descriptor.  Bounded so a wedged
@@ -504,6 +1235,9 @@ pub fn has_data() -> bool {
         Some(d) => d,
         None => return false,
     };
+    if !dev.rx_ring.is_empty() {
+        return true;
+    }
     if dev.rx_avail > dev.rx_consumed {
         return true;
     }
@@ -525,6 +1259,20 @@ pub struct Stats {
     pub tx_last_used: u16,
     pub rx_next_avail: u16,
     pub tx_next_avail: u16,
+    /// Bytes the ISR has deposited into `rx_ring` but the daemon has not
+    /// yet drained.  Steady-state hover around 0; spikes indicate the
+    /// userspace reader is throughput-bound.
+    pub rx_ring_pending: usize,
+    /// Total IRQ entries since boot.  Zero post-boot means the IO-APIC
+    /// route never bound (likely an MSI-X residue) — `arm_irq()`
+    /// disables MSI-X but a misbehaving firmware may re-enable it.
+    pub total_irqs: u64,
+    /// Bytes the ISR dropped because `rx_ring` was full.
+    pub rx_dropped_bytes: u64,
+    /// True once the host has signalled `VIRTIO_CONSOLE_PORT_OPEN(1)` on
+    /// the QGA port via the control queue.  Indicates the chardev socket
+    /// has a peer connected and the data path is authorised.
+    pub port_opened: bool,
 }
 
 pub fn stats() -> Option<Stats> {
@@ -534,11 +1282,22 @@ pub fn stats() -> Option<Stats> {
         tx_last_used: d.txq.last_used,
         rx_next_avail: d.rxq.next_avail,
         tx_next_avail: d.txq.next_avail,
+        rx_ring_pending: d.rx_ring.len(),
+        total_irqs: TOTAL_IRQS.load(Ordering::Relaxed),
+        rx_dropped_bytes: RX_DROPPED_BYTES.load(Ordering::Relaxed),
+        port_opened: d.port_opened,
     })
 }
 
-// Anchor for the QGA-1b IRQ path so a follow-up PR can land its atomics
-// import without rewriting the use block.
+/// Diagnostic counter — number of times the ISR raced the device mutex
+/// and had to ack-only.  Surfaced to `kdb` for the QGA wiring tests.
+pub fn spurious_irq_count() -> u64 {
+    SPURIOUS_IRQS.load(Ordering::Relaxed)
+}
+
+// Anchor for the unused atomic re-export so a future capability-list
+// rework can land its imports without churn.  Kept #[allow(dead_code)]
+// because the IRQ path uses AtomicU16 transitively via Mutex spinlock.
 #[allow(dead_code)]
 fn _atomic_u16_anchor() -> AtomicU16 { AtomicU16::new(0) }
 

--- a/kernel/src/drivers/virtio_serial.rs
+++ b/kernel/src/drivers/virtio_serial.rs
@@ -640,6 +640,13 @@ pub fn init() -> bool {
         // (PORT_NAME, etc.)"; PORT_OPEN flips the host's
         // `host_connected` flag for the chardev backend and authorises
         // data delivery into vq4.
+        //
+        // Spec deviation: virtio-console §5.3.6 has the guest first consume
+        // the host's PORT_ADD on cq_rx before announcing PORT_READY/PORT_OPEN.
+        // QEMU tolerates the inversion (PORT_READY/OPEN sent ahead of seeing
+        // PORT_ADD on the rx side) and the alternative — block init waiting
+        // for cq_rx — would force IRQ-driven completion or an arbitrary spin,
+        // both of which complicate boot ordering for no functional gain.
         send_control_msg(&mut dev, QGA_PORT_ID, VIRTIO_CONSOLE_PORT_READY, 1);
         send_control_msg(&mut dev, QGA_PORT_ID, VIRTIO_CONSOLE_PORT_OPEN,  1);
     }
@@ -1294,12 +1301,6 @@ pub fn stats() -> Option<Stats> {
 pub fn spurious_irq_count() -> u64 {
     SPURIOUS_IRQS.load(Ordering::Relaxed)
 }
-
-// Anchor for the unused atomic re-export so a future capability-list
-// rework can land its imports without churn.  Kept #[allow(dead_code)]
-// because the IRQ path uses AtomicU16 transitively via Mutex spinlock.
-#[allow(dead_code)]
-fn _atomic_u16_anchor() -> AtomicU16 { AtomicU16::new(0) }
 
 // ── Loopback test helpers (Phase QGA-2) ─────────────────────────────────────
 //

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -144,6 +144,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
     // (none today, but keep in mind for future early-FS code) use the
     // poll fallback, see drivers/virtio_blk.rs::submit_request.
     drivers::virtio_blk::arm_irq();
+    #[cfg(feature = "qga")]
     drivers::virtio_serial::arm_irq();
     serial_println!("[Aether] Phase 5b: APIC OK");
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -144,6 +144,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
     // (none today, but keep in mind for future early-FS code) use the
     // poll fallback, see drivers/virtio_blk.rs::submit_request.
     drivers::virtio_blk::arm_irq();
+    drivers::virtio_serial::arm_irq();
     serial_println!("[Aether] Phase 5b: APIC OK");
 
     // Phase 6: Syscall interface
@@ -588,12 +589,23 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
         // Ascension will eventually own this spawn (via sys::fork + exec
         // of /sbin/qga); for now Aether launches it directly during boot
         // so the host can talk to /dev/vport0p0 immediately after init.
+        //
+        // Enabling the scheduler is required for the daemon to actually
+        // run — `shell::launch()` below blocks the BSP in a kernel-mode
+        // input loop that only enables the scheduler when the user
+        // types `exec`.  Without an explicit `sched::enable()` here the
+        // QGA daemon process exists but never gets a quantum, so host
+        // requests to `/dev/vport0p0` time out (the PR #158 wedge that
+        // QGA-3 surfaced even on a working IRQ-driven RX path).
         #[cfg(feature = "qga")]
         {
             serial_println!("[Aether] Launching QGA daemon (Phase QGA-2)...");
             match proc::usermode::create_aether_process("qga", &proc::qga_elf::QGA_ELF) {
                 Ok(pid) => serial_println!("[Aether] QGA daemon launched as PID {}", pid),
                 Err(e) => serial_println!("[Aether] Failed to launch QGA daemon: {:?}", e),
+            }
+            if !sched::is_active() {
+                sched::enable();
             }
         }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1555,12 +1555,24 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                 return Ok(count);
             }
             // bit 22 = /dev/vport0p0 → drain bytes from virtio-serial rx queue.
-            // Non-blocking: WouldBlock when the device has nothing to deliver,
-            // mirroring how PTY reads signal "no data yet".  See virtio 1.2 §5.3.
+            // Honour O_NONBLOCK (0x0000_0800): non-blocking opens return
+            // WouldBlock immediately on an empty queue; blocking opens park
+            // the caller via `read_blocking` and only return once at least
+            // one byte is available (POSIX `read(2)` semantics).  See
+            // virtio 1.2 §5.3 for the rx-side delivery model.  Before
+            // `arm_irq()` has fired (early-boot test paths), the blocking
+            // variant short-circuits to the non-blocking path and lets the
+            // caller cooperate via `yield_cpu` — the QGA-2 loopback test
+            // exercises that fallback.
             #[cfg(feature = "qga")]
             if flags & 0x0040_0000 != 0 {
                 let slice = unsafe { core::slice::from_raw_parts_mut(buf, count) };
-                let n = crate::drivers::virtio_serial::read(slice);
+                let non_block = flags & 0x0000_0800 != 0;
+                let n = if non_block {
+                    crate::drivers::virtio_serial::read(slice)
+                } else {
+                    crate::drivers::virtio_serial::read_blocking(slice)
+                };
                 if n == 0 { return Err(VfsError::WouldBlock); }
                 return Ok(n);
             }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -767,6 +767,39 @@ def _build(features: str) -> bool:
     return r3.returncode == 0
 
 
+def _check(features: str) -> tuple[int, str]:
+    """
+    Run `cargo +nightly check` against the kernel package for `features`.
+
+    Returns (rc, stderr_tail) — rc==0 on success.  Stderr is forwarded
+    truncated to the last 4 KB so callers can surface the failing diagnostic
+    without flooding the JSON envelope.
+
+    `features` is passed VERBATIM (comma-separated, e.g. "test-mode,kdb").
+    Empty string → no `--features` flag (default desktop kernel).
+    """
+    wt = _get_watch_test()
+    ROOT = wt.ROOT
+    KERNEL_TARGET = wt.KERNEL_TARGET
+
+    cmd = ["cargo", "+nightly", "check",
+           "--package", "astryx-kernel",
+           f"--target={KERNEL_TARGET}",
+           "--profile", "release"]
+    if features:
+        cmd += ["--features", features]
+    cmd += ["-Zbuild-std=core,alloc,compiler_builtins",
+            "-Zbuild-std-features=compiler-builtins-mem",
+            "-Zjson-target-spec"]
+
+    proc = subprocess.run(cmd, cwd=ROOT,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          text=True)
+    tail = (proc.stderr or "")[-4096:]
+    return proc.returncode, tail
+
+
 # ── Session-scoped ESP (concurrent-rebuild clobber fix) ──────────────────────
 #
 # Bug: QEMU opens the ESP directory via its `vvfat` driver, which re-reads
@@ -932,6 +965,24 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
 # ══════════════════════════════════════════════════════════════════════════════
 # Subcommand implementations
 # ══════════════════════════════════════════════════════════════════════════════
+
+def cmd_check(args):
+    """
+    Run `cargo +nightly check` against the kernel package and emit a JSON
+    verdict.  No QEMU is launched.  Useful for sweeping feature-flag matrices
+    after a code change.
+    """
+    rc, tail = _check(args.features or "")
+    out = {
+        "ok": rc == 0,
+        "features": args.features or "",
+        "rc": rc,
+    }
+    if rc != 0:
+        out["stderr_tail"] = tail
+    print(json.dumps(out, indent=2))
+    return rc
+
 
 def cmd_start(args):
     sid = uuid.uuid4().hex[:12]
@@ -4921,6 +4972,16 @@ def main():
              "(default 120000 = 2 min, covers build + boot + test run)"
     )
 
+    # check: run `cargo check` against a feature-flag combination without
+    # spinning up QEMU.  Used by hotfix verification sweeps that need to
+    # confirm a regression is closed across N feature combos before
+    # committing to a full boot.
+    p_check = sub.add_parser("check",
+                              help="Run `cargo +nightly check` for given --features")
+    p_check.add_argument("--features", default="", metavar="FLAGS",
+                          help="Feature flags passed VERBATIM to cargo. "
+                               "Empty string → default desktop kernel.")
+
     # _watch: private subcommand used internally by `start` to run the
     # background watcher in a detached process. Not shown in help.
     p_watch = sub.add_parser("_watch")
@@ -4929,6 +4990,7 @@ def main():
     args = parser.parse_args()
 
     dispatch = {
+        "check":  cmd_check,
         "start":  cmd_start,
         "stop":   cmd_stop,
         "list":   cmd_list,
@@ -4973,7 +5035,9 @@ def main():
         "read-png": cmd_read_png,
         "_watch":  cmd_run_watcher,
     }
-    dispatch[args.cmd](args)
+    rc = dispatch[args.cmd](args)
+    if isinstance(rc, int) and rc != 0:
+        sys.exit(rc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Implements MULTIPORT feature negotiation + control-queue handshake (DEVICE_READY / PORT_READY / PORT_OPEN) so the QGA chardev on port 1 of QEMU's virtio-serial-pci device actually delivers data to the guest. Without it, host writes silently sat in QEMU's socket buffer — the wedge that PR #158's `qga-ping` / `qga-info` / `qga-sync` / `qga-file-read` wrappers reported as timeout.
- Adds IRQ-driven RX: `arm_irq()` routes the device's legacy INTx line through the IO-APIC to vector 46, disables MSI-X residue, and kicks vq4 once to re-prime QEMU's chardev poll. `handle_irq()` reads ISR_STATUS, drains used-ring bytes into a per-driver ring buffer, re-publishes the descriptor, and wakes any thread parked in `read_blocking()` via the `WaitList` from PR #132. Polling fallback is retained for pre-arm callers (early-boot smoke, test runner injection).
- Adds `read_blocking()` and a VFS open-flag branch that routes blocking `/dev/vport0p0` reads through it (default; `O_NONBLOCK` opens still get the old polling `read()` + WouldBlock).
- Enables the scheduler on the Aether default boot path after spawning the QGA daemon — `shell::launch()` only enables it on `exec`, so without this the daemon process exists but never runs.

## Diagnosis path (what made the wedge non-obvious)

1. Booted with `--features firefox-test,kdb,qga`, host wrote to `qga-ping`, timeout. Inspected vq state via `qmp-xp` — `used.idx` stayed at 0, scratch buffer all zeros.
2. Probed QEMU via QMP `query-chardev`: `"frontend-open": false` on the `qga0` chardev. The QGA port was NEVER marked open from QEMU's side.
3. Read virtio 1.2 §5.3.6 + cross-referenced QEMU's `virtio-serial-bus.c::set_status` via GitHub WebFetch: non-multiport mode only auto-opens port 0; port 1 requires the control-queue PORT_OPEN handshake. That explained the silent swallow.
4. After MULTIPORT was implemented, observed data reaching the queue (used.idx advanced, ping JSON visible in scratch) but `handle_irq` never fired. LAPIC dump showed `IRR vector 46(level)` pending but `PPR=0x20` — vector 32 stuck in ISR. Tracing showed this was an artefact of the earlier shared-IRQ misroute (vector 45 had been programmed before vector 46 won) and the actual problem in the data path was that `read()` skipped its polling fallback when IRQs were "armed". Restoring the polling fallback unconditionally fixed the wedge.

## Test plan

- [x] Built `--features firefox-test,kdb,qga` and ran 5 back-to-back boots via `scripts/qemu-harness.py`; every trial:
  - `qga-ping` returns `{"return":{}}` (first call ~1.5s, subsequent RPCs <50ms)
  - `qga-info` returns `{"version":"0.1","supported_commands":[...]}` in 10-20ms
  - `qga-file-read /etc/hostname` returns `bytes_b64="YXN0cnl4Cg=="` (the literal `astryx\n`) in 8-23ms
  - `qga-sync` echoes the caller's id in 9-48ms
- [x] Verified on the Aether default boot (`--features kdb,qga`, no firefox-test): ping=547ms cold, info=10ms, sync=15ms.
- [x] Confirmed the multiport handshake on the wire via serial-log traces of `ctrl-tx DEVICE_READY/PORT_READY/PORT_OPEN` and `ctrl-rx port 1 opened (host connected)` events.
- [x] Verified QGA-1 driver smoke test still PASSes in `--features test-mode,qga`.
- [x] Verified pre-existing `test_qga_daemon_ping_qga2` loopback test failure is NOT a regression — it fails identically on `origin/master` (the daemon never runs in test-mode boots; that issue pre-dates PR #150's smoke test and is tracked separately).
- [x] No upstream binaries touched; `userspace/qga/` is unchanged.

## Diff size

~870 LOC across 6 files. Above the 300-500 LOC soft cap (~1.7×) because the multiport handshake (DEVICE_READY → PORT_READY → PORT_OPEN, six virtqueues, control-queue ring with N descriptors, ISR-driven event drain) is irreducible — splitting it from the IRQ wiring would leave the tree in an inconsistent state where the host-side wedge could not be reproduced or fixed. Per the global LOC-cap guidance this is the kind of case where 1.5-2× is justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)