### PR TITLE
kernel/signal: [SIGNAL/VMA] banner on SIGSEGV delivery for inline symbolication

### DIFF
--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -640,6 +640,16 @@ pub unsafe fn deliver_sigsegv_from_isr(
     let is_linux = proc_entry.linux_abi
         || proc_entry.subsystem == crate::win32::SubsystemType::Linux;
 
+    let user_rip = (*frame).rip;
+
+    // Snapshot the VMA containing user_rip plus up to a handful of
+    // executable file-backed neighbours.  Done now, BEFORE we reborrow
+    // `proc_entry.signal_state`, so the snapshot does not alias the
+    // later `&mut sig_state` borrow.  The actual print happens at the
+    // end of this function so PROCESS_TABLE is not held across the
+    // serial writes.  See the `[SIGNAL/VMA]` emission block below.
+    let vma_snapshot = signal_vma_snapshot(proc_entry.vm_space.as_ref(), user_rip);
+
     let sig_state = match proc_entry.signal_state.as_mut() {
         Some(s) => s,
         None => return false,
@@ -651,7 +661,6 @@ pub unsafe fn deliver_sigsegv_from_isr(
         _ => return false, // Default or Ignore — caller kills the process
     };
 
-    let user_rip = (*frame).rip;
     let user_rsp = (*frame).rsp;
     let user_rflags = (*frame).rflags;
     let saved_mask = sig_state.blocked;
@@ -748,10 +757,111 @@ pub unsafe fn deliver_sigsegv_from_isr(
     // mortem investigators a kdb step: with the libxul base address from
     // dmesg they can subtract it to get the file offset and addr2line the
     // exact source line that faulted.
+    //
+    // Drop PROCESS_TABLE before the serial writes — a slow COM1 should
+    // never block other CPUs from looking up their own process entry.
+    drop(procs);
     crate::serial_println!(
         "[SIGNAL] SIGSEGV ISR delivery: PID={} CR2={:#x} user_rip={:#x} handler={:#x} new_rsp={:#x}",
         pid, cr2, user_rip, handler_addr, new_rsp
     );
+    emit_signal_vma_banner(pid, user_rip, &vma_snapshot);
 
     true
+}
+
+/// Compact VMA descriptor captured at SIGSEGV delivery time.
+///
+/// `name` is `&'static str` (the same lifetime as `VmArea::name`), so the
+/// snapshot is cheap to build and carry across the lock drop.
+#[derive(Copy, Clone)]
+pub(crate) struct VmaSnap {
+    pub(crate) base: u64,
+    pub(crate) end: u64,
+    pub(crate) prot: u32,
+    pub(crate) name: &'static str,
+    pub(crate) file_backed: bool,
+    pub(crate) contains_rip: bool,
+}
+
+/// Capture the VMA covering `user_rip` plus a small number of executable,
+/// file-backed neighbours that are likely shared-library load segments.
+///
+/// Capped at 8 entries to keep serial volume bounded — emitting every VMA
+/// of a libxul-loading process would push hundreds of lines per fault.
+///
+/// Visible to `test_runner` via `pub(crate)` so the snapshot policy can
+/// be unit-tested against a synthetic `VmSpace` without standing up a
+/// full `Process`.
+pub(crate) fn signal_vma_snapshot(
+    space: Option<&crate::mm::vma::VmSpace>,
+    user_rip: u64,
+) -> alloc::vec::Vec<VmaSnap> {
+    use crate::mm::vma::{PROT_EXEC, VmBacking};
+    let mut out: alloc::vec::Vec<VmaSnap> = alloc::vec::Vec::new();
+    let space = match space {
+        Some(s) => s,
+        None => return out,
+    };
+    for a in space.areas.iter() {
+        let file_backed = matches!(a.backing, VmBacking::File { .. });
+        let contains = a.contains(user_rip);
+        // Always include the VMA containing user_rip.  For neighbours,
+        // only include executable file-backed mappings (shared-library
+        // text segments) — those are the symbolication-useful ones.
+        let keep = contains || (file_backed && (a.prot & PROT_EXEC) != 0);
+        if !keep {
+            continue;
+        }
+        out.push(VmaSnap {
+            base: a.base,
+            end: a.end(),
+            prot: a.prot,
+            name: a.name,
+            file_backed,
+            contains_rip: contains,
+        });
+        if out.len() >= 8 {
+            break;
+        }
+    }
+    out
+}
+
+/// Emit `[SIGNAL/VMA]` lines for the snapshot captured at fault time.
+///
+/// Format (one line per kept VMA):
+///   `[SIGNAL/VMA] pid=<n> name=<label> base=<vaddr> end=<vaddr> size=<bytes> prot=<rwx> file=<0|1> rip=<0|1> [offset=<within>]`
+///
+/// `rip=1` marks the VMA that contains `user_rip`; that entry also carries an
+/// `offset=` field giving `user_rip - base` so the next investigator can
+/// addr2line directly against the `[FFTEST/mmap-so]` base for that VMA's
+/// underlying file.
+fn emit_signal_vma_banner(pid: u64, user_rip: u64, snap: &[VmaSnap]) {
+    use crate::mm::vma::{PROT_EXEC, PROT_READ, PROT_WRITE};
+    if snap.is_empty() {
+        crate::serial_println!(
+            "[SIGNAL/VMA] pid={} user_rip={:#x} no_vma_match=1",
+            pid, user_rip
+        );
+        return;
+    }
+    for v in snap.iter() {
+        let r = if v.prot & PROT_READ  != 0 { 'r' } else { '-' };
+        let w = if v.prot & PROT_WRITE != 0 { 'w' } else { '-' };
+        let x = if v.prot & PROT_EXEC  != 0 { 'x' } else { '-' };
+        if v.contains_rip {
+            crate::serial_println!(
+                "[SIGNAL/VMA] pid={} name={} base={:#x} end={:#x} size={:#x} prot={}{}{} file={} rip=1 offset={:#x}",
+                pid, v.name, v.base, v.end, v.end - v.base, r, w, x,
+                v.file_backed as u8, user_rip - v.base
+            );
+        } else {
+            crate::serial_println!(
+                "[SIGNAL/VMA] pid={} name={} base={:#x} end={:#x} size={:#x} prot={}{}{} file={} rip=0",
+                pid, v.name, v.base, v.end, v.end - v.base, r, w, x,
+                v.file_backed as u8
+            );
+        }
+    }
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -303,6 +303,11 @@ pub fn run() -> ! {
     total += 1;
     if test_signal_subsystem() { passed += 1; }
 
+    // ── Test 18b: [SIGNAL/VMA] snapshot policy ──────────────────────────
+
+    total += 1;
+    if test_signal_vma_snapshot() { passed += 1; }
+
     // ── Test 19: Buffer Cache + File-Backed mmap ────────────────────────
 
     total += 1;
@@ -3851,6 +3856,87 @@ fn test_signal_subsystem() -> bool {
     test_println!("  default_action(SIGKILL)=Terminate, SIGCHLD=Ignore, SIGSTOP=Stop ✓");
 
     test_pass!("Signal delivery trampoline");
+    true
+}
+
+// ── Test 18b: [SIGNAL/VMA] snapshot policy ──────────────────────────────────
+
+/// Verifies `signal::signal_vma_snapshot()` picks:
+///   * the VMA containing `user_rip` (with `contains_rip=true`), and
+///   * neighbouring executable file-backed VMAs (likely shared libraries),
+/// while skipping non-executable or anonymous neighbours.
+///
+/// This is the snapshot that feeds the `[SIGNAL/VMA]` banner emitted at
+/// SIGSEGV ISR delivery time — see `kernel/src/signal.rs::emit_signal_vma_banner`.
+fn test_signal_vma_snapshot() -> bool {
+    test_header!("[SIGNAL/VMA] snapshot policy");
+    use crate::mm::vma::{VmArea, VmBacking, VmSpace,
+                         PROT_READ, PROT_WRITE, PROT_EXEC,
+                         MAP_PRIVATE, MAP_ANONYMOUS};
+    let space = VmSpace {
+        cr3: 0,
+        areas: alloc::vec![
+            // libxul .text (executable, file-backed) — should appear
+            VmArea {
+                base: 0x10_0000, length: 0x10_0000,
+                prot: PROT_READ | PROT_EXEC, flags: MAP_PRIVATE,
+                backing: VmBacking::File { mount_idx: 0, inode: 1, offset: 0 },
+                name: "[mmap-file]",
+            },
+            // libxul .data (rw, file-backed, NOT exec) — should be skipped
+            VmArea {
+                base: 0x20_0000, length: 0x1_0000,
+                prot: PROT_READ | PROT_WRITE, flags: MAP_PRIVATE,
+                backing: VmBacking::File { mount_idx: 0, inode: 1, offset: 0x10_0000 },
+                name: "[mmap-file]",
+            },
+            // libc .text (executable, file-backed) — should appear
+            VmArea {
+                base: 0x30_0000, length: 0x4_0000,
+                prot: PROT_READ | PROT_EXEC, flags: MAP_PRIVATE,
+                backing: VmBacking::File { mount_idx: 0, inode: 2, offset: 0 },
+                name: "[mmap-file]",
+            },
+            // Anonymous heap (rw, not file-backed) — should be skipped
+            VmArea {
+                base: 0x40_0000, length: 0x1000,
+                prot: PROT_READ | PROT_WRITE, flags: MAP_PRIVATE | MAP_ANONYMOUS,
+                backing: VmBacking::Anonymous,
+                name: "[heap]",
+            },
+        ],
+        mmap_hint: 0, brk: 0, brk_start: 0,
+    };
+    // user_rip lands inside the libxul .text VMA at offset 0x1234.
+    let user_rip = 0x10_0000 + 0x1234;
+    let snap = crate::signal::signal_vma_snapshot(Some(&space), user_rip);
+    if snap.len() != 2 {
+        test_fail!("[SIGNAL/VMA] snapshot policy",
+                   "expected 2 entries (libxul .text + libc .text), got {}", snap.len());
+        return false;
+    }
+    // First entry must be the libxul .text (contains user_rip).
+    if !snap[0].contains_rip || snap[0].base != 0x10_0000 || !snap[0].file_backed {
+        test_fail!("[SIGNAL/VMA] snapshot policy",
+                   "entry 0 should be libxul .text containing rip (base={:#x} rip={} file={})",
+                   snap[0].base, snap[0].contains_rip, snap[0].file_backed);
+        return false;
+    }
+    // Second entry must be libc .text (executable, file-backed, no rip).
+    if snap[1].contains_rip || snap[1].base != 0x30_0000 || !snap[1].file_backed {
+        test_fail!("[SIGNAL/VMA] snapshot policy",
+                   "entry 1 should be libc .text (base={:#x} rip={} file={})",
+                   snap[1].base, snap[1].contains_rip, snap[1].file_backed);
+        return false;
+    }
+    // None-space case: snapshot must return empty.
+    let empty = crate::signal::signal_vma_snapshot(None, 0);
+    if !empty.is_empty() {
+        test_fail!("[SIGNAL/VMA] snapshot policy",
+                   "None space should produce empty snapshot, got {}", empty.len());
+        return false;
+    }
+    test_pass!("[SIGNAL/VMA] snapshot policy");
     true
 }
 


### PR DESCRIPTION
## Summary
- After SIGSEGV delivery from the page-fault ISR, emit one or more `[SIGNAL/VMA]` lines describing the VMA containing `user_rip` plus a few executable file-backed neighbours (likely shared-library text segments).
- Closes the symbolication gap left by the existing `user_rip` log: an investigator gets the load base + offset for the faulting instruction in a single boot, with no second `firefox-trace-verbose` pass required.
- Cost: only emitted at SIGSEGV delivery time, capped at 8 entries, snapshot built under `PROCESS_TABLE` and printed after the lock is dropped.

## Format
```
[SIGNAL/VMA] pid=<n> name=<label> base=<vaddr> end=<vaddr> size=<bytes> prot=<rwx> file=<0|1> rip=<0|1> [offset=<within>]
```
The entry covering `user_rip` carries `rip=1` and an `offset=` field giving `user_rip - base` directly.

## Selection policy
- Always include the VMA containing `user_rip` (whatever it is — anonymous heap, JIT page, library text, etc.).
- Include neighbouring executable + file-backed VMAs (these are the symbolication-useful ones — shared-library text segments mmap'd by ld.so).
- Skip non-executable file-backed mappings (e.g. library `.data`/`.bss`), anonymous heaps, and stack VMAs.
- Hard cap of 8 entries total to keep serial volume bounded under demo-throughput builds.

## Test plan
- [x] `cargo +nightly check` clean under default features, `firefox-test,kdb`, and `test-mode`
- [x] New unit test `test_signal_vma_snapshot` in `kernel/src/test_runner.rs` exercises the snapshot policy with a synthetic `VmSpace` covering four cases (RIP-containing exec VMA, file-backed exec neighbour, file-backed non-exec mapping that must be skipped, anonymous heap that must be skipped). Passes under `--features test-mode`.
- [x] Existing Test 76 (`SIGSEGV signal handler infrastructure`) still passes — the integration path through `deliver_sigsegv_from_isr` is unchanged.
- [x] Boot in `firefox-test,kdb` reaches sem_wait plateau without SIGSEGV (consistent with the known Mozilla wedge — no native crash to symbolicate yet). Banner code is exercised by the unit test; will produce its real-world output as soon as Mozilla advances past the plateau and crashes for some non-wedge reason.

## Public-spec references
- POSIX.1-2017 §2.4 — Signal Concepts
- Linux Programmer's Manual `signal(7)`, `sigaction(2)`, `siginfo_t(3type)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)