### PR TITLE
kernel/idt: VMA re-validation in cache-hit fast-path (W216 H_4h — fourth aliasing path)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1133,6 +1133,66 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
             // moment of install.  The guard ref from `lookup_and_acquire`
             // satisfies that guarantee for all three sub-arms below.
             if let Some(cached_phys) = crate::mm::cache::lookup_and_acquire(mount_idx, inode, file_page_offset) {
+                // === W216 H_4h fix: re-validate VMA before installing cache-hit PTE ===
+                //
+                // PROCESS_TABLE was dropped at line ~1071 and interrupts re-enabled
+                // before this branch.  A concurrent sys_mmap(MAP_FIXED) on a sibling
+                // CPU could have replaced the captured VMA between that drop and now:
+                //   Phase 2a — old VMA removed from VmSpace, frames unmapped+freed
+                //   Phase 2b — pages returned to PMM; PMM may re-issue them
+                //   Phase 3  — new VMA (different backing) inserted
+                //
+                // Without this check we would install `cached_phys` — content valid
+                // for the OLD (inode, file_page_offset) — at a VA whose current VMA
+                // describes a different backing object.  Because libxul is fully
+                // prepopulated, `cached_phys` holds non-zero bytes from the PREVIOUS
+                // offset rather than kernel-page bytes, which is exactly the "non-zero
+                // bytes from a different libxul offset" symptom observed in the W215
+                // post-all-4-fixes verifier.
+                //
+                // The fix mirrors the identical guard PR #226 (W216 Hypothesis-V)
+                // applied to the readahead and single-page paths: re-acquire
+                // PROCESS_TABLE briefly, confirm the (mount_idx, inode,
+                // file_base_offset, vma_base, vma_end) tuple still matches the
+                // snapshot captured before interrupts were re-enabled, and abandon
+                // if it has changed.
+                //
+                // If the VMA is stale we release the guard ref from
+                // `lookup_and_acquire` so the cache's own reference remains the sole
+                // holder (freeing the frame only if the cache has also evicted it).
+                // The user will re-fault against the new VMA and receive correct data.
+                //
+                // Lock ordering preserved: PROCESS_TABLE (top) → nothing else.
+                // MOUNTS is NOT held here; cache/PMM locks are NOT held here.
+                let still_valid = {
+                    let procs = crate::proc::PROCESS_TABLE.lock();
+                    procs.iter()
+                        .find(|p| p.pid == target_pid)
+                        .and_then(|p| p.vm_space.as_ref())
+                        .and_then(|vs| vs.find_vma(faulting_addr))
+                        .map(|v| {
+                            matches!(&v.backing,
+                                crate::mm::vma::VmBacking::File {
+                                    mount_idx: m, inode: ino, offset: o, ..
+                                } if *m == mount_idx && *ino == inode && *o == file_base_offset)
+                            && v.base == vma_base
+                            && v.base + v.length == vma_end
+                        })
+                        .unwrap_or(false)
+                };
+                if !still_valid {
+                    // Release the guard ref — cache's own ref keeps the frame
+                    // alive, or frees it if the cache evicted the entry between
+                    // our lookup and now.
+                    let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                    #[cfg(feature = "firefox-test")]
+                    crate::serial_println!(
+                        "[PF/revalidate] CACHE-HIT VMA stale addr={:#x} \
+                         mount={} inode={} foff={:#x} — abandoning",
+                        faulting_addr, mount_idx, inode, file_page_offset);
+                    return false;
+                }
+
                 // MAP_PRIVATE + writable: give the process a private copy so
                 // writes (e.g., GOT/PLT relocations) don't corrupt the shared
                 // cache page. Without this, a second process loading the same


### PR DESCRIPTION
## Problem

Audit v4 identified four systemic page-aliasing paths. PRs #222, #225, and #226 closed three of them:

- PR #222: mm_sem clone/fork fix
- PR #225: TLB tick-flush quarantine drain
- PR #226 (W216 Hypothesis-V): post-I/O VMA re-validation for the **readahead path** and the **single-page fallback path**

PR #226 missed the **cache-hit fast-path** (`handle_page_fault`, line ~1135). A 3-trial verifier run after all four previous fixes still hit the W215 cluster (libxul offsets 0x4b58f13, 0x4b4eb00, 0x4b2ff13; phys 0x33028000, 0x32fd8000, 0x32ee0000) 3/3 trials. The race character changed: pre-#226 showed kernel-page bytes (all-zero) in the libxul VMA; post-all-four-fixes showed non-zero bytes from a **different** libxul offset. That symptom fingerprints the cache-hit path precisely.

## Race in the cache-hit path

```
1. idt.rs ~1071: PROCESS_TABLE dropped, VMA snapshot captured
2. idt.rs ~1077: interrupts re-enabled
3. idt.rs ~1079-1080: file_page_offset computed from snapshot

-- sibling CPU: MAP_FIXED Phase 2a — VMA removed, frames freed
-- sibling CPU: MAP_FIXED Phase 2b — frames returned to PMM
-- sibling CPU: MAP_FIXED Phase 3  — new VMA (different backing) inserted

4. idt.rs ~1135: cache::lookup_and_acquire() returns cached_phys for OLD offset
5. idt.rs ~1167/1207: map_page_in() installs PTE for content of OLD VMA at
                      VA whose current VMA describes a different file region
```

Because libxul is prepopulated, `cached_phys` holds valid non-zero bytes from the previous offset — explaining the "different libxul offset" verifier symptom.

## Fix

Mirror the identical guard PR #226 applied to the readahead path. Immediately after `lookup_and_acquire` returns `Some`, re-acquire `PROCESS_TABLE` briefly and confirm the tuple `(mount_idx, inode, file_base_offset, vma_base, vma_end)` still matches the snapshot captured before interrupts were re-enabled.

If the VMA has changed:
- Release the guard ref from `lookup_and_acquire` (the cache's own ref keeps the frame alive, or frees it if the cache also evicted the entry)
- Return `false` — the faulting access re-faults against the new VMA and receives correct data

If the VMA is unchanged: fall through to the existing private-copy / alias branching unchanged.

Lock ordering is preserved: `PROCESS_TABLE` (top) → nothing else. `MOUNTS` and cache/PMM locks are not held at the re-validation point.

Per Intel SDM Vol. 3A §4.10.5 and POSIX mmap(2), every PTE installation must guarantee the target frame reflects the current virtual-to-physical mapping contract.

## Scope

`kernel/src/arch/x86_64/idt.rs` only. +60 LOC (comment-heavy; functional delta is ~18 LOC).

## Test plan

- [x] Kernel builds clean with `--features firefox-test,kdb`
- [x] Boot succeeds, Firefox reaches deep library-loading stage (40+ tids, openat/mmap/futex active at sc > 5000)
- [ ] Stretch: single KVM Firefox trial — expect W215-cluster FAULT/PHYS (libxul 0x4b2a–0x4b91) to be absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)