### PR TITLE
scripts/stubs: add C_GetInterface PKCS#11 v3.0 stub (W212 — unblocks libipcclientcerts.so)

### DIFF
--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -134,6 +134,13 @@ fi
 # non-NULL sentinel ("DejaVu Sans") into *out.  Loaded via LD_PRELOAD in the
 # firefox-test envp (see kernel/src/gui/terminal.rs).
 # Spec: https://fontconfig.org/fontconfig-devel/fcpatternget.html
+#
+# W212: the interposer also wraps dlsym() to intercept lookups for
+# "C_GetInterface" (PKCS#11 v3.0 §5.5) — libipcclientcerts.so only exports
+# the v2.x entry point C_GetFunctionList; NSS treats a NULL dlsym return for
+# C_GetInterface as fatal.  Our dlsym wrapper returns CKR_FUNCTION_NOT_SUPPORTED
+# (0x54) so NSS falls back to the v2.x code path.
+# Ref: https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html
 INTERPOSER_DIR="${ROOT_DIR}/userspace/libfontconfig-interposer"
 INTERPOSER_SO="libfontconfig-interposer.so"
 if [ -d "${INTERPOSER_DIR}" ] && command -v gcc &>/dev/null; then

--- a/userspace/libfontconfig-interposer/interposer.c
+++ b/userspace/libfontconfig-interposer/interposer.c
@@ -1,5 +1,6 @@
 /*
- * libfontconfig-interposer.so — defensive FcPatternGet* *out wrappers.
+ * libfontconfig-interposer.so — defensive FcPatternGet* *out wrappers
+ * and PKCS#11 v3.0 shims for libipcclientcerts.so.
  *
  * Real upstream libfontconfig follows the spec strictly: when an
  * FcPatternGet* getter returns a non-Match FcResult (e.g.
@@ -51,12 +52,37 @@
  * This is a userspace-side workaround for a Mozilla caller bug; the
  * upstream libfontconfig binary is never patched, preserving the
  * "no upstream binary edits" invariant.
+ *
+ * ── PKCS#11 v3.0 C_GetInterface shim ────────────────────────────────
+ *
+ * W212: Firefox's content process (pid=3) loads libipcclientcerts.so as
+ * a PKCS#11 module.  NSS's module loader resolves C_GetInterface (the
+ * PKCS#11 v3.0 entry point defined in OASIS PKCS #11 v3.0 §5.5) from
+ * the loaded module handle.  libipcclientcerts.so only exports the v2.x
+ * entry point C_GetFunctionList; C_GetInterface is absent.  NSS treats
+ * the missing symbol as fatal → pid=3 SIGABRT.
+ *
+ * Fix: this interposer wraps dlsym().  When the caller looks up
+ * "C_GetInterface" on any handle, we return a stub that returns
+ * CKR_FUNCTION_NOT_SUPPORTED (0x54 per PKCS #11 v3.0 Table 1), telling
+ * NSS that the module does not implement the v3.0 interface.  NSS then
+ * falls back to the v2.x C_GetFunctionList path that libipcclientcerts
+ * exports correctly.
+ *
+ * The interposer is already LD_PRELOADed before every Firefox child
+ * process, so this wrapper fires for every dlsym() call in the process
+ * regardless of which library issued it.
+ *
+ * Reference: OASIS PKCS #11 Cryptographic Token Interface Base
+ * Specification v3.0 §5.5 C_GetInterface, §11 Return values.
+ * https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html
  */
 
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 /* fontconfig public ABI (from <fontconfig/fontconfig.h>).
  *
@@ -492,4 +518,83 @@ FcPatternGetRange(const FcPattern *p, const char *object, int n, FcRange **r)
         *r = (FcRange *)fc_stub_range;
     }
     return res;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * PKCS#11 v3.0 C_GetInterface stub.
+ *
+ * OASIS PKCS #11 v3.0 §5.5:
+ *   CK_RV C_GetInterface(CK_UTF8CHAR_PTR pInterfaceName,
+ *                        CK_VERSION_PTR  pVersion,
+ *                        CK_INTERFACE_PTR_PTR ppInterface,
+ *                        CK_FLAGS flags);
+ *
+ * All PKCS#11 types are ultimately either pointers or unsigned longs.
+ * We use void* / unsigned long here to avoid pulling in the full
+ * PKCS#11 header; the ABI is identical on x86-64 System V.
+ *
+ * Returning CKR_FUNCTION_NOT_SUPPORTED (0x54) is the correct response
+ * when a v2.x-only module is queried for a v3.0 interface: the caller
+ * (NSS) must fall back to C_GetFunctionList per PKCS #11 v3.0 §6.1.
+ * ──────────────────────────────────────────────────────────────────── */
+static unsigned long
+pkcs11_C_GetInterface_not_supported(void *pInterfaceName,
+                                    void *pVersion,
+                                    void **ppInterface,
+                                    unsigned long flags)
+{
+    (void)pInterfaceName;
+    (void)pVersion;
+    (void)ppInterface;
+    (void)flags;
+    /* CKR_FUNCTION_NOT_SUPPORTED = 0x00000054 per PKCS #11 v3.0 Table 1. */
+    return 0x00000054UL;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * dlsym wrapper — intercept C_GetInterface lookups.
+ *
+ * glibc's dlsym(handle, name) finds only symbols exported by <handle>
+ * and its transitive DT_NEEDED dependencies.  libipcclientcerts.so
+ * exports only C_GetFunctionList (v2.x); C_GetInterface is absent.
+ * We interpose dlsym so that any lookup for "C_GetInterface" — on any
+ * handle — returns our stub above, giving NSS the graceful-failure
+ * response instead of a NULL that it treats as fatal.
+ *
+ * Bootstrap problem: dlsym cannot call dlsym(RTLD_NEXT, "dlsym") to
+ * find itself (infinite recursion).  The POSIX-standard workaround is
+ * dlvsym, which bypasses the wrapper because it requests a versioned
+ * symbol — the version node lives at a different PLT slot.
+ * GLIBC_2.2.5 is the version under which dlsym has been exported since
+ * glibc 2.2.5; all Firefox-target systems carry it.
+ *
+ * All other lookups are forwarded to the real dlsym.
+ * ──────────────────────────────────────────────────────────────────── */
+typedef void *(*dlsym_fn)(void *handle, const char *name);
+
+void *
+dlsym(void *handle, const char *name)
+{
+    static dlsym_fn real_dlsym = NULL;
+
+    /* Intercept first: avoids any risk of a reentrant bootstrap call
+     * while real_dlsym is being initialised on the first dlsym call.
+     * POSIX dlsym(3) guarantees name is non-NULL. */
+    if (strcmp(name, "C_GetInterface") == 0) {
+        return (void *)pkcs11_C_GetInterface_not_supported;
+    }
+
+    /* Bootstrap the real dlsym via dlvsym.  dlvsym is NOT interposed by
+     * this wrapper (different symbol name), so this call does not
+     * recurse.  The version string "GLIBC_2.2.5" is the stable glibc
+     * ABI version for dlsym on all Linux x86-64 platforms. */
+    if (!real_dlsym) {
+        real_dlsym = (dlsym_fn)dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.2.5");
+    }
+
+    if (!real_dlsym) {
+        return NULL;
+    }
+
+    return real_dlsym(handle, name);
 }


### PR DESCRIPTION
## Summary

**W212 evidence**: Firefox content process (pid=3) loads `libipcclientcerts.so` as a PKCS#11 module. NSS's module loader calls `dlsym(handle, "C_GetInterface")` to probe for the PKCS#11 v3.0 entry point. `libipcclientcerts.so` ships only the v2.x entry point `C_GetFunctionList`; `C_GetInterface` is absent from its symbol table. NSS treats a NULL dlsym return as fatal → pid=3 SIGABRT → pid=1 aborts.

## Approach — dlsym interposition in existing LD_PRELOAD library

`libipcclientcerts.so` is a real upstream binary (cannot be modified per the no-upstream-binary-edits invariant). `dlsym(specific_handle, name)` only searches the target library and its transitive DT_NEEDED dependencies — LD_PRELOAD symbols are not visible through a specific-handle lookup. A wrapper `libipcclientcerts.so` would require renaming the original binary, which is fragile.

Instead, we extend the existing `libfontconfig-interposer.so` (already LD_PRELOADed into every Firefox child process via `kernel/src/gui/terminal.rs`) to interpose `dlsym()` itself. When any caller looks up `"C_GetInterface"`, the wrapper returns a static stub returning `CKR_FUNCTION_NOT_SUPPORTED` (`0x00000054` per OASIS PKCS #11 v3.0 Table 1). NSS must fall back to `C_GetFunctionList` on `CKR_FUNCTION_NOT_SUPPORTED`, which `libipcclientcerts.so` exports correctly.

## Bootstrap

The `dlsym` interposer bootstrap problem (calling `dlsym(RTLD_NEXT, "dlsym")` from within a `dlsym` wrapper recurses infinitely) is solved via `dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.2.5")`. `dlvsym` is a separate symbol not interposed by this wrapper, so it reaches the real implementation directly. `GLIBC_2.2.5` is the stable glibc ABI version node for `dlsym` on all Linux x86-64 targets.

## Return value rationale

`CKR_FUNCTION_NOT_SUPPORTED` (`0x54`) is the correct response for a v2.x-only module queried for the v3.0 interface (OASIS PKCS #11 v3.0 §5.5, §11). NSS is required to fall back to `C_GetFunctionList` in this case. Returning `CKR_OK` with `*ppInterface = NULL` was considered as an alternative but risks a NULL-deref in NSS's interface-pointer consumer before it can call `C_GetFunctionList`.

## Files changed

- `userspace/libfontconfig-interposer/interposer.c` — adds `pkcs11_C_GetInterface_not_supported` stub + `dlsym` wrapper (+107 LOC)
- `scripts/create-data-disk.sh` — updates comment to document W212 fix (+7 LOC)

Build: `make` in `userspace/libfontconfig-interposer/` — zero errors, zero warnings. The interposer is rebuilt automatically by `create-data-disk.sh --force` when `interposer.c` is newer than the staged `.so`.

Reference: [OASIS PKCS #11 v3.0 §5.5 C_GetInterface](https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)