### PR TITLE
tools/stubs: FcPatternGet{Bool,Integer,Double} populate-output + return Match (Mozilla NULL-pat fault unblock)

### DIFF
--- a/scripts/install-firefox-stubs.sh
+++ b/scripts/install-firefox-stubs.sh
@@ -282,19 +282,41 @@ _EXACT_CATEGORY = {
     'FcFontMatch':             'fcpattern_one',
     'FcFontSort':              'fcfontset_one',
     'FcFontRenderPrepare':     'fcpattern_one',
-    # FcPatternGet* — typed stubs that return FcResult (int).  The
-    # default 'null' category returns 0 (= FcResultMatch) but leaves the
-    # out-pointer untouched, so Mozilla then dereferences uninitialised
-    # stack memory.  Explicit 'fc_no_match' returns FcResultNoMatch (1)
-    # for everything *except* FcPatternGetString, which has its own
-    # typed body that recognises FC_FILE / FC_FAMILY and writes a real
-    # DejaVu Sans descriptor — that's what lets AddPatternToFontList
-    # insert one entry into mFontFamilies. Spec:
-    # https://fontconfig.org/fontconfig-devel/fcpatternget.html
+    # FcPatternGet* — typed stubs that return FcResult (int).
+    #
+    # Mozilla's gfxFontconfigFontEntry / gfxFontconfigUtils helpers call
+    # FcPatternGetBool/Integer/Double on the FcPattern result of
+    # FcFontMatch / FcFontRenderPrepare, then on EVERY return path check
+    # `if (result) { /* failure */ }`.  Several of those failure branches
+    # then write back into the pattern pointer (`pat->flags |= FOO`) —
+    # which faults if `pat` is NULL (i.e. the caller passed an
+    # uninitialised handle on the no-pattern path).
+    #
+    # The 'fc_no_match' classifier returns 1 = FcResultNoMatch unmodified,
+    # which is spec-correct but pushes Mozilla into those NULL-deref
+    # failure branches.  Pre-PR-#172 the default 'null' classifier
+    # returned 0 = FcResultMatch and left `*[arg4]` uninitialised; on the
+    # lucky-zero stack frame Mozilla took the success branch with b=0 and
+    # never derefed the NULL pattern, which is why the issue was hidden.
+    #
+    # The 'fc_get_*_zero' classifiers reproduce that lucky-zero behaviour
+    # deterministically: populate `*[arg4]` with a zero value of the
+    # correct type, then return 0 = FcResultMatch.  Mozilla takes the
+    # success branch with b=0/i=0/d=0.0, doesn't touch the (possibly
+    # NULL) pattern pointer, and continues init.
+    #
+    # FcPatternGetString already has a typed populate-output body
+    # (recognises the DejaVu Sans sentinel pattern, writes a real
+    # path/family for FC_FILE / FC_FAMILY).  FcPatternGetCharSet /
+    # LangSet / FTFace remain on 'fc_no_match' — their callers in
+    # Mozilla's font-list path handle the NoMatch return cleanly and do
+    # not write back into the (possibly NULL) pattern.
+    #
+    # Spec: https://fontconfig.org/fontconfig-devel/fcpatternget.html
     'FcPatternGetString':      'fc_pattern_get_string',
-    'FcPatternGetBool':        'fc_no_match',
-    'FcPatternGetInteger':     'fc_no_match',
-    'FcPatternGetDouble':      'fc_no_match',
+    'FcPatternGetBool':        'fc_get_bool_zero',
+    'FcPatternGetInteger':     'fc_get_int_zero',
+    'FcPatternGetDouble':      'fc_get_double_zero',
     'FcPatternGetCharSet':     'fc_no_match',
     'FcPatternGetLangSet':     'fc_no_match',
     'FcPatternGetFTFace':      'fc_no_match',
@@ -769,16 +791,60 @@ def emit_stub(name, cat):
             f'}}\n'
         )
     elif cat == 'fc_no_match':
-        # FcPatternGet* (Bool / Integer / CharSet / LangSet / FTFace /
-        # Double / generic) — return FcResultNoMatch (1) so Mozilla
-        # treats the field as absent and falls through to its
-        # default-handling branches.  Critically NOT 'null' (which
-        # returns 0 = FcResultMatch and leaves the out-pointer
-        # uninitialised, causing downstream UB).  Spec:
+        # FcPatternGet* (CharSet / LangSet / FTFace / generic) — return
+        # FcResultNoMatch (1) so Mozilla treats the field as absent and
+        # falls through to its default-handling branches.  Critically
+        # NOT 'null' (which returns 0 = FcResultMatch and leaves the
+        # out-pointer uninitialised, causing downstream UB).  Spec:
         # https://fontconfig.org/fontconfig-devel/fcresult.html
         return (
             f'int {name}(...) {{\n'
             f'    return 1; /* FcResultNoMatch */\n'
+            f'}}\n'
+        )
+    elif cat == 'fc_get_bool_zero':
+        # FcResult FcPatternGetBool(const FcPattern *p, const char
+        # *object, int id, FcBool *b).  Populate *b with FcFalse (0)
+        # and return FcResultMatch (0) so Mozilla takes the success
+        # branch with b == 0 and never falls into failure paths that
+        # may dereference the (possibly NULL) pattern pointer to set
+        # error flags (orb $0x2, 0x9c(%rbx) at libxul+0x185b8a4).
+        # The NULL-out-pointer guard returns NoMatch — if the caller
+        # didn't supply a buffer they can't read uninitialised data.
+        # Spec: https://fontconfig.org/fontconfig-devel/fcpatterngetbool.html
+        # (FcBool is int per fontconfig.h.)
+        return (
+            f'int {name}(const void* p, const char* object, int id, int* b) {{\n'
+            f'    (void)p; (void)object; (void)id;\n'
+            f'    if (!b) return 1; /* defensive: NULL out-pointer → NoMatch */\n'
+            f'    *b = 0; /* FcFalse */\n'
+            f'    return 0; /* FcResultMatch */\n'
+            f'}}\n'
+        )
+    elif cat == 'fc_get_int_zero':
+        # FcResult FcPatternGetInteger(const FcPattern *p, const char
+        # *object, int id, int *i).  Same shape as fc_get_bool_zero:
+        # populate *i with 0 and return Match.  Spec:
+        # https://fontconfig.org/fontconfig-devel/fcpatterngetinteger.html
+        return (
+            f'int {name}(const void* p, const char* object, int id, int* i) {{\n'
+            f'    (void)p; (void)object; (void)id;\n'
+            f'    if (!i) return 1;\n'
+            f'    *i = 0;\n'
+            f'    return 0;\n'
+            f'}}\n'
+        )
+    elif cat == 'fc_get_double_zero':
+        # FcResult FcPatternGetDouble(const FcPattern *p, const char
+        # *object, int id, double *d).  Populate *d with 0.0 and return
+        # Match.  Spec:
+        # https://fontconfig.org/fontconfig-devel/fcpatterngetdouble.html
+        return (
+            f'int {name}(const void* p, const char* object, int id, double* d) {{\n'
+            f'    (void)p; (void)object; (void)id;\n'
+            f'    if (!d) return 1;\n'
+            f'    *d = 0.0;\n'
+            f'    return 0;\n'
             f'}}\n'
         )
     elif cat == 'fc_pattern_get_string':


### PR DESCRIPTION
## Summary

- Widen `FcPatternGetBool` / `FcPatternGetInteger` / `FcPatternGetDouble` stubs to populate the out-pointer with a typed zero (`FcFalse` / `0` / `0.0`) and return `FcResultMatch` (0), mirroring what `FcPatternGetString` already does for the DejaVu Sans sentinel pattern.
- Steers Mozilla's font-init code into the success branch with the zero value rather than the failure branch — the failure branch is what dereferences the (possibly-NULL) `FcPattern *` to set an error flag at `orb $0x2, 0x9c(%rbx)` (W86 reproduction at libxul+0x185b8a4).
- `FcPatternGetCharSet` / `LangSet` / `FTFace` stay on the existing `fc_no_match` classifier — their Mozilla callers handle the NoMatch return cleanly and do not write back into the pattern pointer.
- Each new body has a defensive NULL-out-pointer guard (`if (!arg4) return FcResultNoMatch`).

## Why this matters (W86 verification)

Pre-PR-#172 the default `null` classifier returned `0 = FcResultMatch` and left `*[arg4]` uninitialised. Mozilla took the success branch with whatever stack-garbage `b` happened to hold; on a lucky-zero frame it never derefed the NULL pattern. PR #172 widened these to `fc_no_match` (returns `1 = FcResultNoMatch`), which is spec-correct but deterministically pushes Mozilla into the failure branch that does `orb $0x2, 0x9c(%rbx)` on the (NULL) pattern pointer — W86 saw this in 3/9 firefox-test trials.

The fix here reproduces the pre-PR-#172 lucky-zero behaviour _deterministically_: populate `*b` / `*i` / `*d` with a typed zero, return Match. Mozilla now takes the success branch with `b == 0`, never derefs the pattern.

## objdump verification (libfontconfig.so.1, post-regen)

```
0000000000003722 <FcPatternGetBool>:
    3722:  endbr64
    3726:  push   %rbp
    3727:  mov    %rsp,%rbp
    372a:  mov    %rdi,-0x8(%rbp)
    372e:  mov    %rsi,-0x10(%rbp)
    3732:  mov    %edx,-0x14(%rbp)
    3735:  mov    %rcx,-0x20(%rbp)
    3739:  cmpq   $0x0,-0x20(%rbp)   ; NULL-out-pointer guard
    373e:  jne    3747
    3740:  mov    $0x1,%eax          ; return FcResultNoMatch on NULL b
    3745:  jmp    3756
    3747:  mov    -0x20(%rbp),%rax
    374b:  movl   $0x0,(%rax)        ; *b = FcFalse
    3751:  mov    $0x0,%eax          ; return FcResultMatch
    3756:  pop    %rbp
    3757:  ret
```

`FcPatternGetInteger` has the same shape (`movl $0x0,(%rax)`). `FcPatternGetDouble` uses `pxor %xmm0,%xmm0; movsd %xmm0,(%rax)`. `FcPatternGetCharSet` is unchanged (still the variadic `fc_no_match` body returning 1).

## 5-trial firefox-test progression

| Trial | clone3 | TIDs | spawn | outcome | W86 reproduction? |
|------:|-------:|-----:|------:|:-----|:---|
| 1     | 159    | 52   | 12    | exit_group(11) PID 1 | NO — fault is downstream of W86, post no-GPU fallback (libxul read at offset 0x9c, _not_ the orb-write pattern; user_rip=0x7efff5f168a4 + 0x7efff8711429) |
| 2     | 45     | 17   | 2     | alive — futex plateau | NO |
| 3     | 45     | 17   | 2     | alive — futex plateau, writing /tmp/ff-profile/cookies.sqlite | NO |
| 4     | 45     | 17   | 2     | alive — futex plateau, writing compatibility.ini | NO |
| 5     | 45     | 17   | 2     | alive — futex plateau | NO |

The W86 reproduction (`orb $0x2, 0x9c(%rbx)` write-fault at libxul+0x185b8a4 in the font-init path) no longer fires in any of the 5 trials. Trial 1 hit a different no-GPU-fallback codepath that ends in the W61-known crash sequence (`user_rip=0x7efff8711429`) — that's strictly downstream of the W86 site (post `Failed to initialize shared font list, falling back to in-process list`). Trials 2–5 don't go down the no-GPU fallback path at all and reach the sem_wait plateau noted in prior session memory, with Mozilla actively writing the SQLite profile database, compatibility.ini, etc.

## New wedge

The dominant remaining wedge for 4/5 trials is the **Mozilla sem_wait plateau** referenced in prior session notes — workers parking on POSIX semaphores at `0x7effffa89ae2` (`futex(FUTEX_WAIT_PRIVATE)`). Out of scope for this PR; tracked separately under the glibc sem_t / clone3-TLS layout investigation.

Trial 1 reveals a less-frequent path through Mozilla's no-GPU fallback that still hits a NULL-deref READ at libxul (offset 0x9c, _not_ the W86 orb-write). That's a different callsite (read pattern, not write pattern) and warrants its own dispatch if it persists; this PR closes the W86 reproduction specifically.

## Test plan

- [x] Stub generator regenerates without errors (`bash scripts/install-firefox-stubs.sh --force`)
- [x] objdump of the regenerated libfontconfig.so.1 confirms the populate-output + NULL-guard codegen for Bool/Integer/Double
- [x] FcPatternGetCharSet / LangSet / FTFace remain on the variadic `fc_no_match` body
- [x] 5-trial firefox-test progression: W86 reproduction (`orb $0x2, 0x9c(%rbx)` at libxul+0x185b8a4) no longer fires