### PR TITLE
kernel/main: relax LD_DEBUG to unblock verification trials (W197 — PR #210 regression)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -909,12 +909,17 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // read-deadline.  Extractable post-run via QGA guest-file-read.
         // See https://firefox-source-docs.mozilla.org/xpcom/logging.html
         "MOZ_LOG_FILE=/tmp/mozlog",
-        // Ask ld-linux to narrate every library load, symbol lookup, and
-        // binding it performs.  LD_DEBUG_OUTPUT directs the output to
-        // /tmp/lddbg.<pid> (glibc rtld appends the PID automatically) so
-        // it survives past process exit and can be extracted via QGA.
+        // Ask ld-linux to narrate every library load and per-symbol lookup.
+        // "bindings" is intentionally omitted: it emits one line per PLT/GOT
+        // entry resolved, which for a libxul-sized binary produces >200 K
+        // lines and saturates the kernel serial path at ~7 KB/s, preventing
+        // any trial from reaching Firefox execution within a 30-minute
+        // window (W196/W197).  Re-enable "bindings" only when investigating
+        // a specific symbol-binding question on a short-lived binary.
+        // LD_DEBUG_OUTPUT directs output to /tmp/lddbg.<pid> (glibc rtld
+        // appends the PID automatically) so it survives past process exit.
         // Defined by glibc's dynamic linker; see ld.so(8) §LD_DEBUG.
-        "LD_DEBUG=files,symbols,bindings",
+        "LD_DEBUG=files,symbols",
         "LD_DEBUG_OUTPUT=/tmp/lddbg",
     ];
 


### PR DESCRIPTION
## Summary

PR #210 added `LD_DEBUG=files,symbols,bindings` to the `firefox-test` spawn environment for dynamic-linker observability.  The `bindings` component was the source of a severe serial-log overflow (W196 finding):

- `bindings` emits one diagnostic line per PLT/GOT entry resolved at call time, not per library load.  For libxul (~180 K exported symbols) this produces **>200 K output lines** per run.
- The kernel serial capture path processes these at ~7 KB/s.
- Result: every 10- and 30-minute trial timed out before Firefox execution began.  PR #209's stack walker never fired; PNG verification was completely blocked.

## Fix (Option 1 — surgical)

Drop `bindings` from the `LD_DEBUG` value, keeping:

- `files` — one line per DSO load (low volume, useful for "which libraries loaded in what order")
- `symbols` — one line per symbol resolved to a library (moderate volume, useful for "which library owns symbol X")

Removing `bindings` reduces output by roughly 100×, well within the serial budget for a full Firefox boot sequence.

The `bindings` component can be re-enabled ad hoc via an environment override when investigating a specific symbol-binding question against a smaller, short-lived binary — it should never be on by default for libxul-scale workloads.

`LD_DEBUG_OUTPUT=/tmp/lddbg` is unchanged: output goes to `/tmp/lddbg.<pid>` (glibc rtld appends the PID per ld.so(8) §LD_DEBUG) and can be extracted via QGA post-run.

## Verification

- `cargo +nightly check --features firefox-test` — kernel crate compiles cleanly; the pre-existing workspace-level `panic=unwind` error from the bootloader crate is unchanged and unrelated.
- Logic: the change is a string literal removal in the env array; no kernel code path is affected.
- Trial verification (that trials now reach Firefox execution) is handled by a separate dispatch per task scope.

## Diff size

+10 / −5 lines (1 string literal + updated comment block).