### PR TITLE
kernel/mm: fix TLB shootdown ordering to prevent page-aliasing into user VMAs (W169 root cause)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -929,7 +929,10 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         crate::mm::pmm::PAGE_SIZE,
                     );
                 }
-                crate::mm::refcount::page_ref_dec(old_phys);
+                // CoW: old_phys may still be shared with the parent; we
+                // only release this process's reference.  The CoW copy
+                // (new_phys) takes sole ownership, refcount set to 1 below.
+                let _ = crate::mm::refcount::page_ref_dec(old_phys);
                 crate::mm::refcount::page_ref_set(new_phys, 1);
                 crate::mm::vmm::map_page_in(cr3, page_addr, new_phys, page_flags);
                 // Cross-CPU shootdown: sibling threads sharing the

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -43,7 +43,9 @@ pub fn insert(mount_idx: usize, inode: u64, page_offset: u64, phys: u64) {
         PageCacheEntry { phys, dirty: false },
     ) {
         // Replaced an existing entry — drop old cache reference.
-        crate::mm::refcount::page_ref_dec(old.phys);
+        // Intentional discard: rc may still be > 0 (user PTEs keep
+        // their own references); we only dec the cache's reference.
+        let _ = crate::mm::refcount::page_ref_dec(old.phys);
     }
     // The cache now holds a reference to this page.
     crate::mm::refcount::page_ref_inc(phys);
@@ -61,7 +63,10 @@ pub fn mark_dirty(mount_idx: usize, inode: u64, page_offset: u64) {
 pub fn evict(mount_idx: usize, inode: u64, page_offset: u64) -> Option<u64> {
     let mut cache = PAGE_CACHE.lock();
     if let Some(entry) = cache.remove(&(mount_idx, inode, page_offset)) {
-        crate::mm::refcount::page_ref_dec(entry.phys);
+        // Caller takes ownership of the phys frame; freeing it (with proper
+        // shootdown) is the caller's responsibility.  Here we only release
+        // the cache's reference.
+        let _ = crate::mm::refcount::page_ref_dec(entry.phys);
         Some(entry.phys)
     } else {
         None

--- a/kernel/src/mm/refcount.rs
+++ b/kernel/src/mm/refcount.rs
@@ -57,7 +57,15 @@ pub fn page_ref_inc(phys_addr: u64) {
 }
 
 /// Decrement the reference count for a physical page.
-/// Returns the new count. If it reaches 0, the page can be freed.
+///
+/// Returns the **new** count after the decrement.  Callers MUST check the
+/// return value: when it is zero the frame has no remaining references and
+/// must be freed via `pmm::free_page` only AFTER a completed TLB shootdown
+/// on every CPU that may hold a cached translation to this frame
+/// (see Intel SDM Vol. 3A §4.10.5).
+#[must_use = "dropping the return value of page_ref_dec silently loses the \
+              information needed to decide when to free the frame; check \
+              whether the count reached zero and schedule a shootdown+free"]
 pub fn page_ref_dec(phys_addr: u64) -> u16 {
     let idx = pfn(phys_addr);
     let rc = refcounts();

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -532,8 +532,7 @@ pub fn unmap_page_in(pml4_phys: u64, virt_addr: u64) {
 
 /// Unmap every present page in `[base, base+length)` from an arbitrary page
 /// table, drop one reference on the underlying physical frame, and free the
-/// frame when the last reference goes away.  Each cleared PTE is followed by
-/// `invlpg` on the calling CPU.
+/// frame when the last reference goes away.
 ///
 /// This helper exists so the upper-level mmap / munmap paths can run the
 /// expensive bulk-unmap loop **without holding `PROCESS_TABLE`**.  It only
@@ -543,40 +542,78 @@ pub fn unmap_page_in(pml4_phys: u64, virt_addr: u64) {
 /// `base` and `length` are caller-validated to be page-aligned and bounded
 /// to a user-process VMA range.
 ///
+/// ## SMP ordering invariant (Intel SDM Vol. 3A §4.10.5)
+///
+/// Paging-structure changes must be propagated to all processors before the
+/// physical frames are returned to the allocator.  The required sequence is:
+///
+/// 1. Clear the PTE(s) on the modifying processor.
+/// 2. **Synchronously shootdown TLB entries on every sibling CPU** — via IPI,
+///    waiting for acknowledgement from each target before continuing.
+/// 3. Only then return physical frames to the PMM.
+///
+/// Freeing a frame before step 2 completes creates a window where a sibling
+/// user-mode thread — sharing the same CR3 — still holds a stale TLB entry
+/// mapping a user VA to the recycled frame.  If the kernel allocates that
+/// frame in the meantime (e.g. for a heap Vec, a cache chunk, or a page-table
+/// level), the sibling thread can read kernel data through the stale mapping.
+/// This is NOT prevented by any critical-section discipline: user-mode threads
+/// on other CPUs run concurrently with the syscall handler on this CPU.
+///
+/// The implementation below uses a fixed-size batch buffer to avoid allocator
+/// dependence in this low-level path.  For ranges larger than `BATCH` pages,
+/// it performs multiple shootdown-then-free rounds, each covering at most
+/// `BATCH` pages, so the IPI overhead is bounded.
+///
 /// Returns the number of frames actually freed (rc reached zero).  Pages
 /// that were never demand-paged are skipped.
 pub fn unmap_and_free_range_in(pml4_phys: u64, base: u64, length: u64) -> usize {
+    // Maximum physical addresses to defer per shootdown round.  1024 pages =
+    // 4 MiB.  Keeping the batch finite bounds stack-pressure (this runs on
+    // the kernel stack, not a heap-allocated buffer).
+    const BATCH: usize = 1024;
+
     let mut freed = 0usize;
     let mut pg = base;
     let end = base.saturating_add(length);
-    let mut first_unmapped: Option<u64> = None;
-    let mut last_unmapped: u64 = 0;
+
     while pg < end {
-        if let Some(phys) = virt_to_phys_in(pml4_phys, pg) {
-            unmap_page_in(pml4_phys, pg);
-            // Defer the per-page TLB invalidation to a single coalesced
-            // shootdown after the loop so we send at most one IPI per
-            // unmap call instead of one per page.  The local CPU's TLB
-            // still contains stale entries until that point but the
-            // kernel is single-threaded inside this critical section
-            // (no syscall can touch the same VA range until we return)
-            // so no other AstryxOS code observes the stale translation.
-            // The deferred shootdown also covers other CPUs.
-            if first_unmapped.is_none() {
-                first_unmapped = Some(pg);
+        // --- Pass 1: clear PTEs and collect physical addresses to free. ---
+        // Do NOT free frames yet: TLB entries on sibling CPUs still point at
+        // them and must be invalidated first (see invariant above).
+        let batch_start = pg;
+        let mut to_free = [0u64; BATCH];
+        let mut n = 0usize;
+
+        while pg < end && n < BATCH {
+            if let Some(phys) = virt_to_phys_in(pml4_phys, pg) {
+                unmap_page_in(pml4_phys, pg);
+                let new_rc = crate::mm::refcount::page_ref_dec(phys);
+                if new_rc == 0 {
+                    to_free[n] = phys;
+                    n += 1;
+                }
             }
-            last_unmapped = pg + 0x1000;
-            let new_rc = crate::mm::refcount::page_ref_dec(phys);
-            if new_rc == 0 {
-                pmm::free_page(phys);
+            pg += 0x1000;
+        }
+        let batch_end = pg; // exclusive upper bound for this batch
+
+        if batch_end > batch_start {
+            // --- Pass 2: synchronous TLB shootdown across all CPUs. ---
+            // shootdown_range spins until every target CPU has acknowledged
+            // the IPI and executed invlpg (or a CR3 reload).  On return,
+            // no CPU holds a cached translation for [batch_start, batch_end).
+            crate::mm::tlb::shootdown_range(pml4_phys, batch_start, batch_end);
+
+            // --- Pass 3: return frames to the PMM. ---
+            // Safe now: every stale TLB entry has been evicted by pass 2.
+            for i in 0..n {
+                pmm::free_page(to_free[i]);
                 freed += 1;
             }
         }
-        pg += 0x1000;
     }
-    if let Some(lo) = first_unmapped {
-        crate::mm::tlb::shootdown_range(pml4_phys, lo, last_unmapped);
-    }
+
     freed
 }
 

--- a/kernel/src/proc/vdso.rs
+++ b/kernel/src/proc/vdso.rs
@@ -264,9 +264,11 @@ pub fn map_vdso(cr3: u64, vmas: &mut Vec<VmArea>) -> Option<u64> {
             // Roll back the vvar + any prior vDSO mappings on failure.
             // (Not strictly necessary — the process will be killed if
             // its VmSpace can't be built — but keeps refcounts accurate.)
-            refcount::page_ref_dec(vvar_phys);
+            // Rollback on failure: the process is about to be killed so
+            // no shootdown is required; just balance the refcounts.
+            let _ = refcount::page_ref_dec(vvar_phys);
             for j in 0..i {
-                refcount::page_ref_dec(vdso_phys + (j * PAGE_SIZE) as u64);
+                let _ = refcount::page_ref_dec(vdso_phys + (j * PAGE_SIZE) as u64);
             }
             return None;
         }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3089,32 +3089,78 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     };
     let cr3 = match cr3_opt { Some(c) => c, None => return 0 };
 
+    // SMP ordering invariant (Intel SDM Vol. 3A §4.10.5): PTEs must be cleared
+    // and a synchronous TLB shootdown must complete on all CPUs BEFORE physical
+    // frames are returned to the PMM.  Freeing a frame before the shootdown
+    // creates a window where a sibling user-mode thread's stale TLB entry still
+    // maps the freed frame; if the kernel allocates that frame in the meantime,
+    // the sibling thread reads kernel data through the stale mapping.
+    //
+    // Three-pass approach:
+    //   Pass 1 — zero and clear PTEs, collect physical addresses to free.
+    //   Pass 2 — synchronous shootdown (IPI + ack) across all CPUs.
+    //   Pass 3 — return frames to the PMM (safe after pass 2 completes).
+    //
+    // The batch buffer uses the same BATCH constant as unmap_and_free_range_in.
+    // For MADV_DONTNEED the typical range is a handful of pages (stack trim,
+    // arena shrink), so a single pass of 1024 is more than sufficient.
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    const BATCH: usize = 1024;
+
     let mut page = start;
-    let mut had_unmap = false;
+    let mut any_unmap = false;
+
     while page < end {
-        let pte = crate::mm::vmm::read_pte(cr3, page);
-        if pte & 1 != 0 {
-            // Present — free the physical page.
-            let phys = pte & 0x000F_FFFF_FFFF_F000;
-            // Zero-out and unmap; next access demand-pages a fresh zeroed page.
-            unsafe {
-                core::ptr::write_bytes((PHYS_OFF + phys) as *mut u8, 0, crate::mm::pmm::PAGE_SIZE);
+        // --- Pass 1: zero backing storage, clear PTEs, collect to_free. ---
+        let batch_start = page;
+        let mut to_free = [0u64; BATCH];
+        let mut n = 0usize;
+
+        while page < end && n < BATCH {
+            let pte = crate::mm::vmm::read_pte(cr3, page);
+            if pte & 1 != 0 {
+                let phys = pte & 0x000F_FFFF_FFFF_F000;
+                // Zero the backing storage now (while we still own the frame)
+                // so the next demand-fault sees a fresh zeroed page.
+                unsafe {
+                    core::ptr::write_bytes(
+                        (PHYS_OFF + phys) as *mut u8,
+                        0,
+                        crate::mm::pmm::PAGE_SIZE,
+                    );
+                }
+                // Clear the PTE.  Do NOT free the frame yet.
+                crate::mm::vmm::write_pte(cr3, page, 0);
+                any_unmap = true;
+
+                // Decrement the reference count.  Collect for deferred free
+                // only if the count reaches zero.
+                let rc = crate::mm::refcount::page_ref_count(phys);
+                if rc <= 1 {
+                    crate::mm::refcount::page_ref_set(phys, 0);
+                    to_free[n] = phys;
+                    n += 1;
+                } else {
+                    // rc > 1: shared page (CoW or cache); release one
+                    // reference without freeing.  No shootdown needed here
+                    // because the PTE was cleared above and pass 2 covers it.
+                    let _ = crate::mm::refcount::page_ref_dec(phys);
+                }
             }
-            crate::mm::vmm::write_pte(cr3, page, 0);
-            had_unmap = true;
-            let rc = crate::mm::refcount::page_ref_count(phys);
-            if rc <= 1 {
-                crate::mm::refcount::page_ref_set(phys, 0);
-                crate::mm::pmm::free_page(phys);
-            } else {
-                crate::mm::refcount::page_ref_dec(phys);
+            page += crate::mm::pmm::PAGE_SIZE as u64;
+        }
+        let batch_end = page;
+
+        if any_unmap && batch_end > batch_start {
+            // --- Pass 2: synchronous shootdown. ---
+            // On return every CPU has evicted TLB entries for [batch_start, batch_end).
+            crate::mm::tlb::shootdown_range(cr3, batch_start, batch_end);
+
+            // --- Pass 3: free frames now that no stale TLB entries remain. ---
+            for i in 0..n {
+                crate::mm::pmm::free_page(to_free[i]);
             }
         }
-        page += crate::mm::pmm::PAGE_SIZE as u64;
-    }
-    if had_unmap {
-        crate::mm::tlb::shootdown_range(cr3, start, end);
     }
     0
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -15454,7 +15454,8 @@ fn test_madvise_dontneed() -> bool {
             crate::mm::refcount::page_ref_set(phys, 0);
             crate::mm::pmm::free_page(phys);
         } else {
-            crate::mm::refcount::page_ref_dec(phys);
+            // rc > 1: shared; dec without freeing.
+            let _ = crate::mm::refcount::page_ref_dec(phys);
         }
     }
 


### PR DESCRIPTION
## Summary

- **Root cause (W169 verdict)**: `unmap_and_free_range_in` and `sys_madvise` MADV_DONTNEED freed physical frames inside the PTE-clearing loop and emitted a single coalesced `shootdown_range` only after the loop. This violates the ordering required by Intel SDM Vol. 3A §4.10.5: TLB invalidation on all processors must complete before a frame is returned to the allocator.
- **Failure window**: between `pmm::free_page(phys)` and the deferred `tlb::shootdown_range(...)`, a sibling user-mode thread on another CPU retained a stale TLB entry mapping a user VA to the freed frame. The kernel allocated that frame for internal storage (heap Vec, cache chunk, page-table level, etc.), writing kernel data into it. The sibling thread then read or executed that kernel data through the stale user mapping — producing `#UD` or `SIGSEGV` in the libxul+0x4b* region. W168 captured byte-level evidence: `core::fmt::LowerHex::fmt` function pointers and `PHYS_OFF`-relative addresses appearing in a file-backed libxul VMA.
- **Fix**: three-pass batch pattern in both callsites — (1) clear PTEs and collect frames in a fixed stack array, (2) synchronous shootdown, (3) free frames. This ordering matches `free_process_memory` / `free_vm_space` in `proc/mod.rs`, which already had the invariant correct.
- **Hardening**: `page_ref_dec` is now `#[must_use]`; all intentional discards are annotated with `let _ =` and a comment.

## Affected callsites

| File | Change |
|------|--------|
| `kernel/src/mm/vmm.rs` | `unmap_and_free_range_in`: three-pass batch (primary fix) |
| `kernel/src/subsys/linux/syscall.rs` | `sys_madvise` MADV_DONTNEED: three-pass batch |
| `kernel/src/mm/refcount.rs` | `page_ref_dec` → `#[must_use]` |
| `kernel/src/mm/cache.rs` | `let _ =` at intentional discard sites |
| `kernel/src/arch/x86_64/idt.rs` | `let _ =` at CoW dec site |
| `kernel/src/proc/vdso.rs` | `let _ =` at rollback dec site |
| `kernel/src/test_runner.rs` | `let _ =` at shared-page dec site |

## Verification

3/3 KVM trials (`firefox-test,kdb,syscall-trace`) ran the full Mozilla init sequence with:
- **0/3 SIGSEGV** in libxul+0x4b* cluster (W147 baseline: 4/5)
- **0/3 #UD**
- **0/3 BUGCHECK**
- Trial 3 advanced to the `sem_wait Branch-A` plateau — a separate independent wedge, not affected by this fix

Build: `python3 scripts/qemu-harness.py check --features firefox-test` → `{"ok": true, "rc": 0}`

## References

- Intel SDM Vol. 3A §4.10.5, "Propagation of Paging-Structure Changes to Multiple Processors"
- W169 investigator report (high-confidence verdict: TLB shootdown ordering)
- W168 byte-level aliasing evidence (kernel function pointers in libxul VMA)

## Diff size

206 lines changed (154 additions, 52 deletions) across 7 files. Soft target was ~80 LOC. Overage is ~1.7× and is justified: the three-pass pattern requires substantially more inline documentation than the original loop to make the SMP invariant clear to future maintainers — the comment blocks account for most of the overage beyond the logical fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)