### PR TITLE
tools/stubs: FcPattern* / FcConfig* / FcFont* → placeholder (Mozilla font-list init unblock)

### DIFF
--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -743,9 +743,14 @@ pub unsafe fn deliver_sigsegv_from_isr(
     sig_state.blocked |= 1u64 << SIGSEGV;
     sig_state.blocked &= !((1u64 << SIGKILL) | (1u64 << SIGSTOP));
 
+    // user_rip is the userspace instruction pointer at fault time (before
+    // the IRET redirect to handler_addr).  Logging it inline saves post-
+    // mortem investigators a kdb step: with the libxul base address from
+    // dmesg they can subtract it to get the file offset and addr2line the
+    // exact source line that faulted.
     crate::serial_println!(
-        "[SIGNAL] SIGSEGV ISR delivery: PID={} CR2={:#x} handler={:#x} new_rsp={:#x}",
-        pid, cr2, handler_addr, new_rsp
+        "[SIGNAL] SIGSEGV ISR delivery: PID={} CR2={:#x} user_rip={:#x} handler={:#x} new_rsp={:#x}",
+        pid, cr2, user_rip, handler_addr, new_rsp
     );
 
     true

--- a/scripts/install-firefox-stubs.sh
+++ b/scripts/install-firefox-stubs.sh
@@ -255,13 +255,67 @@ _EXACT_CATEGORY = {
     'g_spawn_close_pid':        'void_noop',
     'g_spawn_check_exit_status':'bool_true',
     'g_spawn_check_wait_status':'bool_true',
+    # --- fontconfig: pointer-returning entries Mozilla's font-list init
+    # path expects to be non-NULL.  These either don't match the
+    # constructor pattern rule (no trailing _new) or are getters that
+    # legitimately produce FcConfig* / FcFontSet* / FcPattern* objects.
+    # gfxFcPlatformFontList iterates set->nfont in a for-loop; pointing
+    # at the zero-initialised _stub_placeholder makes the loop body
+    # execute zero times and the function returns cleanly without
+    # touching set->fonts. Spec: https://fontconfig.org/ — FcFontSet
+    # is {int nfont; int sfont; FcPattern **fonts;}.
+    'FcPatternCreate':         'opaque_ptr',
+    'FcPatternDuplicate':      'opaque_ptr',
+    'FcNameParse':             'opaque_ptr',
+    'FcObjectSetBuild':        'opaque_ptr',
+    'FcConfigGetCurrent':      'opaque_ptr',
+    'FcConfigGetFonts':        'opaque_ptr',
+    'FcConfigReference':       'opaque_ptr',
+    'FcFontList':              'opaque_ptr',
+    'FcFontMatch':             'opaque_ptr',
+    'FcFontSort':              'opaque_ptr',
+    'FcFontRenderPrepare':     'opaque_ptr',
+    # FcNameUnparse returns char* (FcChar8*) — Mozilla wraps in
+    # nsDependentCString which deref's the buffer; pointing at the
+    # zeroed placeholder gives it a valid empty NUL-terminated string.
+    'FcNameUnparse':           'opaque_ptr',
+    # FcInitBringUptoDate returns FcBool — TRUE (1) keeps Mozilla's
+    # init-success path; default 'null' returns 0/FALSE which can
+    # trigger fallback paths that re-read the (still NULL) config.
+    'FcInitBringUptoDate':     'bool_true',
+    # FcGetVersion returns int (e.g. 21300 = "2.13.0"). gfxFcPlatformFontList
+    # gates several "old fontconfig" code paths on FcGetVersion() < 20900.
+    # Default 'null' returns 0, which forces the OLD path that then calls
+    # FcNameUnparse and constructs nsDependentCString on the result.
+    # Returning a modern version steers Mozilla into the safer new path.
+    # Spec: https://fontconfig.org/fontconfig-devel/fcgetversion.html
+    'FcGetVersion':            'fc_version',
 }
 
 # Pattern-based rules applied when no exact match.
 # Each entry: (compiled_regex, category)
+#
+# Conventions seen in libxul's undefined-symbol set:
+#   *_new       — GLib/GTK/Pango idiom (lowercase, trailing _new)
+#   *_alloc     — generic
+#   *_create    — Cairo / XCB / wayland idiom (lowercase, trailing _create
+#                 or _create_<variant> e.g. cairo_image_surface_create,
+#                 cairo_image_surface_create_for_data)
+#   *Create     — fontconfig / X11 idiom (CamelCase, trailing Create
+#                 e.g. FcPatternCreate, XDamageCreate)
+# Every one of these is a pointer-returning constructor that, when
+# stubbed to return NULL, gives Mozilla a NULL ref-counted handle which
+# is then dereferenced further in.  Classify them all as opaque_ptr so
+# the stub returns the zeroed _stub_placeholder.
 _PATTERN_RULES = [
-    # allocators: names ending with _new, _alloc, _malloc, _calloc
+    # constructors: names ending with _new, _alloc, _malloc, _calloc
     (re.compile(r'(?:_new|_alloc|_malloc|_calloc)$'),          'opaque_ptr'),
+    # constructors (Cairo/XCB idiom): _create, or _create_<variant>
+    # e.g. cairo_image_surface_create, cairo_image_surface_create_for_data
+    (re.compile(r'_create(?:_[A-Za-z0-9_]+)?$'),               'opaque_ptr'),
+    # constructors (fontconfig/X11 idiom): trailing CamelCase Create
+    # e.g. FcPatternCreate, XDamageCreate, XCompositeCreateRegion-style
+    (re.compile(r'[A-Z][A-Za-z0-9]+Create(?:[A-Z][A-Za-z0-9]*)?$'), 'opaque_ptr'),
     # free/unref: names ending with _free, _unref, _destroy, _close, _release
     (re.compile(r'(?:_free|_unref|_destroy|_close|_release)$'), 'unref_noop'),
     # ref: names ending with _ref or _ref_sink
@@ -308,8 +362,20 @@ _C_PREAMBLE = """\
 extern char **environ;
 
 /* Singleton placeholder: returned by object-constructor stubs.
- * Read-only, always non-NULL, safe to pass back into unref/free stubs. */
-static const int _stub_placeholder = 0;
+ * Read-only, always non-NULL, safe to pass back into unref/free stubs.
+ *
+ * Sized at 128 bytes so callers that treat the result as a struct and
+ * read fields beyond the first int (e.g. fontconfig FcFontSet has
+ * {int nfont; int sfont; FcPattern **fonts;} — 16 bytes; nsRefPtr-wrapped
+ * Mozilla iterators dereference offsets up to ~64 bytes during shape /
+ * lang-tag walks) all observe zero values rather than adjacent rodata.
+ * For pointer-returning getters this gives a safe "empty zero-initialised
+ * object" without ever needing a real backing allocation.
+ *
+ * Spec: https://fontconfig.org/fontconfig-devel/fcfontsetcreate.html
+ * (FcFontSet layout: nfont @ offset 0 — the loop-bound — drives every
+ * Mozilla iterator that calls these stubs.) */
+static const long _stub_placeholder[16] = {0};
 
 /* GSpawnFlags bits we honour (spec: GLib docs — GSpawnFlags).
  * Others (LEAVE_DESCRIPTORS_OPEN, FILE_AND_ARGV_ZERO, etc.) are ignored —
@@ -591,6 +657,17 @@ def emit_stub(name, cat):
         return (
             f'void* {name}(...) {{\n'
             f'    return (void*)&_stub_placeholder;\n'
+            f'}}\n'
+        )
+    elif cat == 'fc_version':
+        # FcGetVersion() returns int (encoded major*10000+minor*100+rev).
+        # 21300 = fontconfig 2.13.0 — picked to (a) clear the < 20900
+        # legacy-fontconfig branch at gfxFcPlatformFontList:1673 and
+        # (b) avoid the 21094..21101 charset-parse-bug range. Spec:
+        # https://fontconfig.org/fontconfig-devel/fcgetversion.html
+        return (
+            f'int {name}(void) {{\n'
+            f'    return 21300;\n'
             f'}}\n'
         )
     elif cat == 'spawn_with_pipes':


### PR DESCRIPTION
## Summary

W63 traced Mozilla's post-glxtest fault to fontconfig stubs returning NULL where Mozilla's font-list init expects valid pointers. Three-part fix in `scripts/install-firefox-stubs.sh`:

1. **`_PATTERN_RULES` extended** to match lowercase `_create` / `_create_<variant>` (Cairo / XCB idiom — `cairo_image_surface_create_for_data`, `cairo_region_create_rectangle`) and CamelCase trailing `Create` (fontconfig / X11 idiom — `FcPatternCreate`, `XDamageCreate`).

2. **`_EXACT_CATEGORY` additions** for fontconfig getters that don't match either constructor pattern but produce pointer results Mozilla iterates over: `FcConfigGetCurrent`, `FcConfigGetFonts`, `FcConfigReference`, `FcFontList`, `FcFontMatch`, `FcFontSort`, `FcFontRenderPrepare`, `FcNameParse`, `FcNameUnparse`, `FcObjectSetBuild`, `FcPatternDuplicate` → `opaque_ptr`. Plus `FcInitBringUptoDate` → `bool_true` and `FcGetVersion` → `21300` (new `fc_version` category) — steers Mozilla into the modern fontconfig path, away from the `< 20900` legacy branch that runs `FcNameUnparse` + `nsDependentCString` on a NULL result.

3. **`_stub_placeholder` enlarged** from `const int = 0` (4 bytes) to `const long[16] = {0}` (128 bytes). FcFontSet is `{int nfont; int sfont; FcPattern **fonts;}` (16 bytes); other callers may read deeper struct fields. The larger zero-filled region guarantees any in-struct deref up to 128 bytes reads zero rather than adjacent rodata.

Plus a kernel-side debug aid: `[SIGNAL] SIGSEGV ISR delivery` banner in `kernel/src/signal.rs` now includes `user_rip=<addr>` (5-LOC change). The userspace instruction pointer at fault time was previously only recoverable via live kdb — inline logging lets investigators subtract libxul's load base and `addr2line` straight to the faulting source line without a kdb roundtrip.

## Validation

`firefox-test` session `6f1cc6e4e166` (features `firefox-test,kdb,syscall-trace`):
- Booted, loaded libxul + libfontconfig.so.1 stub
- Spawned glxtest helper which printed `WARNING\ncannot access /sys/bus/pci\nERROR\nlibGL.so.1 missing\n` and clean-exited (`exit_group(0)`)
- Firefox PID 1 ran through 22 worker thread spawns into pthread futex parking
- **No SIGSEGV**, no `MOZ_RELEASE_ASSERT`, no `exit_group(11)` — session ran 172s without faulting
- `sc` count reached 2357, `pf` count 9168 (vs W62's 3441 pre-fix plateau)

Second session `c88c0ded7b24` (features `firefox-test,kdb`, no syscall-trace) also progressed: 42 thread spawns, sc=4249/pf=14084, then faulted at libxul **0x7efff9f38fd5** — a completely different code region from W62/W63's font-list-init fault at libxul **0x7efffa3572c4**. The font-list NULL-deref is gone; the next wedge is in deeper content-process / main-loop territory (separate workstream, likely matches the existing "Mozilla sem_wait plateau post-#126" memory).

`objdump` confirms the new non-NULL stubs:
```
0000000000003512 <FcPatternCreate>:
    3512: 48 8d 05 e7 0a 00 00   lea    0xae7(%rip),%rax  # 4000 <_stub_placeholder>
    3519: c9                     leave
    351a: c3                     ret
```
(was `mov $0x0, %eax` previously)

Same `lea _stub_placeholder, %rax` pattern for `FcConfigGetCurrent`, `FcConfigGetFonts`, `FcFontSort`, `FcPatternDuplicate`, `FcNameParse`. `FcGetVersion` correctly emits `mov $0x5334, %eax` (21300). `FcInitBringUptoDate` emits `mov $0x1, %eax` (TRUE).

## Test plan

- [x] Stub regen produces non-NULL bodies for all FcPattern* / FcConfig* / FcFont* constructors and getters
- [x] firefox-test session boots, glxtest spawns + clean-exits, libxul thread pool initialises
- [x] No SIGSEGV at libxul 0x7efffa3572c4 (W62/W63 font-list init fault)
- [x] Diff size 87/-5 within 80–200 LOC budget
- [ ] Land + downstream Firefox investigation can target the new (deeper) wedge

Spec citations: https://fontconfig.org/ (FcFontSet layout, FcGetVersion semantics).