### PR TITLE
scripts/qemu-harness: deprecate --no-kvm default in firefox-test (W139 soak shows KVM +58% sc, 3/5 quit-app-granted vs 0/5 TCG)

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -9,6 +9,23 @@ Session state is stored in ~/.astryx-harness/<sid>.json.
 Events are written to ~/.astryx-harness/<sid>.events.jsonl.
 QMP socket: ~/.astryx-harness/<sid>.qmp.sock
 
+## KVM default (W139 recommendation)
+
+When /dev/kvm is available the harness uses KVM automatically — no flag
+required. A 10-trial soak (W139, 2026-05-13) showed KVM consistently reaches
+deeper than TCG on this host:
+
+  * Mean syscall count:        +58 % (4 893 TCG vs 7 751 KVM)
+  * quit-application-granted:   0/5 TCG vs 3/5 KVM
+  * W127-cluster SIGSEGV rate: 80 % TCG vs 40 % KVM
+
+W109 confirmed that the KVM serial-port recursion deadlock (W107) is closed
+by PR #156 on master, so KVM is safe for all current firefox-test runs.
+
+Do NOT pass --no-kvm unless you are explicitly reproducing a TCG-only
+environment or testing on a host without /dev/kvm. The harness will emit a
+WARNING to stderr when --no-kvm is used and /dev/kvm is available.
+
 Tier 1 — session management:
     python3 scripts/qemu-harness.py start [--features FLAGS] [--no-build]
                                           [--gdb-port PORT] [--gdb-wait]
@@ -1325,6 +1342,19 @@ def cmd_start(args):
     force_kvm_flag = bool(getattr(args, "force_kvm", False))
     if no_kvm_flag:
         kvm_arg = False
+        # W139 deprecation warning: --no-kvm degrades firefox-test fidelity.
+        # Emit when /dev/kvm is present so agents and humans see the cost
+        # of opting out. Suppressed on hosts without KVM (where TCG is the
+        # only option and the flag is a no-op).
+        if astryx_qemu._detect_kvm():
+            print(
+                "WARNING: --no-kvm passed but /dev/kvm is available. "
+                "KVM disabled — firefox-test progresses 58% further under KVM "
+                "per W139 soak (2026-05-13): sc +58%, quit-application-granted "
+                "3/5 KVM vs 0/5 TCG. Remove --no-kvm unless reproducing a "
+                "TCG-specific regression.",
+                file=sys.stderr,
+            )
     elif force_kvm_flag:
         kvm_arg = True
     else:
@@ -4920,9 +4950,13 @@ def main():
     p_start.add_argument("--gdb-wait", action="store_true",
                           help="Start QEMU frozen (-S); debugger must 'cont' to unfreeze")
     p_start.add_argument("--no-kvm", dest="no_kvm", action="store_true",
-                          help="Force-disable KVM acceleration. Reproduces CI's "
-                               "TCG-only environment (qemu64 CPU model). Useful "
-                               "when a test hangs only without KVM.")
+                          help="[DEPRECATED] Force-disable KVM acceleration. "
+                               "Use only to reproduce a TCG-only environment or "
+                               "on hosts without /dev/kvm. A 10-trial soak "
+                               "(W139, 2026-05-13) showed KVM reaches 58%% more "
+                               "syscalls and hit quit-application-granted 3/5 vs "
+                               "0/5 for TCG — avoid this flag for firefox-test "
+                               "unless you have a specific TCG regression to chase.")
     p_start.add_argument("--kvm", dest="force_kvm", action="store_true",
                           help="Force-enable KVM acceleration. Errors out if "
                                "/dev/kvm is unavailable.")


### PR DESCRIPTION
## Summary

- W139 10-trial soak (2026-05-13) showed KVM is consistently superior to TCG for firefox-test: +58% mean syscall depth, quit-application-granted 3/5 KVM vs 0/5 TCG, W127-cluster SIGSEGV rate 40% KVM vs 80% TCG.
- W109 confirmed the KVM serial-port recursion deadlock (W107) is fully closed by PR #156 on current master — KVM is safe for all firefox-test runs.
- The harness already autodetects `/dev/kvm` and uses KVM by default. Agents adding `--no-kvm` to dispatch prompts were silently degrading fidelity.

## Changes

**`scripts/qemu-harness.py`** (+37 / -3):

1. **Module docstring** — adds a `## KVM default (W139 recommendation)` section documenting the soak numbers, the W109 safety clearance, and an explicit "do NOT pass --no-kvm" instruction so agents reading `help(module)` have the full picture.

2. **Runtime WARNING** — when `--no-kvm` is passed on a host where `/dev/kvm` is available, the harness now prints to stderr:
   ```
   WARNING: --no-kvm passed but /dev/kvm is available. KVM disabled —
   firefox-test progresses 58% further under KVM per W139 soak
   (2026-05-13): sc +58%, quit-application-granted 3/5 KVM vs 0/5 TCG.
   Remove --no-kvm unless reproducing a TCG-specific regression.
   ```
   Suppressed on hosts without `/dev/kvm` (where TCG is the only option).

3. **Argparse help** — marks `--no-kvm` as `[DEPRECATED]` and embeds the W139 numbers directly so `--help` is self-documenting.

## No breaking changes

All JSON output fields are additive. `--no-kvm` continues to function for legitimate TCG-reproduction workflows (the warning just makes the cost visible).

## Test plan

- [x] `python3 scripts/qemu-harness.py start --features firefox-test --no-build` → `cpu_model_reason: "kvm-host"`, `kvm_effective: true`, no warning
- [x] `python3 scripts/qemu-harness.py start --features firefox-test --no-kvm --no-build 2>&1 | grep WARNING` → warning fires, `kvm_effective: false`
- [x] `python3 scripts/qemu-harness.py start --help | grep -A6 no-kvm` → `[DEPRECATED]` and W139 numbers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)