### PR TITLE
kernel/proc+mm: close file-VMA + brk teardown frame leaks (W216 audit follow-up)

### DIFF
--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -868,16 +868,17 @@ impl VmSpace {
                 }
             }
 
-            // Unmap pages in [new_brk, old_brk).  TLB invalidation is
-            // coalesced into a single cross-CPU shootdown after the
-            // loop — one IPI for the whole brk shrink.
-            let mut page_addr = new_brk;
-            while page_addr < old_brk {
-                crate::mm::vmm::unmap_page_in(self.cr3, page_addr);
-                page_addr += 0x1000;
-            }
+            // Unmap pages in [new_brk, old_brk) and return their frames to the
+            // PMM.  `unmap_and_free_range_in` clears each PTE, decrements the
+            // page refcount, performs a cross-CPU TLB shootdown, and frees any
+            // frame whose refcount reaches zero (or routes through quarantine if
+            // the shootdown timed out).  This replaces the former
+            // unmap_page_in + shootdown_range pair, which cleared PTEs and
+            // issued the TLB shootdown but never called page_ref_dec or
+            // pmm::free_page — leaking every shrunk heap page permanently into
+            // the PMM until process exit (W216 audit brk-shrink finding).
             if new_brk < old_brk {
-                crate::mm::tlb::shootdown_range(self.cr3, new_brk, old_brk);
+                crate::mm::vmm::unmap_and_free_range_in(self.cr3, new_brk, old_brk - new_brk);
             }
         }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1169,9 +1169,9 @@ pub fn exit_thread(exit_code: i64) {
 
 /// Free all physical memory owned by a process (user page frames + page tables).
 ///
-/// Walks the process's VmSpace VMAs, decrements refcounts of all present anonymous
-/// pages, and frees any whose refcount reaches zero.  Also frees the private
-/// user-half page table structures (PT → PD → PDPT → PML4).
+/// Walks the process's VmSpace VMAs, decrements refcounts of all present pages
+/// (both anonymous and file-backed), and frees any whose refcount reaches zero.
+/// Also frees the private user-half page table structures (PT → PD → PDPT → PML4).
 ///
 /// Call after marking the process Zombie and after all threads are Dead, but
 /// before removing the process from PROCESS_TABLE.  Safe to call from the
@@ -1216,16 +1216,31 @@ pub fn free_process_memory(pid: Pid) {
     // (cheaper than per-page invlpg over the entire user half).
     let shootdown_clean = crate::mm::tlb::shootdown_full_user(cr3);
 
-    // Walk all VMAs and free physical frames (anonymous pages only).
-    // File-backed pages are managed by the page cache; device pages are MMIO.
+    // Walk all VMAs and free physical frames.
+    //
+    // Both anonymous and file-backed VMAs have their frames ref-counted: every
+    // present PTE holds one reference that was incremented when the page was
+    // faulted or mapped in.  File-backed pages are shared with the page cache
+    // (cache holds rc=1, each mapping PTE adds rc=1); decrementing here drops
+    // the mapping ref.  If the cache also drops its ref later (eviction), rc
+    // reaches zero and the frame is freed then.  Device VMAs are MMIO — they
+    // have no backing frames in the PMM and must be skipped.
+    //
+    // Skipping file-backed PTEs (the pre-fix behaviour) left a permanent rc=1
+    // from the mapping ref, preventing the cache from ever reclaiming those
+    // frames.  Under Firefox bringup, every shared library segment leaked its
+    // entire working set, inflating PMM pressure and increasing the probability
+    // that the next-fit allocator wrapped around into frames still cached by
+    // the page-aliasing path (W216 audit).
     const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
     const PAGE_PRESENT: u64 = 1;
 
     for vma in &vm_space.areas {
-        match &vma.backing {
-            VmBacking::File { .. } | VmBacking::Device { .. } => continue,
-            VmBacking::Anonymous => {}
-        }
+        // Skip MMIO device VMAs — their "physical addresses" are I/O registers,
+        // not PMM-tracked frames; decrementing their refcount would corrupt the
+        // PMM's bookkeeping.
+        if let VmBacking::Device { .. } = &vma.backing { continue; }
+
         let mut addr = vma.base;
         while addr < vma.base + vma.length {
             let pte = vmm::read_pte(cr3, addr);
@@ -1234,7 +1249,8 @@ pub fn free_process_memory(pid: Pid) {
                 if refcount::page_ref_dec(phys) == 0 {
                     // If the shootdown did not receive all ACKs, defer the
                     // PMM release until every CPU has passed through a
-                    // quiescent state (timer ISR), guaranteeing TLB drain.
+                    // quiescent state (timer ISR tick), guaranteeing TLB
+                    // drain before the frame is recycled.
                     if shootdown_clean {
                         pmm::free_page(phys);
                     } else {
@@ -1258,10 +1274,10 @@ pub fn free_process_memory(pid: Pid) {
 /// and passes the old one in by value.  Ownership is consumed, so there is no
 /// risk of double-free.
 ///
-/// Walks every anonymous VMA, decrements the per-page refcount, and frees any
-/// physical frame whose refcount reaches zero (CoW pages shared with a child
-/// are not freed until the last reference drops).  Then frees the private
-/// user-half page table structures (PT → PD → PDPT → PML4).
+/// Walks every anonymous and file-backed VMA, decrements the per-page refcount,
+/// and frees any physical frame whose refcount reaches zero (CoW pages shared
+/// with a child are not freed until the last reference drops).  Then frees the
+/// private user-half page table structures (PT → PD → PDPT → PML4).
 ///
 /// # Safety contract for the caller
 /// The caller MUST have already switched the hardware CR3 away from this
@@ -1297,16 +1313,24 @@ pub fn free_vm_space(vm_space: crate::mm::vma::VmSpace) {
     // could still hold cached translations into this address space.
     let shootdown_clean = crate::mm::tlb::shootdown_full_user(cr3);
 
-    // Walk all anonymous VMAs and decrement/free the backing physical pages.
-    // File-backed pages belong to the page cache; device pages are MMIO.
+    // Walk all VMAs and decrement/free the backing physical pages.
+    //
+    // Identical semantics to the free_process_memory path: both anonymous and
+    // file-backed VMAs hold one refcount per mapped PTE.  File-backed mappings
+    // share frames with the page cache (cache holds rc=1, PTE holds rc=1);
+    // dropping the PTE ref here allows the cache to reclaim the frame on
+    // eviction.  Device VMAs are MMIO and must be skipped.
+    //
+    // The pre-fix code skipped file-backed VMAs, leaking the PTE ref
+    // permanently and preventing cache reclamation of every shared-library
+    // segment loaded by execve — the dominant allocation pattern during
+    // Firefox bringup (W216 audit teardown-leak finding).
     const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
     const PAGE_PRESENT: u64 = 1;
 
     for vma in &vm_space.areas {
-        match &vma.backing {
-            VmBacking::File { .. } | VmBacking::Device { .. } => continue,
-            VmBacking::Anonymous => {}
-        }
+        if let VmBacking::Device { .. } = &vma.backing { continue; }
+
         let mut addr = vma.base;
         while addr < vma.base + vma.length {
             let pte = vmm::read_pte(cr3, addr);


### PR DESCRIPTION
## Summary

The W216 audit v3 identified two teardown paths that permanently leak physical frames, inflating PMM occupancy across Firefox session lifetimes and making the page-aliasing class easier to hit (next-fit cursor wraps further into cached-but-leaked frames).

### Leak 1 — file-backed VMAs skipped in `free_process_memory` / `free_vm_space`

**File**: `kernel/src/proc/mod.rs`

Both teardown functions walked the VMA list and `continue`-d on `VmBacking::File` and `VmBacking::Device`. File-backed VMAs — every shared-library segment loaded by `mmap` or `execve` — have present PTEs that each hold one frame reference (incremented by the demand-fault or mmap-prepopulate path). Skipping those PTEs left the mapping reference permanently live: the page cache's own reference could never cause `rc → 0`, so `pmm::free_page` was never called on process exit.

Fix: remove the `File` skip. Both `Anonymous` and `File` PTEs now follow the same path: `page_ref_dec`, then `pmm::free_page` (shootdown clean) or `quarantine_free` (shootdown timeout). `Device` VMAs remain skipped — their physical addresses are MMIO registers, not PMM-tracked frames.

### Leak 2 — `adjust_brk` shrink never frees frames

**File**: `kernel/src/mm/vma.rs`

When `brk(2)` shrinks the heap, the former code called `unmap_page_in` (PTE clear) then `shootdown_range` (TLB invalidation) but never called `page_ref_dec` or `pmm::free_page`. Every heap page freed by a brk shrink leaked into the PMM indefinitely.

Fix: replace the inline unmap+shootdown loop with `unmap_and_free_range_in(self.cr3, new_brk, old_brk - new_brk)`, which already implements the correct PTE-clear → ref-dec → batch-shootdown → free-or-quarantine sequence (same discipline as `munmap`).

### Impact on the aliasing path

The page-aliasing class (W216 root cause: freed frames recycled before TLB shootdown completes) is made *easier* to hit when the PMM is under pressure, because the next-fit allocator cursor advances faster and is more likely to wrap around into frames still referenced by cached libxul pages. Closing these two leak paths reduces steady-state PMM occupancy and lowers cursor-wrap frequency.

## Test plan

- [x] `cargo build` (release): clean, 20 pre-existing warnings, zero new diagnostics
- [x] `qemu-harness.py start --features firefox-test,kdb --no-kvm`: boot completes, no `BUGCHECK`, no `panic`
- [x] Firefox progresses to shared-library `calling init:` stage (10k+ serial events: `FF/write`, `PROC`, `SIGNAL` lines)
- [x] Merge-base verified: `git merge-base HEAD origin/master` == `41808d5` (current master HEAD at time of branch)
- [x] Files touched: `kernel/src/proc/mod.rs`, `kernel/src/mm/vma.rs` only — `idt.rs` not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)