### PR TITLE
scripts/qemu-harness: auto-regen data.img on staleness (close W61 silent-wedge trap)

### DIFF
--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -371,6 +371,71 @@ def run_tier3(no_build: bool = False):
     print()
 
 
+def run_staleness_check():
+    """
+    Tier 1.5 host-only check: exercise `_data_img_staleness` directly to confirm
+    the W7 staleness detector works on fresh, stale, and missing-input inputs.
+
+    This is a pure host-side import test — no QEMU launched. The point is that
+    a future refactor of qemu-harness.py cannot accidentally break the
+    auto-regen guard without this smoke test failing first.
+    """
+    print("=== Tier 1.5: data.img staleness detector (host-only) ===")
+    print()
+    import importlib.util
+    import os
+    import tempfile
+    spec = importlib.util.spec_from_file_location("qh_smoke_load", str(HARNESS))
+    mod = importlib.util.module_from_spec(spec)
+    # Module-level side effects only mkdir ~/.astryx-harness — no QEMU.
+    _orig_argv = sys.argv
+    sys.argv = ["qemu-harness.py", "list"]
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    finally:
+        sys.argv = _orig_argv
+
+    fn = getattr(mod, "_data_img_staleness", None)
+    check("staleness fn importable", fn is not None, "")
+    if fn is None:
+        return
+
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        img = tdp / "data.img"
+        disk = tdp / "disk"
+        disk.mkdir()
+        f1 = disk / "lib.so"
+        f1.write_text("x")
+        # Case A: data.img missing — soft-fail with error string.
+        r = fn(img, disk)
+        check("missing data.img → stale=False",  not r["stale"])
+        check("missing data.img → error set",    bool(r["error"]))
+
+        # Case B: data.img newer than every disk file — not stale.
+        img.write_text("img")
+        os.utime(img, (time.time() + 60, time.time() + 60))
+        r = fn(img, disk)
+        check("fresh data.img → stale=False",    not r["stale"], str(r))
+        check("fresh data.img → error=None",     r["error"] is None, str(r))
+        check("fresh data.img → files_scanned",  r["files_scanned"] >= 1, str(r))
+
+        # Case C: a disk file newer than data.img — stale=True.
+        os.utime(img, (time.time() - 60, time.time() - 60))
+        r = fn(img, disk)
+        check("stale data.img → stale=True",     r["stale"], str(r))
+        check("stale data.img → newest_path",    bool(r["newest_path"]), str(r))
+
+        # Case D: disk dir missing — soft-fail.
+        r = fn(img, tdp / "nope")
+        check("missing disk_dir → stale=False",  not r["stale"])
+        check("missing disk_dir → error set",    bool(r["error"]))
+
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="AstryxOS qemu-harness smoke test")
@@ -382,6 +447,9 @@ def main():
                          help="TCP port for GDB stub in Tier 2 (default 1234)")
     parser.add_argument("--no-build", action="store_true",
                          help="Skip cargo build; use existing kernel.bin")
+    parser.add_argument("--staleness-only", action="store_true",
+                         help="Run only the host-side staleness detector check "
+                              "(no QEMU); fast (<1s).")
     args = parser.parse_args()
 
     print(f"[{INFO}] AstryxOS qemu-harness smoke test")
@@ -391,6 +459,22 @@ def main():
     if args.tier3:
         print(f"[{INFO}] Tier 3 kdb hostfwd smoke enabled")
     print()
+
+    # Always run the host-only staleness detector check — it's < 1 second and
+    # protects the W7 silent-wedge guard against future refactors.
+    run_staleness_check()
+
+    if args.staleness_only:
+        # Early exit for CI cycles that just want the cheap detector check.
+        n_fail = len(failures)
+        if n_fail == 0:
+            print(f"\033[32m\nStaleness check passed.\033[0m")
+            sys.exit(0)
+        else:
+            print(f"\033[31m\n{n_fail} check(s) FAILED:\033[0m")
+            for f in failures:
+                print(f"  - {f}")
+            sys.exit(1)
 
     run_tier1(no_build=args.no_build)
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -965,6 +965,165 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
 # ══════════════════════════════════════════════════════════════════════════════
 # Subcommand implementations
 # ══════════════════════════════════════════════════════════════════════════════
+#
+# Data-disk staleness detection (W7 silent-wedge guard)
+#
+# Pattern: agents stage updated runtime libraries / stubs under build/disk/
+# (e.g. install-firefox-stubs.sh writes libglib-2.0.so.0 there) but forget
+# to re-pack them into build/data.img via create-data-disk.sh --force.
+# QEMU then boots with the OLD data.img — the guest sees the OLD libraries
+# regardless of what's on the host. The failure mode is silent: no warning,
+# tests behave as if the fix never landed, and verifiers mis-attribute the
+# stall to whichever PR is currently under test.
+#
+# The check is timestamp-based: if any regular file under build/disk/ has an
+# mtime newer than build/data.img, the image is stale and must be repacked.
+# We bound the scan (max files / time budget) so a giant /opt/firefox tree
+# can never wedge `start`.
+
+# Soft cap on files scanned per staleness check. The full build/disk tree
+# during firefox-test work has ~3000-5000 files; we don't need to look at
+# every byte to detect staleness — finding *any* file newer than data.img
+# is sufficient. We early-exit on the first newer file.
+_STALENESS_SCAN_FILE_BUDGET = 20000
+_STALENESS_SCAN_TIME_BUDGET_S = 4.0
+
+
+def _data_img_staleness(data_img: Path, disk_dir: Path) -> dict:
+    """
+    Check whether `data_img` is older than any regular file under `disk_dir`.
+
+    Returns a dict with:
+      stale: bool                 — True iff a newer file was found
+      newest_path: Optional[str]  — first newer file (early-exit; not the global newest)
+      newest_mtime: Optional[float]
+      data_img_mtime: Optional[float]
+      files_scanned: int
+      scan_seconds: float
+      error: Optional[str]        — set when the check could not run (soft-fail)
+
+    The check is best-effort: any I/O error returns `stale=False` with `error`
+    populated. Callers should treat `error` as "could not determine" — boot
+    proceeds either way.
+    """
+    out = {
+        "stale": False,
+        "newest_path": None,
+        "newest_mtime": None,
+        "data_img_mtime": None,
+        "files_scanned": 0,
+        "scan_seconds": 0.0,
+        "error": None,
+    }
+    try:
+        if not data_img.exists():
+            out["error"] = "data_img missing"
+            return out
+        if not disk_dir.exists() or not disk_dir.is_dir():
+            out["error"] = f"disk_dir not present: {disk_dir}"
+            return out
+        di_mtime = data_img.stat().st_mtime
+        out["data_img_mtime"] = di_mtime
+        deadline = time.monotonic() + _STALENESS_SCAN_TIME_BUDGET_S
+        scanned = 0
+        t0 = time.monotonic()
+        # os.scandir-based walk is meaningfully faster than Path.rglob on
+        # the large /opt/firefox subtree (~3000 files). Stop scanning on
+        # first hit — even one newer file is sufficient evidence.
+        stack = [disk_dir]
+        while stack:
+            d = stack.pop()
+            try:
+                with os.scandir(d) as it:
+                    for entry in it:
+                        # Budget guards: bail out cleanly if we've spent too
+                        # much time or seen too many files. We prefer a
+                        # false-negative (boot the stale image) over delaying
+                        # the harness start by seconds.
+                        if scanned >= _STALENESS_SCAN_FILE_BUDGET:
+                            out["error"] = (
+                                f"file-budget exhausted ({scanned} files)"
+                            )
+                            out["files_scanned"] = scanned
+                            out["scan_seconds"] = time.monotonic() - t0
+                            return out
+                        if time.monotonic() > deadline:
+                            out["error"] = (
+                                f"time-budget exhausted "
+                                f"({_STALENESS_SCAN_TIME_BUDGET_S:.1f}s)"
+                            )
+                            out["files_scanned"] = scanned
+                            out["scan_seconds"] = time.monotonic() - t0
+                            return out
+                        try:
+                            if entry.is_dir(follow_symlinks=False):
+                                stack.append(Path(entry.path))
+                                continue
+                            if not entry.is_file(follow_symlinks=False):
+                                continue
+                            scanned += 1
+                            st = entry.stat(follow_symlinks=False)
+                            if st.st_mtime > di_mtime:
+                                out["stale"] = True
+                                out["newest_path"] = entry.path
+                                out["newest_mtime"] = st.st_mtime
+                                out["files_scanned"] = scanned
+                                out["scan_seconds"] = time.monotonic() - t0
+                                return out
+                        except (OSError, PermissionError):
+                            continue
+            except (OSError, PermissionError):
+                continue
+        out["files_scanned"] = scanned
+        out["scan_seconds"] = time.monotonic() - t0
+        return out
+    except Exception as e:
+        out["error"] = f"{type(e).__name__}: {e}"
+        return out
+
+
+def _regen_data_img(root_dir: Path) -> dict:
+    """
+    Invoke `scripts/create-data-disk.sh --force` and capture its outcome.
+
+    Returns:
+      ok: bool        — True iff the script exited 0
+      rc: int
+      duration_s: float
+      tail: str       — last ~1500 chars of stderr (so a failure surfaces)
+
+    The script logs to stdout (mixed with stderr by some sub-scripts); we
+    fold both streams together and keep the tail for diagnostics.
+    """
+    script = root_dir / "scripts" / "create-data-disk.sh"
+    out = {"ok": False, "rc": -1, "duration_s": 0.0, "tail": ""}
+    if not script.exists():
+        out["tail"] = f"create-data-disk.sh not found at {script}"
+        return out
+    t0 = time.monotonic()
+    try:
+        proc = subprocess.run(
+            ["bash", str(script), "--force"],
+            cwd=str(root_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=900,  # 15 min — generous; full Firefox copy is ~3 min
+        )
+        out["rc"] = proc.returncode
+        out["ok"] = proc.returncode == 0
+        merged = proc.stdout.decode("utf-8", errors="replace") if proc.stdout else ""
+        out["tail"] = merged[-1500:]
+    except subprocess.TimeoutExpired as e:
+        out["rc"] = -2
+        out["tail"] = f"timeout after {e.timeout}s"
+    except Exception as e:
+        out["rc"] = -3
+        out["tail"] = f"{type(e).__name__}: {e}"
+    out["duration_s"] = time.monotonic() - t0
+    return out
+
+
+# ══════════════════════════════════════════════════════════════════════════════
 
 def cmd_check(args):
     """
@@ -1075,6 +1234,92 @@ def cmd_start(args):
                 file=sys.stderr,
             )
 
+    # ── data.img staleness check (W7 silent-wedge guard) ─────────────────────
+    # Pattern: `install-firefox-stubs.sh` (and other build helpers) writes
+    # updated runtime libraries into build/disk/ but does NOT repack
+    # build/data.img. Subsequent firefox-test runs boot the OLD image and
+    # silently exercise the OLD stubs/libraries. The trap is invisible at
+    # boot — symptoms only show up deep in the test run (e.g. glxtest
+    # spinning on an unopened pipe fd, or an exec'd helper running the
+    # last-decade version of libxul).
+    #
+    # We detect this by mtime: if any file under build/disk/ is newer than
+    # data.img, the image is stale. Default action: auto-regenerate via
+    # `scripts/create-data-disk.sh --force`. The user can opt out with
+    # --no-regen-data-img, in which case we still emit a loud WARNING so
+    # the next "why doesn't my fix work?" is one harness invocation away.
+    #
+    # Soft-fail throughout: any I/O or scan error → boot proceeds without
+    # the auto-regen. We surface the situation through stderr + session
+    # state, never through a hard exit.
+    _data_img_stale = False
+    _data_img_regenerated = False
+    _data_img_staleness_info: dict = {}
+    _data_img_regen_info: dict = {}
+    _no_regen = bool(getattr(args, "no_regen_data_img", False))
+    if not _data_img_missing:
+        _disk_dir = Path(wt.ROOT) / "build" / "disk"
+        _data_img_staleness_info = _data_img_staleness(_data_img_path, _disk_dir)
+        _data_img_stale = bool(_data_img_staleness_info.get("stale"))
+    if _data_img_stale:
+        _newest = _data_img_staleness_info.get("newest_path") or "?"
+        _di_mt  = _data_img_staleness_info.get("data_img_mtime")
+        _new_mt = _data_img_staleness_info.get("newest_mtime")
+        try:
+            _di_age = time.strftime("%Y-%m-%d %H:%M",
+                                    time.localtime(_di_mt)) if _di_mt else "?"
+            _ne_age = time.strftime("%Y-%m-%d %H:%M",
+                                    time.localtime(_new_mt)) if _new_mt else "?"
+        except Exception:
+            _di_age, _ne_age = "?", "?"
+        # `_newest` may be a long path — keep a short tail for the banner.
+        _newest_short = _newest
+        if len(_newest_short) > 56:
+            _newest_short = "..." + _newest_short[-53:]
+        print(
+            "╔══════════════════════════════════════════════════════════════╗\n"
+            "║  WARNING: data disk image is STALE                           ║\n"
+            f"║  data.img  mtime: {_di_age:<43}║\n"
+            f"║  newer file:      {_newest_short:<43}║\n"
+            f"║  newer mtime:     {_ne_age:<43}║\n"
+            "║  (build/disk/ has updates not yet packed into data.img)      ║\n"
+            "╚══════════════════════════════════════════════════════════════╝",
+            file=sys.stderr,
+        )
+        if _no_regen:
+            print(
+                "║  --no-regen-data-img set; booting stale image as requested.  ║",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "║  Auto-regenerating via scripts/create-data-disk.sh --force … ║",
+                file=sys.stderr,
+            )
+            _data_img_regen_info = _regen_data_img(Path(wt.ROOT))
+            _data_img_regenerated = bool(_data_img_regen_info.get("ok"))
+            if _data_img_regenerated:
+                # Re-scan; the regen should have updated data.img mtime so the
+                # follow-up check is informational only.
+                try:
+                    _data_img_staleness_info = _data_img_staleness(
+                        _data_img_path, _disk_dir)
+                    _data_img_stale = bool(_data_img_staleness_info.get("stale"))
+                except Exception:
+                    pass
+                _dur = _data_img_regen_info.get("duration_s", 0.0)
+                print(
+                    f"║  data.img regenerated in {_dur:.1f}s.                          ║",
+                    file=sys.stderr,
+                )
+            else:
+                _tail = (_data_img_regen_info.get("tail") or "")[-400:]
+                print(
+                    "║  REGEN FAILED — booting stale image; check stderr above.    ║\n"
+                    f"║  rc={_data_img_regen_info.get('rc')}, tail: {_tail!r:<48}",
+                    file=sys.stderr,
+                )
+
     kvm_arg: Optional[bool]
     if getattr(args, "no_kvm", False):
         kvm_arg = False
@@ -1112,6 +1357,16 @@ def cmd_start(args):
         # attempt). Agents inspecting this field can immediately distinguish a
         # firefox-test wedge caused by missing /disk from a real regression.
         "data_img_missing": _data_img_missing,
+        # True iff a file under build/disk/ was newer than data.img at session
+        # start. When `data_img_regenerated` is also True, the image was
+        # rebuilt before launch and the stale flag describes the pre-launch
+        # state. When `data_img_regenerated` is False, the boot ran against
+        # the stale image (either --no-regen-data-img was set or the regen
+        # script failed — see `data_img_regen_tail`).
+        "data_img_stale": _data_img_stale,
+        "data_img_regenerated": _data_img_regenerated,
+        "data_img_staleness_info": _data_img_staleness_info,
+        "data_img_regen_info": _data_img_regen_info,
         # Session-scoped kernel binary (concurrent-rebuild clobber fix).
         # NOTE: snapshot files saved via `qemu-harness.py snap save` are tied
         # to the kernel binary loaded at the time. Loading a snapshot in a
@@ -1139,6 +1394,14 @@ def cmd_start(args):
           # True when data.img was absent (even after auto-symlink attempt).
           # Agents should treat this as a hard warning for firefox-test runs.
           "data_img_missing": _data_img_missing,
+          # True iff build/disk/ had files newer than data.img at session
+          # start. False after a successful auto-regen (the post-regen value
+          # is stored — pre-regen state is in `data_img_staleness_info`).
+          "data_img_stale": _data_img_stale,
+          # True iff the harness auto-ran create-data-disk.sh --force this
+          # session. False when not needed, when --no-regen-data-img was set,
+          # or when the regen script failed (check `data_img_regen_info`).
+          "data_img_regenerated": _data_img_regenerated,
           # Per-session QGA UNIX chardev socket path. Empty string when the
           # session was started without --features qga; non-empty paths may
           # not yet exist on disk if QEMU hasn't bound the socket yet
@@ -4622,6 +4885,14 @@ def main():
                                "'host' under KVM, otherwise "
                                "'qemu64,+rdtscp,+ssse3,+sse4_1,+sse4_2'. Used "
                                "by perf sweeps to vary VMEXIT surface.")
+    p_start.add_argument("--no-regen-data-img", action="store_true",
+                          dest="no_regen_data_img",
+                          help="Skip the auto-regen of build/data.img when "
+                               "build/disk/ has files newer than the image "
+                               "(W7 silent-wedge guard). The staleness banner "
+                               "still prints to stderr so the situation is "
+                               "never hidden. Use when reproducing a bug that "
+                               "depends on the existing data.img contents.")
 
     # stop
     p_stop = sub.add_parser("stop", help="Kill a QEMU session")


### PR DESCRIPTION
## Summary

- When `build/disk/` carries fresher files than `build/data.img` (e.g. an `install-*` helper updated a stub library but the operator forgot the `--force` repack), the harness now detects it via mtime scan, prints a STALE banner, and auto-invokes `scripts/create-data-disk.sh --force` before launching QEMU. Opt-out via `--no-regen-data-img`; banner still prints either way.
- Pre-launch state lands on the session-state JSON and on the `start` JSON output as `data_img_stale` / `data_img_regenerated` (additive fields — downstream tools tolerate extra keys, so this is a non-breaking extension).
- Host-only smoke test (`qemu-harness-smoke.py --staleness-only`, runs in < 1 s, always-on) covers fresh / stale / missing-img / missing-disk-dir paths to keep the guard from regressing.

## Why this matters (W61 verification)

W61 found that every Window 7 firefox-test run in the shared tree was booting the OLD no-op `g_spawn_async_with_pipes` GLib stub because `build/data.img` (May 1) was 12 days older than the host-side `build/disk/lib64/libglib-2.0.so.0` (May 13). Worktree-isolated agents re-pack data.img naturally and so saw the fix; the shared tree did not.

Post-fix firefox-test run on a freshly-regenerated worktree data.img:

| Signal           | Pre-fix (W61) | Post-regen        |
|------------------|---------------|-------------------|
| total syscalls   | 0 (silent)    | 3441              |
| CLONE3 events    | 0             | 51 (TIDs 2..52)   |
| `execve` target  | none          | `/disk/opt/firefox/glxtest` (posix_spawn child) |
| `fork`/`vfork`   | 0             | 0 (Mozilla uses clone3+execve only) |
| `--contentproc`  | 0             | 0 (Firefox crashed before content-process step) |
| TID 1 GPF        | yes           | NO — the two faults are user-mode SIGSEGV inside libxul, NOT a kernel #GP |
| Firefox exit     | wedged sc=0   | `exit_group(11)` deep in Mozilla's no-GPU fallback |

The "TID 1 GPF" reported by W61 disappears post-regen; the remaining failures are Mozilla-side user-space SIGSEGV at user RIPs `0x7efff8711429` / `0x7efffa3572c4` (no-GPU fallback NULL-deref after glxtest output read fails). That's a Mozilla issue, not a kernel ABI bug.

## Test plan

- [x] Syntax check (`ast.parse`) on both files
- [x] `python3 scripts/qemu-harness-smoke.py --staleness-only` → 11 PASS (fresh / stale / missing-data.img / missing-disk-dir cases)
- [x] `python3 scripts/qemu-harness.py list` → existing sessions still parse
- [x] Fresh worktree `python3 scripts/qemu-harness.py start --features firefox-test --no-kvm` → JSON output now includes `data_img_stale`/`data_img_regenerated`; firefox-test progressed to glxtest exec + 51 clone3s before Mozilla-side SIGSEGV
- [x] Disassembly check: `mcopy -i build/data.img ::/lib64/libglib-2.0.so.0 /tmp/x.so && objdump -d /tmp/x.so` shows `call _stub_spawn_core` in the post-regen image (vs `mov $0x0,%eax; leave; ret` no-op pre-regen)

## Stretch follow-ups (not in this PR)

- Stretch D from the dispatch: boot-time `[STUB-CHECK]` SHA-256 fingerprint of the loaded `libglib-2.0.so.0` `.text` vs a manifest baked at data-disk-build time. Out of scope here; track separately if the staleness banner still misses cases (e.g. someone swaps data.img by hand without updating mtime).