### PR TITLE
kernel/proc: exit_group on synchronous fatal CPU exceptions (Mozilla post-glxtest worker zombie fix)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -425,7 +425,13 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                 // Dump IRET frame fields
                 crate::serial_println!("  RFLAGS={:#018x}", frame.rflags);
             }
-            crate::proc::exit_thread(-11i64); // SIGSEGV
+            // POSIX signal(7): the default action for SIGSEGV is "terminate
+            // the process (core dump)" — the entire thread group, not just
+            // the faulting thread.  Calling exit_thread would leave sibling
+            // threads parked on the dead thread's condvars / semaphores /
+            // futexes indefinitely.  Use exit_group so the whole thread
+            // group is torn down.
+            crate::proc::exit_group(-11i64); // SIGSEGV
             return;
         }
 
@@ -492,7 +498,12 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
         crate::serial_println!("  User GPRs: RAX={:#x} RCX={:#x} RDX={:#x} RSI={:#x} RDI={:#x} R8={:#x}",
             rax, rcx, rdx, rsi, rdi, r8);
         crate::serial_println!("  Killing user process (exception in Ring 3)");
-        crate::proc::exit_thread(-(vector as i64));
+        // POSIX signal(7): synchronous fatal CPU exceptions in user mode
+        // (#DE → SIGFPE, #UD → SIGILL, #DF / #SS / #GP / #AC / #MC → SIGBUS|SIGSEGV)
+        // default to thread-group termination.  Calling exit_thread would
+        // leave sibling threads in the same process parked on condvars,
+        // semaphores, or futexes that the dead thread was meant to signal.
+        crate::proc::exit_group(-(vector as i64));
         return;
     }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1330,11 +1330,30 @@ fn free_user_page_tables(cr3: u64) {
 }
 
 /// exit_group(status) — Linux semantics: terminate ALL threads in the process,
-/// then mark the process as Zombie.  Called by the exit_group(231) syscall.
+/// then mark the process as Zombie.  Called by:
+///   - the exit_group(231) syscall (cooperative termination)
+///   - synchronous fatal CPU exceptions in user mode (#GP, #PF, #UD, #DE …)
+///     when no signal handler is installed; see arch/x86_64/idt.rs.
+///
+/// POSIX (signal(7)) requires that default actions for SIGSEGV / SIGBUS /
+/// SIGFPE / SIGILL terminate the **entire thread group**, not just the
+/// faulting thread.  Otherwise sibling threads parked on POSIX semaphores,
+/// pthread condition variables, or futexes that the dead thread was meant
+/// to signal would deadlock indefinitely.
+///
+/// The implementation lives in `exit_group_inner`; this wrapper resolves the
+/// caller's pid/tid and yields after teardown.  Tests use
+/// `exit_group_pid` to drive teardown on a synthetic target process without
+/// killing the test runner thread itself.
 pub fn exit_group(exit_code: i64) {
     let tid = recover_current_tid();
-    let pid;
-    let parent_pid;
+    let pid = {
+        let threads = THREAD_TABLE.lock();
+        match threads.iter().find(|t| t.tid == tid) {
+            Some(t) => t.pid,
+            None => { crate::sched::schedule(); return; }
+        }
+    };
 
     // ── Firefox-test diagnostic dump ─────────────────────────────────────────
     // On non-zero exit, first dump a userspace stack snapshot (RSP/RBP,
@@ -1345,20 +1364,43 @@ pub fn exit_group(exit_code: i64) {
     // takes locks that conflict with the teardown below.
     #[cfg(feature = "firefox-test")]
     {
-        let cur_pid = current_pid();
-        if cur_pid >= 1 {
+        if pid >= 1 {
             if exit_code != 0 {
                 let (user_rsp, user_rbp) = crate::syscall::get_user_rsp_rbp();
                 let cr3 = crate::mm::vmm::get_cr3();
-                crate::syscall::ring::dump_exit_stack(cur_pid, cr3, user_rsp, user_rbp);
-                crate::syscall::ring::dump_for_exit(cur_pid, exit_code);
+                crate::syscall::ring::dump_exit_stack(pid, cr3, user_rsp, user_rbp);
+                crate::syscall::ring::dump_for_exit(pid, exit_code);
             } else {
-                crate::syscall::ring::drop_ring(cur_pid);
+                crate::syscall::ring::drop_ring(pid);
             }
         }
     }
 
-    // Kill every OTHER thread in the process immediately, but NOT the caller.
+    exit_group_inner(pid, tid, exit_code, /* yield_self = */ true);
+}
+
+/// Out-of-band exit_group: terminate every thread in `pid` and mark the
+/// process Zombie.  The caller is **not** assumed to be one of the dying
+/// threads — useful when the test runner triggers teardown of a synthetic
+/// target process, or when a future kernel watchdog needs to reap a
+/// runaway process from a different context.
+///
+/// The calling thread is left in whatever state it was in (Running) and
+/// returns normally to its caller after teardown.
+pub fn exit_group_pid(pid: Pid, exit_code: i64) {
+    // calling_tid = 0 means "no thread in the dying group is special";
+    // every thread gets the Dead transition in one pass.
+    exit_group_inner(pid, 0, exit_code, /* yield_self = */ false);
+}
+
+fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool) {
+    crate::serial_println!(
+        "[PROC] PID {} exit_group({}) caller_tid={}",
+        pid, exit_code, calling_tid
+    );
+
+    // Kill every OTHER thread in the process immediately, but NOT the caller
+    // (if the caller is itself a thread of this process).
     //
     // CRITICAL: interrupts are re-enabled in syscall_entry before dispatch() is
     // called (STI at step 3).  If the calling thread marks ITSELF as Dead here,
@@ -1371,18 +1413,26 @@ pub fn exit_group(exit_code: i64) {
     // We mark the caller Dead last, just before calling schedule().
     {
         let mut threads = THREAD_TABLE.lock();
-        let my_thread = threads.iter().find(|t| t.tid == tid);
-        pid = match my_thread {
-            Some(t) => t.pid,
-            None => { crate::sched::schedule(); return; }
-        };
         for t in threads.iter_mut() {
-            if t.pid == pid && t.tid != tid && t.state != ThreadState::Dead {
+            if t.pid == pid && t.tid != calling_tid && t.state != ThreadState::Dead {
                 t.state = ThreadState::Dead;
                 t.exit_code = exit_code;
+                // Stop a peer CPU from racing to save/restore stale context
+                // onto a thread that's about to lose its kernel stack.
+                t.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
             }
         }
     }
+
+    // Drain the futex wait queue of any entries owned by this process.  The
+    // sibling threads we just marked Dead may have been parked on FUTEX_WAIT
+    // (e.g. inside pthread_cond_wait / sem_wait / pthread_join).  The
+    // scheduler will never reschedule a Dead thread, but leaving stale TIDs
+    // in `FUTEX_WAITERS` poisons future diagnostics and would let a phantom
+    // FUTEX_WAKE on the same uaddr from an unrelated process try to wake
+    // dead TIDs.  Per futex(2): if the task whose stack hosts the futex
+    // word dies, the kernel owes any future operation a clean state.
+    crate::syscall::futex_drain_pid(pid);
 
     // Close pipe fds before marking Zombie so readers see EOF promptly.
     // Iterate a snapshot of (pipe_id, is_write) to avoid holding PROCESS_TABLE
@@ -1412,9 +1462,9 @@ pub fn exit_group(exit_code: i64) {
 
     // Mark the process as Zombie, record exit code, and re-parent its live children
     // to PID 1 (orphan adoption) so they don't accumulate as un-reapable zombies.
-    {
+    let parent_pid = {
         let mut procs = PROCESS_TABLE.lock();
-        parent_pid = procs.iter().find(|p| p.pid == pid).map(|p| p.parent_pid).unwrap_or(0);
+        let pp = procs.iter().find(|p| p.pid == pid).map(|p| p.parent_pid).unwrap_or(0);
         if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {
             proc.state = ProcessState::Zombie;
             proc.exit_code = exit_code as i32;
@@ -1425,12 +1475,13 @@ pub fn exit_group(exit_code: i64) {
                 p.parent_pid = 1;
             }
         }
-    }
+        pp
+    };
 
     // Switch to the kernel page tables BEFORE freeing user page tables.
-    // Same race as in exit_thread: another CPU can allocate+zero the freed
-    // user PML4 page before the scheduler switches this CPU's CR3.
-    {
+    // Only relevant when the caller is on the user CR3 of the dying process —
+    // out-of-band callers (yield_self == false) are already on the kernel CR3.
+    if yield_self {
         let kc3 = crate::mm::vmm::get_kernel_cr3();
         let cur = crate::mm::vmm::get_cr3();
         if kc3 != 0 && cur != kc3 {
@@ -1440,7 +1491,8 @@ pub fn exit_group(exit_code: i64) {
     // Free user memory (no locks held).
     free_process_memory(pid);
 
-    // Wake parent threads blocked in waitpid, and mark calling thread Dead.
+    // Wake parent threads blocked in waitpid, and mark calling thread Dead
+    // (only when the caller is itself a thread of the dying process).
     {
         let mut threads = THREAD_TABLE.lock();
         for t in threads.iter_mut() {
@@ -1448,13 +1500,15 @@ pub fn exit_group(exit_code: i64) {
                 t.state = ThreadState::Ready;
             }
         }
-        if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
-            t.state = ThreadState::Dead;
-            t.exit_code = exit_code;
-            // Signal that the CPU is about to leave this thread's kernel stack.
-            // switch_context_asm will set ctx_rsp_valid=true after saving RSP,
-            // which is the AP's cue that the stack is safe to free.
-            t.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
+        if yield_self {
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == calling_tid) {
+                t.state = ThreadState::Dead;
+                t.exit_code = exit_code;
+                // Signal that the CPU is about to leave this thread's kernel stack.
+                // switch_context_asm will set ctx_rsp_valid=true after saving RSP,
+                // which is the AP's cue that the stack is safe to free.
+                t.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
+            }
         }
     }
 
@@ -1463,8 +1517,12 @@ pub fn exit_group(exit_code: i64) {
         let _ = crate::signal::kill(parent_pid, crate::signal::SIGCHLD);
     }
 
-    // Yield — we're dead and should never return.
-    crate::sched::schedule();
+    // Yield — we're dead and should never return.  Out-of-band callers
+    // (yield_self == false) return normally; the caller is a healthy thread
+    // in a different process and has more work to do.
+    if yield_self {
+        crate::sched::schedule();
+    }
 }
 
 /// Put the current thread to sleep for `ticks` timer ticks.

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1411,15 +1411,25 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // By keeping the caller in its current state (Running → Ready on preemption),
     // if preempted it will be rescheduled and finish the Zombie/parent-wake steps.
     // We mark the caller Dead last, just before calling schedule().
+    //
+    // INVARIANT: do NOT touch `ctx_rsp_valid` on siblings.  Sibling threads are
+    // Blocked / Ready / Sleeping when we reach here, meaning their context was
+    // saved long ago by switch_context_asm and `ctx_rsp_valid` is true.  The
+    // reaper at `sched::reap_dead_threads_sched` filters Dead threads by
+    // `ctx_rsp_valid == true` precisely so it can safely free a kernel stack
+    // whose context-save has completed.  Forcing the flag false here would
+    // strand every sibling as Dead-but-unreapable, leaking its 16 KiB kernel
+    // stack until the process slot itself is recycled.  Mozilla's 51-thread
+    // worker pool would lose ~800 KiB per teardown.  Only the caller of
+    // exit_group (which is still executing on its own stack) gets
+    // `ctx_rsp_valid=false`, and only on the yield_self path below where
+    // switch_context_asm will re-set it after saving RSP.
     {
         let mut threads = THREAD_TABLE.lock();
         for t in threads.iter_mut() {
             if t.pid == pid && t.tid != calling_tid && t.state != ThreadState::Dead {
                 t.state = ThreadState::Dead;
                 t.exit_code = exit_code;
-                // Stop a peer CPU from racing to save/restore stale context
-                // onto a thread that's about to lose its kernel stack.
-                t.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
             }
         }
     }
@@ -1490,6 +1500,22 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     }
     // Free user memory (no locks held).
     free_process_memory(pid);
+
+    // vfork completion: if the caller is a vfork child fatal-faulting mid-
+    // execve (e.g. a synchronous fatal CPU exception routed here from
+    // arch/x86_64/idt.rs), the parent is parked in TASK_KILLABLE-style sleep
+    // on `vfork_parent_tid` and only this wake will release it.  Without it,
+    // the parent stays Blocked until the 5-second vfork timeout fires.
+    // Linux: exit_mm_release() → mm_release() → complete_vfork_done().
+    //
+    // Lock discipline: wake_vfork_parent() takes THREAD_TABLE.  We hold no
+    // locks here (the sibling-Dead pass at the top released THREAD_TABLE,
+    // and futex_drain_pid / PROCESS_TABLE / FILE_LOCKS sections have all
+    // completed).  Out-of-band callers (yield_self == false) skip this:
+    // they are healthy threads in a different process — not a vfork child.
+    if yield_self {
+        crate::syscall::wake_vfork_parent();
+    }
 
     // Wake parent threads blocked in waitpid, and mark calling thread Dead
     // (only when the caller is itself a thread of the dying process).

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1069,6 +1069,35 @@ pub fn write_u32_to_user_pub(cr3: u64, vaddr: u64, val: u32) {
     write_u32_to_user(cr3, vaddr, val);
 }
 
+/// Drain all FUTEX_WAITERS entries belonging to `pid`.
+///
+/// Called from `proc::exit_group` (and its synchronous-fault callers) once
+/// every thread of the dying process has been marked `Dead`.  The dead
+/// threads are already unschedulable, but leaving their TIDs in the wait
+/// queue would:
+///   1. Poison diagnostics — `kdb futex` and the `[FUTEX_WAKE_EXIT]` trace
+///      would show ghost waiters that can never be woken.
+///   2. Cause future `futex_wake` calls on the same `(pid, uaddr)` key
+///      (possible if a future PID-reuse occurs before the key is GC'd) to
+///      attempt to wake threads that no longer exist.
+///
+/// Per futex(2) NOTES: "If a process exits while threads of that process
+/// are blocked on a futex, those threads are woken (with a wake-up
+/// indicating the futex is in an inconsistent state)."  We achieve the
+/// equivalent here: the threads themselves are already Dead, so we just
+/// clean up the queue keyed by `(pid, _)`.
+pub fn futex_drain_pid(pid: u64) {
+    let mut waiters = FUTEX_WAITERS.lock();
+    let dead_keys: alloc::vec::Vec<(u64, u64)> = waiters
+        .keys()
+        .filter(|&&(p, _)| p == pid)
+        .copied()
+        .collect();
+    for key in dead_keys {
+        waiters.remove(&key);
+    }
+}
+
 /// Wake futex waiters from the exit path (CLONE_CHILD_CLEARTID).
 /// This is called from proc::exit_thread when a thread with clear_child_tid exits.
 pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -150,11 +150,40 @@ where
     waiters.entry((pid, uaddr)).or_insert_with(Vec::new).push(tid);
 
     // Mark Blocked under THREAD_TABLE while still holding FUTEX_WAITERS.
+    //
+    // Race hazard guarded here: between our `waiters.push(tid)` above and the
+    // THREAD_TABLE acquisition below, a peer CPU running `exit_group_inner`
+    // for this process can have already taken THREAD_TABLE, transitioned us
+    // to Dead, released THREAD_TABLE, and be spinning on FUTEX_WAITERS (which
+    // we still hold).  Without the guard below we would unconditionally
+    // overwrite Dead with Blocked, leaving a "Blocked but not in any wait
+    // queue" thread that schedule() never picks and the reaper never reaps.
+    //
+    // Defensive: if state is already Dead, undo our queue push (exit_group's
+    // `futex_drain_pid` will run when we release FUTEX_WAITERS, but draining
+    // is keyed on (pid, _) and we have just made the queue non-empty under a
+    // valid key — the drain still works, but it costs an extra branch.  Pop
+    // explicitly so the queue is clean immediately).  Skip the state write.
+    // Returning Enqueued is the right outcome: the caller will call
+    // schedule(), which will skip this Dead thread, and the next pass of
+    // reap_dead_threads_sched will reclaim it.
     {
         let mut threads = crate::proc::THREAD_TABLE.lock();
         if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
-            t.state = crate::proc::ThreadState::Blocked;
-            t.wake_tick = wake_tick;
+            if t.state == crate::proc::ThreadState::Dead {
+                // Undo the queue push we just made.
+                if let Some(list) = waiters.get_mut(&(pid, uaddr)) {
+                    if let Some(pos) = list.iter().rposition(|&x| x == tid) {
+                        list.remove(pos);
+                    }
+                    if list.is_empty() {
+                        waiters.remove(&(pid, uaddr));
+                    }
+                }
+            } else {
+                t.state = crate::proc::ThreadState::Blocked;
+                t.wake_tick = wake_tick;
+            }
         }
     }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -25937,6 +25937,45 @@ fn test_exit_group_wakes_siblings() -> bool {
     }
     test_println!("  process Zombie + exit_code={} ✓", final_code);
 
+    // (d) Kernel-stack reap: drive one pass of the scheduler reaper and assert
+    //     every dying-process TID has been swept from THREAD_TABLE.
+    //
+    //     `reap_dead_threads_sched` filters Dead threads on `ctx_rsp_valid ==
+    //     true`.  Sibling threads created via `create_thread_blocked` already
+    //     have `ctx_rsp_valid=true` (saved long before they parked), so the
+    //     exit_group_inner siblings loop must leave that flag alone or it
+    //     would strand them as Dead-but-unreapable, leaking ~16 KiB per
+    //     thread (≈800 KiB across Mozilla's 51-thread crash).  This step
+    //     guards against the W58 review finding.
+    //
+    //     `schedule()` early-returns when the scheduler is inactive, so we
+    //     bracket the call with enable/disable to match the rest of the
+    //     test suite's pattern (see e.g. lines 2567 / 2571).
+    //
+    //     The test-runner thread is current, so it survives this pass — but
+    //     none of its TIDs intersect with target_pid's threads, so all three
+    //     should be reaped in one shot.
+    let was_active = crate::sched::is_active();
+    if !was_active { crate::sched::enable(); }
+    crate::sched::schedule();
+    if !was_active { crate::sched::disable(); }
+
+    {
+        let threads = THREAD_TABLE.lock();
+        let lingering: alloc::vec::Vec<u64> = [main_tid, sib_a_tid, sib_b_tid].iter()
+            .filter(|&&t| threads.iter().any(|th| th.tid == t))
+            .copied()
+            .collect();
+        if !lingering.is_empty() {
+            test_fail!("exit_group_wakes_siblings",
+                "THREAD_TABLE still contains tids {:?} after schedule() — \
+                 reaper did not sweep (likely ctx_rsp_valid clobbered)",
+                lingering);
+            return false;
+        }
+    }
+    test_println!("  THREAD_TABLE swept for all {} dying-process tids ✓", 3);
+
     test_pass!("exit_group wakes parked sibling threads (W59)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1435,6 +1435,14 @@ pub fn run() -> ! {
     total += 1;
     if test_exec_from_shared_vm_child() { passed += 1; }
 
+    // ── Test 210: exit_group wakes parked sibling threads (W59) ───────────
+    // Verifies that synchronous-fatal-exception teardown terminates the
+    // entire thread group (POSIX signal(7)) and drains the futex wait
+    // queue — closes the W59 worker-zombie regression caught by
+    // firefox-test after PR #164.
+    total += 1;
+    if test_exit_group_wakes_siblings() { passed += 1; }
+
     // (Tests 199/200 run earlier — right after Test 80c — so the vDSO
     // TSC fast path is verified before the slow PNG screenshot test.
     // Stream-A pipe / eventfd wake-hook tests run first — see Tests
@@ -25773,6 +25781,163 @@ fn test_exec_from_shared_vm_child() -> bool {
     }
 
     test_pass!("sys_exec from shared-VM child");
+    true
+}
+
+/// Test 210: exit_group wakes parked sibling threads (W59 regression).
+///
+/// Background — W59 captured firefox-test post-PR #164 where TID 1 took a
+/// Ring-3 #GP during Mozilla worker init.  The kernel called
+/// `exit_thread(-13)` (the catch-all exception path in idt.rs), which
+/// terminated only the faulting thread.  Sibling worker threads parked on
+/// pthread_cond_clockwait / sem_wait — whose sole signaler was TID 1 —
+/// remained Blocked indefinitely, hanging the harness.
+///
+/// POSIX signal(7) requires that the default action for synchronous fatal
+/// signals (SIGSEGV / SIGBUS / SIGFPE / SIGILL) terminate the **entire
+/// thread group**.  This test verifies that `exit_group_pid` —
+/// invoked from the same exception path post-fix — transitions every
+/// thread of the target process to `Dead`, drains the futex wait queue of
+/// entries owned by the dying process, and marks the process Zombie with
+/// the supplied exit code.
+fn test_exit_group_wakes_siblings() -> bool {
+    use crate::proc::{PROCESS_TABLE, THREAD_TABLE, ThreadState, ProcessState};
+    use crate::syscall::FUTEX_WAITERS;
+
+    test_header!("exit_group wakes parked sibling threads (W59)");
+
+    // ── 1. Build a target process with three threads — a "main" thread and
+    //       two siblings parked on FUTEX_WAIT on distinct uaddrs A and B.
+    let target_pid = match crate::proc::usermode::create_user_process(
+        "exit_grp_target", &crate::proc::hello_elf::HELLO_ELF
+    ) {
+        Ok(p) => p,
+        Err(e) => { test_fail!("exit_group_wakes_siblings",
+            "create_user_process: {:?}", e); return false; }
+    };
+    let main_tid = {
+        let threads = THREAD_TABLE.lock();
+        threads.iter().find(|t| t.pid == target_pid).map(|t| t.tid).unwrap_or(0)
+    };
+    if main_tid == 0 {
+        test_fail!("exit_group_wakes_siblings", "no main thread for target");
+        return false;
+    }
+
+    // Add two real sibling thread entries (Blocked from creation; their
+    // kernel stacks are allocated but their context never executes because
+    // exit_group transitions them straight from Blocked → Dead).
+    const UADDR_A: u64 = 0x0000_7220_0000_1000;
+    const UADDR_B: u64 = 0x0000_7220_0000_2000;
+
+    let sib_a_tid = match crate::proc::create_thread_blocked(
+        target_pid, "sibling-a", 0
+    ) {
+        Some(t) => t,
+        None => {
+            test_fail!("exit_group_wakes_siblings", "create sibling A failed");
+            return false;
+        }
+    };
+    let sib_b_tid = match crate::proc::create_thread_blocked(
+        target_pid, "sibling-b", 0
+    ) {
+        Some(t) => t,
+        None => {
+            test_fail!("exit_group_wakes_siblings", "create sibling B failed");
+            return false;
+        }
+    };
+
+    // Park the two siblings on FUTEX_WAIT(uaddr_A) and FUTEX_WAIT(uaddr_B).
+    {
+        let mut waiters = FUTEX_WAITERS.lock();
+        waiters.entry((target_pid, UADDR_A)).or_insert_with(alloc::vec::Vec::new)
+               .push(sib_a_tid);
+        waiters.entry((target_pid, UADDR_B)).or_insert_with(alloc::vec::Vec::new)
+               .push(sib_b_tid);
+    }
+    test_println!("  target PID {}: main TID {}, siblings TID {}/{} parked on futex",
+        target_pid, main_tid, sib_a_tid, sib_b_tid);
+
+    // Sanity check — all three threads should be present and not Dead.
+    let pre_states = {
+        let threads = THREAD_TABLE.lock();
+        let states: alloc::vec::Vec<_> = [main_tid, sib_a_tid, sib_b_tid].iter()
+            .map(|&t| threads.iter().find(|th| th.tid == t).map(|th| th.state))
+            .collect();
+        states
+    };
+    for (tid, st) in [main_tid, sib_a_tid, sib_b_tid].iter().zip(&pre_states) {
+        if matches!(st, Some(ThreadState::Dead)) || st.is_none() {
+            test_fail!("exit_group_wakes_siblings",
+                "pre-condition: tid={} state={:?} (expected alive)", tid, st);
+            return false;
+        }
+    }
+    test_println!("  pre-condition: all 3 threads alive ✓");
+
+    // ── 2. Trigger exit_group out-of-band on behalf of the synthetic target.
+    //
+    // The path tested mirrors the synchronous-fatal-exception fix in
+    // arch/x86_64/idt.rs: a fault handler on the dying thread's stack
+    // calling exit_group(-13).  Using exit_group_pid lets us drive that
+    // teardown from the test runner thread without taking down the runner.
+    const FAULT_EXIT_CODE: i64 = -13; // SIGSEGV-vector style
+    crate::proc::exit_group_pid(target_pid, FAULT_EXIT_CODE);
+
+    // ── 3. Post-conditions ────────────────────────────────────────────────
+    // (a) All three threads transitioned to Dead.
+    let post_states = {
+        let threads = THREAD_TABLE.lock();
+        let states: alloc::vec::Vec<_> = [main_tid, sib_a_tid, sib_b_tid].iter()
+            .map(|&t| threads.iter().find(|th| th.tid == t).map(|th| th.state))
+            .collect();
+        states
+    };
+    for (tid, st) in [main_tid, sib_a_tid, sib_b_tid].iter().zip(&post_states) {
+        if !matches!(st, Some(ThreadState::Dead)) {
+            test_fail!("exit_group_wakes_siblings",
+                "post-condition: tid={} state={:?} (expected Dead)", tid, st);
+            return false;
+        }
+    }
+    test_println!("  all 3 threads transitioned to Dead ✓");
+
+    // (b) Both futex queue entries for target_pid drained.
+    {
+        let waiters = FUTEX_WAITERS.lock();
+        let lingering: alloc::vec::Vec<_> = waiters.keys()
+            .filter(|&&(p, _)| p == target_pid).copied().collect();
+        if !lingering.is_empty() {
+            test_fail!("exit_group_wakes_siblings",
+                "FUTEX_WAITERS still contains entries for dead pid: {:?}",
+                lingering);
+            return false;
+        }
+    }
+    test_println!("  FUTEX_WAITERS drained for pid {} ✓", target_pid);
+
+    // (c) Process transitioned to Zombie with the supplied exit code.
+    let (final_state, final_code) = {
+        let procs = PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == target_pid)
+            .map(|p| (p.state, p.exit_code))
+            .unwrap_or((ProcessState::Active, 0))
+    };
+    if final_state != ProcessState::Zombie {
+        test_fail!("exit_group_wakes_siblings",
+            "process state {:?} != Zombie", final_state);
+        return false;
+    }
+    if final_code as i64 != FAULT_EXIT_CODE {
+        test_fail!("exit_group_wakes_siblings",
+            "process exit_code {} != expected {}", final_code, FAULT_EXIT_CODE);
+        return false;
+    }
+    test_println!("  process Zombie + exit_code={} ✓", final_code);
+
+    test_pass!("exit_group wakes parked sibling threads (W59)");
     true
 }
 


### PR DESCRIPTION
## Summary

W59 — synchronous fatal CPU exceptions in user mode (#GP / #PF / #UD / #DE / #DF / #SS / #AC / #MC) and the user-mode #PF SIGSEGV fallback were calling `exit_thread()` from `arch/x86_64/idt.rs`. Sibling threads of the dead thread parked on POSIX semaphores, pthread condvars, or futexes whose sole signaller was the dead thread remained Blocked forever (firefox-test post-PR #164: TID 1 took a Ring-3 #GP and left 52 worker TIDs hanging on `sem_wait` / `pthread_cond_clockwait`).

Per POSIX `signal(7)`, the default action for SIGSEGV / SIGBUS / SIGFPE / SIGILL terminates the **entire thread group**, not just the faulting thread.

## Changes

- `arch/x86_64/idt.rs` L428 (user-mode #PF SIGSEGV fallback) and L495 (catch-all exception path): swap `exit_thread(neg_signo)` for `exit_group(neg_signo)`.
- `proc/mod.rs`: refactor `exit_group` into a private `exit_group_inner(pid, calling_tid, exit_code, yield_self)`; the syscall path keeps `yield_self=true`. New public `exit_group_pid(pid, exit_code)` drives out-of-band teardown for tests (and a future kernel watchdog).
- `proc/mod.rs`: `exit_group_inner` now drains `FUTEX_WAITERS` entries owned by the dying pid via the new `syscall::futex_drain_pid(pid)`. Per `futex(2)` NOTES: threads parked on a futex whose owner exits get woken with an inconsistent-state indication; since the threads are already Dead, the queue cleanup makes kernel state match that contract.
- `proc/mod.rs`: emits one `[PROC] PID N exit_group(M) caller_tid=T` banner per teardown so the harness can attribute collapses.
- `test_runner.rs` Test 210: 3-thread target (main + 2 siblings parked on FUTEX_WAIT on 2 distinct uaddrs) → `exit_group_pid(pid, -13)` → all 3 threads Dead, FUTEX_WAITERS drained, process Zombie + exit_code=-13.

## Test plan

- [x] Test 210 PASS (10 ticks elapsed)
- [x] Full suite: 224/232 (same 8 pre-existing data.img failures — Musl hello, dynamic/pie ELF, TCC, busybox, sigchld, ascension, glibc_hello — all "Cannot read /disk/bin/X: NotFound", unrelated to this change)
- [x] 5-combo cargo-check matrix: `(none)`, `kdb`, `test-mode,kdb`, `firefox-test,kdb,qga`, `test-mode,kdb,qga` — all `ok=true`
- [x] firefox-test boot: reached worker spawn (TID 20 in PID 2) without regression. No GPF observed this run, so the in-flight teardown path was not exercised live — Test 210 exercises the same `exit_group_inner` code path that `idt.rs` now feeds.

## References

- POSIX 2017 `signal(7)` — default actions for synchronous signals terminate the process.
- `kill(2)` — process termination affects the entire thread group.
- `futex(2)` NOTES — woken-with-inconsistent-state on owner death.
- Intel SDM Vol. 3A §6.15 — exception classes and synchronous fault semantics in long mode.

Closes: W59