### PR TITLE
kernel/linux/syscall: readlink returns ENOENT for missing exe_path (close W156 Bug A — libxul slice panic)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1534,21 +1534,27 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
 
             // /proc/self/exe — resolve to current process exe path.
             //
-            // If the process has no `exe_path` (kernel-only process, transient
-            // setup race), return an empty string — same shape Linux uses for
-            // processes whose `mm_struct->exe_file` is NULL (dead/kernel
-            // threads).  Returning a fake path like `/bin/init` is harmful: it
-            // misleads programs that derive sibling resources from their
-            // executable path (Mozilla's dependentlibs.list — W120/W121).
+            // Per readlink(2), if the target symlink cannot be resolved the
+            // syscall returns -ENOENT.  Returning an empty string when
+            // `exe_path` is None causes callers that do not check the returned
+            // length before slicing (e.g. Mozilla's BinaryPath::Get, which
+            // performs `path[0..len-3]`) to panic or fault on an
+            // out-of-bounds access.  ENOENT is the correct sentinel: callers
+            // such as glibc's `__execvpe` and Mozilla's fallback path handle
+            // ENOENT gracefully by switching to an alternative resolution
+            // strategy.  (See readlink(2), POSIX.1-2017.)
             let target_str: alloc::string::String = if path_str == "/proc/self/exe"
                 || path_str == "/proc/self/fd/exe"
             {
                 let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();
-                procs.iter().find(|p| p.pid == pid)
+                match procs.iter().find(|p| p.pid == pid)
                     .and_then(|p| p.exe_path.as_ref())
                     .map(|s| s.clone())
-                    .unwrap_or_else(alloc::string::String::new)
+                {
+                    Some(p) => p,
+                    None => return -2, // ENOENT — no exe path recorded for this process
+                }
             } else if path_str == "/proc/self/cwd"
                 || path_str == "/proc/self/root"
             {
@@ -2307,15 +2313,21 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // to vfs::readlink() for these would return EINVAL on the symlink
             // dispatch (per proc(5)).
             let target: alloc::string::String = if full_path == "/proc/self/exe" {
-                // See `readlink(2)` arm above (case 89) — empty string for
-                // processes without an exe_path; never the fake "/bin/init"
-                // fallback that misleads dependentlibs path resolution.
+                // Per readlink(2) / readlinkat(2), return ENOENT when the
+                // target symlink has no recorded destination.  An empty string
+                // would cause callers that slice the result without bounds
+                // checking to fault or panic.  ENOENT is the canonical
+                // "symlink target not available" error; callers handle it
+                // gracefully via their own fallback paths.  (POSIX.1-2017.)
                 let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();
-                procs.iter().find(|p| p.pid == pid)
+                match procs.iter().find(|p| p.pid == pid)
                     .and_then(|p| p.exe_path.as_ref())
                     .map(|s| s.clone())
-                    .unwrap_or_else(alloc::string::String::new)
+                {
+                    Some(p) => p,
+                    None => return -2, // ENOENT
+                }
             } else if full_path == "/proc/self/cwd" {
                 let pid = crate::proc::current_pid_lockless();
                 let procs = crate::proc::PROCESS_TABLE.lock();


### PR DESCRIPTION
## Problem

W156 identified a 30 % NO-SPAWN rate across 10 KVM trials caused by a Rust
panic in `core::str::slice_error_fail` at libxul+0x4b4eb00.

Mozilla's `BinaryPath::Get` calls `readlink(\"/proc/self/exe\")` and then
unconditionally slices the returned string as `path[0..len-3]` to strip the
trailing executable name.  When a process has no recorded `exe_path` (e.g. a
transient content-process thread that has not yet called `execve(2)`), the
kernel was returning an **empty string with rc=0**.  `len-3` underflows to
`usize::MAX` on an empty string, triggering the bounds-check panic:

```
core::str::slice_error_fail(begin=0, end=18446744073709551613, s="")
```

The register state was bit-for-bit identical across every affected trial
(`rax=0, rsi=0, rdx=0x1a`), confirming a deterministic code path rather than
a race.

## Fix

Per `readlink(2)` (POSIX.1-2017): when a symbolic link target cannot be
resolved, the correct return value is `-ENOENT`.  An empty string with `rc=0`
is never a valid `readlink(2)` response for an unresolvable symlink.

Changed both the `readlink(2)` handler (syscall 89) and the `readlinkat(2)`
handler (syscall 267): replace `.unwrap_or_else(String::new)` with an explicit
`match` that returns `-ENOENT` when `exe_path` is `None`.

Mozilla's `BinaryPath::Get` wrapper handles `ENOENT` gracefully by falling
back to its alternative executable-path resolution strategy.  No in-process
code path relies on the old empty-string behaviour; `Test 214` (exe_path
propagation, W121) always populates `exe_path = Some(...)` before exercising
the readlink path and is unaffected.

## Verification — 5-trial KVM run (post-fix)

| Trial | Terminal event | `slice_error_fail` | `4b4eb00` | glxtest exec |
|-------|---------------|-------------------|-----------|--------------|
| T1 | `exit_group(0)` | 0 | 0 | yes |
| T2 | `exit_group(0)` | 0 | 0 | yes |
| T3 | `exit_group(0)` | 0 | 0 | yes |
| T4 | `exit_group(0)` | 0 | 0 | yes |
| T5 | `exit_group(0)` | 0 | 0 | yes |

**Bug A NO-SPAWN rate: 0/5 (was ~30 % / 3 in 10 before fix).**

All 5 trials reach `[EXEC]` for `glxtest` (content-process spawn path
exercised) and exit cleanly via `exit_group(0)`.

## Diff

```
kernel/src/subsys/linux/syscall.rs | 38 +++++++++++++++++++++++++-------------
1 file changed, 25 insertions(+), 13 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)