### PR TITLE
userspace/libfontconfig-interposer: defensive *out write for full FcPatternGet* family

### DIFF
--- a/userspace/libfontconfig-interposer/interposer.c
+++ b/userspace/libfontconfig-interposer/interposer.c
@@ -1,34 +1,44 @@
 /*
- * libfontconfig-interposer.so — defensive FcPatternGetString *out wrapper.
+ * libfontconfig-interposer.so — defensive FcPatternGet* *out wrappers.
  *
- * Real upstream libfontconfig follows the spec strictly: when
- * FcPatternGetString() returns FcResultNoMatch (1) it leaves the
- * caller-supplied output pointer untouched and the contents are
- * undefined.  See:
+ * Real upstream libfontconfig follows the spec strictly: when an
+ * FcPatternGet* getter returns a non-Match FcResult (e.g.
+ * FcResultNoMatch == 1) the caller-supplied output pointer is left
+ * untouched and the contents are undefined.  See:
  *   https://fontconfig.org/fontconfig-devel/fcpatternget.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetbool.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetinteger.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetdouble.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetmatrix.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetcharset.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetlangset.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetftface.html
+ *   https://fontconfig.org/fontconfig-devel/fcpatterngetrange.html
  *   https://fontconfig.org/fontconfig-devel/fcresult.html
  *
  * Firefox's gfxFcPlatformFontList per-language alias enumeration in
  * libxul (vaddr regions exhibited at +0x185b8a4 and +0x4056429 in the
  * shipping ESR 115 build) iterates a list of font slots, calling
- * FcPatternGetString(p, ..., id, &slot) for each id, and on
- * FcResultNoMatch dereferences `*slot` unconditionally — slot still
- * holds whatever value the caller staged before the call, which is
- * commonly NULL.  The result is a %rbx=NULL fault at the next
- * `mov 0x..(%rbx), <reg>` or `orb $.., 0x..(%rbx)` instruction.
+ * FcPatternGet*(p, ..., id, &slot) for each id, and on the non-Match
+ * path dereferences `*slot` unconditionally — slot still holds whatever
+ * value the caller staged before the call, which is commonly NULL.
+ * The result is a %rbx=NULL fault at the next `mov 0x..(%rbx), <reg>`
+ * or `orb $.., 0x..(%rbx)` instruction.
  *
- * This interposer wraps FcPatternGetString — it dlsym()s the real
- * implementation from libfontconfig.so.1 via RTLD_NEXT, calls through,
- * and on FcResultNoMatch additionally writes a non-NULL sentinel
- * pointer into *out so the buggy caller dereferences a valid empty
- * NUL-terminated string instead of NULL.
+ * PR #188 fixed FcPatternGetString.  W128 traced the next post-#188
+ * SIGSEGV cluster (libxul+0x4b8db40, libxul+0x2f99429) to the same
+ * defect in the sister FcPatternGet* family.  This file wraps the full
+ * FcPatternGet* family — it dlsym()s each real implementation from
+ * libfontconfig.so.1 via RTLD_NEXT, calls through, and on the non-Match
+ * path writes a defined sentinel value into *out so the buggy caller
+ * dereferences a valid object instead of NULL.
  *
  * The interposer must be loaded before libfontconfig.so.1.  Inject via
  * LD_PRELOAD=/lib64/libfontconfig-interposer.so in the firefox-test
  * environment — set in kernel/src/gui/terminal.rs.  Real libfontconfig
  * remains in place for every other call.
  *
- * This is userspace-side workaround for a Mozilla caller bug; the
+ * This is a userspace-side workaround for a Mozilla caller bug; the
  * upstream libfontconfig binary is never patched, preserving the
  * "no upstream binary edits" invariant.
  */
@@ -37,27 +47,68 @@
 #include <dlfcn.h>
 #include <stddef.h>
 
-/* fontconfig public ABI (from <fontconfig/fontconfig.h>):
+/* fontconfig public ABI (from <fontconfig/fontconfig.h>).
+ *
+ *   typedef int FcBool;
  *   typedef unsigned char FcChar8;
  *   typedef enum _FcResult {
  *       FcResultMatch, FcResultNoMatch, FcResultTypeMismatch,
  *       FcResultNoId,  FcResultOutOfMemory
  *   } FcResult;
  *   typedef struct _FcPattern FcPattern;
- *   FcResult FcPatternGetString(const FcPattern *p, const char *object,
- *                               int n, FcChar8 **s);
+ *   typedef struct _FcMatrix  { double xx, xy, yx, yy; } FcMatrix;
+ *   typedef struct _FcCharSet FcCharSet;
+ *   typedef struct _FcLangSet FcLangSet;
+ *   typedef struct _FcRange   FcRange;
+ *   typedef struct FT_FaceRec_ *FT_Face;
+ *
+ *   FcResult FcPatternGetString (const FcPattern *, const char *, int, FcChar8 **);
+ *   FcResult FcPatternGetBool   (const FcPattern *, const char *, int, FcBool *);
+ *   FcResult FcPatternGetInteger(const FcPattern *, const char *, int, int *);
+ *   FcResult FcPatternGetDouble (const FcPattern *, const char *, int, double *);
+ *   FcResult FcPatternGetMatrix (const FcPattern *, const char *, int, FcMatrix **);
+ *   FcResult FcPatternGetCharSet(const FcPattern *, const char *, int, FcCharSet **);
+ *   FcResult FcPatternGetLangSet(const FcPattern *, const char *, int, FcLangSet **);
+ *   FcResult FcPatternGetFTFace (const FcPattern *, const char *, int, FT_Face *);
+ *   FcResult FcPatternGetRange  (const FcPattern *, const char *, int, FcRange **);
  */
-typedef int FcResult;
-typedef void FcPattern;
+typedef int           FcResult;
+typedef int           FcBool;
+typedef void          FcPattern;
 typedef unsigned char FcChar8;
+typedef struct { double xx, xy, yx, yy; } FcMatrix;
+typedef void          FcCharSet;   /* opaque */
+typedef void          FcLangSet;   /* opaque */
+typedef void          FcRange;     /* opaque */
+typedef void         *FT_Face;     /* opaque pointer */
 
 #define FC_RESULT_MATCH       0
 #define FC_RESULT_NO_MATCH    1
 
-/* Non-NULL, NUL-terminated sentinel.  "DejaVu Sans" is also the family
- * the firefox-stubs generator uses for the in-process font list. */
+/* ────────────────────────────────────────────────────────────────────
+ * Sentinel storage for non-NULL writes on the NoMatch path.
+ *
+ * For string output we use a small NUL-terminated literal so a caller
+ * that walks the bytes terminates on the first iteration.  For the
+ * opaque struct outputs we provide an over-sized zero-initialised
+ * buffer aligned to 8 bytes — large enough to cover any reasonable
+ * field offset Mozilla might probe.  The identity matrix is a defined
+ * value chosen because Mozilla applies it directly to glyph
+ * transformations and an all-zero matrix would collapse glyph metrics.
+ * ──────────────────────────────────────────────────────────────────── */
+
+/* "DejaVu Sans" matches the family the firefox-stubs generator uses
+ * for the in-process font list.  Reused by FcPatternGetString. */
 static const FcChar8 fc_stub_family[] = "DejaVu Sans";
 
+static FcMatrix      fc_stub_identity_matrix = { 1.0, 0.0, 0.0, 1.0 };
+static unsigned char fc_stub_charset[256]    __attribute__((aligned(8))) = {0};
+static unsigned char fc_stub_langset[256]    __attribute__((aligned(8))) = {0};
+static unsigned char fc_stub_range[64]       __attribute__((aligned(8))) = {0};
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetString — string output.
+ * ──────────────────────────────────────────────────────────────────── */
 typedef FcResult (*FcPatternGetString_t)(const FcPattern *, const char *,
                                          int, FcChar8 **);
 
@@ -72,25 +123,282 @@ FcPatternGetString(const FcPattern *p, const char *object, int n,
     }
 
     if (!s) {
-        /* Caller supplied no output buffer — nothing to defend against. */
         return real ? real(p, object, n, s) : FC_RESULT_NO_MATCH;
     }
 
     if (!real) {
-        /* dlsym failed (real libfontconfig not loaded?) — surface a
-         * defined result so the caller's NoMatch fault-path still sees
-         * a valid pointer. */
         *s = (FcChar8 *)fc_stub_family;
         return FC_RESULT_NO_MATCH;
     }
 
     FcResult r = real(p, object, n, s);
     if (r != FC_RESULT_MATCH && *s == NULL) {
-        /* Mozilla's caller dereferences *s on the NoMatch path.  Write
-         * a non-NULL sentinel; the spec leaves *s undefined on
-         * non-Match results so this is conformant — we are choosing a
-         * defined value where libfontconfig would leave it unchanged. */
         *s = (FcChar8 *)fc_stub_family;
     }
     return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetBool — int (FcBool) output.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetBool_t)(const FcPattern *, const char *,
+                                       int, FcBool *);
+
+FcResult
+FcPatternGetBool(const FcPattern *p, const char *object, int n, FcBool *b)
+{
+    static FcPatternGetBool_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetBool_t)dlsym(RTLD_NEXT, "FcPatternGetBool");
+    }
+
+    if (!b) {
+        return real ? real(p, object, n, b) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *b = 0;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, b);
+    if (r != FC_RESULT_MATCH) {
+        /* The spec leaves *b undefined on non-Match; choose 0 (FcFalse)
+         * so callers that read the byte after a NoMatch see a defined
+         * value instead of stack garbage. */
+        *b = 0;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetInteger — int output.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetInteger_t)(const FcPattern *, const char *,
+                                          int, int *);
+
+FcResult
+FcPatternGetInteger(const FcPattern *p, const char *object, int n, int *i)
+{
+    static FcPatternGetInteger_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetInteger_t)dlsym(RTLD_NEXT, "FcPatternGetInteger");
+    }
+
+    if (!i) {
+        return real ? real(p, object, n, i) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *i = 0;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, i);
+    if (r != FC_RESULT_MATCH) {
+        *i = 0;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetDouble — double output.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetDouble_t)(const FcPattern *, const char *,
+                                         int, double *);
+
+FcResult
+FcPatternGetDouble(const FcPattern *p, const char *object, int n, double *d)
+{
+    static FcPatternGetDouble_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetDouble_t)dlsym(RTLD_NEXT, "FcPatternGetDouble");
+    }
+
+    if (!d) {
+        return real ? real(p, object, n, d) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *d = 0.0;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, d);
+    if (r != FC_RESULT_MATCH) {
+        *d = 0.0;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetMatrix — FcMatrix* output.
+ *
+ * Mozilla feeds the returned matrix straight into glyph transforms;
+ * the identity matrix is the safe defined value.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetMatrix_t)(const FcPattern *, const char *,
+                                         int, FcMatrix **);
+
+FcResult
+FcPatternGetMatrix(const FcPattern *p, const char *object, int n, FcMatrix **m)
+{
+    static FcPatternGetMatrix_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetMatrix_t)dlsym(RTLD_NEXT, "FcPatternGetMatrix");
+    }
+
+    if (!m) {
+        return real ? real(p, object, n, m) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *m = &fc_stub_identity_matrix;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, m);
+    if (r != FC_RESULT_MATCH && *m == NULL) {
+        *m = &fc_stub_identity_matrix;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetCharSet — opaque FcCharSet* output.
+ *
+ * The real FcCharSet header is not public ABI; treat as opaque and
+ * point callers at a zero-initialised aligned scratch large enough to
+ * cover any structure version Mozilla might probe.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetCharSet_t)(const FcPattern *, const char *,
+                                          int, FcCharSet **);
+
+FcResult
+FcPatternGetCharSet(const FcPattern *p, const char *object, int n,
+                    FcCharSet **c)
+{
+    static FcPatternGetCharSet_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetCharSet_t)dlsym(RTLD_NEXT, "FcPatternGetCharSet");
+    }
+
+    if (!c) {
+        return real ? real(p, object, n, c) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *c = (FcCharSet *)fc_stub_charset;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, c);
+    if (r != FC_RESULT_MATCH && *c == NULL) {
+        *c = (FcCharSet *)fc_stub_charset;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetLangSet — opaque FcLangSet* output.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetLangSet_t)(const FcPattern *, const char *,
+                                          int, FcLangSet **);
+
+FcResult
+FcPatternGetLangSet(const FcPattern *p, const char *object, int n,
+                    FcLangSet **l)
+{
+    static FcPatternGetLangSet_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetLangSet_t)dlsym(RTLD_NEXT, "FcPatternGetLangSet");
+    }
+
+    if (!l) {
+        return real ? real(p, object, n, l) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *l = (FcLangSet *)fc_stub_langset;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, l);
+    if (r != FC_RESULT_MATCH && *l == NULL) {
+        *l = (FcLangSet *)fc_stub_langset;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetFTFace — FT_Face (FreeType face) output.
+ *
+ * Unlike the other getters, Mozilla checks the FT_Face for NULL before
+ * dereferencing.  Keep NULL on the NoMatch path so the existing NULL
+ * check in libxul fires and the no-face fallback path executes.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetFTFace_t)(const FcPattern *, const char *,
+                                         int, FT_Face *);
+
+FcResult
+FcPatternGetFTFace(const FcPattern *p, const char *object, int n, FT_Face *f)
+{
+    static FcPatternGetFTFace_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetFTFace_t)dlsym(RTLD_NEXT, "FcPatternGetFTFace");
+    }
+
+    if (!f) {
+        return real ? real(p, object, n, f) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *f = NULL;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult r = real(p, object, n, f);
+    if (r != FC_RESULT_MATCH) {
+        /* Mozilla NULL-checks before deref — leave defined NULL. */
+        *f = NULL;
+    }
+    return r;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * FcPatternGetRange — opaque FcRange* output.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef FcResult (*FcPatternGetRange_t)(const FcPattern *, const char *,
+                                        int, FcRange **);
+
+FcResult
+FcPatternGetRange(const FcPattern *p, const char *object, int n, FcRange **r)
+{
+    static FcPatternGetRange_t real = NULL;
+
+    if (!real) {
+        real = (FcPatternGetRange_t)dlsym(RTLD_NEXT, "FcPatternGetRange");
+    }
+
+    if (!r) {
+        return real ? real(p, object, n, r) : FC_RESULT_NO_MATCH;
+    }
+
+    if (!real) {
+        *r = (FcRange *)fc_stub_range;
+        return FC_RESULT_NO_MATCH;
+    }
+
+    FcResult res = real(p, object, n, r);
+    if (res != FC_RESULT_MATCH && *r == NULL) {
+        *r = (FcRange *)fc_stub_range;
+    }
+    return res;
 }


### PR DESCRIPTION
## Summary

PR #188 (W124b) shipped an LD_PRELOAD shim wrapping **only** \`FcPatternGetString\`, working around Mozilla's gfxFcPlatformFontList code dereferencing \`*out\` on the \`FcResultNoMatch\` path (where real libfontconfig leaves \`*out\` untouched per the [FcPatternGet spec](https://fontconfig.org/fontconfig-devel/fcpatternget.html) and [FcResult spec](https://fontconfig.org/fontconfig-devel/fcresult.html)).

W128 traced the next post-#188 SIGSEGV cluster (libxul+0x4b8db40, libxul+0x2f99429) to the same caller-side defect in eight sister functions in the FcPatternGet* family.

This PR extends \`userspace/libfontconfig-interposer/interposer.c\` to wrap all 9 \`FcPatternGet*\` getters using the same RTLD_NEXT dlsym pattern.

### Sentinels per output type

| API | Output type | Sentinel on non-Match |
|---|---|---|
| FcPatternGetString | FcChar8** | "DejaVu Sans" literal (existing, PR #188) |
| FcPatternGetBool | FcBool* | 0 (FcFalse) |
| FcPatternGetInteger | int* | 0 |
| FcPatternGetDouble | double* | 0.0 |
| FcPatternGetMatrix | FcMatrix** | &identity_matrix (1,0,0,1) |
| FcPatternGetCharSet | FcCharSet** | &zeroed 256B aligned scratch |
| FcPatternGetLangSet | FcLangSet** | &zeroed 256B aligned scratch |
| FcPatternGetFTFace | FT_Face* | NULL (Mozilla NULL-checks this one) |
| FcPatternGetRange | FcRange** | &zeroed 64B aligned scratch |

The identity matrix is the only non-zero default — chosen because Mozilla feeds the matrix directly into glyph transforms and an all-zero matrix would collapse glyph metrics. The opaque-struct sentinels use over-sized aligned scratch buffers to cover any field offset the caller might probe.

## Verification

Built clean (\`make\` in \`userspace/libfontconfig-interposer/\`):

\`\`\`
$ nm -D libfontconfig-interposer.so | grep FcPatternGet
00000000000011f0 T FcPatternGetBool
00000000000014d0 T FcPatternGetCharSet
0000000000001350 T FcPatternGetDouble
0000000000001670 T FcPatternGetFTFace
00000000000012a0 T FcPatternGetInteger
00000000000015a0 T FcPatternGetLangSet
0000000000001400 T FcPatternGetMatrix
0000000000001720 T FcPatternGetRange
0000000000001120 T FcPatternGetString
\`\`\`

1 firefox-test trial (\`firefox-test,kdb,syscall-trace\`, no-kvm):

- Trial reaches \`[SYSCALL] exec("/disk/opt/firefox/glxtest")\` and \`[PROC] PID 2 exit_group(0)\` — glxtest child cleanly spawns and exits.
- Mozilla parent (pid=1) advances past the post-glxtest GfxInfo parse, logs "No GPUs detected", and falls through to a Mozilla-side \`exit_group(-13)\` (EACCES, init-time graceful abort).
- **No libxul SIGSEGV anywhere in trace** — all four prior FcPatternGet* fault vaddrs absent:
  - libxul+0x185b8a4, libxul+0x4056429 (W91)
  - libxul+0x4b8db40, libxul+0x2f99429 (W128)

### Demo-gate distance

The post-glxtest libxul NULL-deref cluster is closed. The next wedge is a higher-level Mozilla EACCES exit during browser-instance setup, several thousand syscalls deeper than the post-#188 plateau. Next investigation targets the EACCES syscall, not FcPattern* getters.

## Test plan

- [x] Built with \`make\` — \`nm -D\` shows all 9 \`FcPatternGet*\` exports
- [x] 1 firefox-test trial: no libxul SIGSEGV; glxtest child spawn + exit_group(0) clean; pid=1 advances past previous wedge
- [x] No upstream binary edits; no kernel changes; LD_PRELOAD plumbing in \`kernel/src/gui/terminal.rs\` and \`scripts/create-data-disk.sh\` unchanged

## Diff notes

+339 / -31 (≈308 net LOC). Slightly above the 150-200 LOC soft target — the bulk is 8 near-identical wrapper functions that resist consolidation without a macro; preferred the explicit per-function form for greppability and reviewability (each wrapper is independently auditable against its spec page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)