### PR TITLE
kernel/vfs: [VFS/resolve] trace + 1s deadline in resolve_path_opts (W83 wedge diagnostic + safety net)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -82,6 +82,15 @@ futex-wait-scan = []
 # which adds the matching `virtio-serial-pci` + `virtserialport` device on
 # the host side.  See virtio 1.2 §5.3 (Console Device).
 qga = []
+# VFS path-resolution tracing (W83 diagnostic).  Emits one `[VFS/resolve]` line
+# per directory component traversed in `vfs::resolve_path_opts` and one extra
+# line per symlink follow.  Capped at 20 lines per outermost resolve to bound
+# log volume.  Implied by `firefox-test`; standalone for headless diagnostic
+# runs (e.g. tracking down a hang in a non-Firefox workload).  When neither
+# this nor `firefox-test` is enabled, the trace helper compiles to nothing —
+# the 1s deadline in `resolve_path_opts` is *not* feature-gated and is always
+# on.
+vfs-trace = []
 
 [dependencies]
 astryx-shared = { path = "../shared" }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -730,6 +730,11 @@ pub fn run() -> ! {
     total += 1;
     if test_vfs_file_locking() { passed += 1; }
 
+    // ── Test 87b: VFS — resolve_path_opts trace + 1s deadline (W83 safety net)
+
+    total += 1;
+    if test_vfs_resolve_deadline() { passed += 1; }
+
     // ── Test 88: VFS C4 — /proc/<PID>/ dynamic per-process directory ────────
 
     total += 1;
@@ -14509,6 +14514,74 @@ fn test_vfs_file_locking() -> bool {
     }
 
     if ok { test_pass!("VFS C1: POSIX file locking"); }
+    ok
+}
+
+// ── VFS resolve_path_opts — W83 trace + 1s deadline safety net ──────────────
+//
+// Two sub-cases:
+//   (a) Happy path: a deeply-nested directory chain plus a symlink resolves
+//       well within the 1s budget, returns Ok.
+//   (b) Forced-timeout: invoke the private `_test_resolve_with_deadline`
+//       entrypoint with `deadline_ticks = 0` (already in the past) and assert
+//       it returns `VfsError::TimedOut` — proving the deadline check on the
+//       hot path fires before the next concrete-FS dispatch.
+//
+// The happy-path leg is the regression guard: if a future change accidentally
+// makes deep-path resolution take seconds (e.g. by holding a global lock
+// across a slow disk read), this test will start failing.
+fn test_vfs_resolve_deadline() -> bool {
+    test_header!("VFS resolve_path_opts: trace + 1s deadline (W83)");
+    let mut ok = true;
+
+    // ── (a) Deep nesting + symlink resolves quickly ─────────────────────
+    let _ = crate::vfs::mkdir("/tmp/w83");
+    let _ = crate::vfs::mkdir("/tmp/w83/a");
+    let _ = crate::vfs::mkdir("/tmp/w83/a/b");
+    let _ = crate::vfs::mkdir("/tmp/w83/a/b/c");
+    let _ = crate::vfs::mkdir("/tmp/w83/a/b/c/d");
+    let _ = crate::vfs::create_file("/tmp/w83/a/b/c/d/target.txt");
+    let _ = crate::vfs::write_file("/tmp/w83/a/b/c/d/target.txt", b"hi");
+
+    // /tmp/w83/link → a/b/c/d/target.txt (relative symlink)
+    let _ = crate::vfs::symlink("/tmp/w83/link", "a/b/c/d/target.txt");
+
+    let t0 = crate::arch::x86_64::irq::get_ticks();
+    let res = crate::vfs::resolve_path("/tmp/w83/link");
+    let elapsed = crate::arch::x86_64::irq::get_ticks().saturating_sub(t0);
+    if res.is_ok() && elapsed < 100 {
+        test_println!("  (a) deep symlink resolved in {} ticks (< 1s) ✓", elapsed);
+    } else {
+        test_fail!("VFS resolve deadline",
+            "(a) deep symlink: res={:?} elapsed={} ticks (expected Ok and <100)", res, elapsed);
+        ok = false;
+    }
+
+    // ── (b) Forced-expired deadline returns ETIMEDOUT ──────────────────
+    // Use deadline_ticks = 0 — strictly less than any get_ticks() value on
+    // a booted system, so the very first iteration of the resolve loop
+    // observes get_ticks() >= 0 and bails out.
+    match crate::vfs::_test_resolve_with_deadline("/tmp/w83/a/b/c/d/target.txt", 0) {
+        Err(crate::vfs::VfsError::TimedOut) => {
+            test_println!("  (b) deadline=0 → VfsError::TimedOut (errno 110) ✓");
+        }
+        other => {
+            test_fail!("VFS resolve deadline",
+                "(b) deadline=0 expected TimedOut, got {:?}", other);
+            ok = false;
+        }
+    }
+
+    // ── Cleanup ─────────────────────────────────────────────────────────
+    let _ = crate::vfs::remove("/tmp/w83/link");
+    let _ = crate::vfs::remove("/tmp/w83/a/b/c/d/target.txt");
+    let _ = crate::vfs::remove("/tmp/w83/a/b/c/d");
+    let _ = crate::vfs::remove("/tmp/w83/a/b/c");
+    let _ = crate::vfs::remove("/tmp/w83/a/b");
+    let _ = crate::vfs::remove("/tmp/w83/a");
+    let _ = crate::vfs::remove("/tmp/w83");
+
+    if ok { test_pass!("VFS resolve_path_opts: trace + 1s deadline (W83)"); }
     ok
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -50,6 +50,14 @@ pub enum VfsError {
     Unsupported = 95,   // EOPNOTSUPP
     Io = 5,             // EIO
     WouldBlock = 11,    // EAGAIN / EWOULDBLOCK
+    /// Operation could not complete within an internal wall-clock budget.
+    /// Currently emitted by `resolve_path_opts` when a single path resolution
+    /// exceeds the 1s deadline — see W83 wedge (`/usr → /disk/usr` symlink
+    /// traversal hung indefinitely in 2/3 firefox-test trials).  POSIX `open(2)`
+    /// does not list ETIMEDOUT, but Linux uses it for several FS paths under
+    /// extreme contention (e.g. NFS) and it cleanly distinguishes a hang from
+    /// EIO or ENOENT in serial logs.
+    TimedOut = 110,     // ETIMEDOUT
 }
 
 impl From<VfsError> for astryx_shared::NtStatus {
@@ -69,6 +77,7 @@ impl From<VfsError> for astryx_shared::NtStatus {
             VfsError::Unsupported => STATUS_NOT_SUPPORTED,
             VfsError::Io => STATUS_IO_DEVICE_ERROR,
             VfsError::WouldBlock => STATUS_NO_MORE_FILES,
+            VfsError::TimedOut => STATUS_TIMEOUT,
         }
     }
 }
@@ -889,13 +898,92 @@ fn init_ata_disks() {
 
 /// Resolve a path to (mount_index, inode), following all symlinks.
 pub fn resolve_path(path: &str) -> VfsResult<(usize, u64)> {
-    resolve_path_opts(path, 0, true)
+    let deadline = resolve_deadline_ticks();
+    let mut tctx = ResolveTrace::new();
+    resolve_path_opts(path, 0, true, deadline, &mut tctx)
 }
 
 /// Resolve a path but do NOT follow the final component if it is a symlink.
 /// Intermediate symlinks are still followed.  Used by lstat() and readlink().
 fn resolve_path_no_follow(path: &str) -> VfsResult<(usize, u64)> {
-    resolve_path_opts(path, 0, false)
+    let deadline = resolve_deadline_ticks();
+    let mut tctx = ResolveTrace::new();
+    resolve_path_opts(path, 0, false, deadline, &mut tctx)
+}
+
+/// Test-only entrypoint to resolve a path with a caller-supplied deadline.
+///
+/// Exposed so `test_runner` can verify that the W83 deadline fires when the
+/// budget has already expired.  Production callers must use [`resolve_path`].
+#[doc(hidden)]
+pub fn _test_resolve_with_deadline(path: &str, deadline_ticks: u64) -> VfsResult<(usize, u64)> {
+    let mut tctx = ResolveTrace::new();
+    resolve_path_opts(path, 0, true, deadline_ticks, &mut tctx)
+}
+
+/// Compute the absolute tick value at which a path resolution must give up.
+///
+/// PIT runs at ~100 Hz (`arch::x86_64::irq::init`), so 100 ticks ≈ 1 s.  See
+/// the docstring on [`resolve_path_opts`] for why this bound exists.  When
+/// the tick counter hasn't been wired up yet (extremely early boot), we set
+/// the deadline to `u64::MAX` so the deadline check is a no-op — the boot
+/// path that runs before IRQs are unmasked must not be capable of being
+/// "timed out" because there's no clock to measure against.
+#[inline]
+fn resolve_deadline_ticks() -> u64 {
+    let now = crate::arch::x86_64::irq::get_ticks();
+    if now == 0 {
+        // PIT not yet ticking — disable the deadline rather than fail closed.
+        u64::MAX
+    } else {
+        now.saturating_add(100)
+    }
+}
+
+/// Per-resolution trace state.
+///
+/// We cap to a small number of lines per outermost resolve to keep the
+/// serial log readable even on a wedged path (which would otherwise emit
+/// one line per loop iteration × symlink-recursion-depth combinations).
+struct ResolveTrace {
+    /// Lines already emitted by this outermost resolve call (and its
+    /// recursive descendants).
+    emitted: u32,
+}
+
+impl ResolveTrace {
+    const MAX_LINES: u32 = 20;
+    #[inline]
+    fn new() -> Self { Self { emitted: 0 } }
+}
+
+/// Emit one `[VFS/resolve]` trace line, respecting the per-resolve cap.
+///
+/// Gated behind the `vfs-trace` feature flag (always-on diagnostic) and
+/// `firefox-test` (default-on for the browser bring-up).  In a release build
+/// without either flag, this compiles to nothing — the deadline still fires,
+/// but per-component spew does not.  The serial log on the `firefox-test`
+/// path is already dense; capping the emitter avoids flooding it when a path
+/// genuinely needs >20 iterations to resolve.
+#[inline]
+fn resolve_trace(tctx: &mut ResolveTrace, args: core::fmt::Arguments<'_>) {
+    #[cfg(any(feature = "vfs-trace", feature = "firefox-test"))]
+    {
+        if tctx.emitted < ResolveTrace::MAX_LINES {
+            crate::serial_println!("{}", args);
+            tctx.emitted += 1;
+            if tctx.emitted == ResolveTrace::MAX_LINES {
+                crate::serial_println!(
+                    "[VFS/resolve] (trace cap reached, suppressing further per-component lines)"
+                );
+            }
+        }
+    }
+    #[cfg(not(any(feature = "vfs-trace", feature = "firefox-test")))]
+    {
+        let _ = tctx;
+        let _ = args;
+    }
 }
 
 /// Inner resolver with symlink depth tracking and final-follow control.
@@ -903,7 +991,34 @@ fn resolve_path_no_follow(path: &str) -> VfsResult<(usize, u64)> {
 /// * `follow_final` – when `true`, follow the last path component if it is a
 ///   symlink (stat / open behaviour).  When `false`, stop at the symlink inode
 ///   itself (lstat / readlink behaviour).
-fn resolve_path_opts(path: &str, depth: u32, follow_final: bool) -> VfsResult<(usize, u64)> {
+///
+/// # Wall-clock deadline (W83 safety net)
+///
+/// Some pathological combinations of mount-table layout, symlinks, and
+/// concrete-FS state can cause path resolution to make no forward progress
+/// (W83 reproducer: every `firefox-test` trial wedged on the first traversal
+/// of `/usr → /disk/usr/.../libGL.so.1`).  To bound the worst case we compute
+/// an absolute 1s deadline at the outermost call (`resolve_path` /
+/// `resolve_path_no_follow`) and thread it through `resolve_path_opts` as an
+/// explicit argument, so a symlink chase cannot reset the budget by
+/// recursing.  When the deadline expires we return [`VfsError::TimedOut`]
+/// (`ETIMEDOUT`, errno 110) and emit `[VFS/resolve] DEADLINE EXCEEDED` to the
+/// serial log along with the partial-resolved path — the exact diagnostic
+/// that names the hang point.
+///
+/// One second is intentionally generous: every block-backed FS in this
+/// kernel has its own sub-second IRQ-or-poll budget per disk request and a
+/// directory of a few hundred entries reads in well under that limit even
+/// on virtio-blk poll-fallback (~100ms worst case, per `wait_completion`).
+/// If a real workload ever legitimately exceeds 1s of pure VFS work, raise
+/// the bound — don't remove it.
+fn resolve_path_opts(
+    path: &str,
+    depth: u32,
+    follow_final: bool,
+    deadline_ticks: u64,
+    tctx: &mut ResolveTrace,
+) -> VfsResult<(usize, u64)> {
     const MAX_SYMLINK_DEPTH: u32 = 16;
     if depth > MAX_SYMLINK_DEPTH {
         return Err(VfsError::NotFound); // symlink loop
@@ -951,6 +1066,21 @@ fn resolve_path_opts(path: &str, depth: u32, follow_final: bool) -> VfsResult<(u
     for (i, component) in remaining.iter().enumerate() {
         let is_final = i + 1 == remaining.len();
 
+        // ── W83 trace: per-component progress marker ────────────────────────
+        resolve_trace(tctx, format_args!(
+            "[VFS/resolve] depth={} component='{}' cur_mount={} resolved_so_far='{}'",
+            depth, component, cur_mount, resolved_so_far,
+        ));
+
+        // ── W83 deadline: bail out before the next concrete-FS dispatch ────
+        if crate::arch::x86_64::irq::get_ticks() >= deadline_ticks {
+            crate::serial_println!(
+                "[VFS/resolve] DEADLINE EXCEEDED depth={} stuck-at='{}' next-component='{}' input-path='{}'",
+                depth, resolved_so_far, component, path,
+            );
+            return Err(VfsError::TimedOut);
+        }
+
         // Snapshot the current FS handle before each dispatch.  Holding
         // `MOUNTS` across `lookup` / `stat` / `readlink` would deadlock if
         // the FS implementation faults on a user-supplied or file-backed
@@ -975,10 +1105,12 @@ fn resolve_path_opts(path: &str, depth: u32, follow_final: bool) -> VfsResult<(u
             let target = fs.readlink(child_inode)?;
 
             // Build the new path: target + remaining components after this one.
+            // We borrow `target` here rather than moving it so the W83 trace
+            // below can still print its raw value.
             let rest: Vec<&str> = remaining[i + 1..].to_vec();
-            let new_path = if rest.is_empty() {
+            let new_path: String = if rest.is_empty() {
                 if target.starts_with('/') {
-                    target
+                    target.clone()
                 } else {
                     alloc::format!("{}/{}", resolved_so_far.trim_end_matches('/'), target)
                 }
@@ -993,7 +1125,11 @@ fn resolve_path_opts(path: &str, depth: u32, follow_final: bool) -> VfsResult<(u
             // Recurse with incremented depth.  When following intermediate
             // symlinks the recursive call always follows the final component
             // (the rest of the path after the symlink).
-            return resolve_path_opts(&new_path, depth + 1, true);
+            resolve_trace(tctx, format_args!(
+                "[VFS/resolve] follow-symlink depth={} from='{}' target='{}' new_path='{}'",
+                depth, resolved_so_far, target, new_path,
+            ));
+            return resolve_path_opts(&new_path, depth + 1, true, deadline_ticks, tctx);
         }
 
         // Not a symlink — advance.


### PR DESCRIPTION
## Summary

- Add `VfsError::TimedOut` (errno 110, ETIMEDOUT) and propagate an absolute 1s wall-clock deadline through `vfs::resolve_path_opts`.  If a single path resolution doesn't complete within ~100 PIT ticks, return `Err(TimedOut)` and emit `[VFS/resolve] DEADLINE EXCEEDED depth=... stuck-at='...' next-component='...' input-path='...'` — the exact diagnostic that names the hang point.
- Add per-component `[VFS/resolve]` tracing gated behind a new `vfs-trace` Cargo feature (implied by `firefox-test`).  Each loop iteration logs depth / component / mount / partial path; the symlink-follow path adds a `follow-symlink` line with the rewritten target.  Capped at 20 lines per outermost resolve to keep the serial log readable.
- Add `test_vfs_resolve_deadline` (Test 87b) covering both the happy path (deep symlink resolves in 0 ticks) and the forced-expired path (deadline=0 → `VfsError::TimedOut`).

## Why

W83 reported that 2/3 firefox-test trials wedged in `vfs::open()` for `/usr/lib/x86_64-linux-gnu/glibc-hwcaps/x86-64-v2/libGL.so.1` — the first path crossing the `/usr → /disk/usr` symlink into the virtio-blk FAT32 mount.  Without instrumentation we could not tell whether the hang was in symlink recursion, FAT32 enumeration, or somewhere else.  This PR makes the next such hang self-diagnose (deadline + log line names the partial path) AND bounds the worst case (1s, then ETIMEDOUT).  POSIX `open(2)` does not list ETIMEDOUT, but Linux uses it for several FS paths under extreme contention; it cleanly distinguishes a hang from EIO / ENOENT in serial logs.

## Three-trial firefox-test result

Built and ran 3 trials on this branch (commit 3f6aea4).  **The W83 reproducer did NOT recur** — path resolution is healthy across the tested workload.

| Trial | Wedge state | DEADLINE EXCEEDED fired? |
|---|---|---|
| 1 | Mozilla content-process #UD at RIP 0x7efffa07aa7e (clone3 to 44+ threads, then invalid opcode in user mode) | no |
| 2 | Mozilla futex/sem plateau (per `project_mozilla_sem_wait_plateau` memory) — TID 8/12 spinning on `0x7eff6d1a3668` | no |
| 3 | Same futex plateau, sc=4788, pf=14732, 50+ libs loaded (libxul, libnss3, libgtk-3, libcairo, libfreetype, libpangocairo, ...) | no |

The trace stream confirms `/usr → /disk/usr` and `/lib → /disk/lib` symlink chases are taken at depth=0 and subsequent component lookups complete in one tick.  Example:

```
[VFS/resolve] depth=0 component='lib' cur_mount=0 resolved_so_far='/'
[VFS/resolve] follow-symlink depth=0 from='/' target='/disk/lib' new_path='/disk/lib/x86_64-linux-gnu/glibc-hwcaps/x86-64-v2/libpthread.so.0'
[VFS/resolve] depth=1 component='glibc-hwcaps' cur_mount=4 resolved_so_far='/disk/lib/x86_64-linux-gnu'
[FF/open-ret] pid=1 path=/lib/x86_64-linux-gnu/glibc-hwcaps/x86-64-v2/libpthread.so.0 ret=-2
```

## Mozilla progression delta

Trial 3 ran to ~20.3M ticks before the harness wait timed out — sc=4788 / pf=14732 / 50+ libs loaded.  This is consistent with the existing post-#157 Mozilla sem_wait plateau and is not a regression introduced by this PR.

## Did this name the exact hang point?

**No — but for the right reason.**  The wedge described in W83 did not reproduce on this branch (3/3 trials progressed past `libGL` cleanly to either a content-process #UD or the Mozilla futex plateau).  The trace + deadline are now in place as a safety net for the next regression; the moment a future build wedges in path resolution, the serial log will carry the `[VFS/resolve] DEADLINE EXCEEDED` line with the exact partial-resolved path, and the syscall returns ETIMEDOUT instead of holding the thread forever.

## Test plan
- [x] `python3 scripts/qemu-harness.py check --features firefox-test` → `ok: true`
- [x] `python3 scripts/qemu-harness.py check --features test-mode` → `ok: true`
- [x] `python3 scripts/qemu-harness.py check --features test-mode,firefox-test` → `ok: true`
- [x] `python3 scripts/qemu-harness.py check --features ""` → `ok: true`
- [x] Test 87b passes: `[TEST-JSON] {"name":"VFS resolve_path_opts: trace + 1s deadline (W83)","result":"pass","elapsed_ticks":5}`
- [x] Full suite: 224/231 pass (7 pre-existing failures unrelated — `data.img` missing `/disk/bin/{hello,tcc,busybox}`).
- [x] 3× firefox-test trials, no DEADLINE EXCEEDED firings, no VFS-attributable regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)