### PR TITLE
kernel/signal+idt: add fault-time phys-page diagnostic + audit residual aliasing (W198)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -465,6 +465,18 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                 let tid = crate::proc::current_tid();
                 crate::proc::stack_walk::stack_walk_user(pid, tid, frame.rip, rbp_at_fault);
             }
+            // Aliasing-detection diagnostic: emit [FAULT/PHYS] +
+            // [FAULT/RIP-CONTENT] so two trials with the same vma_offset
+            // can be cross-checked for physical-frame identity.  Different
+            // rip_phys at the same vma_offset proves the libxul code page
+            // is aliased into multiple address spaces (W196 / W190-H_A).
+            // Cite: Intel SDM Vol. 3A §4.10 (paging-structure caches).
+            {
+                let cr3_now: u64;
+                unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags)); }
+                let pid = crate::proc::current_pid_lockless();
+                crate::signal::emit_fault_phys_for_fatal(pid, frame.rip, cr2, cr3_now);
+            }
             // POSIX signal(7): the default action for SIGSEGV is "terminate
             // the process (core dump)" — the entire thread group, not just
             // the faulting thread.  Calling exit_thread would leave sibling
@@ -774,6 +786,18 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             let pid = crate::proc::current_pid_lockless();
             let tid = crate::proc::current_tid();
             crate::proc::stack_walk::stack_walk_user(pid, tid, frame.rip, rbp_at_fault);
+        }
+        // Aliasing-detection diagnostic: emit [FAULT/PHYS] +
+        // [FAULT/RIP-CONTENT] for fatal #UD/#GP/#AC so the same mismatch
+        // test that applies to fatal #PF (Ring-3 SIGSEGV path above) also
+        // covers exceptions whose terminal cause may be aliased text bytes
+        // misinterpreted as opcodes.  cr2 has no meaning for non-#PF
+        // vectors here, so pass 0.  Cite: Intel SDM Vol. 3A §4.10.
+        {
+            let cr3_now: u64;
+            unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags)); }
+            let pid = crate::proc::current_pid_lockless();
+            crate::signal::emit_fault_phys_for_fatal(pid, frame.rip, 0, cr3_now);
         }
         // POSIX signal(7): synchronous fatal CPU exceptions in user mode
         // (#DE → SIGFPE, #UD → SIGILL, #DF / #SS / #GP / #AC / #MC → SIGBUS|SIGSEGV)

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1007,6 +1007,17 @@ pub unsafe fn deliver_sigsegv_from_isr(
     );
     emit_signal_vma_banner(pid, user_rip, cr2, &vma_snapshot);
 
+    // ── [FAULT/PHYS] + [FAULT/RIP-CONTENT] — physical-frame identity ─────────
+    // Aliasing-detection diagnostic.  Two fault deliveries with the same
+    // (vma_offset, library) must resolve to the same physical frame backing
+    // the user RIP page; if they differ we have proven the executable page is
+    // aliased between processes.  See W196 / W190-H_A.
+    {
+        let cr3_now: u64;
+        core::arch::asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags));
+        emit_fault_phys_diagnostic(pid, user_rip, cr3_now, &vma_snapshot);
+    }
+
     true
 }
 
@@ -1234,6 +1245,156 @@ fn emit_signal_vma_banner(pid: u64, user_rip: u64, cr2: u64, snap: &[VmaSnap]) {
                 "[SIGNAL/VMA] pid={} name={} base={:#x} end={:#x} size={:#x} prot={}{}{} file={} rip={} cr2={}{}",
                 pid, v.name, v.base, v.end, v.end - v.base, r, w, x,
                 v.file_backed as u8, rip_flag, cr2_flag, anon_tag
+            );
+        }
+    }
+}
+
+/// Emit `[FAULT/PHYS]` + `[FAULT/RIP-CONTENT]` for fatal Ring-3 faults.
+///
+/// Convenience entry point for the `idt.rs` paths that kill the process
+/// without delivering a signal (no installed handler, or fatal #UD/#GP/#PF).
+/// Builds the VMA snapshot internally so callers do not need to plumb one
+/// through.  Acquires `PROCESS_TABLE` briefly to read the VmSpace; lock is
+/// released before the diagnostic prints.
+///
+/// `cr3` is the live CR3 read by the caller in ISR context (always equal
+/// to the faulting process's PML4 phys; we cannot derive it from the VmSpace
+/// here without re-acquiring locks already dropped).
+pub fn emit_fault_phys_for_fatal(pid: u64, user_rip: u64, cr2: u64, cr3: u64) {
+    // Snapshot under the PROCESS_TABLE lock, then release before printing.
+    let snap = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        let space = procs.iter().find(|p| p.pid == pid).and_then(|p| p.vm_space.as_ref());
+        signal_vma_snapshot(space, user_rip, cr2)
+    };
+    emit_fault_phys_diagnostic(pid, user_rip, cr3, &snap);
+}
+
+/// Emit `[FAULT/PHYS]` and `[FAULT/RIP-CONTENT]` diagnostic lines.
+///
+/// `[FAULT/PHYS]` exposes the physical frame backing the user RIP page so
+/// two trials with identical `vma_offset` can be cross-checked: a healthy
+/// page cache returns the same `rip_phys` for the same (mount, inode,
+/// page_offset); aliasing produces different `rip_phys` values.
+///
+/// Format:
+///   `[FAULT/PHYS] pid=<n> tid=<n> rip=<vaddr> rip_phys=<paddr|UNMAPPED> vma_offset=<off|NO_VMA>`
+///
+/// `[FAULT/RIP-CONTENT]` dumps the first 16 bytes at the user RIP so the
+/// executed instruction stream can be compared against the on-disk libxul.
+/// A mismatch confirms page aliasing or content corruption.
+///
+/// Format:
+///   `[FAULT/RIP-CONTENT] rip=<vaddr> bytes=<32 hex chars + spaces>`
+///   `[FAULT/RIP-CONTENT] rip=<vaddr> unmapped_or_fault`
+///
+/// Cite: Intel SDM Vol. 3A §4.10 (TLB / paging-structure caches), §4.5
+/// (4-Level Paging).
+///
+/// Lock-safe: callable from ISR context (no PROCESS_TABLE / MOUNTS).
+/// Uses `virt_to_phys_in` directly off `cr3`, mirroring the existing
+/// `[UD/RIP-BYTES]` pattern in `arch/x86_64/idt.rs`.
+pub(crate) fn emit_fault_phys_diagnostic(
+    pid: u64,
+    user_rip: u64,
+    cr3: u64,
+    vma_snapshot: &[VmaSnap],
+) {
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    const KERNEL_BASE: u64 = 0x0000_8000_0000_0000;
+    let tid = crate::proc::current_tid();
+
+    // ── [FAULT/PHYS] ────────────────────────────────────────────────────────
+    let rip_page = user_rip & !0xFFFu64;
+    let rip_phys = if user_rip < KERNEL_BASE {
+        crate::mm::vmm::virt_to_phys_in(cr3, rip_page)
+    } else {
+        None
+    };
+
+    // Find the VMA containing user_rip in the snapshot to report
+    // vma_offset (the in-VMA byte offset of the faulting instruction).
+    // Cross-trial equality of vma_offset is the prerequisite for the
+    // rip_phys mismatch test to be conclusive.
+    let mut vma_off: Option<u64> = None;
+    for v in vma_snapshot.iter() {
+        if v.contains_rip {
+            vma_off = Some(user_rip - v.base);
+            break;
+        }
+    }
+
+    match (rip_phys, vma_off) {
+        (Some(p), Some(off)) => {
+            crate::serial_println!(
+                "[FAULT/PHYS] pid={} tid={} rip={:#x} rip_phys={:#x} vma_offset={:#x}",
+                pid, tid, user_rip, p, off,
+            );
+        }
+        (Some(p), None) => {
+            crate::serial_println!(
+                "[FAULT/PHYS] pid={} tid={} rip={:#x} rip_phys={:#x} vma_offset=NO_VMA",
+                pid, tid, user_rip, p,
+            );
+        }
+        (None, Some(off)) => {
+            crate::serial_println!(
+                "[FAULT/PHYS] pid={} tid={} rip={:#x} rip_phys=UNMAPPED vma_offset={:#x}",
+                pid, tid, user_rip, off,
+            );
+        }
+        (None, None) => {
+            crate::serial_println!(
+                "[FAULT/PHYS] pid={} tid={} rip={:#x} rip_phys=UNMAPPED vma_offset=NO_VMA",
+                pid, tid, user_rip,
+            );
+        }
+    }
+
+    // ── [FAULT/RIP-CONTENT] ─────────────────────────────────────────────────
+    // 16 bytes at the user RIP, mirroring the [UD/RIP-BYTES] format.  A
+    // healthy libxul .text page must show the same opcode bytes across
+    // trials at the same vma_offset; a mismatch is direct evidence the
+    // physical page contents differ from what the ELF says (aliasing or
+    // post-load corruption).
+    if user_rip < KERNEL_BASE {
+        const N: usize = 16;
+        let mut buf = [0u8; N];
+        let mut got = 0usize;
+        for i in 0..N {
+            let va = user_rip.wrapping_add(i as u64);
+            if va >= KERNEL_BASE { break; }
+            match crate::mm::vmm::virt_to_phys_in(cr3, va) {
+                Some(phys) => {
+                    buf[i] = unsafe {
+                        core::ptr::read_volatile((PHYS_OFF + phys) as *const u8)
+                    };
+                    got += 1;
+                }
+                None => break,
+            }
+        }
+        if got > 0 {
+            const HEX: &[u8] = b"0123456789abcdef";
+            let mut hex = [0u8; N * 3];
+            for i in 0..got {
+                hex[i * 3]     = HEX[(buf[i] >> 4) as usize];
+                hex[i * 3 + 1] = HEX[(buf[i] & 0xF) as usize];
+                hex[i * 3 + 2] = b' ';
+            }
+            // SAFETY: HEX bytes are ASCII; trailing space exists for got >= 1.
+            let hex_str = unsafe {
+                core::str::from_utf8_unchecked(&hex[..got * 3 - 1])
+            };
+            crate::serial_println!(
+                "[FAULT/RIP-CONTENT] rip={:#x} bytes={}",
+                user_rip, hex_str,
+            );
+        } else {
+            crate::serial_println!(
+                "[FAULT/RIP-CONTENT] rip={:#x} unmapped_or_fault",
+                user_rip,
             );
         }
     }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3133,18 +3133,29 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
                 crate::mm::vmm::write_pte(cr3, page, 0);
                 any_unmap = true;
 
-                // Decrement the reference count.  Collect for deferred free
-                // only if the count reaches zero.
-                let rc = crate::mm::refcount::page_ref_count(phys);
-                if rc <= 1 {
-                    crate::mm::refcount::page_ref_set(phys, 0);
+                // Atomic decrement (W198 / W190-H_G fix).  Pre-fix code
+                // performed a non-atomic `page_ref_count` followed by
+                // `page_ref_set(phys, 0)`, which silently wiped any
+                // concurrent `page_ref_inc` from the readahead path or
+                // a sibling `clone_for_fork` — driving the new count to
+                // zero, freeing the frame, and creating an aliasing path
+                // for the sibling whose still-installed PTE pointed at
+                // the recycled frame.
+                //
+                // `page_ref_dec` returns the new count atomically
+                // (fetch_sub).  Collect for deferred free iff it reaches
+                // zero; otherwise the frame is still referenced (CoW
+                // sibling, page cache) and the dec already accounts for
+                // this PTE's released reference.
+                //
+                // Cite: Intel SDM Vol. 3A §4.10.5 (TLB consistency);
+                // POSIX madvise(2) MADV_DONTNEED — the kernel may free
+                // the pages but must do so without violating concurrent
+                // mapping invariants.
+                let new_rc = crate::mm::refcount::page_ref_dec(phys);
+                if new_rc == 0 {
                     to_free[n] = phys;
                     n += 1;
-                } else {
-                    // rc > 1: shared page (CoW or cache); release one
-                    // reference without freeing.  No shootdown needed here
-                    // because the PTE was cleared above and pass 2 covers it.
-                    let _ = crate::mm::refcount::page_ref_dec(phys);
                 }
             }
             page += crate::mm::pmm::PAGE_SIZE as u64;


### PR DESCRIPTION
## Summary

Two-part response to W196's finding that the post-PR-#208 SIGSEGV cluster
(libxul `_Base_manager<std::function<void(unsigned long const&)>>` hits at
three offsets, with three different CR2 values and two different error_code
classes — write vs execute — at the *same* function) is another page-aliasing
path distinct from the BracketMatcher path PR #208 closed.

### Part 1 — Diagnostic (smoking-gun confirmation)

Add `[FAULT/PHYS]` and `[FAULT/RIP-CONTENT]` lines at every Ring-3 fatal
exception delivery site:

* `signal::deliver_sigsegv_from_isr` (handled signal path)
* `idt::exception_handler` Ring-3 fatal `#PF` no-handler path
* `idt::exception_handler` Ring-3 fatal `#UD`/`#GP`/`#AC` path

Format:

```
[FAULT/PHYS] pid=N tid=M rip=0xV rip_phys=0xP|UNMAPPED vma_offset=0xO|NO_VMA
[FAULT/RIP-CONTENT] rip=0xV bytes=XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX
```

Two trials with the same `vma_offset` MUST produce the same `rip_phys` when
the page cache is healthy. A mismatch is direct evidence of physical-frame
aliasing of a libxul code page. The 16-byte content dump extends PR #202's
`[UD/RIP-BYTES]` (which only fired on `#UD`) to the dominant fatal-`#PF`
path that the W196 cluster hits.

Implementation: one new helper `signal::emit_fault_phys_diagnostic` (common
formatter; lock-free; ISR-safe via `virt_to_phys_in` + PHYS_OFF) plus a
thin wrapper `signal::emit_fault_phys_for_fatal` that builds a VMA snapshot
internally for the no-handler / fatal-exception callers.
`deliver_sigsegv_from_isr` reuses the snapshot it already captured.

### Part 2 — Fix (W190-H_G)

Close the `sys_madvise(MADV_DONTNEED)` TOCTOU race at
`subsys/linux/syscall.rs:3138`. Pre-fix code:

```rust
let rc = page_ref_count(phys);   // load
if rc <= 1 {
    page_ref_set(phys, 0);       // store, NOT atomic with the load
    to_free[n] = phys; ...
}
```

A concurrent `page_ref_inc` from the readahead path or a sibling
`clone_for_fork` between the load and the set was silently wiped — the
set-to-zero clobbered the increment. The frame was then handed to PMM while
a sibling PTE still pointed at it. Textbook aliasing, distinct from the
W190-H_A path PR #208 closed.

Replaced with a single atomic `page_ref_dec`:

```rust
let new_rc = page_ref_dec(phys);  // atomic fetch_sub returning new count
if new_rc == 0 {
    to_free[n] = phys; ...
}
```

This matches the pattern `unmap_and_free_range_in` already uses post PR #203.

### Audit notes — residual aliasing not fixed in this PR

* **H_E (brk-shrink leak at `mm/vma.rs:701-711`)**: confirmed — pages
  unmapped + shootdown but never `page_ref_dec`-ed or freed. Memory leak
  only, not aliasing. Filed for follow-up; out of scope here because the
  fix needs the three-pass `unmap_and_free_range_in` discipline rather
  than a one-line change.
* **H_D (file-VMA teardown ratchet via `clone_for_fork`)**: confirmed —
  refcount leak only, not aliasing. Out of scope.
* **`sys_mremap`**: re-audited; delegates to `sys_mmap`/`sys_munmap`
  which are correct post-PR #203. No new path.
* **`sys_mprotect`**: re-audited; only retags PTEs and shoots down. No
  refcount touch, no new aliasing.
* **CoW write-fault**: re-audited; `page_ref_dec` on the source and
  `page_ref_set(new, 1)` on a freshly-allocated frame, which is
  exclusively owned at that moment — no aliasing window.

### Why this PR is single-commit

Diagnostic and fix together ≤ 200 LOC (target). The fix is mechanical
once H_G is identified, and landing the diagnostic at the same time means
the next trial cycle produces the conclusive evidence (matching `vma_offset`,
mismatching `rip_phys`) for whichever residual path remains.

### Specs cited

* Intel SDM Vol. 3A §4.10 (paging-structure caches), §4.10.5 (TLB consistency)
* Intel SDM Vol. 3A §4.5 (4-Level Paging)
* POSIX signal(7), POSIX madvise(2)

## Test plan

- [x] `cargo +nightly check --features firefox-test` — clean (warnings only, all pre-existing)
- [x] `cargo +nightly check` (default features) — clean (warnings only, all pre-existing)
- [ ] Boot smoke test (out of scope for this PR per W198 task description — diagnostic only)
- [ ] Next trial cycle: confirm `[FAULT/PHYS]` lines appear in serial at SIGSEGV; verify the `rip_phys` mismatch hypothesis when the W196 cluster reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)