### PR TITLE
tools/stubs: bump _stub_placeholder size for deeper struct accesses (Mozilla worker init progression)

### DIFF
--- a/scripts/install-firefox-stubs.sh
+++ b/scripts/install-firefox-stubs.sh
@@ -373,18 +373,26 @@ extern char **environ;
 /* Singleton placeholder: returned by object-constructor stubs.
  * Read-only, always non-NULL, safe to pass back into unref/free stubs.
  *
- * Sized at 128 bytes so callers that treat the result as a struct and
- * read fields beyond the first int (e.g. fontconfig FcFontSet has
- * {int nfont; int sfont; FcPattern **fonts;} — 16 bytes; nsRefPtr-wrapped
- * Mozilla iterators dereference offsets up to ~64 bytes during shape /
- * lang-tag walks) all observe zero values rather than adjacent rodata.
- * For pointer-returning getters this gives a safe "empty zero-initialised
- * object" without ever needing a real backing allocation.
+ * Sized at 1024 bytes (128 longs).  Callers that treat the result as a
+ * struct read fields at varying offsets:
+ *   - fontconfig FcFontSet  — {int nfont; int sfont; FcPattern **fonts;}
+ *     (16 bytes; iterator loop-bound at offset 0)
+ *   - GLib GObject / GTypeInstance — header up to ~64 bytes
+ *   - Cairo / Pango / GIO opaque handles — observed accesses up to
+ *     offset ~0xa8 (168 bytes) during Mozilla shape / lang-tag / X11
+ *     screen-init walks before the call reaches a real implementation
+ *
+ * 1 KiB gives all known struct shapes room to live entirely inside the
+ * zero-initialised buffer, so any field read at any plausible offset
+ * sees zero rather than adjacent rodata bytes (which on some link
+ * orderings happen to be non-zero string constants that look like
+ * valid pointers, then trigger a second-level fault).  Still well
+ * under one page so the BSS footprint per stub library is trivial.
  *
  * Spec: https://fontconfig.org/fontconfig-devel/fcfontsetcreate.html
  * (FcFontSet layout: nfont @ offset 0 — the loop-bound — drives every
  * Mozilla iterator that calls these stubs.) */
-static const long _stub_placeholder[16] = {0};
+static const long _stub_placeholder[128] = {0};
 
 /* GSpawnFlags bits we honour (spec: GLib docs — GSpawnFlags).
  * Others (LEAVE_DESCRIPTORS_OPEN, FILE_AND_ARGV_ZERO, etc.) are ignored —


### PR DESCRIPTION
## Summary

Bumps the singleton `_stub_placeholder` backing constructor-style stubs (`opaque_ptr` category) from **128 bytes (16 longs) → 1024 bytes (128 longs)** in `scripts/install-firefox-stubs.sh`.

Stacks on top of #168 (X11 `XCreate*` prefix family → placeholder). Resolves the W70 SIGSEGV @ CR2=0xa8 / 0xa9 wedge that surfaced after #168 advanced worker init.

## Rationale

After #168, Mozilla worker init advances past the X11 prefix-family NULL-return barrier but then hits a new fault: struct-field reads at offsets 0xa8 / 0xa9 (168-169 decimal) from a placeholder pointer. Those offsets are past the end of the 128-byte buffer, so the read lands in adjacent `.rodata` (string-constant bytes that look like valid pointers on some link orderings, then chain into a deeper deref).

1 KiB gives every observed struct shape (GLib `GObject`, GTK `GtkWindow`, fontconfig `FcFontSet`, Cairo opaque handles) room to live entirely inside the zero-initialised buffer. Still well under one page so the BSS footprint per stub library is unchanged in practical terms.

## Verification

**objdump confirms new size across multiple stub libraries:**

```
libfontconfig.so.1   _stub_placeholder size 0x00000400  (1024)
libX11.so.6          _stub_placeholder size 0x00000400  (1024)
libglib-2.0.so.0     _stub_placeholder size 0x00000400  (1024)
libgtk-3.so.0        _stub_placeholder size 0x00000400  (1024)
libcairo.so.2        _stub_placeholder size 0x00000400  (1024)
```
(Was 0x80 = 128 before the bump.)

**firefox-test 3-trial sweep — CR2=0xa8/0xa9 SIGSEGV RESOLVED:**

| Trial | TIDs | sc | Futex parks | SIGSEGV | Outcome |
|---|---|---|---|---|---|
| 1 | 21+ | 2217 | 13 | **NONE** | HB-plateau (no fatal) |
| 2 | 18+ | 2189 | 13 | **NONE** | HB-plateau (no fatal) |
| 3 | 19+ | 2278 | 13 | **NONE** | HB-plateau (no fatal) |

Pre-fix W70 baseline (PR #168 only):
- Trial 1: 29 TIDs, SIGSEGV CR2=0xa9 → exit_group(11)
- Trial 2: 22+ TIDs, glxtest exit 0, parent live
- Trial 3: 49 TIDs, SIGSEGV CR2=0xa8 + 0x0 → exit_group(11)

All three post-fix trials timed out the 180s SIGSEGV watch without seeing the fatal signature. The single `exit_group` in each trial is the glxtest helper exiting cleanly with status 0 (expected).

## Next wedge

The 0xa8/0xa9 SIGSEGV is gone; the new ceiling is the **pre-existing Mozilla sem_wait / futex plateau** (documented in window-6 handoff). Workers park on POSIX semaphores at `rip=0x7effffa89ae2` in libxul, kernel futex behaviour is correct, missing ABI surface appears to be sem_t-related (TLS layout / clone3-spawned thread stack alignment).

That's a separate kernel/ABI investigation, not a stubs-side fix.

## Test plan

- [x] objdump verifies new 0x400-byte placeholder in regenerated stubs
- [x] firefox-test 3 trials, all show CR2=0xa8/0xa9 SIGSEGV is gone
- [x] No regression on glxtest helper path (still exits 0)
- [x] Worker init progresses to futex-park plateau

🤖 Generated with [Claude Code](https://claude.com/claude-code)