### PR TITLE
kernel/signal+idt: walk user stack on Ring-3 fault for caller-chain diagnostics (W193)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -453,6 +453,18 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                 // Dump IRET frame fields
                 crate::serial_println!("  RFLAGS={:#018x}", frame.rflags);
             }
+            // Walk the RBP-linked frame chain to emit a caller-chain backtrace.
+            // RBP is saved at frame[-12] by the ISR push sequence:
+            //   frame[-2]=rax … frame[-11]=rbx frame[-12]=rbp (see isr_with_error layout).
+            // Per System V AMD64 ABI §3.4.1, with -fno-omit-frame-pointer each
+            // frame satisfies [rbp+0]=saved_rbp, [rbp+8]=return_address.
+            {
+                let base = frame as *const InterruptFrame as *const u64;
+                let rbp_at_fault = unsafe { *base.sub(12) };
+                let pid = crate::proc::current_pid_lockless();
+                let tid = crate::proc::current_tid();
+                crate::proc::stack_walk::stack_walk_user(pid, tid, frame.rip, rbp_at_fault);
+            }
             // POSIX signal(7): the default action for SIGSEGV is "terminate
             // the process (core dump)" — the entire thread group, not just
             // the faulting thread.  Calling exit_thread would leave sibling
@@ -751,6 +763,18 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             }
         }
 
+        // Walk the RBP-linked frame chain to emit a caller-chain backtrace
+        // before tearing down the process.  RBP is at frame[-12] in the
+        // ISR push sequence (see isr_with_error / isr_no_error layout).
+        // Per System V AMD64 ABI §3.4.1, with -fno-omit-frame-pointer each
+        // frame satisfies [rbp+0]=saved_rbp, [rbp+8]=return_address.
+        {
+            let base = frame as *const InterruptFrame as *const u64;
+            let rbp_at_fault = unsafe { *base.sub(12) };
+            let pid = crate::proc::current_pid_lockless();
+            let tid = crate::proc::current_tid();
+            crate::proc::stack_walk::stack_walk_user(pid, tid, frame.rip, rbp_at_fault);
+        }
         // POSIX signal(7): synchronous fatal CPU exceptions in user mode
         // (#DE → SIGFPE, #UD → SIGILL, #DF / #SS / #GP / #AC / #MC → SIGBUS|SIGSEGV)
         // default to thread-group termination.  Calling exit_thread would

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -22,6 +22,7 @@ pub mod pe;
 pub mod qga_elf;
 #[cfg(feature = "firefox-test")]
 pub mod sample;
+pub mod stack_walk;
 pub mod thread;
 pub mod usermode;
 pub mod vdso;

--- a/kernel/src/proc/stack_walk.rs
+++ b/kernel/src/proc/stack_walk.rs
@@ -1,0 +1,350 @@
+//! User-space stack-frame walker for fault-time caller-chain diagnostics.
+//!
+//! When the kernel terminates a Ring-3 process following a fatal exception
+//! (SIGSEGV, SIGILL, SIGBUS, etc.) the faulting RIP names the instruction
+//! that trapped but gives no information about the call chain that led
+//! there.  This module walks the RBP-linked frame chain from the kernel
+//! exception handler, emitting up to `MAX_DEPTH` frames as structured
+//! `[STACK]` / `[STACK/VMA]` log lines without acquiring any blocking lock.
+//!
+//! ## Frame layout (System V AMD64 ABI §3.4.1)
+//!
+//! With `-fno-omit-frame-pointer` (the default for Mozilla libxul and most
+//! system libraries), every frame satisfies:
+//!
+//! ```text
+//!   [rbp + 0]  = saved RBP of caller frame
+//!   [rbp + 8]  = return address (saved RIP of caller)
+//! ```
+//!
+//! The chain terminates when `saved_rbp` is zero (bottom of the main thread
+//! stack) or when any sanity guard fires.
+//!
+//! ## Safety model
+//!
+//! All user-memory reads go through `read_user_u64`, which performs the
+//! 4-level page-table walk using the process's CR3 (passed in by the
+//! caller) and reads the physical frame via the kernel's direct physical map
+//! (`PHYS_OFF`).  No `unsafe { ptr::read }` on a user virtual address is
+//! ever issued.  A page-table miss results in an `Err` return and terminates
+//! the walk gracefully rather than causing a nested kernel fault.
+//!
+//! ## Lock ordering
+//!
+//! `stack_walk_user` does NOT hold `PROCESS_TABLE`.  The caller is expected
+//! to have already dropped it (the same discipline used by `emit_signal_vma_banner`
+//! and the `[UD/VMA]` emission block).  VMA resolution acquires
+//! `PROCESS_TABLE` briefly per frame; this is the same pattern used by the
+//! existing Ring-3 diagnostics.
+//!
+//! ## Output format
+//!
+//! ```text
+//! [STACK] pid=1 tid=3 depth=0 rip=0x7efff... rbp=0x7fff... (faulting frame)
+//! [STACK/VMA] pid=1 tid=3 depth=0 rip=0x7efff... vma_base=0x7efff... vma_end=0x7f000... file=libxul.so offset_in_vma=0x1234 offset_in_file=0x1234 vaddr_in_elf=0x5678
+//! [STACK] pid=1 tid=3 depth=1 rip=0x7effa... rbp=0x7fff...
+//! [STACK/VMA] pid=1 tid=3 depth=1 rip=0x7effa... vma_base=...
+//! ...
+//! [STACK] terminated reason=saved_rbp_zero depth=N
+//! ```
+
+/// Highest user-space virtual address (exclusive).  Identical to
+/// `signal::USER_ADDR_END`; repeated here to keep this module self-contained.
+const USER_ADDR_END: u64 = 0x0000_8000_0000_0000;
+
+/// Physical-to-virtual offset for the kernel's direct physical map.
+const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+
+/// Maximum number of frames emitted.  Capped to bound serial output per fault.
+const MAX_DEPTH: usize = 20;
+
+/// Minimum valid user-space address.  Addresses below this (within the first
+/// page) are always invalid; catching NULL-derived offsets early avoids a
+/// pointless page-table walk.
+const USER_ADDR_MIN: u64 = 0x1000;
+
+/// Read a `u64` from the user address `va` in the page table rooted at
+/// `cr3`, using the direct physical map for the actual memory access.
+///
+/// Returns `Ok(value)` if the address is mapped and readable, `Err(())`
+/// if the page-table walk finds no present mapping.
+///
+/// The read is performed as a volatile load to prevent the compiler from
+/// speculating the access across an absent page.
+#[inline]
+fn read_user_u64(cr3: u64, va: u64) -> Result<u64, ()> {
+    match crate::mm::vmm::virt_to_phys_in(cr3, va) {
+        Some(phys) => {
+            // SAFETY: `phys` is a valid physical address returned by the page-
+            // table walker.  `PHYS_OFF + phys` is within the kernel's direct
+            // physical map, which covers all installed RAM.  The volatile load
+            // prevents the compiler from hoisting this past the page-table check.
+            let val = unsafe {
+                core::ptr::read_volatile((PHYS_OFF + phys) as *const u64)
+            };
+            Ok(val)
+        }
+        None => Err(()),
+    }
+}
+
+/// Attempt to read a `u64` from `va`; if the first 8-byte word spans a page
+/// boundary, each byte is read separately via individual physical translations.
+///
+/// Most frame-pointer reads are naturally aligned (the ABI requires RSP to be
+/// 16-byte aligned at call sites), but this handles the rare cross-page case
+/// without a kernel fault.
+#[inline]
+fn read_user_u64_safe(cr3: u64, va: u64) -> Result<u64, ()> {
+    // Fast path: both start and end are on the same 4 KiB page.
+    let page_start = va & !0xFFF;
+    let page_end   = (va + 7) & !0xFFF;
+    if page_start == page_end {
+        return read_user_u64(cr3, va);
+    }
+    // Slow path: 8 bytes straddle a page boundary — read byte-by-byte.
+    let mut buf = [0u8; 8];
+    for i in 0..8u64 {
+        match crate::mm::vmm::virt_to_phys_in(cr3, va + i) {
+            Some(phys) => {
+                buf[i as usize] = unsafe {
+                    core::ptr::read_volatile((PHYS_OFF + phys) as *const u8)
+                };
+            }
+            None => return Err(()),
+        }
+    }
+    Ok(u64::from_le_bytes(buf))
+}
+
+/// Compact VMA data for a single `rip`, extracted under `PROCESS_TABLE` lock
+/// and used for the `[STACK/VMA]` line after the lock is dropped.
+#[derive(Copy, Clone)]
+struct StackVmaInfo {
+    vma_base:       u64,
+    vma_end:        u64,
+    offset_in_vma:  u64,
+    /// Non-zero only for file-backed VMAs.
+    offset_in_file: u64,
+    /// Non-zero only for ELF PT_LOAD segments.
+    vaddr_in_elf:   u64,
+    /// `&'static str` from `VmArea::name` — valid for the kernel's lifetime.
+    name:           &'static str,
+    is_file:        bool,
+}
+
+/// Emit a `[STACK/VMA]` line for the given `rip` at the specified `depth`.
+///
+/// Acquires `PROCESS_TABLE` briefly to snapshot the VMA covering `rip`, then
+/// drops the lock before calling `serial_println!` (COM1 is slow and must not
+/// be held across the spinlock; identical discipline to `emit_signal_vma_banner`).
+fn emit_stack_vma_line(pid: u64, tid: u64, depth: usize, rip: u64) {
+    use crate::mm::vma::VmBacking;
+
+    // ── Phase 1: snapshot VMA data under the lock ────────────────────────────
+    let info: Option<StackVmaInfo> = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs
+            .iter()
+            .find(|p| p.pid == pid)
+            .and_then(|proc_entry| proc_entry.vm_space.as_ref())
+            .and_then(|vs| vs.find_vma(rip))
+            .map(|vma| {
+                let offset_in_vma = rip - vma.base;
+                let (is_file, offset_in_file, vaddr_in_elf) = match &vma.backing {
+                    VmBacking::File { offset, elf_load_delta, .. } => {
+                        let off_file = offset + offset_in_vma;
+                        let vaddr    = if *elf_load_delta != 0 {
+                            off_file.wrapping_add(*elf_load_delta)
+                        } else {
+                            0
+                        };
+                        (true, off_file, vaddr)
+                    }
+                    _ => (false, 0, 0),
+                };
+                StackVmaInfo {
+                    vma_base:      vma.base,
+                    vma_end:       vma.end(),
+                    name:          vma.name,
+                    offset_in_vma,
+                    offset_in_file,
+                    vaddr_in_elf,
+                    is_file,
+                }
+            })
+        // lock dropped here
+    };
+
+    // ── Phase 2: emit after the lock is released ─────────────────────────────
+    match info {
+        None => {
+            crate::serial_println!(
+                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} no_vma=1",
+                pid, tid, depth, rip,
+            );
+        }
+        Some(v) if v.is_file && v.vaddr_in_elf != 0 => {
+            crate::serial_println!(
+                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
+                 vma_base={:#x} vma_end={:#x} file={} \
+                 offset_in_vma={:#x} offset_in_file={:#x} vaddr_in_elf={:#x}",
+                pid, tid, depth, rip,
+                v.vma_base, v.vma_end, v.name,
+                v.offset_in_vma, v.offset_in_file, v.vaddr_in_elf,
+            );
+        }
+        Some(v) if v.is_file => {
+            crate::serial_println!(
+                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
+                 vma_base={:#x} vma_end={:#x} file={} \
+                 offset_in_vma={:#x} offset_in_file={:#x}",
+                pid, tid, depth, rip,
+                v.vma_base, v.vma_end, v.name,
+                v.offset_in_vma, v.offset_in_file,
+            );
+        }
+        Some(v) => {
+            // Anonymous or device mapping.
+            crate::serial_println!(
+                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
+                 vma_base={:#x} vma_end={:#x} file=<anon> offset_in_vma={:#x}",
+                pid, tid, depth, rip,
+                v.vma_base, v.vma_end, v.offset_in_vma,
+            );
+        }
+    }
+}
+
+/// Walk the user-space RBP-linked frame chain starting from the faulting
+/// frame and emit up to `MAX_DEPTH` frames as `[STACK]` / `[STACK/VMA]`
+/// log lines.
+///
+/// # Arguments
+///
+/// * `pid`  — Process ID, used to tag log lines and look up the VmSpace.
+/// * `tid`  — Thread ID, used to tag log lines.
+/// * `rip0` — RIP at the faulting instruction (depth-0 frame).
+/// * `rbp0` — RBP at the faulting instruction (depth-0 frame).
+///
+/// CR3 is read from the hardware register inside this function.  The
+/// exception handler must not have switched CR3 before calling; in
+/// practice, all Ring-3 exception paths stay on the process CR3 until
+/// `exit_group` tears down the address space.
+///
+/// # Termination conditions
+///
+/// The walk stops (emitting a `[STACK] terminated reason=…` line) when:
+///
+/// * `rbp` is zero (bottom of the main-thread stack, as set by the C
+///   runtime or dynamic linker entry point).
+/// * `rbp` is not 8-byte aligned (corrupted or non-frame-pointer code).
+/// * `rbp` is outside `[USER_ADDR_MIN, USER_ADDR_END)`.
+/// * Reading `[rbp+0]` or `[rbp+8]` fails (unmapped page).
+/// * `saved_rbp <= rbp` (frames must advance toward higher addresses as
+///   the stack grows downward — violation means corrupted chain or a leaf
+///   function compiled without a frame pointer).
+/// * `MAX_DEPTH` frames have been emitted.
+///
+/// # Lock ordering
+///
+/// This function must NOT be called while `PROCESS_TABLE` is held.
+/// It briefly acquires and releases it once per frame for VMA resolution
+/// (the same discipline used by `emit_signal_vma_banner`).
+pub fn stack_walk_user(pid: u64, tid: u64, rip0: u64, rbp0: u64) {
+    // Read the current page-table root.  Intel SDM Vol. 3A §2.5: CR3
+    // holds the physical base address of the PML4 table.  Reading it at
+    // CPL 0 (inside the exception handler) reflects the process's own
+    // address space because no CR3 switch has occurred yet.
+    let cr3: u64;
+    unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3, options(nomem, nostack, preserves_flags)); }
+    let cr3 = cr3 & crate::mm::vmm::ADDR_MASK;
+    // ── Depth-0: the faulting frame itself ──────────────────────────────────
+    crate::serial_println!(
+        "[STACK] pid={} tid={} depth=0 rip={:#x} rbp={:#x} (faulting frame)",
+        pid, tid, rip0, rbp0,
+    );
+    if rip0 >= USER_ADDR_MIN && rip0 < USER_ADDR_END {
+        emit_stack_vma_line(pid, tid, 0, rip0);
+    }
+
+    let mut rbp = rbp0;
+
+    for depth in 1..MAX_DEPTH {
+        // ── Sanity: rbp must be a plausible user-space frame-pointer ────────
+        if rbp == 0 {
+            crate::serial_println!(
+                "[STACK] terminated reason=saved_rbp_zero depth={}",
+                depth,
+            );
+            break;
+        }
+        if rbp & 0x7 != 0 {
+            crate::serial_println!(
+                "[STACK] terminated reason=rbp_misaligned depth={} rbp={:#x}",
+                depth, rbp,
+            );
+            break;
+        }
+        if rbp < USER_ADDR_MIN || rbp >= USER_ADDR_END {
+            crate::serial_println!(
+                "[STACK] terminated reason=rbp_out_of_range depth={} rbp={:#x}",
+                depth, rbp,
+            );
+            break;
+        }
+
+        // ── Read saved RBP at [rbp+0] ────────────────────────────────────────
+        let saved_rbp = match read_user_u64_safe(cr3, rbp) {
+            Ok(v) => v,
+            Err(_) => {
+                crate::serial_println!(
+                    "[STACK] terminated reason=read_fault_rbp depth={} rbp={:#x}",
+                    depth, rbp,
+                );
+                break;
+            }
+        };
+
+        // ── Read saved RIP at [rbp+8] ────────────────────────────────────────
+        let saved_rip = match read_user_u64_safe(cr3, rbp + 8) {
+            Ok(v) => v,
+            Err(_) => {
+                crate::serial_println!(
+                    "[STACK] terminated reason=read_fault_rip depth={} rbp={:#x}",
+                    depth, rbp,
+                );
+                break;
+            }
+        };
+
+        // ── Emit this frame ──────────────────────────────────────────────────
+        crate::serial_println!(
+            "[STACK] pid={} tid={} depth={} rip={:#x} rbp={:#x}",
+            pid, tid, depth, saved_rip, saved_rbp,
+        );
+        if saved_rip >= USER_ADDR_MIN && saved_rip < USER_ADDR_END {
+            emit_stack_vma_line(pid, tid, depth, saved_rip);
+        } else if saved_rip != 0 {
+            // Kernel address or zero in the return slot — log but don't walk VMA.
+            crate::serial_println!(
+                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} out_of_user_range=1",
+                pid, tid, depth, saved_rip,
+            );
+        }
+
+        // ── Advance: stack grows downward so valid saved_rbp > current rbp ──
+        // Per System V AMD64 ABI §3.4.1: the frame pointer of any callee
+        // frame is at a higher address than the frame pointer of its caller.
+        if saved_rbp <= rbp {
+            crate::serial_println!(
+                "[STACK] terminated reason=frame_did_not_advance depth={} \
+                 rbp={:#x} saved_rbp={:#x}",
+                depth + 1, rbp, saved_rbp,
+            );
+            break;
+        }
+
+        rbp = saved_rbp;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `kernel/src/proc/stack_walk.rs`: a page-table-safe RBP-chain walker that emits up to 20 `[STACK]` / `[STACK/VMA]` log lines on every fatal Ring-3 exception, converting the single-RIP snapshot into a full caller chain.
- Wires the walker into both Ring-3 fatal paths in `exception_handler`: the `#PF`-no-handler path and the general exception path (`#UD`, `#GP`, `#SS`, etc.).
- `cargo +nightly check --features firefox-test` passes clean.

## Motivation

W184 and W189 evidence: single-RIP symbolication repeatedly names deeply inlined libxul helpers (e.g. `MOZ_RELEASE_ASSERT` stubs, Fc-pattern null-deref sites) whose actual callers — visible only in the call stack — are the root cause.  Without a backtrace, investigation requires attaching a debugger or educated guessing from a single RIP and VMA range.  With `-fno-omit-frame-pointer` (Mozilla's release default for crash-reporting), the RBP chain is intact through libxul, glibc, and most runtime libraries, making a kernel-side walk fully viable.

## Frame layout

Per System V AMD64 ABI Vol. 1 §3.4.1, each frame with a frame pointer satisfies:
```
[rbp + 0] = saved RBP of caller frame
[rbp + 8] = return address (saved RIP of caller)
```
Intel SDM Vol. 3A §2.5: CR3 holds the PML4 physical base; reading it inside the exception handler (before any CR3 switch) gives the faulting process's own page table.

## Safety model

All user-memory reads go through `virt_to_phys_in(cr3, va)` followed by a volatile load through the kernel's direct physical map (`PHYS_OFF = 0xFFFF_8000_0000_0000`).  No unsafe dereference of a user virtual address is issued.  A page-table miss returns `Err(())` and terminates the walk with a tagged reason line rather than faulting in kernel mode.

Cross-page reads (8-byte word straddling a 4 KiB boundary) fall back to byte-by-byte physical translation.

## VMA resolution (lock ordering)

`emit_stack_vma_line` acquires and immediately releases `PROCESS_TABLE` to snapshot the VMA for each `rip`, then emits `[STACK/VMA]` after the lock is dropped — same discipline as `emit_signal_vma_banner` (PR #181) and `[UD/VMA]`.  `stack_walk_user` must not be called while `PROCESS_TABLE` is held; both call sites satisfy this invariant.

## Sanity guards

Walk terminates (with tagged reason) on:
- `rbp == 0` — C runtime marks the bottom of the main-thread stack with a zeroed frame
- `rbp & 7 != 0` — misaligned, not a frame pointer
- `rbp` outside `[0x1000, USER_ADDR_END)`
- read fault on `[rbp+0]` or `[rbp+8]`
- `saved_rbp <= rbp` — would loop or go backward (stack grows down)
- 20-frame cap exhausted

## Call sites

RBP is taken from the ISR kernel stack at `frame[-12]`, per the documented `isr_with_error` push sequence in `idt.rs`.

## Expected output

```
[STACK] pid=1 tid=48 depth=0 rip=0x7efff4b8d40 rbp=0x7fffe7f8b40 (faulting frame)
[STACK/VMA] pid=1 tid=48 depth=0 rip=0x7efff4b8d40 vma_base=0x7efff000000 vma_end=0x7f0004e7000 file=libxul.so offset_in_vma=0x3b8d40 offset_in_file=0x3b8d40 vaddr_in_elf=0x3b8d40
[STACK] pid=1 tid=48 depth=1 rip=0x7efff4b9120 rbp=0x7fffe7f8b70
[STACK/VMA] pid=1 tid=48 depth=1 rip=0x7efff4b9120 vma_base=0x7efff000000 vma_end=0x7f0004e7000 file=libxul.so offset_in_vma=0x3b9120 offset_in_file=0x3b9120 vaddr_in_elf=0x3b9120
...
[STACK] terminated reason=saved_rbp_zero depth=14
```

The `vaddr_in_elf` field is the link-time ELF virtual address that `addr2line -e libxul.so 0x3b8d40` expects — no offline arithmetic needed.

## Diff

- `kernel/src/proc/stack_walk.rs` NEW 350 lines (~194 functional, rest docs/comments)
- `kernel/src/proc/mod.rs`         +1 line (module declaration)
- `kernel/src/arch/x86_64/idt.rs`  +24 lines (two call sites)

**No QEMU trials run** — W192 is running KVM PNG verification concurrently.

## Test plan

- [ ] `cargo +nightly check --features firefox-test` passes (verified: zero new errors)
- [ ] W192 KVM trials complete → use output to verify `[STACK]` lines appear on the next SIGSEGV / `#UD` / `#GP` fault
- [ ] Run `addr2line -e build/disk/usr/lib/x86_64-linux-gnu/libxul.so <vaddr_in_elf>` on a captured `[STACK/VMA]` line to confirm symbolication is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)