### PR TITLE
kernel/idt: log VMA on Ring-3 #UD for symbolication (W164 follow-up)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -555,6 +555,56 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             "  [exc/regs] r13={:#018x} r14={:#018x} r15={:#018x}",
             r13, r14, r15);
         crate::serial_println!("  Killing user process (exception in Ring 3)");
+
+        // For Ring-3 #UD (vector 6) emit a VMA-range line so the faulting
+        // instruction can be symbolicated against the shared-library load
+        // base (which varies with ASLR).  This mirrors the [SIGNAL/VMA]
+        // banner emitted on SIGSEGV but is scoped to just the VMA that
+        // covers RIP — #UD carries no secondary fault address.
+        //
+        // Lock ordering: PROCESS_TABLE is not held by any path that delivers
+        // a #UD from Ring 3; the snapshot is taken and released before
+        // invalidate_syscall_frame / exit_group.
+        if vector == 6 {
+            let rip = frame.rip;
+            let pid = crate::proc::current_pid_lockless();
+            let procs = crate::proc::PROCESS_TABLE.lock();
+            if let Some(proc_entry) = procs.iter().find(|p| p.pid == pid) {
+                if let Some(vm_space) = proc_entry.vm_space.as_ref() {
+                    if let Some(vma) = vm_space.find_vma(rip) {
+                        use crate::mm::vma::VmBacking;
+                        let (file_name, file_offset) = match &vma.backing {
+                            VmBacking::File { offset, .. } => (vma.name, *offset),
+                            _ => ("<anon>", 0u64),
+                        };
+                        let offset_in_vma  = rip - vma.base;
+                        let offset_in_file = file_offset + offset_in_vma;
+                        crate::serial_println!(
+                            "[UD/VMA] pid={} tid={} rip={:#x} vma_base={:#x} vma_end={:#x} \
+                             file={} offset_in_file={:#x} offset_in_vma={:#x}",
+                            pid,
+                            crate::proc::current_tid(),
+                            rip,
+                            vma.base,
+                            vma.end(),
+                            file_name,
+                            offset_in_file,
+                            offset_in_vma,
+                        );
+                    } else {
+                        crate::serial_println!(
+                            "[UD/VMA] pid={} tid={} rip={:#x} no_vma_match=1",
+                            pid,
+                            crate::proc::current_tid(),
+                            rip,
+                        );
+                    }
+                }
+            }
+            // Drop PROCESS_TABLE before exit_group — exit_group acquires it.
+            drop(procs);
+        }
+
         // POSIX signal(7): synchronous fatal CPU exceptions in user mode
         // (#DE → SIGFPE, #UD → SIGILL, #DF / #SS / #GP / #AC / #MC → SIGBUS|SIGSEGV)
         // default to thread-group termination.  Calling exit_thread would


### PR DESCRIPTION
## Summary

W164 found that the Compositor thread (tid=54) hits a Ring-3 `#UD` (invalid-opcode, vector 6) at libxul RIP `0x7efffa2cff82` after a successful 1-byte IPC write.  Because libxul is loaded at an ASLR-randomised base, this absolute RIP cannot be directly resolved against the library's symbol table without knowing the load base for that particular boot.

The kernel already emits a `[SIGNAL/VMA]` banner on SIGSEGV (PR #181/W79) that gives the libxul base + file offset.  This PR adds the same capability for `#UD`, which previously produced no VMA context in the serial log.

## What changed

`kernel/src/arch/x86_64/idt.rs` — in the Ring-3 branch of the generic exception handler, when `vector == 6`:

1. Acquire `PROCESS_TABLE`, look up the current process's `VmSpace`.
2. Call `find_vma(rip)` to locate the VMA covering the faulting RIP.
3. Emit `[UD/VMA] pid=N tid=M rip=0xXX vma_base=0xXX vma_end=0xXX file=<name> offset_in_file=0xXX offset_in_vma=0xXX` (or a `no_vma_match=1` variant if RIP is unmapped).
4. Drop `PROCESS_TABLE` before the existing `invalidate_syscall_frame` / `exit_group` sequence (which re-acquires it).

No new locks are introduced.  Lock ordering matches the existing SIGSEGV and page-fault paths.

## Lock ordering note

`#UD` from Ring-3 enters via the IDT interrupt gate (IF cleared by CPU on entry).  The generic exception handler re-enables IF early for Ring-3 faults (line 489).  `PROCESS_TABLE` is not held by any path that could have caused the Ring-3 `#UD`; the snapshot is a single read-lock acquisition that is released before `exit_group`.

## Verification

1 firefox-test trial (KVM, `--features firefox-test,kdb,syscall-trace`) completed with `exit_group(0)` — no `#UD` on this run (the fault is not deterministic across all trials).  The code path fires whenever vector 6 is delivered from Ring-3; the build itself is the primary verification that the Rust borrow checker accepts the lock-order and type contracts.

## Usage for W166

When the `[UD/VMA]` line appears, compute:
```
libxul_base = vma_base - 0  # if file_offset == 0 for the .text mapping
symbol_offset = offset_in_file
```
Then: `objdump -d /path/to/libxul.so | grep -A5 "<offset_in_file>"`
or: `addr2line -e libxul.so <offset_in_file>`

## Diff stats

1 file changed, 50 insertions(+) (`kernel/src/arch/x86_64/idt.rs`)