### PR TITLE
kernel/proc/exec: log argv on execve (close content-process role diagnostic gap)

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -805,6 +805,84 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
         }
     };
 
+    // Log the final argv so content-process roles (--contentproc <type> <fd>)
+    // are visible in the serial trace.  Truncated to 8 args and 256 cumulative
+    // bytes to avoid log spam on deeply-nested command lines.
+    {
+        let pid = crate::proc::current_pid_lockless();
+        let tid = crate::proc::current_tid();
+        let total_args = argv_owned.len();
+        // Build a compact representation into a fixed-size stack buffer.
+        // We use a simple byte-array writer to stay no_std / no-alloc.
+        const BUF: usize = 320;
+        let mut buf = [0u8; BUF];
+        let mut pos = 0usize;
+        let mut byte_budget: usize = 256;
+        let mut args_shown: usize = 0;
+
+        macro_rules! push_byte {
+            ($b:expr) => {
+                if pos < BUF - 1 {
+                    buf[pos] = $b;
+                    pos += 1;
+                }
+            };
+        }
+        macro_rules! push_str {
+            ($s:expr) => {
+                for b in $s.as_bytes() {
+                    push_byte!(*b);
+                }
+            };
+        }
+
+        for (i, arg) in argv_owned.iter().enumerate() {
+            if i >= 8 || byte_budget == 0 {
+                break;
+            }
+            if i > 0 {
+                push_byte!(b' ');
+            }
+            push_byte!(b'"');
+            // Check for non-printable bytes; if any, emit <binary len=N> instead.
+            let all_print = arg.bytes().all(|b| b >= 0x20 && b < 0x7f);
+            if all_print {
+                let take = arg.len().min(byte_budget);
+                for b in arg.as_bytes()[..take].iter() {
+                    push_byte!(*b);
+                }
+                byte_budget = byte_budget.saturating_sub(arg.len());
+            } else {
+                // Non-printable: emit placeholder without counting against budget.
+                push_str!("<binary len=");
+                // Emit decimal length inline.
+                let n = arg.len();
+                if n >= 100 { push_byte!(b'0' + (n / 100) as u8); }
+                if n >= 10  { push_byte!(b'0' + ((n / 10) % 10) as u8); }
+                push_byte!(b'0' + (n % 10) as u8);
+                push_byte!(b'>');
+            }
+            push_byte!(b'"');
+            args_shown += 1;
+        }
+
+        // NUL-terminate for safety, then convert the used slice.
+        buf[pos] = 0;
+        let shown = unsafe { core::str::from_utf8_unchecked(&buf[..pos]) };
+        let truncated = total_args > args_shown || byte_budget == 0;
+        if truncated {
+            crate::serial_println!(
+                "[EXEC] pid={} tid={} argv={} ({} of {} args shown)",
+                pid, tid, shown, args_shown, total_args
+            );
+        } else {
+            crate::serial_println!(
+                "[EXEC] pid={} tid={} argv={} ({} args)",
+                pid, tid, shown, total_args
+            );
+        }
+    }
+
     // Validate it's an ELF binary (resolve_shebang guarantees this on Ok).
     if !crate::proc::elf::is_elf(&elf_data) {
         crate::serial_println!("[SYSCALL] exec: not an ELF binary");


### PR DESCRIPTION
## Summary

- W116's 5-trial baseline showed the first content-process spawn in 6 weeks: PID 3 CoW-fork + exec(firefox-bin) → exit_group(255). The only kernel log was `[SYSCALL] exec("/path")` — no argv — so the Mozilla content-process role that died was unidentifiable.
- Mozilla content processes are distinguished by the argv pattern `--contentproc <type> <fd>` (tab, gpu, socket, etc.), which is completely invisible without argv logging.
- This PR adds an `[EXEC] pid=N tid=N argv=... (N args)` line to `sys_exec()`, emitted after shebang resolution so the final effective argv is recorded regardless of interpreter chains.

## Implementation

Added in `kernel/src/syscall/mod.rs::sys_exec()`, right after `resolve_shebang()` returns the final `argv_owned`:

- Truncation: at most **8 args** and **256 cumulative bytes** rendered; surplus summarised as `(N of M args shown)`.
- Non-printable args replaced with `<binary len=N>` to protect serial log integrity.
- Uses a 320-byte **stack buffer** — no heap allocation, no dependency on `core::fmt::Write`.
- Unconditional across all feature flags and build configurations.

## Verification (1 trial, TCG no-KVM)

```
[EXEC] pid=2 tid=4 argv="/disk/opt/firefox/glxtest" "-f" "8" (3 args)
```

glxtest spawn logged correctly. If a content process spawns in a future trial, `--contentproc <type>` will appear on the `[EXEC]` line for immediate triage.

## Test plan

- [x] `qemu-harness.py check --features firefox-test` — clean compile, 0 errors
- [x] 1-trial TCG run: `[EXEC]` argv line present for glxtest (3 args, no truncation, no log spam)
- [x] No `[EXEC]` noise from non-exec paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)