### PR TITLE
kernel/main: drop LD_DEBUG=symbols (PR #212 was insufficient — W200)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -909,17 +909,16 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // read-deadline.  Extractable post-run via QGA guest-file-read.
         // See https://firefox-source-docs.mozilla.org/xpcom/logging.html
         "MOZ_LOG_FILE=/tmp/mozlog",
-        // Ask ld-linux to narrate every library load and per-symbol lookup.
-        // "bindings" is intentionally omitted: it emits one line per PLT/GOT
-        // entry resolved, which for a libxul-sized binary produces >200 K
-        // lines and saturates the kernel serial path at ~7 KB/s, preventing
-        // any trial from reaching Firefox execution within a 30-minute
-        // window (W196/W197).  Re-enable "bindings" only when investigating
-        // a specific symbol-binding question on a short-lived binary.
-        // LD_DEBUG_OUTPUT directs output to /tmp/lddbg.<pid> (glibc rtld
-        // appends the PID automatically) so it survives past process exit.
+        // Ask ld-linux to narrate every library load (one line per DSO open,
+        // ~30 lines for a Firefox process — negligible serial budget).
+        // "bindings" omitted since PR #212 (W197): one line per PLT/GOT entry
+        // resolved in libxul produces >200 K lines, saturating serial at ~7 KB/s.
+        // "symbols" omitted since this PR (W200): combined with syscall-trace the
+        // serial flood runs at ~13 SC/s × ~81,600 entries ≈ 6,277 s, so libxul
+        // never loads in a 10-min trial.  "files" only is sufficient to confirm
+        // which DSOs are opened; re-add "symbols" only for short-lived binaries.
         // Defined by glibc's dynamic linker; see ld.so(8) §LD_DEBUG.
-        "LD_DEBUG=files,symbols",
+        "LD_DEBUG=files",
         "LD_DEBUG_OUTPUT=/tmp/lddbg",
     ];
 


### PR DESCRIPTION
## Problem

PR #212 (W197) removed `bindings` from `LD_DEBUG`, but left `symbols` in
(`LD_DEBUG=files,symbols`).

W199 measured that `symbols` + `syscall-trace` together flood the kernel
serial path at approximately **13 SC/s × 81,600 entries ≈ 6,277 seconds**
to resolve all symbols for `firefox-bin`.  A standard 10-minute trial
covers less than 10 % of that work — `libxul` never finishes loading, and
no `[FAULT/PHYS]` or `[STACK]` diagnostic events ever fire.  This renders
every KVM trial during the residual-aliasing investigation a no-op.

## Fix

Set `LD_DEBUG=files` only.

The `files` category emits one line per DSO open — approximately 30 lines
for a Firefox process.  That is negligible serial budget and preserves
load-order visibility without per-symbol noise.  Per `ld.so(8)` §LD_DEBUG:

> `files`   print progress for input file handling
> `symbols` print each symbol lookup

Re-add `symbols` only when investigating a specific lookup on a
short-lived binary where the total symbol count is bounded.

## Verification

`cargo +nightly check --package astryx-kernel --target kernel/x86_64-astryx.json --features firefox-test -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem -Zjson-target-spec` passes with 0 errors (20 pre-existing warnings, unchanged).

KVM trial verification dispatched separately (W199 re-run).

## Diff

1 file changed, 9 insertions(+), 10 deletions(-) — within the ≤10 LOC budget.