### PR TITLE
kernel/linux/epoll: consult AF_UNIX has_data() for EPOLLIN (close Mozilla IPC spin)

### DIFF
--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -452,9 +452,38 @@ pub fn shutdown(id: u64, shut_rd_flag: bool, shut_wr_flag: bool) -> i64 {
     0
 }
 
+/// Tear down an AF_UNIX socket.
+///
+/// In addition to resetting the local slot we propagate the close as a
+/// half-shutdown to the connected peer — flipping its `shut_rd` so any
+/// subsequent local read on that peer returns 0 (orderly EOF) and any
+/// epoll/poll waiter observes `EPOLLHUP` / `POLLHUP`.  This mirrors
+/// Linux AF_UNIX where closing one end surfaces on the other as EOF
+/// and a poll-readiness wake — IEEE 1003.1 §close / §poll, and the
+/// `man 7 unix` description of stream-socket teardown.
+///
+/// We ring `PollBellSource::UnixShutdown` so any thread currently parked
+/// in `epoll_wait` / `poll` on the peer fd is woken in the same tick
+/// rather than waiting out the 1 s resync floor — the wedge that caused
+/// the Mozilla parent IPC bus to spin on a closed child socket.
 pub fn close(id: u64) {
     if id as usize >= MAX_UNIX_SOCKETS { return; }
-    TABLE.lock().0[id as usize].reset();
+    let mut t = TABLE.lock();
+    let peer_id = t.0[id as usize].peer_id;
+    t.0[id as usize].reset();
+    let mut ring = false;
+    if (peer_id as usize) < MAX_UNIX_SOCKETS {
+        let peer = &mut t.0[peer_id as usize];
+        if peer.state == UnixState::Connected {
+            peer.shut_rd = true;
+            ring = true;
+        }
+    }
+    drop(t);
+    if ring {
+        crate::ipc::waitlist::ring_poll_bell_for(
+            crate::ipc::waitlist::PollBellSource::UnixShutdown);
+    }
 }
 
 pub fn has_data(id: u64) -> bool {
@@ -466,6 +495,26 @@ pub fn has_data(id: u64) -> bool {
     } else {
         s.recv_available() > 0
     }
+}
+
+/// Returns true if the local side has been half-closed for reading
+/// (either by a local `shutdown(SHUT_RD)` or by the peer's `shutdown(SHUT_WR)`
+/// / `close()` propagation per `shutdown()` / `close()` below) and is
+/// therefore at EOF for subsequent reads.  Epoll callers use this to
+/// raise `EPOLLHUP` once any buffered data has been drained — POSIX
+/// `poll(2)` / IEEE 1003.1 §poll require `POLLHUP` to coexist with
+/// `POLLIN` while bytes remain, and to be reported regardless of
+/// whether the caller asked for it.
+pub fn peer_closed(id: u64) -> bool {
+    if id as usize >= MAX_UNIX_SOCKETS { return false; }
+    let t = TABLE.lock();
+    let s = &t.0[id as usize];
+    if s.state == UnixState::Free { return true; }
+    if s.shut_rd { return true; }
+    let peer = s.peer_id;
+    if peer == u64::MAX { return false; }
+    if (peer as usize) >= MAX_UNIX_SOCKETS { return false; }
+    t.0[peer as usize].state == UnixState::Free
 }
 
 pub fn bytes_available(id: u64) -> usize {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -5922,48 +5922,93 @@ fn write_hex64(out: &mut Vec<u8>, mut v: u64) {
 fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
     use crate::ipc::epoll::{EPOLLIN, EPOLLOUT, EPOLLERR, EPOLLHUP};
 
-    // Snapshot fd metadata with a brief lock hold.
-    let info: Option<(u64, u32, bool, bool, crate::vfs::FileType)> = {
+    // Snapshot fd metadata with a brief lock hold.  `mount_idx == usize::MAX`
+    // together with the SOCKET_FD bit (`0x4000_0000`) in `flags` identifies a
+    // socket fd; the UNIX_SOCKET_FLAG bit (`0x0080_0000`) disambiguates
+    // AF_UNIX from AF_INET/AF_INET6 — matching `is_socket_fd` /
+    // `is_unix_socket_fd` in `crate::syscall`.
+    let info: Option<(u64, u32, bool, bool, crate::vfs::FileType, usize)> = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         procs.iter().find(|p| p.pid == pid).and_then(|proc| {
             proc.file_descriptors.get(fd)?.as_ref().map(|f| {
                 let is_epoll = f.open_path.as_str() == "[epoll]";
-                (f.inode, f.flags, f.is_console, is_epoll, f.file_type)
+                (f.inode, f.flags, f.is_console, is_epoll, f.file_type, f.mount_idx)
             })
         })
     };
 
+    const SOCKET_FD_BIT:  u32 = 0x4000_0000;
+    const UNIX_SOCK_BIT:  u32 = 0x0080_0000;
+    const PIPE_FD_BIT:    u32 = 0x8000_0000;
+    const O_WRONLY_BIT:   u32 = 0x01;
+
     match info {
         None => match fd { 0 => 0, 1 | 2 => EPOLLOUT, _ => EPOLLERR },
-        Some((_, _, _, true, _)) => 0,
-        Some((_, _, true, _, _)) => EPOLLOUT,
-        Some((inode, _flags, false, false, crate::vfs::FileType::EventFd)) => {
+        Some((_, _, _, true, _, _)) => 0,
+        Some((_, _, true, _, _, _)) => EPOLLOUT,
+        Some((inode, _flags, false, false, crate::vfs::FileType::EventFd, _)) => {
             if crate::ipc::eventfd::is_readable(inode) { EPOLLIN } else { 0 }
         }
-        Some((inode, _flags, false, false, crate::vfs::FileType::TimerFd)) => {
+        Some((inode, _flags, false, false, crate::vfs::FileType::TimerFd, _)) => {
             if crate::ipc::timerfd::is_readable(inode) { EPOLLIN } else { 0 }
         }
-        Some((inode, _flags, false, false, crate::vfs::FileType::SignalFd)) => {
+        Some((inode, _flags, false, false, crate::vfs::FileType::SignalFd, _)) => {
             if crate::ipc::signalfd::is_readable(inode) { EPOLLIN } else { 0 }
         }
-        Some((_inode, _flags, false, false, crate::vfs::FileType::InotifyFd)) => {
+        Some((_inode, _flags, false, false, crate::vfs::FileType::InotifyFd, _)) => {
             0 // stub: never delivers events
         }
-        Some((inode, _flags, false, false, crate::vfs::FileType::PtyMaster)) => {
+        Some((inode, _flags, false, false, crate::vfs::FileType::PtyMaster, _)) => {
             if crate::drivers::pty::master_readable(inode as u8) { EPOLLIN | EPOLLOUT } else { EPOLLOUT }
         }
-        Some((inode, _flags, false, false, crate::vfs::FileType::PtySlave)) => {
+        Some((inode, _flags, false, false, crate::vfs::FileType::PtySlave, _)) => {
             if crate::drivers::pty::slave_readable(inode as u8) { EPOLLIN | EPOLLOUT } else { EPOLLOUT }
         }
-        Some((inode, flags, false, false, _)) => {
-            if flags & 0x8000_0000 != 0 {
-                // Pipe fd
-                if flags & 0x01 == 0 {
+        Some((inode, flags, false, false, _, mount_idx)) => {
+            // Pipe — readable end signals EPOLLIN on data and EPOLLHUP on
+            // writer-close EOF.  Per POSIX `poll(2)`, `POLLHUP` is set even
+            // when not requested and may coexist with `POLLIN` while data
+            // remains buffered.
+            if flags & PIPE_FD_BIT != 0 {
+                if flags & O_WRONLY_BIT == 0 {
                     if crate::ipc::pipe::pipe_has_data(inode)    { EPOLLIN }
                     else if crate::ipc::pipe::pipe_is_eof(inode) { EPOLLHUP }
                     else { 0 }
                 } else {
                     EPOLLOUT
+                }
+            } else if mount_idx == usize::MAX && flags & SOCKET_FD_BIT != 0 {
+                // Socket fd.  AF_UNIX uses an in-memory ring (always
+                // writable for partial writes) — gate EPOLLIN on the
+                // backend `has_data()` instead of asserting readability
+                // unconditionally, which would make `epoll_wait` return
+                // readable for an empty socket and force userspace to
+                // burn cycles on `recvmsg → -EAGAIN` (POSIX `epoll_wait(2)`
+                // edge-trigger spurious-wake guidance, and the Mozilla
+                // IPC spin pattern observed under firefox-test).
+                //
+                // AF_INET goes through the protocol's `socket_has_data`
+                // — same shape, distinct backend.
+                if flags & UNIX_SOCK_BIT != 0 {
+                    let mut ev = EPOLLOUT;
+                    let has_d = crate::net::unix::has_data(inode);
+                    if has_d {
+                        ev |= EPOLLIN;
+                    }
+                    if crate::net::unix::peer_closed(inode) {
+                        // Buffered bytes win over EOF for the EPOLLIN
+                        // signal but coexist with EPOLLHUP so a draining
+                        // reader can finish before observing the
+                        // half-close — per `poll(2)`/`epoll_wait(2)`.
+                        ev |= EPOLLHUP;
+                    }
+                    ev
+                } else {
+                    let mut ev = EPOLLOUT;
+                    if crate::net::socket::socket_has_data(inode) {
+                        ev |= EPOLLIN;
+                    }
+                    ev
                 }
             } else {
                 EPOLLIN | EPOLLOUT

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -10171,6 +10171,66 @@ fn test_epoll_and_proc_fd() -> bool {
             }
         }
 
+        // ─── 7c-bis. AF_UNIX socketpair + epoll EPOLLIN coherence ──────────
+        //
+        // Regression test: before W111 the epoll readiness path returned
+        // `EPOLLIN | EPOLLOUT` unconditionally for any socket fd, which
+        // made `epoll_wait` report a freshly-created AF_UNIX socket as
+        // readable even though `recv` would immediately return -EAGAIN.
+        // Mozilla's IPC bus tripped on this and burned ~5000 syscalls/s
+        // in a recv→epoll spin loop.  After the fix, EPOLLIN must only
+        // fire once the peer has actually written; EPOLLOUT remains
+        // asserted for the in-memory ring (always writable for partial
+        // writes — IEEE 1003.1 §poll, §write on AF_UNIX streams).
+        {
+            let epfd4 = dispatch(291, 0, 0, 0, 0, 0, 0);
+            if epfd4 >= 0 {
+                let mut sp: [u64; 2] = [u64::MAX; 2];
+                // socketpair(AF_UNIX=1, SOCK_STREAM=1, 0, sp)
+                let spr = dispatch(53, 1, 1, 0, sp.as_mut_ptr() as u64, 0, 0);
+                if spr == 0 {
+                    let a = sp[0] as usize;
+                    let b = sp[1] as usize;
+                    let ev = make_ev(EPOLLIN | EPOLLOUT, a as u64);
+                    let _ = dispatch(233, epfd4 as u64, CTL_ADD, a as u64,
+                                     ev.as_ptr() as u64, 0, 0);
+
+                    // 1. With no data buffered, EPOLLIN must NOT be set.
+                    //    EPOLLOUT is fine (write-ready).
+                    let mut buf = [[0u8; 12]; 4];
+                    let r1 = dispatch(232, epfd4 as u64, buf[0].as_mut_ptr() as u64,
+                                      4, 0, 0, 0); // timeout=0 → non-blocking
+                    let ev1 = if r1 >= 1 { ev_events(&buf[0]) } else { 0 };
+                    let in_before = ev1 & EPOLLIN != 0;
+
+                    // 2. Peer writes one byte; EPOLLIN must now fire.
+                    let msg = b"u";
+                    let _ = dispatch(1, b as u64, msg.as_ptr() as u64, 1, 0, 0, 0);
+                    let r2 = dispatch(232, epfd4 as u64, buf[0].as_mut_ptr() as u64,
+                                      4, 1000, 0, 0);
+                    let ev2 = ev_events(&buf[0]);
+                    let in_after = r2 >= 1 && ev2 & EPOLLIN != 0;
+
+                    if !in_before && in_after {
+                        test_println!(
+                            "  AF_UNIX socketpair epoll: EPOLLIN gated on data ok (before={:#x} after={:#x})",
+                            ev1, ev2);
+                    } else {
+                        test_fail!("unix socketpair EPOLLIN gating",
+                            "before r={} ev={:#x} (expect no EPOLLIN), after r={} ev={:#x} (expect EPOLLIN)",
+                            r1, ev1, r2, ev2);
+                        ok = false;
+                    }
+
+                    let _ = crate::vfs::close(pid, a);
+                    let _ = crate::vfs::close(pid, b);
+                } else {
+                    test_println!("  AF_UNIX socketpair epoll: skipped (socketpair() = {})", spr);
+                }
+                let _ = dispatch(3, epfd4 as u64, 0, 0, 0, 0, 0);
+            }
+        }
+
         // ─── 7d. select(2) blocking contract (timeval actually waits) ──────
         //
         // Mirror the epoll case for select: a non-NULL non-zero timeval must


### PR DESCRIPTION
## Summary

`epoll_poll_events()` returned `EPOLLIN | EPOLLOUT` unconditionally for any socket fd — so `epoll_wait` reported a freshly-created AF_UNIX socket as readable even when its receive ring was empty. Userspace responded with `recvmsg`, got `-EAGAIN`, and looped: W110 observed Mozilla's parent IPC bus burning ~5000 syscalls/s in 3/5 firefox-test trials on a thread that should have been parked.

This PR:

- Gates `EPOLLIN` for AF_UNIX on `crate::net::unix::has_data(uid)` and for AF_INET / AF_INET6 on `crate::net::socket::socket_has_data(sid)`. `EPOLLOUT` stays asserted: AF_UNIX uses an in-memory ring so partial writes are always possible (IEEE 1003.1 §write).
- Surfaces `EPOLLHUP` when the AF_UNIX peer has half-closed or fully closed. POSIX `poll(2)` / `epoll_wait(2)` require `POLLHUP` to be reported unconditionally and to coexist with `POLLIN` while bytes remain buffered, so a draining reader can finish before observing EOF.
- **Stretch**: makes `net::unix::close()` mirror the existing `shutdown()` peer-notification discipline — flip the peer's `shut_rd` and ring `PollBellSource::UnixShutdown` so any thread parked in `epoll_wait` / `poll` on the peer fd wakes in the same tick instead of waiting out the 1 s resync floor (man 7 unix EOF surfacing).
- Adds new test `7c-bis` in `test_epoll_and_proc_fd` asserting the gating contract: a fresh socketpair must show `EPOLLOUT`-only, then `EPOLLIN` once the peer writes a byte.

## Test plan

- [x] `qemu-harness.py check --features firefox-test` — clean
- [x] firefox-test, TCG (`--no-kvm`), 9-minute single trial:
  - tid=5 made **267 total syscalls** (41 `epoll_wait`, **zero** `recvmsg`, **zero** `recvfrom`, **zero** `-EAGAIN`) — vs W110 baseline of ~5000 sc/s of `recvmsg→epoll_wait` spin.
  - The next blocker has shifted to the long-standing Window-6 sem_wait plateau on tid=7 (`rip=0x7effffa89ae2`, `nr=7` poll) — separate W112 investigation.
- [x] Test 7c-bis: AF_UNIX socketpair + epoll EPOLLIN gating coherence

## Diff

170 insertions / 16 deletions across 3 files (`net/unix.rs`, `subsys/linux/syscall.rs`, `test_runner.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)