### PR TITLE
tools/stubs: FcPatternGetString always populate *out (close libxul NULL-deref cluster)

### DIFF
--- a/scripts/install-firefox-stubs.sh
+++ b/scripts/install-firefox-stubs.sh
@@ -849,32 +849,42 @@ def emit_stub(name, cat):
         )
     elif cat == 'fc_pattern_get_string':
         # FcResult FcPatternGetString(const FcPattern *p, const char
-        # *object, int id, FcChar8 **s).  Returns FcResultMatch (0) for
-        # FC_FILE / FC_FAMILY queries against the DejaVu Sans pattern
-        # and FcResultNoMatch (1) otherwise.  Only id == 0 satisfies a
-        # match — the per-language loops in FindCanonicalNameIndex /
-        # AddPatternToFontList's otherFamilyNames walk increment id
-        # past zero and need the NoMatch to terminate.  Spec:
+        # *object, int id, FcChar8 **s).  ALWAYS populates *out with a
+        # valid non-NULL C string and returns FcResultMatch (0).
+        #
+        # Rationale: Mozilla's gfxFcPlatformFontList iterates per-language
+        # aliases by calling FcPatternGetString(p, ..., &out) repeatedly.
+        # When the stub previously returned NoMatch for non-sentinel
+        # patterns it left *out unset / NULL for non-matching slots; later
+        # code dereferenced the NULL string and faulted at libxul+0x185b8a4
+        # (mov reg, +const(%rbx) with %rbx=NULL) and libxul+0x4056429.
+        # Mirroring the fc_get_{bool,integer,double}_zero treatment (PR
+        # #175) and the precedent of always-populated FcPatternGet*: keep
+        # the AFCFBUTS-sentinel pattern's typed discrimination
+        # (object="file" → TTF path) so the access(F_OK|R_OK) check still
+        # succeeds, and for every other pattern / object / id return the
+        # family name "DejaVu Sans".  The NULL-out-pointer guard still
+        # returns NoMatch — a caller that didn't supply a buffer cannot
+        # read the result.  Spec:
         # https://fontconfig.org/fontconfig-devel/fcpatterngetstring.html
         return (
             f'int {name}(const void* p, const char* object, int id, const char** out) {{\n'
-            f'    if (!out) return 1;\n'
-            f'    *out = (const char*)0;\n'
-            f'    /* Only the DejaVu pattern carries real strings.  Other\n'
-            f'     * FcPattern pointers (e.g. _stub_placeholder) fall through. */\n'
-            f'    if (!p) return 1;\n'
-            f'    const unsigned long* w = (const unsigned long*)p;\n'
-            f'    if (w[0] != {hex(0x5354554246434641)}UL) return 1;\n'
-            f'    if (id != 0 || !object) return 1;\n'
-            f'    if (strcmp(object, "file") == 0) {{\n'
-            f'        *out = _stub_font_path;\n'
-            f'        return 0;\n'
+            f'    (void)id;\n'
+            f'    if (!out) return 1; /* defensive: NULL out-pointer → NoMatch */\n'
+            f'    /* AFCFBUTS-sentinel pattern with object="file" id=0 returns\n'
+            f'     * the TTF path so AddFontSetFamilies access() succeeds. */\n'
+            f'    if (p && object && strcmp(object, "file") == 0) {{\n'
+            f'        const unsigned long* w = (const unsigned long*)p;\n'
+            f'        if (w[0] == {hex(0x5354554246434641)}UL) {{\n'
+            f'            *out = _stub_font_path;\n'
+            f'            return 0;\n'
+            f'        }}\n'
             f'    }}\n'
-            f'    if (strcmp(object, "family") == 0) {{\n'
-            f'        *out = _stub_font_family;\n'
-            f'        return 0;\n'
-            f'    }}\n'
-            f'    return 1;\n'
+            f'    /* All other queries (any p incl. NULL, any object incl. NULL,\n'
+            f'     * any id): populate with the family name so Mozilla\'s per-\n'
+            f'     * language alias loops never see a NULL *out. */\n'
+            f'    *out = _stub_font_family;\n'
+            f'    return 0; /* FcResultMatch */\n'
             f'}}\n'
         )
     elif cat == 'fc_version':


### PR DESCRIPTION
## Summary

Mozilla's `gfxFcPlatformFontList` iterates per-language aliases by calling
`FcPatternGetString(p, ..., &out)` repeatedly. When the stub returned
`FcResultNoMatch` for non-AFCFBUTS-sentinel patterns it left `*out` unset
(or zeroed it) for the unmatched slot; libxul then dereferenced the NULL
string and faulted at two sites observed under W94's 7-trial soak:

- `libxul+0x185b8a4` — `mov reg, +const(%rbx)` with `%rbx=NULL` (2/7 trials)
- `libxul+0x4056429` — `mov reg, +const(%rbx)` with `%rbx=NULL` (same cluster)

Mirroring the `fc_get_{bool,integer,double}_zero` precedent in PR #175,
this PR makes `FcPatternGetString` **always populate `*out` with a valid
non-NULL C string and return `FcResultMatch` (0)**:

- AFCFBUTS-sentinel pattern + `object="file"` + `id=0` -> `_stub_font_path`
  (the TTF path, so `AddFontSetFamilies` `access(F_OK|R_OK)` still succeeds)
- Every other query — any `p` (incl. NULL), any `object` (incl. NULL),
  any `id` — populates with `_stub_font_family` ("DejaVu Sans") and returns
  Match.
- The NULL-out-pointer guard (`!out`) still returns `NoMatch (1)` defensively.

## objdump verification (build/disk/lib64/libfontconfig.so.1)

```
0000000000003904  cmpq   $0x0,-0x30(%rbp)         ; NULL-out guard
0000000000003909  jne    3912
000000000000390b  mov    $0x1,%eax                ; NoMatch
0000000000003910  jmp    3980

0000000000003912  cmpq   $0x0,-0x18(%rbp)         ; p != NULL ?
0000000000003917  je     396d
0000000000003919  cmpq   $0x0,-0x20(%rbp)         ; object != NULL ?
000000000000391e  je     396d
0000000000003920..3938  strcmp(object, "file") == 0 ?
000000000000393a..3956  w[0] == 0x5354554246434641 (AFCFBUTS) ?
0000000000003958  *out = _stub_font_path
0000000000003966  eax = 0                          ; Match
000000000000396b  jmp    3980

000000000000396d  *out = _stub_font_family         ; fallback
0000000000003978  eax = 0                          ; Match

0000000000003980  leave ; ret
```

Confirms: NULL-out guard returns NoMatch + AFCFBUTS+`object="file"`
populates with the TTF path + every other path populates with the family
name and returns Match.

## Latent follow-up (not in this PR)

W94 also flagged a weak-undefined `moz_xmalloc` reference in libxul with
no defining provider on the data disk. The always-populate behaviour
above will mask that latent NULL source if it was contributing to either
crash site. Once the FcPatternGetString cluster is confirmed closed,
audit for residual weak-undefined symbols whose runtime resolution to 0
could produce similar `mov-(%rbx)` faults.

## Test plan

- [ ] objdump verification matches (already shown above)
- [ ] 5-trial firefox-test soak: confirm `libxul+0x185b8a4` and `libxul+0x4056429`
      SIGSEGVs are gone
- [ ] 5/5 trials reach the `sem_wait` plateau (no libxul NULL-deref crashes en route)
- [ ] Capture Mozilla progression counters: sc / clone3 / execve / TID counts
- [ ] Surface any new crash sites (e.g. moz_xmalloc latent issue surfacing)

Diff: 1 file, +32 / -22 (stub body comment expansion + 2-line behaviour change).

Builds on PR #175 (FcPatternGet{Bool,Integer,Double} populate-output) and
PR #172 (one-element FcFontSet + DejaVuSans.ttf install).