### PR TITLE
kernel/main: enable LD_DEBUG + MOZ_LOG in FFTEST for runtime observability (W194)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -905,6 +905,17 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // See https://firefox-source-docs.mozilla.org/xpcom/logging.html
         "MOZ_LOG=all:5,nsresult:5,xpcom:5",
         "NSPR_LOG_MODULES=all:5",
+        // Redirect MOZ_LOG output to a file so it survives past any pipe
+        // read-deadline.  Extractable post-run via QGA guest-file-read.
+        // See https://firefox-source-docs.mozilla.org/xpcom/logging.html
+        "MOZ_LOG_FILE=/tmp/mozlog",
+        // Ask ld-linux to narrate every library load, symbol lookup, and
+        // binding it performs.  LD_DEBUG_OUTPUT directs the output to
+        // /tmp/lddbg.<pid> (glibc rtld appends the PID automatically) so
+        // it survives past process exit and can be extracted via QGA.
+        // Defined by glibc's dynamic linker; see ld.so(8) §LD_DEBUG.
+        "LD_DEBUG=files,symbols,bindings",
+        "LD_DEBUG_OUTPUT=/tmp/lddbg",
     ];
 
     // Spawn blocked so we can attach the pipe before the child can run.


### PR DESCRIPTION
## Summary

- Adds `MOZ_LOG_FILE=/tmp/mozlog` to the FFTEST Firefox envp so Mozilla's
  internal logging (already enabled at level 5 via `MOZ_LOG=all:5`) persists
  to a file that survives past the pipe read-deadline.  Without this,
  XPCOM/IPC startup narrative is cut off when the pipe closes.
- Adds `LD_DEBUG=files,symbols,bindings` and `LD_DEBUG_OUTPUT=/tmp/lddbg` so
  glibc's dynamic linker narrates every library load, symbol lookup, and
  binding it makes.  The linker appends the process PID to the output path
  automatically (`/tmp/lddbg.<pid>`), allowing post-run extraction via QGA
  even when the process exits abnormally.
- Both additions are guarded inside the existing `firefox-test`-feature
  envp block; they are no-ops on every other feature path.

## Motivation

We have been diagnosing Mozilla startup wedges from syscall-trace alone.
These two logging channels provide complementary, high-signal narration
that doesn't require kernel instrumentation changes:

- `LD_DEBUG` tells us which `.so` files were found, which were missing
  or rejected, and at what symbol a load failure occurred — invaluable
  for diagnosing the ld-linux early-crash cluster seen in W147.
- `MOZ_LOG_FILE` captures the full XPCOM/IPC startup story (all:5)
  through content-process spawn and the semaphore plateau, pinpointing
  the component that wedges rather than inferring it from stack samples.

## Extracting logs post-run

```
python3 scripts/qga_client.py read /tmp/mozlog
python3 scripts/qga_client.py read /tmp/lddbg.<pid>
```

## References

- Mozilla logging: https://firefox-source-docs.mozilla.org/xpcom/logging.html
- glibc dynamic linker debug variables: ld.so(8), §LD_DEBUG and §LD_DEBUG_OUTPUT

## Test plan

- [x] `cargo +nightly check -p astryx-kernel --features firefox-test` — no new errors introduced (pre-existing freestanding-target panic-unwind error unchanged)
- [ ] No QEMU trials run (W192 trials still in flight per task spec)
- [ ] Follow-up dispatch to extract `/tmp/mozlog` and `/tmp/lddbg.<pid>` via QGA after next trial completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)