### PR TITLE
scripts/astryx_qemu: TCG-safe CPU model fallback (close AVX-512 IFUNC trap)

### DIFF
--- a/scripts/astryx_qemu.py
+++ b/scripts/astryx_qemu.py
@@ -31,14 +31,19 @@ differences are therefore visible in one file.
    controllers, so the ATA probe sees hardware regardless of where
    the data.img is attached.
 
-2. **CPU — `host` when KVM available, `qemu64,+rdtscp,+sse4_2` under TCG.**
+2. **CPU — `host` under KVM, a TCG-safe baseline under TCG.**
 
-   Rationale: `host` matches what a physical boot would encounter on
-   the developer's workstation (the target surface Firefox actually
-   hits). `qemu64,+rdtscp,+sse4_2` is the minimum feature set we rely
-   on in the kernel (rdtscp for vDSO-style timing, sse4.2 for
-   compiler-generated string ops). Firefox-test mode can force `host`
-   because it requires KVM to be fast enough anyway.
+   Rationale: under KVM, `host` matches what a physical boot would
+   encounter on the developer's workstation (the target surface
+   Firefox actually hits). Under TCG, we must NOT advertise host
+   CPUID — glibc's IFUNC resolver reads CPUID and selects
+   AVX-512/AVX10/SHA-NI variants of `memcpy`/`strcmp`/etc that TCG
+   cannot decode at runtime, triggering #UD and looking like a
+   userspace crash. The TCG baseline (`qemu64` + safe extensions
+   through AVX2/FMA, no AVX-512, no AVX10, no SHA-NI) gives glibc
+   enough ISA to pick fast SSE/AVX2 variants while staying inside
+   TCG's emulated instruction set. See QEMU `docs/system/i386/cpu.rst`
+   for the per-feature decode status.
 
 3. **Memory — 1 GiB default, 2 GiB for firefox mode.**
 
@@ -78,6 +83,29 @@ _SMP = int(os.environ.get("ASTRYX_SMP", "2"))
 #: 1 → QEMU exit(3)=fail. Shared with run-test.sh semantics.
 _ISA_DEBUG_EXIT = ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"]
 
+#: TCG-safe CPU baseline. `qemu64` is the QEMU-defined model whose
+#: feature set TCG fully decodes; the `+` extensions below are all
+#: TCG-decoded in QEMU >= 7 and give glibc's IFUNC resolver enough
+#: ISA surface to pick a fast (SSE4.2 / AVX2 / FMA) variant of
+#: `memcpy`, `strcmp`, etc. Critically we do NOT advertise:
+#:   • AVX-512* (any flavour) — TCG decodes a subset only; many
+#:     vector ops trap as #UD at runtime
+#:   • AVX10 (Intel) — not in TCG
+#:   • SHA-NI (Intel SHA extension) — Mozilla NSS picks this when
+#:     present; TCG decodes only a subset and the resolver falls
+#:     into a path that issues an unsupported opcode
+#: When KVM is in use we want `-cpu host` instead so guest CPUID
+#: matches hardware exactly.
+_TCG_SAFE_CPU = (
+    "qemu64"
+    ",+ssse3,+sse4_1,+sse4_2"   # SSE family — palignr, pcmpistri
+    ",+avx,+avx2,+fma"           # AVX2 + FMA for memcpy/memmove
+    ",+rdtscp"                   # vDSO-style timing path
+    ",+popcnt"                   # std::popcount IFUNC
+    ",+aes,+pclmulqdq"           # NSS AES-NI / CRC32C
+    ",+cmov"                     # universally assumed since P6
+)
+
 
 # ── Host feature detection ────────────────────────────────────────────────────
 
@@ -88,32 +116,38 @@ def _detect_kvm() -> bool:
 
 # ── Block assemblers ──────────────────────────────────────────────────────────
 
-def _cpu_args(mode: str, kvm: bool, cpu_override: Optional[str] = None) -> list[str]:
+def cpu_model_for(mode: str, kvm: bool,
+                  cpu_override: Optional[str] = None) -> tuple[str, str]:
     """
-    CPU model. Under KVM we prefer `host` because that matches what a
-    real-hardware boot would encounter — critical for Firefox and any
-    test that exercises CPUID. Under TCG we fall back to a feature set
-    that mirrors what glibc's IFUNC dispatcher will select on a typical
-    modern host (+rdtscp, +ssse3, +sse4.1, +sse4.2): glibc's optimised
-    string routines (strcmp, strncmp, memcpy) emit `palignr` (SSSE3)
-    and `pcmpistri` (SSE4.2), so omitting either makes the very first
-    libc call from any non-trivial userspace process raise #UD.
+    Return ``(cpu_model, reason)`` for the given mode + KVM state.
 
-    firefox-test forces `-cpu host` because its perf target is
-    unreachable under TCG; if KVM is absent the run will be slow but
-    correct.
+    ``reason`` is a short tag suitable for structured logging:
+      * ``"override"``  — caller passed ``cpu_override`` verbatim
+      * ``"kvm-host"``  — KVM available, using ``-cpu host`` for fidelity
+      * ``"tcg-safe"``  — TCG path, using the AVX2/FMA-capped baseline
+                          to avoid AVX-512/AVX10/SHA-NI IFUNC traps
 
-    `cpu_override` (if set) bypasses every other rule and passes
-    `-cpu <value>` verbatim. Used by perf investigations that need to
-    sweep CPU models (e.g. `-cpu max`, `-cpu Cascadelake-Server`).
+    The "firefox-test forces host" special case (formerly here) has
+    been removed: under TCG it would advertise host CPUID, glibc's
+    IFUNC resolver would pick AVX-512 ``memcpy`` variants, and TCG
+    would fault on the first unsupported vector op. Firefox-test under
+    TCG is slow regardless; correctness wins.
     """
     if cpu_override:
-        return ["-cpu", cpu_override]
-    if mode == "firefox-test":
-        return ["-cpu", "host"]
+        return cpu_override, "override"
     if kvm:
-        return ["-cpu", "host"]
-    return ["-cpu", "qemu64,+rdtscp,+ssse3,+sse4_1,+sse4_2"]
+        return "host", "kvm-host"
+    return _TCG_SAFE_CPU, "tcg-safe"
+
+
+def _cpu_args(mode: str, kvm: bool, cpu_override: Optional[str] = None) -> list[str]:
+    """
+    QEMU ``-cpu`` argv fragment. Delegates the model choice to
+    :func:`cpu_model_for`; this wrapper exists so callers that only
+    want the argv (most of them) need not unpack the reason tag.
+    """
+    model, _reason = cpu_model_for(mode, kvm, cpu_override)
+    return ["-cpu", model]
 
 
 def _memory_args(mode: str) -> list[str]:

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -1321,14 +1321,34 @@ def cmd_start(args):
                 )
 
     kvm_arg: Optional[bool]
-    if getattr(args, "no_kvm", False):
+    no_kvm_flag = bool(getattr(args, "no_kvm", False))
+    force_kvm_flag = bool(getattr(args, "force_kvm", False))
+    if no_kvm_flag:
         kvm_arg = False
-    elif getattr(args, "force_kvm", False):
+    elif force_kvm_flag:
         kvm_arg = True
     else:
         kvm_arg = None  # autodetect
     smp = int(getattr(args, "smp", 2) or 2)
     cpu_model = getattr(args, "cpu_model", None)
+
+    # Resolve effective KVM state + CPU model up-front so we can log the
+    # decision (W106: catches "TCG run with -cpu host advertising AVX-512
+    # → glibc IFUNC trap → spurious #UD" misconfiguration before launch).
+    kvm_effective = (
+        kvm_arg if kvm_arg is not None else astryx_qemu._detect_kvm()
+    )
+    cpu_model_resolved, cpu_model_reason = astryx_qemu.cpu_model_for(
+        mode="test", kvm=kvm_effective, cpu_override=cpu_model,
+    )
+    kvm_available = astryx_qemu._detect_kvm()
+    print(
+        f"[harness] cpu_model={cpu_model_resolved} reason={cpu_model_reason} "
+        f"(kvm_available={kvm_available}, no_kvm_flag={no_kvm_flag}, "
+        f"force_kvm_flag={force_kvm_flag})",
+        file=sys.stderr,
+    )
+
     proc = _launch_qemu_harness(sid, serial_log, qmp_sock, ovmf_vars,
                                  gdb_port=gdb_port, gdb_wait=gdb_wait,
                                  kdb_host_port=kdb_host_port,
@@ -1352,6 +1372,16 @@ def cmd_start(args):
         "kdb_host_port": kdb_host_port,
         "smp":         smp,
         "cpu_model":   cpu_model or "default",
+        # W106: capture the resolved CPU model + reason so post-hoc
+        # investigations can tell whether a run was on `-cpu host` (KVM
+        # fidelity path) or the TCG-safe baseline. Additive — never
+        # rename these keys without updating downstream agents.
+        "cpu_model_resolved": cpu_model_resolved,
+        "cpu_model_reason":   cpu_model_reason,
+        "kvm_available":      kvm_available,
+        "kvm_effective":      bool(kvm_effective),
+        "no_kvm_flag":        no_kvm_flag,
+        "force_kvm_flag":     force_kvm_flag,
         "breakpoints": [],
         # True when data.img was absent at session start (after any auto-symlink
         # attempt). Agents inspecting this field can immediately distinguish a
@@ -1389,8 +1419,30 @@ def cmd_start(args):
     session["watcher_pid"] = watcher_proc.pid
     _save_session(session)
 
+    # W106: record the CPU-model decision in the event stream so a single
+    # `events <sid>` invocation reveals whether the run was on KVM fidelity
+    # or the TCG-safe baseline. Investigations of "spurious #UD" / SIGSEGV
+    # clusters check this first.
+    _emit_event(sid, {
+        "kind": "cpu_model",
+        "model": cpu_model_resolved,
+        "reason": cpu_model_reason,
+        "kvm_available": kvm_available,
+        "kvm_effective": bool(kvm_effective),
+        "no_kvm_flag": no_kvm_flag,
+        "force_kvm_flag": force_kvm_flag,
+        "cpu_override": cpu_model,
+    })
+
     _out({"sid": sid, "pid": proc.pid, "serial_log": serial_log,
           "gdb_port": gdb_port, "kdb_host_port": kdb_host_port,
+          # W106: structured CPU-model fields. `cpu_model_resolved` is
+          # the literal string passed to QEMU `-cpu`; `cpu_model_reason`
+          # is one of "override" | "kvm-host" | "tcg-safe".
+          "cpu_model_resolved": cpu_model_resolved,
+          "cpu_model_reason":   cpu_model_reason,
+          "kvm_available":      kvm_available,
+          "kvm_effective":      bool(kvm_effective),
           # True when data.img was absent (even after auto-symlink attempt).
           # Agents should treat this as a hard warning for firefox-test runs.
           "data_img_missing": _data_img_missing,
@@ -4882,9 +4934,10 @@ def main():
                           help="Override QEMU -cpu model verbatim (e.g. 'host', "
                                "'max', 'Cascadelake-Server', 'EPYC-Genoa-v1', "
                                "'qemu64'). When unset, astryx_qemu.py picks: "
-                               "'host' under KVM, otherwise "
-                               "'qemu64,+rdtscp,+ssse3,+sse4_1,+sse4_2'. Used "
-                               "by perf sweeps to vary VMEXIT surface.")
+                               "'host' under KVM, otherwise the TCG-safe "
+                               "qemu64+SSE4.2/AVX2/FMA baseline (no AVX-512, "
+                               "no AVX10, no SHA-NI — see astryx_qemu._TCG_SAFE_CPU). "
+                               "Used by perf sweeps to vary VMEXIT surface.")
     p_start.add_argument("--no-regen-data-img", action="store_true",
                           dest="no_regen_data_img",
                           help="Skip the auto-regen of build/data.img when "


### PR DESCRIPTION
## Summary

`scripts/astryx_qemu.py` unconditionally selected `-cpu host` for
`mode=firefox-test` regardless of KVM availability. Under TCG (e.g. when
the harness is invoked with `--no-kvm`), that advertised the host's full
CPUID — including AVX-512, AVX10, and SHA-NI — to the guest. glibc's
IFUNC resolver reads CPUID and selects `memcpy` / `strcmp` /
`__strncpy_avx2_rtm` variants accordingly; TCG cannot decode many of
those opcodes at runtime, and the very first call into one of them
raised #UD. The kernel reflected the trap to userspace as a fatal
exception, which the trace pipeline rendered as `SIGSEGV` /
`exit_group(-6)` clusters in the `0x7efff{a,b}...` libc / libxul
region — the **W100-CLUSTER-A** symptom investigations had been
chasing as a real Mozilla bug.

This change removes the special-case and makes the selection a function
of KVM state only:

- `--cpu MODEL` → use MODEL verbatim (`reason="override"`)
- KVM available + not `--no-kvm` → `-cpu host` (`reason="kvm-host"`)
- KVM unavailable OR `--no-kvm` → TCG-safe baseline (`reason="tcg-safe"`)

The TCG-safe baseline is:

```
qemu64,+ssse3,+sse4_1,+sse4_2,+avx,+avx2,+fma,
      +rdtscp,+popcnt,+aes,+pclmulqdq,+cmov
```

— enough ISA for glibc's IFUNC dispatcher to pick fast SSE4.2 / AVX2 /
FMA variants while staying inside TCG's emulated instruction set, with
**no** AVX-512 / AVX10 / SHA-NI advertised. Per QEMU's per-feature
emulation matrix (`docs/system/i386/cpu.rst`), all of these features are
fully decoded under TCG.

The harness now logs the decision at start time:

```
[harness] cpu_model=qemu64,+ssse3,+sse4_1,+sse4_2,+avx,+avx2,+fma,+rdtscp,+popcnt,+aes,+pclmulqdq,+cmov
          reason=tcg-safe
          (kvm_available=True, no_kvm_flag=True, force_kvm_flag=False)
```

emits a `{"kind": "cpu_model", ...}` event into the session's
`events.jsonl`, and exposes `cpu_model_resolved`, `cpu_model_reason`,
`kvm_available`, `kvm_effective` (all **additive**) on both the session
JSON and the `start` subcommand's stdout payload — so a single
`events <sid>` or `status <sid>` call reveals whether a run was on KVM
fidelity or the TCG baseline.

## Files

- `scripts/astryx_qemu.py` — add `_TCG_SAFE_CPU` constant, factor
  selection into `cpu_model_for(mode, kvm, override) -> (model, reason)`,
  `_cpu_args()` becomes a thin wrapper.
- `scripts/qemu-harness.py` — call `cpu_model_for()` up-front in
  `cmd_start`, log the decision, persist + emit it via session JSON,
  event stream, and the start-subcommand stdout payload.

## Verification

3 trials with `--no-kvm`, `--features firefox-test,kdb,syscall-trace`:

| trial | sc     | pf    | clone | execve | SIGSEGV | #UD | bugcheck | exit_group | terminal           |
|-------|--------|-------|-------|--------|---------|-----|----------|------------|--------------------|
| 1     | 1947   | 9017  | 19    | 0      | 0       | 0   | 0        | 0          | openat-fd loop / sem_wait plateau |
| 2     | 272    | 316   | 10    | 0      | 0       | 0   | 0        | 0          | openat-fd loop     |
| 3     | (early)| n/a   |  1    | 0      | 0       | 0   | 0        | 0          | libxul mmap stall  |

Pre-fix post-#176 baseline (recorded in the agent-memory baseline
note): **3/5 SIGSEGV→exit_group(11), 1/5 #UD→exit_group(-6)** — 80% of
runs ended in the W100-CLUSTER-A fault cluster.
Post-fix: **0/3** SIGSEGV/#UD/bugcheck/exit_group events.

The harness boot log now shows:

```
[harness] cpu_model=qemu64,+ssse3,+sse4_1,+sse4_2,+avx,+avx2,+fma,+rdtscp,+popcnt,+aes,+pclmulqdq,+cmov reason=tcg-safe (kvm_available=True, no_kvm_flag=True, force_kvm_flag=False)
```

and `ps -p <pid> -o args` confirms QEMU was launched with the new
`-cpu` argv and without `-enable-kvm`.

## Verdict

The W100-CLUSTER-A "0x7efffa-region NULL-deref" cluster was a **TCG ISA
mismatch artefact**, not a real Mozilla bug. With the TCG-safe model
in place, Mozilla under TCG now reaches deeper Branch-A / openat-fd
recursion / libxul-mmap states — actual guest-kernel issues to
investigate separately.

## Test plan

- [x] Trial 1: `--no-kvm`, firefox-test → no SIGSEGV / #UD / bugcheck / exit_group; reaches sc=1947 with 19 clone threads.
- [x] Trial 2: `--no-kvm`, firefox-test → same, different early wedge (procfs fd recursion).
- [x] Trial 3: `--no-kvm`, firefox-test → same, wedges in libxul mmap (no userspace fault).
- [x] `ps -p <pid> -o args` confirms `-cpu qemu64,+ssse3,...` and no `-enable-kvm` in argv.
- [x] `events.jsonl` contains `{"kind": "cpu_model", "reason": "tcg-safe", ...}`.
- [x] `python3 -m py_compile scripts/astryx_qemu.py scripts/qemu-harness.py` OK.
- [x] `cpu_model_for()` smoke test: TCG / KVM / override paths return the expected tuples.
- [x] QEMU accepts the new `-cpu` model string (boot-probed to timeout).

## Breaking changes

None. All new fields on session JSON, stdout, and the event stream are
additive (`cpu_model_resolved`, `cpu_model_reason`, `kvm_available`,
`kvm_effective`, `no_kvm_flag`, `force_kvm_flag`). No existing key was
renamed.