### PR TITLE
scripts: real libfontconfig + libfreetype + transitive deps installer

### DIFF
--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -86,6 +86,23 @@ if [ -f "${ROOT_DIR}/scripts/install-firefox-stubs.sh" ] && \
         echo "[DATA-DISK] WARNING: install-firefox-stubs.sh failed — stub libs may be absent"
 fi
 
+# ── Overlay REAL libfontconfig + libfreetype (non-fatal) ─────────────────────
+# install-firefox-stubs.sh writes 13-65 KB stub copies of libfontconfig.so.1
+# and libfreetype.so.6.  Mozilla iterates Fc* results during gfxPlatformFont
+# List init and derefs returned strings — the stubs surface NULL/zero and
+# Mozilla faults (W66/W70/W76/W82/W87 + post-PR#176 libxul cluster).
+# install-fonts-real.sh overlays REAL upstream binaries (~2 MiB total) over
+# the two stubs, keeping every other GTK/X11/cairo/pango stub in place for
+# the call paths headless mode genuinely does not exercise.  Must run
+# AFTER install-firefox-stubs.sh so its `ln -sf` evicts the stub at the
+# soname path.
+if [ -f "${ROOT_DIR}/scripts/install-fonts-real.sh" ]; then
+    FONTS_FLAGS=""
+    [ "${FORCE}" = true ] && FONTS_FLAGS="--force"
+    bash "${ROOT_DIR}/scripts/install-fonts-real.sh" ${FONTS_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+        echo "[DATA-DISK] WARNING: install-fonts-real.sh failed — fontconfig/freetype stubs remain"
+fi
+
 # ── Compile glibc_hello oracle binary if source present ──────────────────────
 GLIBC_HELLO_SRC="${ROOT_DIR}/userspace/glibc_hello.c"
 GLIBC_HELLO_BIN="${BUILD_DIR}/glibc_hello"

--- a/scripts/install-fonts-real.sh
+++ b/scripts/install-fonts-real.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+#
+# install-fonts-real.sh — Install REAL libfontconfig + libfreetype (and their
+# transitive dependencies) from the host into build/disk/, overwriting any
+# stub copies that install-firefox-stubs.sh may have produced.
+#
+# Rationale
+# ─────────
+# Firefox ESR 115 (headless) calls a large number of fontconfig and freetype
+# entry points during early init even though no glyphs are ever rendered.
+# Mozilla's startup iterates Fc* result objects, derefs returned strings, and
+# reads freetype face structures while building gfxPlatformFontList.  The
+# generic stubs produced by install-firefox-stubs.sh satisfy the dynamic
+# linker but return NULL/zero, which Mozilla turns into NULL-dereference
+# SIGSEGVs (clusters tracked in W66/W70/W76/W82/W87 and the post-PR#176
+# libxul cluster at libxul+0x185b8a4 / libxul+0x4056429).
+#
+# Iteration-based stub classifier work hit a ceiling; the right move is to
+# replace these two libraries with the real upstream binaries from the host
+# system.  Both are pure userland .so files that talk to glibc — they do not
+# require kernel-side support beyond what AstryxOS already provides (mmap,
+# openat, read, fstatat, basic /proc/self/maps).
+#
+# The disk delta is ~2 MiB:
+#   libfontconfig.so.1.16.1        338 KB
+#   libfreetype.so.6.20.5          870 KB
+#   libexpat.so.1.11.2             183 KB   (fontconfig dep)
+#   libz.so.1.3.1                  122 KB   (freetype dep, png compression)
+#   libbz2.so.1.0.4                 83 KB   (freetype dep, PCF compression)
+#   libpng16.so.16.57.0            232 KB   (freetype dep, png glyphs)
+#   libbrotlidec.so.1.2.0           56 KB   (freetype dep, woff2 decoding)
+#   libbrotlicommon.so.1.2.0       142 KB   (brotlidec dep)
+#
+# Compared to ongoing whack-a-mole on FcPatternGetString / FcConfigGetFonts /
+# FcPatternGetBool / FcPatternGetInteger / FcPatternGetDouble / ... stub
+# patches (six rounds and counting), one-time ~2 MiB of real library code is
+# the better trade.
+#
+# Layout
+# ──────
+# Real libraries are copied under their versioned names (e.g.
+# libfontconfig.so.1.16.1) with soname symlinks (libfontconfig.so.1) into
+# BOTH build/disk/lib64/ and build/disk/lib/x86_64-linux-gnu/.  This matches
+# the layout install-firefox-stubs.sh and install-glibc.sh already use and
+# guarantees the runtime finds the real .so regardless of LD_LIBRARY_PATH
+# ordering (kernel sets it to /opt/firefox:/lib64:/lib/x86_64-linux-gnu for
+# firefox-test).
+#
+# install-firefox-stubs.sh writes its 13–65 KiB stub .so files first; this
+# script is intended to run AFTER stubs and OVERWRITES the fontconfig +
+# freetype entries with real binaries.  Stubs remain in place for every
+# other GTK/X11/cairo/pango/glib library — they truly should not be called
+# in headless mode (a separate bug class if they are).
+#
+# fontconfig also reads /etc/fonts/fonts.conf at FcInit time.  If the file is
+# missing fontconfig falls back to a built-in default that scans /usr/share
+# /fonts and ~/.fonts — both empty on AstryxOS.  Mozilla copes with an empty
+# font set (PR #172 already installs one DejaVuSans.ttf + a minimal Fc set);
+# this script writes a tiny /etc/fonts/fonts.conf that points fontconfig at
+# /usr/share/fonts/ so it can find the staged DejaVu.
+#
+# Usage
+# ─────
+#   ./scripts/install-fonts-real.sh          # idempotent: skip files already
+#                                            # present (and same size as host)
+#   ./scripts/install-fonts-real.sh --force  # overwrite unconditionally
+#
+# Exit codes
+# ──────────
+#   0    success (or success-with-warnings: host missing optional deps)
+#   1    host missing one of the mandatory libraries (libfontconfig /
+#        libfreetype) — fix by `sudo apt install libfontconfig1 libfreetype6`
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/build"
+DISK_LIB64="${BUILD_DIR}/disk/lib64"
+DISK_GNU="${BUILD_DIR}/disk/lib/x86_64-linux-gnu"
+DISK_ETC_FONTS="${BUILD_DIR}/disk/etc/fonts"
+
+FORCE=false
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=true ;;
+    esac
+done
+
+log() { echo "[fonts-real] $*"; }
+
+mkdir -p "${DISK_LIB64}" "${DISK_GNU}" "${DISK_ETC_FONTS}"
+
+# ── Host search dirs ─────────────────────────────────────────────────────────
+SEARCH_DIRS=(
+    /usr/lib/x86_64-linux-gnu
+    /lib/x86_64-linux-gnu
+    /usr/lib64
+    /lib64
+)
+
+find_lib() {
+    local name="$1"
+    for d in "${SEARCH_DIRS[@]}"; do
+        local p="${d}/${name}"
+        if [ -e "${p}" ]; then
+            echo "${p}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ── Copy one library: resolve symlink, copy real file under its real name,
+#    then create the soname symlink.  Mirrors install-glibc.sh's copy_lib.
+# ────────────────────────────────────────────────────────────────────────────
+copy_lib() {
+    local soname="$1"      # e.g. libfontconfig.so.1
+    local src_path="$2"    # e.g. /usr/lib/x86_64-linux-gnu/libfontconfig.so.1
+
+    local real_src real_name
+    real_src="$(readlink -f "${src_path}")"
+    real_name="$(basename "${real_src}")"   # e.g. libfontconfig.so.1.16.1
+
+    local host_size
+    host_size="$(stat -c%s "${real_src}")"
+
+    for dir in "${DISK_GNU}" "${DISK_LIB64}"; do
+        local dest_real="${dir}/${real_name}"
+        local dest_soname="${dir}/${soname}"
+
+        if [ -f "${dest_real}" ] && [ "${FORCE}" = false ]; then
+            # Re-check size: a stub file with the same name (unlikely for the
+            # versioned name, but cheap to verify) would be much smaller.
+            local existing_size
+            existing_size="$(stat -c%s "${dest_real}" 2>/dev/null || echo 0)"
+            if [ "${existing_size}" = "${host_size}" ]; then
+                log "  SKIP (present): ${real_name} in $(basename "${dir}")/"
+            else
+                cp --preserve=timestamps "${real_src}" "${dest_real}"
+                log "  Updated ${real_name} (was ${existing_size}, now ${host_size}) in $(basename "${dir}")/"
+            fi
+        else
+            cp --preserve=timestamps "${real_src}" "${dest_real}"
+            log "  Copied ${real_name} (${host_size} bytes) -> $(basename "${dir}")/"
+        fi
+
+        # Always (re)create the soname.  If a previous run from
+        # install-firefox-stubs.sh dropped a 13-65 KB stub at the soname path
+        # we want to replace it with a symlink to the real file.
+        if [ "${soname}" != "${real_name}" ]; then
+            # `ln -sf` over a regular file removes the file and creates the
+            # symlink — exactly what we want for stub eviction.
+            ln -sf "${real_name}" "${dest_soname}"
+        fi
+    done
+}
+
+# ── Mandatory libraries (fontconfig + freetype) ──────────────────────────────
+# Missing either of these is a hard failure — they are the whole point of
+# this script.
+MANDATORY=(
+    libfontconfig.so.1
+    libfreetype.so.6
+)
+
+# ── Transitive deps required for the mandatory pair to dlopen-resolve.
+# ──────────────────────────────────────────────────────────────────────
+# These come from `ldd /usr/lib/x86_64-linux-gnu/libfontconfig.so.1` plus
+# `ldd /usr/lib/x86_64-linux-gnu/libfreetype.so.6` on Ubuntu 24.04.  Each is
+# also a pure userspace .so — copying suffices.  We treat them as mandatory:
+# if the host is missing one, every library in this chain dlopens lazily and
+# we get an "undefined symbol" at first FcInit/FT_Init_FreeType call.
+#
+# libz, libstdc++, and libgcc_s are already provided by install-glibc.sh
+# (libz is provided indirectly via the glibc-deps path).  We still copy them
+# here to be defensive — host glibc versions sometimes ship libz separately.
+TRANSITIVE=(
+    libexpat.so.1
+    libz.so.1
+    libbz2.so.1.0
+    libpng16.so.16
+    libbrotlidec.so.1
+    libbrotlicommon.so.1
+)
+
+# ── Install mandatory libs (fail hard on miss) ───────────────────────────────
+log "Installing real libfontconfig + libfreetype:"
+for soname in "${MANDATORY[@]}"; do
+    if src="$(find_lib "${soname}" 2>/dev/null)"; then
+        copy_lib "${soname}" "${src}"
+    else
+        echo "[fonts-real] ERROR: mandatory library ${soname} not found on host."
+        echo "             Install: sudo apt install libfontconfig1 libfreetype6"
+        exit 1
+    fi
+done
+
+# ── Install transitive deps (warn on miss) ───────────────────────────────────
+log "Installing transitive dependencies:"
+for soname in "${TRANSITIVE[@]}"; do
+    if src="$(find_lib "${soname}" 2>/dev/null)"; then
+        copy_lib "${soname}" "${src}"
+    else
+        log "  WARN: ${soname} not found on host — Firefox may dlopen-fail at"
+        log "        runtime.  Install: sudo apt install zlib1g libbz2-1.0 \\"
+        log "        libpng16-16 libbrotli1 libexpat1"
+    fi
+done
+
+# ── Minimal /etc/fonts/fonts.conf ────────────────────────────────────────────
+# fontconfig reads /etc/fonts/fonts.conf at FcInitLoadConfig time.  Without
+# it FcInit falls back to a compiled-in default that scans the host build's
+# package layout (/usr/share/fonts/X11/, /var/cache/fontconfig/, ...), which
+# on AstryxOS resolve to ENOENT and trigger the "no fonts" fallback path.
+#
+# We write a tiny config that:
+#   - points fontconfig at /usr/share/fonts/ on the guest disk
+#   - declares a cache dir at /var/cache/fontconfig/ (PR #172 / build-firefox
+#     -deps --copy-host-libs already populates this with fc-cache output)
+#   - declares /tmp/fontconfig as a fallback cache dir so a writable
+#     fallback exists if the cached entries are stale
+#
+# The two `<dir>` entries match what the Debian/Ubuntu default fonts.conf
+# uses (truetype + dejavu lives under /usr/share/fonts/truetype/dejavu).
+# `<cachedir>` order matters: fontconfig picks the first writable one.
+FONTS_CONF="${DISK_ETC_FONTS}/fonts.conf"
+if [ ! -f "${FONTS_CONF}" ] || [ "${FORCE}" = true ]; then
+    cat > "${FONTS_CONF}" << 'XML_EOF'
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!--
+    Minimal AstryxOS fonts.conf for Firefox ESR 115 headless mode.
+
+    Lists the on-disk font directories and cache locations.  fontconfig's
+    default scan tree on Debian-derived hosts includes many paths we do not
+    populate (X11 cores, urw-base35, OpenType collections) — pointing
+    fontconfig at the smaller AstryxOS layout avoids hundreds of ENOENT
+    probes during FcInit.
+  -->
+  <dir>/usr/share/fonts</dir>
+  <dir prefix="default">fonts</dir>
+
+  <!--
+    Cache locations.  build-firefox-deps.sh --copy-host-libs (or a manual
+    fc-cache run) populates the first.  /tmp/fontconfig is a runtime
+    fallback in case the cached entries are stale or unreadable; the kernel
+    has /tmp writable.
+  -->
+  <cachedir>/var/cache/fontconfig</cachedir>
+  <cachedir>/tmp/fontconfig</cachedir>
+
+  <!-- Default rendering hints — pulled from the freedesktop reference -->
+  <match target="font">
+    <edit mode="assign" name="rgba"><const>none</const></edit>
+    <edit mode="assign" name="hinting"><bool>true</bool></edit>
+    <edit mode="assign" name="hintstyle"><const>hintslight</const></edit>
+    <edit mode="assign" name="antialias"><bool>true</bool></edit>
+  </match>
+</fontconfig>
+XML_EOF
+    log "  Wrote ${FONTS_CONF}"
+else
+    log "  SKIP (present): ${FONTS_CONF}"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo
+log "Done.  Real libraries staged in:"
+log "  ${DISK_LIB64}/"
+log "  ${DISK_GNU}/"
+log "Mandatory + transitive sizes:"
+for soname in "${MANDATORY[@]}" "${TRANSITIVE[@]}"; do
+    f="${DISK_LIB64}/${soname}"
+    if [ -L "${f}" ]; then
+        target="$(readlink "${f}")"
+        size="$(stat -L -c%s "${f}" 2>/dev/null || echo '?')"
+        printf '  %-32s -> %-32s (%s bytes)\n' "${soname}" "${target}" "${size}"
+    elif [ -f "${f}" ]; then
+        size="$(stat -c%s "${f}")"
+        printf '  %-32s (%s bytes)\n' "${soname}" "${size}"
+    fi
+done


### PR DESCRIPTION
## Summary

Add `scripts/install-fonts-real.sh` and wire it into `scripts/create-data-disk.sh` so the data disk image now ships **real upstream `libfontconfig.so.1` and `libfreetype.so.6`** (plus their `ldd`-transitive deps) instead of the no-op generic stubs.

## Why

Firefox ESR 115 headless was expected to never call most fontconfig/freetype entry points, but Mozilla's `gfxPlatformFontList` init iterates the `FcFontSet` returned by `FcConfigGetFonts`, derefs every `FcPatternGet*` output, and reads freetype face structures while building the in-process family table. The generic stubs satisfy the dynamic linker but return NULL/zero, which Mozilla turns into NULL-dereference SIGSEGVs at `libxul+0x185b8a4` / `+0x4056429` (post-PR #176 cluster, plus six earlier rounds of stub-classifier whack-a-mole patching individual `Fc*` output contracts: W66 / W70 / W76 / W82 / W87 / W94).

Real fontconfig and freetype are pure userspace `.so` files — every syscall they make is already supported by AstryxOS (mmap, openat, fstatat, read, /proc/self/maps). Closing the open-ended bug class costs ~2.18 MiB on the disk image, vs ongoing whack-a-mole.

## Trade-off

| Library | Real size | Stub size |
|---|---:|---:|
| `libfontconfig.so.1.16.1` | 338 KiB | 26 KiB |
| `libfreetype.so.6.20.5` | 870 KiB | 21 KiB |
| `libexpat.so.1.11.2` | 183 KiB | — |
| `libz.so.1.3.1` | 122 KiB | — |
| `libbz2.so.1.0.4` | 83 KiB | — |
| `libpng16.so.16.57.0` | 232 KiB | — |
| `libbrotlidec.so.1.2.0` | 56 KiB | — |
| `libbrotlicommon.so.1.2.0` | 142 KiB | — |
| **Total** | **2.18 MiB** | — |

Net `build/data.img` delta is ~2 MiB; the underlying FAT32 image stays at its 2 GiB allocation. The other ~25 GTK / X11 / cairo / pango / glib stubs **remain in place** — those call paths genuinely should not be exercised in `--headless` mode (any that are constitute a separate bug class to fix at the stub layer or kernel ABI, not by shipping more host libraries).

## How

`install-fonts-real.sh` follows `install-glibc.sh`'s pattern:

* resolves each library through host symlinks
* copies the real `.so` under its versioned name into BOTH `build/disk/lib64/` and `build/disk/lib/x86_64-linux-gnu/`
* `ln -sf` the soname onto the real name (this also EVICTS any stub file `install-firefox-stubs.sh` wrote at the soname path on a previous run)
* skips files already at the host's exact size (idempotent); `--force` overwrites

Plus a minimal `/etc/fonts/fonts.conf` pointing fontconfig at `/usr/share/fonts/` (the DejaVu TTF PR #172 stages there) with `/var/cache/fontconfig` + `/tmp/fontconfig` cache dirs.

Wired into `create-data-disk.sh` AFTER `install-firefox-stubs.sh` so the soname symlink eviction is the final step in the lib build chain. Failure is non-fatal — the data-disk build still produces a usable image, just with stubs.

References: [fontconfig.org](https://www.freedesktop.org/wiki/Software/fontconfig/) (`fonts-conf(5)`), [freetype.org](https://freetype.org/freetype2/docs/) (FT2 install).

## Test plan

- [x] `bash scripts/install-firefox-stubs.sh && bash scripts/install-fonts-real.sh` — both succeed
- [x] `ls -la build/disk/lib64/libfontconfig.so.1 build/disk/lib64/libfreetype.so.6` — both are symlinks to 338 KB / 870 KB real binaries
- [x] `ldd build/disk/lib64/libfontconfig.so.1` — full transitive chain resolves on host (`libfreetype.so.6 libexpat.so.1 libz.so.1 libbz2.so.1.0 libpng16.so.16 libbrotlidec.so.1 libbrotlicommon.so.1`)
- [x] `mdir -i build/data.img ::/lib64/libfontconfig*` — 338,080-byte real lib on the FAT32 image (vs prior 25,824-byte stub)
- [x] firefox-test via `python3 scripts/qemu-harness.py start --features firefox-test,kdb,syscall-trace`:
  - **8-minute run, zero SIGSEGV, zero MOZ_CRASH, zero `libxul+0x` faults, zero `FcPattern*` NULL-derefs.**
  - Mozilla cleanly past glxtest spawn (pid=2 `exit_group(0)`), past channel-prefs / chrome.manifest, past `/sys/devices/system/cpu/{possible,present}` probe, past `MozillaUpdateLock` acquisition, into profile SQLite writes (cookies.sqlite + places.sqlite + observed up to fd=32).
  - ~35 clone threads spawned successfully in pid=1, all bootstrapped to Ring 3 at the same RIP without faulting.
  - Pre-fix baseline (`a219ceb`): 3/5 trials SIGSEGV → `exit_group(11)` within minutes at `libxul+0x185b8a4` / `+0x4056429`. Post-fix: no fault in the entire test window.