### PR TITLE
kernel/vfs/procfs: emit real /proc/self/maps content from VMA table (W195)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -9532,9 +9532,11 @@ fn test_proc_maps_content() -> bool {
     test_println!("  read {} bytes ✓", n);
 
     let content = &buf[..n as usize];
-    // Check that at least one line has hex address range format "xxxxxxxxxxxxxxxx-"
-    let has_addr = content.windows(17).any(|w| {
-        w[16] == b'-' && w[..16].iter().all(|&c| c.is_ascii_hexdigit())
+    // Check that at least one line has a hex address range — format is
+    // "%lx-%lx" per proc(5), so width varies (8–16 hex digits) depending
+    // on the actual address value.  Match any run of hex digits followed by '-'.
+    let has_addr = content.iter().zip(content.iter().skip(1)).any(|(&a, &b)| {
+        a.is_ascii_hexdigit() && b == b'-'
     });
     if !has_addr {
         // Warn but don't fail — VmSpace may be empty in test mode

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1859,32 +1859,11 @@ fn serve_dynamic_read(content: &[u8], offset: u64, buf: *mut u8, count: usize,
 }
 
 /// Generate /proc/self/maps content from the process's VMAs.
+///
+/// Delegates to `procfs::generate_proc_maps`, which is the single canonical
+/// implementation of the proc(5) /proc/<pid>/maps format.
 fn generate_proc_maps(pid: crate::proc::Pid) -> alloc::vec::Vec<u8> {
-    use alloc::string::ToString;
-    let vmas = {
-        let procs = crate::proc::PROCESS_TABLE.lock();
-        procs.iter().find(|p| p.pid == pid)
-            .and_then(|p| p.vm_space.as_ref().map(|vs| vs.areas.clone()))
-            .unwrap_or_default()
-    };
-    let mut out = alloc::vec::Vec::new();
-    for vma in &vmas {
-        use crate::mm::vma::{PROT_READ, PROT_WRITE, PROT_EXEC, MAP_ANONYMOUS};
-        let r = if vma.prot & PROT_READ  != 0 { 'r' } else { '-' };
-        let w = if vma.prot & PROT_WRITE != 0 { 'w' } else { '-' };
-        let x = if vma.prot & PROT_EXEC  != 0 { 'x' } else { '-' };
-        let s = if vma.flags & MAP_ANONYMOUS != 0 { 'p' } else { 's' };
-        let line = alloc::format!(
-            "{:016x}-{:016x} {}{}{}{} 00000000 00:00 0 {}\n",
-            vma.base, vma.base + vma.length, r, w, x, s, vma.name
-        );
-        out.extend_from_slice(line.as_bytes());
-    }
-    if out.is_empty() {
-        // Fallback for processes without VmSpace (kernel threads).
-        out.extend_from_slice(b"0000000000000000-0000000000001000 r--p 00000000 00:00 0 [vvar]\n");
-    }
-    out
+    procfs::generate_proc_maps(pid)
 }
 
 /// Generate /proc/self/status content for the process.

--- a/kernel/src/vfs/procfs.rs
+++ b/kernel/src/vfs/procfs.rs
@@ -176,10 +176,12 @@ impl ProcFs {
             INO_MOUNTS  => Some(generate_mounts()),
             INO_STAT    => Some(generate_stat()),
             INO_CMDLINE => Some(b"astryx_kernel root=/dev/ramdisk0 console=fb0\n".to_vec()),
-            // /proc/self/maps, /proc/self/status, /proc/self/stat, /proc/self/cmdline
-            // are intercepted by fd_read() before fs.read() is called.
-            // Return a non-empty stub so stat().size > 0 doesn't confuse callers.
-            INO_SELF_MAPS     => Some(b"0000000000000000-0000000000001000 r--p 00000000 00:00 0 [vvar]\n".to_vec()),
+            // /proc/self/maps — real content from the calling process's VMA table.
+            // fd_read() intercepts this path first (see vfs/mod.rs) and delegates
+            // to generate_proc_maps() with the caller's PID.  This arm is the
+            // fallback when ProcFs::read() is invoked directly (e.g. from the
+            // kernel debug shell or a stat-only probe).
+            INO_SELF_MAPS     => Some(generate_proc_maps(crate::proc::current_pid())),
             INO_SELF_STATUS   => Some(b"Name:\tastryx\nState:\tR (running)\nPid:\t1\nPPid:\t0\n".to_vec()),
             INO_SELF_CMDLINE  => Some(b"astryx\0".to_vec()),
             INO_SELF_STAT     => Some(b"1 (astryx) R 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 20 0 1 0 0 65536 0 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n".to_vec()),
@@ -921,6 +923,118 @@ pub fn generate_mountinfo() -> Vec<u8> {
 /// and the controller-list is empty.
 pub fn generate_cgroup() -> Vec<u8> {
     b"0::/\n".to_vec()
+}
+
+/// Generate `/proc/<pid>/maps` content from the process's live VMA table.
+///
+/// Each line follows the canonical six-field format specified in proc(5):
+///
+/// ```text
+/// address           perms offset   dev   inode  pathname
+/// 00400000-00452000 r-xp 00000000 00:00 0       /bin/foo
+/// ```
+///
+/// Fields:
+/// * `address`  — `start-end` in hex, no `0x` prefix, not zero-padded to a
+///                fixed width (plain `%lx` per the kernel ABI).
+/// * `perms`    — four characters: `r`/`-`, `w`/`-`, `x`/`-`,
+///                `p` (private/CoW) or `s` (shared).  A mapping is shared
+///                when `MAP_SHARED` is set in the VMA's flags; all other
+///                mappings — including anonymous and file-backed private ones —
+///                are private (`p`).
+/// * `offset`   — file offset of the first byte mapped, 8-digit zero-padded
+///                hex; zero for anonymous / device VMAs.
+/// * `dev`      — device as `major:minor` in hex.  AstryxOS does not track
+///                device IDs in the VMA table, so this is always `00:00`.
+/// * `inode`    — decimal inode number of the mapped file; 0 for anonymous.
+/// * `pathname` — file path, or a bracketed tag such as `[heap]`, `[stack]`,
+///                `[vdso]`, `[vvar]`, `[anon]`.  May be empty for unnamed
+///                anonymous ranges.  Separated from the inode field by spaces
+///                to align to column 73 (matching the Linux kernel convention).
+///
+/// Output is capped at 100 KiB to bound allocation for processes with many
+/// fine-grained mappings (e.g. dynamically-linked C++ binaries).
+///
+/// The output is sorted by start address; the VMA list is always maintained
+/// in sorted order (`VmSpace::insert_vma`), so no re-sorting is needed here.
+///
+/// This function is the single source of truth for maps content.  Both the
+/// VFS `fd_read` hot-path (`vfs/mod.rs`) and the ProcFs inode fallback
+/// delegate to it.
+pub fn generate_proc_maps(pid: crate::proc::Pid) -> Vec<u8> {
+    use crate::mm::vma::{PROT_READ, PROT_WRITE, PROT_EXEC, MAP_SHARED, VmBacking};
+
+    // Snapshot the VMA list while briefly holding PROCESS_TABLE, then release
+    // the lock before formatting to keep the critical section tight.
+    let vmas: Vec<crate::mm::vma::VmArea> = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter()
+            .find(|p| p.pid == pid)
+            .and_then(|p| p.vm_space.as_ref().map(|vs| vs.areas.clone()))
+            .unwrap_or_default()
+    };
+
+    // Upper bound: ~100 KiB.  Each line is at most ~100 bytes; 1024 VMAs fits
+    // in that budget.  Truncate beyond that to avoid unbounded allocation.
+    const MAX_BYTES: usize = 100 * 1024;
+    let mut out = Vec::with_capacity(vmas.len().min(256) * 80);
+
+    for vma in &vmas {
+        if out.len() >= MAX_BYTES {
+            break;
+        }
+
+        let r = if vma.prot & PROT_READ  != 0 { b'r' } else { b'-' };
+        let w = if vma.prot & PROT_WRITE != 0 { b'w' } else { b'-' };
+        let x = if vma.prot & PROT_EXEC  != 0 { b'x' } else { b'-' };
+        // Shared iff MAP_SHARED is set; every other mapping (anonymous,
+        // file-backed private, stack, heap) is private (CoW).
+        let p = if vma.flags & MAP_SHARED != 0 { b's' } else { b'p' };
+
+        // Extract offset and inode from the backing descriptor.
+        let (offset, inode) = match &vma.backing {
+            VmBacking::File { offset, inode, .. } => (*offset, *inode),
+            _ => (0u64, 0u64),
+        };
+
+        // Format: start-end perms offset dev inode pathname\n
+        // Use core::fmt::Write into a stack-local String to avoid nested allocs.
+        use core::fmt::Write as FmtWrite;
+        let mut line = alloc::string::String::with_capacity(96);
+        let _ = write!(
+            line,
+            "{:x}-{:x} {}{}{}{} {:08x} 00:00 {}",
+            vma.base,
+            vma.end(),
+            r as char, w as char, x as char, p as char,
+            offset,
+            inode,
+        );
+        // Pathname field: align to column 73 (matching the kernel's seq_printf
+        // convention), then append the name.  Use at least one space.
+        if !vma.name.is_empty() {
+            // Pad with spaces so pathname starts at column 73 when possible.
+            // Column index of the current end (0-based): line.len() chars so far.
+            let col = line.len();
+            let spaces = if col < 72 { 72 - col } else { 1 };
+            for _ in 0..spaces {
+                line.push(' ');
+            }
+            line.push_str(vma.name);
+        }
+        line.push('\n');
+        out.extend_from_slice(line.as_bytes());
+    }
+
+    if out.is_empty() {
+        // Safety net for kernel threads / processes with no user VMAs: emit
+        // the vvar placeholder so parsers that require at least one line succeed.
+        out.extend_from_slice(
+            b"0000000000000000-0000000000001000 r--p 00000000 00:00 0 [vvar]\n"
+        );
+    }
+
+    out
 }
 
 /// Generate `/proc/stat` content.


### PR DESCRIPTION
## Summary

- Replaces the single-line `[vvar]` placeholder in `/proc/self/maps` with a full per-VMA renderer that iterates the calling process's live VMA table and produces canonical proc(5) `/proc/<pid>/maps` format.
- Fixes correctness bugs in the prior `vfs/mod.rs` implementation: wrong shared/private flag (used `!MAP_ANONYMOUS` instead of `MAP_SHARED`), hardcoded file offset `00000000` instead of `VmBacking::File { offset }`, and hardcoded inode `0` instead of `VmBacking::File { inode }`.
- `procfs::generate_proc_maps(pid)` is now the single source of truth; both the `fd_read` hot-path (normal read route) and the `ProcFs::read` inode fallback delegate to it.

## Context (W193/W195)

The W193 stack-walk PR added user-stack symbolication infrastructure. Mozilla's breakpad `LinuxDumper` separately reads `/proc/self/maps` to enumerate loaded module addresses before writing a minidump — without real VMA content, breakpad cannot produce valid crash reports even when the kernel reports faults cleanly. `glibc`'s `dl_iterate_phdr` also falls back to `/proc/maps` in some configurations for module enumeration.

## Format correctness (proc(5))

Each output line:
```
start-end perms 00000000 00:00 0       [name]\n
7f1a3a4ad000-7f1a3a4b6000 r-xp 00000000 00:00 173521 /disk/lib/libxul.so
7ffe2a55b000-7ffe2a57e000 rw-p 00000000 00:00 0       [stack]
```

- Address range: plain `%lx-%lx` (variable-width per proc(5) ABI)
- Perms: `MAP_SHARED` → `s`; all others (anon, file-backed private, stack, heap) → `p`
- Offset: from `VmBacking::File { offset }`, zero for anonymous/device VMAs
- Inode: from `VmBacking::File { inode }`, zero for anonymous
- Pathname: right-padded to column 73; empty for unnamed anonymous regions
- Output capped at 100 KiB (bound for processes with many fine-grained ELF mappings)

## Test plan

- [ ] `cargo +nightly check --features firefox-test` passes (only pre-existing "unwinding panics" error on `cargo check` without proper `--target` and `-Zbuild-std`; no new errors)
- [ ] Test 55 (`test_proc_maps_content`): address-range check updated for variable-width hex
- [ ] Test 99 (`test_procfs_self_maps`): already uses compatible variable-width check

🤖 Generated with [Claude Code](https://claude.com/claude-code)