### PR TITLE
kernel/mm+idt: unified VmSpace generation concurrency model for the entire PFH (W216)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -964,6 +964,16 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
             }
         };
 
+        // W216 H_5j-B (unified concurrency): sample VmSpace generation before
+        // the CoW copy + install sequence.  A sibling CPU running
+        // `sys_munmap` / `MAP_FIXED` Phase 2b / `MADV_DONTNEED` /
+        // `clone_for_fork` can mutate the address space — and free `old_phys`
+        // — while we are mid-copy.  Re-checking the generation immediately
+        // before the install ensures we abort instead of installing a PTE
+        // pointing at a frame the sibling has just queued for free.  See
+        // `VmSpace::generation` doc-comment.
+        let gen_at_start = vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
+
         let pte = crate::mm::vmm::read_pte(cr3, page_addr);
         let old_phys = pte & 0x000F_FFFF_FFFF_F000;
 
@@ -976,6 +986,26 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         (PHYS_OFF_COW + new_phys) as *mut u8,
                         crate::mm::pmm::PAGE_SIZE,
                     );
+                }
+                // Re-check generation right before install — Acquire pairs
+                // with the Release fetch_add in `bump_generation_for_cr3`
+                // and `VmSpace::*` mutators (Intel SDM Vol. 3A §8.2.3).
+                let gen_now = vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
+                if gen_now != gen_at_start {
+                    #[cfg(feature = "firefox-test")]
+                    {
+                        static CNT: core::sync::atomic::AtomicU64 =
+                            core::sync::atomic::AtomicU64::new(0);
+                        let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                        if n < 5 || n % 500 == 0 {
+                            crate::serial_println!(
+                                "[PF/gen-abort] COW-COPY #{} addr={:#x} \
+                                 gen_at_start={} gen_now={} — dropping new frame",
+                                n, page_addr, gen_at_start, gen_now);
+                        }
+                    }
+                    crate::mm::pmm::free_page(new_phys);
+                    return false;
                 }
                 // CoW: old_phys may still be shared with the parent; we
                 // only release this process's reference.  The CoW copy
@@ -992,7 +1022,12 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
             }
             return false; // OOM
         } else {
-            // Single owner — just make it writable
+            // Single owner — just make it writable.  The in-place PTE bit
+            // flip does NOT install a new physical frame, so no aliasing
+            // race is possible here; the gen-check above is overkill for
+            // this sub-arm and the result is unused — but the cheap sample
+            // pays for itself by keeping the source readable as a single
+            // entry-point for the whole CoW arm.
             let new_pte = old_phys | page_flags | PAGE_PRESENT;
             crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
             crate::mm::tlb::shootdown_page(cr3, page_addr);
@@ -1164,11 +1199,26 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 //
                 // Lock ordering preserved: PROCESS_TABLE (top) → nothing else.
                 // MOUNTS is NOT held here; cache/PMM locks are NOT held here.
+                // W216 H_5j-B (unified concurrency): capture the VmSpace
+                // generation Arc + post-revalidate sample under the same
+                // PROCESS_TABLE critical section as the revalidate.  Re-checked
+                // immediately before each `map_page_in` in the install sub-arms
+                // below to catch sibling-CPU VMA mutations that fire between
+                // this revalidate and the install.
+                let mut ch_vm_generation:
+                    Option<alloc::sync::Arc<core::sync::atomic::AtomicU64>> = None;
+                let mut ch_gen_at_revalidate: u64 = 0;
                 let still_valid = {
                     let procs = crate::proc::PROCESS_TABLE.lock();
-                    procs.iter()
+                    let vs_opt = procs.iter()
                         .find(|p| p.pid == target_pid)
-                        .and_then(|p| p.vm_space.as_ref())
+                        .and_then(|p| p.vm_space.as_ref());
+                    if let Some(vs) = vs_opt {
+                        ch_vm_generation = Some(vs.generation.clone());
+                        ch_gen_at_revalidate =
+                            vs.generation.load(core::sync::atomic::Ordering::Acquire);
+                    }
+                    vs_opt
                         .and_then(|vs| vs.find_vma(faulting_addr))
                         .map(|v| {
                             matches!(&v.backing,
@@ -1192,6 +1242,21 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         faulting_addr, mount_idx, inode, file_page_offset);
                     return false;
                 }
+
+                // Closure: per-arm generation re-check.  Returns true if the
+                // caller should abort (and the caller must release `cached_phys`
+                // appropriately before returning false).  The CoW-copy sub-arm
+                // additionally frees its freshly-allocated `private_phys` via
+                // its own check immediately before installing.
+                let gen_unchanged = || -> bool {
+                    match ch_vm_generation.as_ref() {
+                        Some(g) => {
+                            let now = g.load(core::sync::atomic::Ordering::Acquire);
+                            now == ch_gen_at_revalidate
+                        }
+                        None => true,
+                    }
+                };
 
                 // MAP_PRIVATE + writable: give the process a private copy so
                 // writes (e.g., GOT/PLT relocations) don't corrupt the shared
@@ -1222,6 +1287,25 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                 (COW_OFF + private_phys) as *mut u8,
                                 crate::mm::pmm::PAGE_SIZE,
                             );
+                        }
+                        // W216 H_5j-B (unified concurrency): re-check generation
+                        // immediately before install — see arm-level closure.
+                        if !gen_unchanged() {
+                            #[cfg(feature = "firefox-test")]
+                            {
+                                static CNT: core::sync::atomic::AtomicU64 =
+                                    core::sync::atomic::AtomicU64::new(0);
+                                let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                                if n < 5 || n % 500 == 0 {
+                                    crate::serial_println!(
+                                        "[PF/gen-abort] CACHE-PRIVATE #{} addr={:#x} \
+                                         gen_at_rev={} — releasing private+cache refs",
+                                        n, page_addr, ch_gen_at_revalidate);
+                                }
+                            }
+                            crate::mm::pmm::free_page(private_phys);
+                            let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                            return false;
                         }
                         crate::mm::refcount::page_ref_set(private_phys, 1);
                         crate::mm::vmm::map_page_in(cr3, page_addr, private_phys, page_flags);
@@ -1264,6 +1348,27 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // reference — do NOT call `page_ref_inc` again here.
                     // Steady state after install: cache holds one ref,
                     // this PTE holds one ref (the promoted guard ref) = rc ≥ 2.
+                    //
+                    // W216 H_5j-B (unified concurrency): re-check generation
+                    // immediately before install.  On abort we release the
+                    // guard ref so the cache's own reference remains the sole
+                    // holder of `cached_phys`.
+                    if !gen_unchanged() {
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            static CNT: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 5 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/gen-abort] CACHE-ALIAS #{} addr={:#x} \
+                                     gen_at_rev={} — releasing guard ref",
+                                    n, page_addr, ch_gen_at_revalidate);
+                            }
+                        }
+                        let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                        return false;
+                    }
                     crate::mm::vmm::map_page_in(cr3, page_addr, cached_phys, page_flags);
                     crate::mm::vmm::invlpg(page_addr);
                     // Guard ref is intentionally NOT released — it has been
@@ -1889,10 +1994,39 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         );
                     }
                 }
+                // W216 H_5j-B (unified concurrency): sample the VmSpace
+                // generation before the allocation+zero+install sequence.
+                // Anonymous faults have a narrower race window than file-backed
+                // (no I/O drop of PROCESS_TABLE) but a sibling-CPU
+                // sys_munmap / MAP_FIXED Phase 2b can still mutate the VMA list
+                // between the find_vma above and the install below; the check
+                // keeps the abort-and-retry invariant uniform across all PFH
+                // install arms.  See `VmSpace::generation`.
+                let gen_at_start =
+                    vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
                 // Allocate a zeroed page
                 if let Some(phys) = crate::mm::pmm::alloc_page() {
                     unsafe {
                         core::ptr::write_bytes((PHYS_OFF + phys) as *mut u8, 0, crate::mm::pmm::PAGE_SIZE);
+                    }
+                    // Re-check generation immediately before install.
+                    let gen_now =
+                        vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
+                    if gen_now != gen_at_start {
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            static CNT: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 5 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/gen-abort] ANON #{} addr={:#x} \
+                                     gen_at_start={} gen_now={} — releasing frame",
+                                    n, page_addr, gen_at_start, gen_now);
+                            }
+                        }
+                        crate::mm::pmm::free_page(phys);
+                        return false;
                     }
                     crate::mm::refcount::page_ref_set(phys, 1);
                     crate::mm::vmm::map_page_in(cr3, page_addr, phys, page_flags);

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1430,34 +1430,31 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
             // recycled physical frames (the residual 5th-class aliasing that
             // remained after PRs #222 / #225 / #226 / #230).
             //
-            // Fix: after the cheap revalidate succeeds, ESCALATE `mm_sem` to write
-            // for the duration of the install loop.  This excludes any concurrent
-            // teardown (munmap / madvise / MAP_FIXED Phase 2b) until every PTE is
-            // installed.  The cost is only paid on file-backed faults that
-            // actually allocated readahead pages; the revalidate fast-path keeps
-            // the cost away from the stale-VMA case entirely.
-            //
-            // Lock ordering: PROCESS_TABLE (already dropped) → MOUNTS (already
-            // dropped) → mm_sem.write (acquired below) → MM_REGISTRY (leaf,
-            // transient inside `mm_sem_for_cr3`) → VMM_LOCK / PMM_LOCK /
-            // PAGE_CACHE (leaves, taken by the install primitives).  This matches
-            // the invariant documented in `kernel/src/mm/vma.rs`.
-            //
-            // Scope: this exclusion is per-VmSpace and only spans the install
-            // loop (microseconds, no I/O held under the lock).  It does NOT
-            // serialise the whole address-space against the PMM globally —
-            // independent VmSpaces remain fully parallel, and any reader on the
-            // same VmSpace (e.g. another #PF on a different VA) blocks only for
-            // the install duration.  Per Intel SDM Vol. 3A §4.10.5, PTE writes
-            // must be globally ordered with respect to other PTE mutators on the
-            // same paging hierarchy; the write-lock provides exactly that
-            // ordering for the duration of the multi-page install.
+            // Lock ordering preserved: PROCESS_TABLE (top) → nothing else here.
+            // MOUNTS is NOT held at this point; cache/PMM locks are NOT held yet.
+            // W216 H_5j-B: also capture the VmSpace generation Arc + a
+            // post-revalidate sample so we can detect any further VMA-list
+            // mutation that happens BETWEEN this revalidate and each
+            // cache::insert + map_page_in iteration in the install loop
+            // below.  PR #226's revalidate alone catches mutations that
+            // happened during the I/O phase; the install loop itself can
+            // span microseconds during which a sibling CPU running
+            // sys_munmap / MAP_FIXED Phase 2b / MADV_DONTNEED can drain
+            // frames out from under us.  See `VmSpace::generation`.
+            let mut vm_generation: Option<alloc::sync::Arc<core::sync::atomic::AtomicU64>> = None;
+            let mut gen_at_revalidate: u64 = 0;
             if n_pages > 0 {
                 let still_valid = {
                     let procs = crate::proc::PROCESS_TABLE.lock();
-                    procs.iter()
+                    let vs_opt = procs.iter()
                         .find(|p| p.pid == target_pid)
-                        .and_then(|p| p.vm_space.as_ref())
+                        .and_then(|p| p.vm_space.as_ref());
+                    if let Some(vs) = vs_opt {
+                        vm_generation = Some(vs.generation.clone());
+                        gen_at_revalidate =
+                            vs.generation.load(core::sync::atomic::Ordering::Acquire);
+                    }
+                    vs_opt
                         .and_then(|vs| vs.find_vma(faulting_addr))
                         .map(|v| {
                             matches!(&v.backing,
@@ -1508,39 +1505,42 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
             let needs_private_copy_vma = is_writable_vma && !is_shared;
             let mapped_faulting = n_pages > 0;
 
-            // W216 H_5j-A: escalate mm_sem to write across the install loop.
-            //
-            // The guard is bound for the duration of `_install_guard` and
-            // dropped automatically on any path out of the block — including
-            // the early-return at OOM-during-private-copy below — by Rust
-            // RAII.  `map_page_in_locked` is used inside the loop because
-            // `map_page_in` would otherwise recursively acquire `mm_sem` in
-            // read mode (and `spin::RwLock` is non-reentrant — that would
-            // self-deadlock).
-            //
-            // The OOM-fallback to single-page (n_pages == 0, mapped_faulting
-            // == false) skips this block entirely and the lock is never
-            // taken, so the single-page arm acquires its own write lock
-            // below without contending against ourselves.
-            let _install_sem = if n_pages > 0 {
-                crate::mm::vma::mm_sem_for_cr3(cr3)
-            } else {
-                None
-            };
-            let _install_guard = _install_sem.as_ref().map(|s| s.write());
-            #[cfg(feature = "firefox-test")]
-            if n_pages > 0 {
-                static PF_INSTALL_LOCK_N: core::sync::atomic::AtomicU64 =
-                    core::sync::atomic::AtomicU64::new(0);
-                let nl = PF_INSTALL_LOCK_N.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                if nl < 5 || nl % 500 == 0 {
-                    crate::serial_println!(
-                        "[PF/install-lock] readahead #{} addr={:#x} pages={}",
-                        nl, page_addr, n_pages);
-                }
-            }
             for i in 0..n_pages {
                 let (vaddr, phys, foff) = pages_to_map[i];
+
+                // W216 H_5j-B: per-iteration generation re-check.  Any sibling
+                // CPU that mutated the address space (sys_munmap, MAP_FIXED
+                // Phase 2b, MADV_DONTNEED, mprotect, sysv_shm push/remove,
+                // brk grow/shrink, clone_for_fork CoW write-protect) since
+                // the post-revalidate sample bumps `vm_space.generation`.
+                // A mismatch means the snapshot we computed before this
+                // iteration is no longer authoritative — abort the install
+                // loop, free remaining frames, return false so the user
+                // re-faults against the new VMA.  Per Intel SDM Vol. 3A
+                // §8.2.3, this Acquire load pairs with the Release fetch_add
+                // in `bump_generation_for_cr3` and `VmSpace::*` mutators.
+                if let Some(g) = vm_generation.as_ref() {
+                    let gen_now = g.load(core::sync::atomic::Ordering::Acquire);
+                    if gen_now != gen_at_revalidate {
+                        #[cfg(feature = "firefox-test")]
+                        crate::serial_println!(
+                            "[PF/gen-abort] READAHEAD addr={:#x} mount={} inode={} \
+                             foff={:#x} gen_at_rev={} gen_now={} — releasing {} \
+                             unmapped frames",
+                            faulting_addr, mount_idx, inode, file_base_offset,
+                            gen_at_revalidate, gen_now, n_pages.saturating_sub(i));
+                        // Release every frame we have not yet installed.
+                        // Frames already installed in earlier iterations (i'
+                        // < i) are reachable via PTE refs and the cache, so
+                        // they remain valid; the user keeps observing them
+                        // through the existing PTEs.
+                        for j in i..n_pages {
+                            let (_v, p, _f) = pages_to_map[j];
+                            crate::mm::pmm::free_page(p);
+                        }
+                        return false;
+                    }
+                }
 
                 // ---- Bug-B fix: guard reference ----------------------------
                 // Acquire a guard reference on `phys` BEFORE inserting it into
@@ -1608,10 +1608,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             );
                         }
                         crate::mm::refcount::page_ref_set(private_phys, 1);
-                        // W216 H_5j-A: we hold `mm_sem.write` already — call the
-                        // `_locked` variant to avoid `spin::RwLock` non-reentrant
-                        // self-deadlock.  See block-level comment above.
-                        crate::mm::vmm::map_page_in_locked(cr3, vaddr, private_phys, page_flags);
+                        crate::mm::vmm::map_page_in(cr3, vaddr, private_phys, page_flags);
                         // Cache keeps its ref to phys (the clean shared copy).
                         // Drop guard ref — steady state: cache ref(phys) = 1.
                         let _ = crate::mm::refcount::page_ref_dec(phys);
@@ -1640,8 +1637,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // MAP_SHARED writable, or any read-only mapping: alias
                     // the cache page directly.
                     crate::mm::refcount::page_ref_inc(phys);
-                    // W216 H_5j-A: see _locked rationale on private-copy arm.
-                    crate::mm::vmm::map_page_in_locked(cr3, vaddr, phys, page_flags);
+                    crate::mm::vmm::map_page_in(cr3, vaddr, phys, page_flags);
                     // Drop guard ref — steady state: cache(1) + PTE(1) = 2.
                     let _ = crate::mm::refcount::page_ref_dec(phys);
                 }
@@ -1738,12 +1734,27 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 // drop (before I/O) and here, a sibling CPU running sys_mmap
                 // MAP_FIXED Phase 2b may have freed the frames backing this VA and
                 // replaced the VMA with a new one.  Re-validate before installing.
+                // W216 H_5j-B: capture the VmSpace generation post-revalidate
+                // and re-check it just before the cache::insert + map_page_in
+                // below.  Single-page path has one install, but a sibling CPU
+                // can still mutate the address space between the revalidate
+                // critical section and the install — same race class as the
+                // readahead arm above.  See `VmSpace::generation` doc comment.
+                let mut sp_vm_generation:
+                    Option<alloc::sync::Arc<core::sync::atomic::AtomicU64>> = None;
+                let mut sp_gen_at_revalidate: u64 = 0;
                 {
                     let still_valid = {
                         let procs = crate::proc::PROCESS_TABLE.lock();
-                        procs.iter()
+                        let vs_opt = procs.iter()
                             .find(|p| p.pid == target_pid)
-                            .and_then(|p| p.vm_space.as_ref())
+                            .and_then(|p| p.vm_space.as_ref());
+                        if let Some(vs) = vs_opt {
+                            sp_vm_generation = Some(vs.generation.clone());
+                            sp_gen_at_revalidate =
+                                vs.generation.load(core::sync::atomic::Ordering::Acquire);
+                        }
+                        vs_opt
                             .and_then(|vs| vs.find_vma(faulting_addr))
                             .map(|v| {
                                 matches!(&v.backing,
@@ -1767,35 +1778,20 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         return false;
                     }
                 }
-                // W216 H_5j-A: escalate mm_sem to write across the single-page
-                // install.  See the readahead arm above for the full rationale:
-                // the cheap PR #226 revalidate closes the racing
-                // TEARDOWN-then-INSTALL case, but the cache::insert →
-                // read_pte → map_page_in_locked install sequence below also
-                // needs exclusion against a concurrent munmap / MAP_FIXED
-                // Phase 2b on a sibling CPU.  `map_page_in_locked` is used
-                // because we hold `mm_sem.write` and `spin::RwLock` is
-                // non-reentrant.
-                //
-                // Lock ordering: PROCESS_TABLE (already dropped) → MOUNTS
-                // (already dropped) → mm_sem.write → VMM_LOCK / PMM_LOCK /
-                // PAGE_CACHE (leaves).  Per Intel SDM Vol. 3A §4.10.5 the
-                // write-lock provides PTE-write ordering for the install.
-                let _spf_sem = crate::mm::vma::mm_sem_for_cr3(cr3);
-                let _spf_guard = _spf_sem.as_ref().map(|s| s.write());
-                #[cfg(feature = "firefox-test")]
-                {
-                    static PF_INSTALL_LOCK_N_SPF: core::sync::atomic::AtomicU64 =
-                        core::sync::atomic::AtomicU64::new(0);
-                    let nl = PF_INSTALL_LOCK_N_SPF
-                        .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                    if nl < 5 || nl % 500 == 0 {
+                // W216 H_5j-B: re-check generation immediately before install.
+                if let Some(g) = sp_vm_generation.as_ref() {
+                    let gen_now = g.load(core::sync::atomic::Ordering::Acquire);
+                    if gen_now != sp_gen_at_revalidate {
+                        #[cfg(feature = "firefox-test")]
                         crate::serial_println!(
-                            "[PF/install-lock] single-page #{} addr={:#x}",
-                            nl, page_addr);
+                            "[PF/gen-abort] SINGLE-PAGE addr={:#x} mount={} inode={} \
+                             foff={:#x} gen_at_rev={} gen_now={} — dropping frame",
+                            faulting_addr, mount_idx, inode, file_page_offset,
+                            sp_gen_at_revalidate, gen_now);
+                        crate::mm::pmm::free_page(phys);
+                        return false;
                     }
                 }
-
                 // Bug-B fix (single-page fallback): hold a guard reference
                 // before inserting into the cache, mirroring the readahead-
                 // path fix above.  Without the guard, a concurrent cache::insert
@@ -1835,8 +1831,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             );
                         }
                         crate::mm::refcount::page_ref_set(private_phys, 1);
-                        // W216 H_5j-A: _locked variant; mm_sem.write is held.
-                        crate::mm::vmm::map_page_in_locked(cr3, page_addr, private_phys, page_flags);
+                        crate::mm::vmm::map_page_in(cr3, page_addr, private_phys, page_flags);
                         crate::mm::vmm::invlpg(page_addr);
                         // Cache keeps its own ref to phys (clean shared copy).
                         // Release guard — steady state: cache ref(phys) = 1.
@@ -1864,8 +1859,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // cache page directly.  Writes via MAP_SHARED are visible to
                     // all other mappers — required by mmap(2) MAP_SHARED contract.
                     crate::mm::refcount::page_ref_inc(phys); // PTE reference
-                    // W216 H_5j-A: _locked variant; mm_sem.write is held.
-                    crate::mm::vmm::map_page_in_locked(cr3, page_addr, phys, page_flags);
+                    crate::mm::vmm::map_page_in(cr3, page_addr, phys, page_flags);
                     crate::mm::vmm::invlpg(page_addr);
                     // Release guard — steady state: cache(1) + PTE(1) = 2.
                     let _ = crate::mm::refcount::page_ref_dec(phys);

--- a/kernel/src/ipc/sysv_shm.rs
+++ b/kernel/src/ipc/sysv_shm.rs
@@ -171,6 +171,9 @@ pub fn shmat(shmid: u32, shmaddr: u64, _shmflg: i32) -> i64 {
                     backing: crate::mm::vma::VmBacking::Device { phys_base },
                     name:    "[shm]",
                 });
+                // W216 H_5j-B: notify the PFH install loop of the VMA-list
+                // mutation (this site bypasses insert_vma).
+                vs.generation.fetch_add(1, core::sync::atomic::Ordering::Release);
             }
         }
     }
@@ -205,6 +208,9 @@ pub fn shmdt(shmaddr: u64) -> i64 {
         match idx {
             Some(i) => {
                 let vma = vs.areas.remove(i);
+                // W216 H_5j-B: notify the PFH install loop of the VMA-list
+                // mutation (this site bypasses remove_range).
+                vs.generation.fetch_add(1, core::sync::atomic::Ordering::Release);
                 match vma.backing {
                     crate::mm::vma::VmBacking::Device { phys_base } => (phys_base, vma.length),
                     _ => unreachable!(),

--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -18,6 +18,7 @@ use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
+use core::sync::atomic::{AtomicU64, Ordering};
 use spin::{Mutex, RwLock};
 
 /// VMA protection flags (mmap-compatible).
@@ -275,6 +276,26 @@ pub struct VmSpace {
     /// can both hold a handle; the registry deregisters when the
     /// `VmSpace` is dropped and the last `Arc` ref vanishes.
     pub mm_sem: Arc<RwLock<()>>,
+    /// Monotonic counter bumped on every VMA-list mutation (W216 H_5j-B,
+    /// 5th systemic aliasing path).  The page-fault handler in
+    /// `arch/x86_64/idt.rs` samples this counter immediately after the
+    /// PR #226 / #230 post-I/O VMA re-validation succeeds, then re-loads
+    /// it before each `cache::insert + map_page_in` install iteration in
+    /// the readahead and single-page fallback arms.  A mismatch indicates
+    /// that a sibling CPU mutated the address space between revalidate
+    /// and the current iteration; the install loop aborts and the user
+    /// re-faults against the new VMA, mirroring the abort-and-retry
+    /// pattern used elsewhere in the PFH for stale snapshots.
+    ///
+    /// The counter is shared (`Arc<AtomicU64>`) so that low-level helpers
+    /// like `unmap_and_free_range_in` — which only have a `cr3`, not a
+    /// `&VmSpace` — can bump the generation via `bump_generation_for_cr3`.
+    /// Acquire/Release ordering is per Intel SDM Vol. 3A §8.2.3 (memory-
+    /// ordering guarantees of LOCK-prefixed atomics on x86-64): a
+    /// release-store on the mutator side happens-before an acquire-load
+    /// on the PFH side, so any VMA-list write that preceded the bump is
+    /// visible to a PFH iteration that observes the new generation.
+    pub generation: Arc<AtomicU64>,
 }
 
 /// Default user-space mmap starting address.
@@ -329,6 +350,58 @@ pub fn mm_sem_for_cr3(cr3: u64) -> Option<Arc<RwLock<()>>> {
     reg.get(&cr3).cloned()
 }
 
+// ============================================================================
+// MM generation registry — parallel to MM_REGISTRY, keyed by cr3.
+// Allows low-level helpers (unmap_and_free_range_in, MADV_DONTNEED bulk
+// teardown) that only have a cr3 to bump the owning VmSpace's generation
+// without threading a `&VmSpace` reference through the call graph.
+// See `VmSpace::generation` doc-comment for the use case.
+// ============================================================================
+
+static MM_GEN_REGISTRY: Mutex<BTreeMap<u64, Arc<AtomicU64>>> = Mutex::new(BTreeMap::new());
+
+/// Insert (cr3 → generation counter) into the parallel registry.  Idempotent
+/// (replaces any prior entry) for the same reasons described in
+/// `register_mm_sem`.
+pub(crate) fn register_mm_generation(cr3: u64, gen_arc: Arc<AtomicU64>) {
+    if cr3 == 0 {
+        return;
+    }
+    let mut reg = MM_GEN_REGISTRY.lock();
+    reg.insert(cr3, gen_arc);
+}
+
+/// Remove the generation counter entry for `cr3` (no-op if absent).
+#[allow(dead_code)]
+pub(crate) fn unregister_mm_generation(cr3: u64) {
+    if cr3 == 0 {
+        return;
+    }
+    let mut reg = MM_GEN_REGISTRY.lock();
+    reg.remove(&cr3);
+}
+
+/// Bump the VmSpace generation counter associated with `cr3`.  Called by
+/// PTE-mutating helpers that only have a `cr3` (see `mm/vmm.rs`).  Cheap
+/// (registry lookup + one atomic fetch_add); no-op for unknown CR3s.
+///
+/// The fetch_add uses Release ordering so that VMA-list / PTE writes that
+/// precede the bump on the same CPU are observable to any other CPU that
+/// subsequently performs an Acquire load of the counter (Intel SDM
+/// Vol. 3A §8.2.3).
+pub fn bump_generation_for_cr3(cr3: u64) {
+    if cr3 == 0 {
+        return;
+    }
+    let arc = {
+        let reg = MM_GEN_REGISTRY.lock();
+        reg.get(&cr3).cloned()
+    };
+    if let Some(g) = arc {
+        g.fetch_add(1, Ordering::Release);
+    }
+}
+
 /// Allocate a fresh `mm_sem` handle for use in test struct-literal
 /// `VmSpace { ... }` construction.  Production code paths should construct
 /// `VmSpace` via `new_kernel`, `new_user`, `from_existing_cr3`, or
@@ -338,12 +411,20 @@ pub fn make_mm_sem_for_test() -> Arc<RwLock<()>> {
     Arc::new(RwLock::new(()))
 }
 
+/// Allocate a fresh generation counter for use in test struct-literal
+/// `VmSpace { ... }` construction.  Mirrors `make_mm_sem_for_test`.
+pub fn make_generation_for_test() -> Arc<AtomicU64> {
+    Arc::new(AtomicU64::new(0))
+}
+
 impl VmSpace {
     /// Create a new empty address space for a kernel process (shares kernel CR3).
     pub fn new_kernel() -> Self {
         let cr3 = crate::mm::vmm::get_cr3();
         let mm_sem = Arc::new(RwLock::new(()));
         register_mm_sem(cr3, mm_sem.clone());
+        let generation = Arc::new(AtomicU64::new(0));
+        register_mm_generation(cr3, generation.clone());
         Self {
             cr3,
             areas: Vec::new(),
@@ -351,6 +432,7 @@ impl VmSpace {
             brk: HEAP_BASE,
             brk_start: HEAP_BASE,
             mm_sem,
+            generation,
         }
     }
 
@@ -378,6 +460,20 @@ impl VmSpace {
         // present (the parent's VmSpace registered it at construction).  No
         // re-registration is needed — `mm_sem_for_cr3(cr3)` already returns
         // this Arc.
+        //
+        // Generation counter: shares the parent's counter so any mutation made
+        // by either share-CR3 sibling is observed by both at the PFH check.
+        // Falls back to a fresh counter if the parent is no longer registered
+        // (defensive — should not occur in practice).
+        let generation = {
+            let reg = MM_GEN_REGISTRY.lock();
+            reg.get(&cr3).cloned()
+        }
+        .unwrap_or_else(|| {
+            let g = Arc::new(AtomicU64::new(0));
+            register_mm_generation(cr3, g.clone());
+            g
+        });
         Self {
             cr3,
             areas: Vec::new(),
@@ -385,6 +481,7 @@ impl VmSpace {
             brk: HEAP_BASE,
             brk_start: HEAP_BASE,
             mm_sem: parent_mm_sem,
+            generation,
         }
     }
 
@@ -440,6 +537,8 @@ impl VmSpace {
 
         let mm_sem = Arc::new(RwLock::new(()));
         register_mm_sem(new_pml4, mm_sem.clone());
+        let generation = Arc::new(AtomicU64::new(0));
+        register_mm_generation(new_pml4, generation.clone());
         Some(Self {
             cr3: new_pml4,
             areas: Vec::new(),
@@ -447,6 +546,7 @@ impl VmSpace {
             brk: HEAP_BASE,
             brk_start: HEAP_BASE,
             mm_sem,
+            generation,
         })
     }
 
@@ -652,6 +752,13 @@ impl VmSpace {
         // the new lock with the child's freshly-allocated PML4.
         let child_mm_sem = Arc::new(RwLock::new(()));
         register_mm_sem(child_pml4_phys, child_mm_sem.clone());
+        let child_generation = Arc::new(AtomicU64::new(0));
+        register_mm_generation(child_pml4_phys, child_generation.clone());
+
+        // Bump the parent's generation: the CoW write-protect pass above
+        // mutated parent PTEs (clear PAGE_WRITABLE), which the PFH treats
+        // analogously to a VMA-list mutation for race-detection purposes.
+        self.generation.fetch_add(1, Ordering::Release);
 
         Some(VmSpace {
             cr3: child_pml4_phys,
@@ -660,6 +767,7 @@ impl VmSpace {
             brk: self.brk,
             brk_start: self.brk_start,
             mm_sem: child_mm_sem,
+            generation: child_generation,
         })
     }
 
@@ -689,6 +797,8 @@ impl VmSpace {
         let pos = self.areas.iter().position(|v| v.base > vma.base)
             .unwrap_or(self.areas.len());
         self.areas.insert(pos, vma);
+        // W216 H_5j-B: notify the PFH install loop that the VMA list changed.
+        self.generation.fetch_add(1, Ordering::Release);
         Ok(())
     }
 
@@ -703,6 +813,11 @@ impl VmSpace {
     /// remnant reservation pages, corrupting its internal load-address
     /// structures and producing garbage mprotect/relocation addresses.
     pub fn remove_range(&mut self, base: u64, length: u64) -> Result<(), VmaError> {
+        // W216 H_5j-B: notify the PFH install loop that the VMA list is about
+        // to change.  Bumped before the mutation so any PFH iteration that
+        // observes the new generation will also (via the lock acquisition in
+        // `unmap_and_free_range_in`) see the post-mutation areas list.
+        self.generation.fetch_add(1, Ordering::Release);
         let end = base + length;
         let mut i = 0;
 
@@ -839,6 +954,11 @@ impl VmSpace {
             return self.brk;
         }
 
+        // W216 H_5j-B: heap VMA grow/shrink mutates the area list; notify the
+        // PFH install loop.  insert_vma below also bumps on the create-heap
+        // path; double-bump is harmless (counter is monotonic).
+        self.generation.fetch_add(1, Ordering::Release);
+
         if new_brk > self.brk {
             // Expanding: ensure we have a heap VMA
             if let Some(heap_vma) = self.areas.iter_mut().find(|v| v.name == "[heap]") {
@@ -945,6 +1065,19 @@ impl Drop for VmSpace {
             // versa) still holds a clone — leave the registry entry intact.
             if Arc::ptr_eq(slot, &self.mm_sem) && Arc::strong_count(&self.mm_sem) == 2 {
                 reg.remove(&self.cr3);
+                // Generation registry tracks the same lifecycle (per-cr3,
+                // shared with from_existing_cr3 vfork siblings).  Remove the
+                // entry only when the sem entry was also removed so the two
+                // registries stay coherent.
+                drop(reg);
+                let mut greg = MM_GEN_REGISTRY.lock();
+                if let Some(gslot) = greg.get(&self.cr3) {
+                    if Arc::ptr_eq(gslot, &self.generation)
+                        && Arc::strong_count(&self.generation) == 2
+                    {
+                        greg.remove(&self.cr3);
+                    }
+                }
             }
         }
     }

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -494,28 +494,6 @@ pub fn map_page_in(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -
     // `None` arm is a no-op (no concurrent fork to serialise against).
     let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
     let _mm_read = _mm_guard.as_ref().map(|s| s.read());
-    map_page_in_locked(pml4_phys, virt_addr, phys_addr, flags)
-}
-
-/// Variant of [`map_page_in`] that **does not** acquire `mm_sem`.
-///
-/// The caller must already hold the per-VmSpace `mm_sem` in either read or
-/// write mode for `pml4_phys` (or know that no `VmSpace` is registered for
-/// this CR3 — kernel-only / AP-idle paths).  This exists so the page-fault
-/// handler can escalate `mm_sem` to a write lock for the duration of a
-/// multi-page install loop (W216 H_5j-A — see
-/// `kernel/src/arch/x86_64/idt.rs`) without provoking the non-reentrant
-/// `spin::RwLock` recursion that the unconditional read-acquire in
-/// `map_page_in` would otherwise cause.
-///
-/// `VMM_LOCK` is still taken — it serialises raw page-table edits across
-/// CPUs.  Per Intel SDM Vol. 3A §4.10.5 the PTE write itself must be ordered
-/// with respect to other PTE mutators on the same paging hierarchy.
-///
-/// # Safety
-/// `pml4_phys` must point to a valid PML4 page table, and the caller must
-/// hold `mm_sem_for_cr3(pml4_phys)` in read or write mode.
-pub fn map_page_in_locked(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -> bool {
     let _lock = VMM_LOCK.lock();
 
     let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -623,6 +623,14 @@ pub fn unmap_and_free_range_in(pml4_phys: u64, base: u64, length: u64) -> usize 
     let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
     let _mm_read = _mm_guard.as_ref().map(|s| s.read());
 
+    // W216 H_5j-B: notify any in-flight PFH install loop that frames in this
+    // address space are being freed.  The PFH samples the generation after
+    // the post-I/O VMA revalidate (PR #226 / #230) and re-checks before each
+    // cache::insert + map_page_in iteration; bumping here ensures the loop
+    // aborts before it can install a PTE pointing at a frame this routine
+    // has just queued for free.
+    crate::mm::vma::bump_generation_for_cr3(pml4_phys);
+
     let mut freed = 0usize;
     let mut pg = base;
     let end = base.saturating_add(length);

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3103,6 +3103,12 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     };
     let cr3 = match cr3_opt { Some(c) => c, None => return 0 };
 
+    // W216 H_5j-B: MADV_DONTNEED clears PTEs and frees frames; the area list
+    // itself is not mutated, but the PFH install loop must abort if it has
+    // any in-flight install for the same address space (otherwise it could
+    // map a stale `pages_to_map[i]` whose underlying frame we just freed).
+    crate::mm::vma::bump_generation_for_cr3(cr3);
+
     // Acquire the per-address-space read lock for the full clear→shootdown→free
     // sequence.  This serialises against any concurrent `clone_for_fork` that
     // holds the write side of the same mm_sem while walking the PML4.  Without
@@ -4164,6 +4170,11 @@ fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
         None => return -22,
     };
     let cr3 = space.cr3;
+
+    // W216 H_5j-B: mprotect rewrites VMA prot/areas in place; bump generation
+    // to invalidate any in-flight PFH install loop that snapshotted the old
+    // VMA before this call.
+    space.generation.fetch_add(1, core::sync::atomic::Ordering::Release);
 
     // Update VMA prot fields that overlap this range, splitting VMAs as needed
     // so that only the exact [base, end) portion gets the new prot.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -4006,6 +4006,7 @@ fn test_signal_vma_snapshot() -> bool {
     let space = VmSpace {
         cr3: 0,
         mm_sem: crate::mm::vma::make_mm_sem_for_test(),
+        generation: crate::mm::vma::make_generation_for_test(),
         areas: alloc::vec![
             // libxul .text (executable, file-backed) — should appear
             VmArea {
@@ -4131,6 +4132,7 @@ fn test_signal_vma_snapshot() -> bool {
         let delta_space = VmSpace {
             cr3: 0,
             mm_sem: crate::mm::vma::make_mm_sem_for_test(),
+            generation: crate::mm::vma::make_generation_for_test(),
             areas: alloc::vec![
                 VmArea {
                     base: delta_vma_base, length: 0x100_0000,


### PR DESCRIPTION
## Summary

- Adds `VmSpace::generation: Arc<AtomicU64>` bumped on every VMA-list / PTE bulk-rewrite mutator.  Every PFH install arm samples the counter post-revalidate and re-checks it immediately before each install; mismatch ⇒ abort, free the freshly-allocated frames, return false so the user re-faults against the new VMA.
- **Unified concurrency model** — replaces the per-arm whack-a-mole pattern (PRs #231 PMM-quarantine, #234 mm_sem.write, #238 cache-hit surgical).  One mechanism covers all PFH install arms; one decision point for "is the snapshot still authoritative?".
- Closes the W216 5th systemic page-aliasing class (W215 FAULT/PHYS cluster, libxul+0x4b*-region) without structural changes to hot kernel paths.

## Coverage matrix

| Arm | Install kind | idt.rs lines | Gen-check | Diagnostic counter |
|-----|--------------|--------------|-----------|--------------------|
| A. Copy-on-Write (write+present) | `pmm::alloc_page` + copy + install | 970-985 | yes | `[PF/gen-abort] COW-COPY` |
| B. NX fixup | PTE bit flip only — no install | 1042-1043 | n/a (no aliasing) | — |
| C. Cache-hit private-copy | `pmm::alloc_page` + copy + install | 1212-1227 | yes | `[PF/gen-abort] CACHE-PRIVATE` |
| D. Cache-hit alias | guard ref promoted to PTE ref + install | 1267-1268 | yes | `[PF/gen-abort] CACHE-ALIAS` |
| E. Readahead install loop | up-to-32 `cache::insert` + install | 1542-1644 | yes (per-iteration) | `[PF/gen-abort] READAHEAD` |
| F. Single-page fallback | one `cache::insert` + install | 1668-1872 | yes | `[PF/gen-abort] SINGLE-PAGE` |
| G. Anonymous zero-fill | `pmm::alloc_page` + zero + install | 1899-1904 | yes | `[PF/gen-abort] ANON` |
| H. Device MMIO | identity-map fixed BAR phys | 1910-1914 | n/a (no PMM allocation) | — |

6 of 8 arms get the check; arms B and H cannot exhibit page aliasing by construction.

## The unified mechanism

```text
mutator side                          fault-path arm
------------                          --------------
                                      gen_at_start = generation.load(Acquire)
                                      ... allocate / copy / I/O / revalidate ...
generation.fetch_add(1, Release)      gen_now = generation.load(Acquire)
                                      if gen_now != gen_at_start { abort+free; return false }
                                      map_page_in(...)
```

The Acquire/Release pairing follows Intel SDM Vol. 3A §8.2.3 — x86-64 LOCK-prefixed atomics establish the happens-before edge between the mutator's Release fetch_add and the fault-path's Acquire load.

## Mutator coverage (bump every VMA-list / PTE bulk-rewrite path)

- High-level helpers: `insert_vma`, `remove_range`, `adjust_brk` (cover `sys_mmap` MAP_FIXED Phases 2a/3, `sys_munmap`, `sys_brk`, `sys_mremap`, ELF loader, vDSO install, fork-child VMA install).
- Low-level (cr3-keyed via `bump_generation_for_cr3`): `unmap_and_free_range_in` (MAP_FIXED Phase 2b, brk shrink), `sys_madvise(MADV_DONTNEED)`.
- Direct `areas.push` / `areas.remove`: `sys_mprotect` (whole-call bump), `sysv_shm::shmat` / `shmdt`.
- `clone_for_fork` parent CoW write-protect pass.

PFH revalidates from PRs #226 / #230 remain in place as cheap early-outs; the generation check is the authoritative answer.

## Why a generation counter, not a lock

| Concern | PR #231 (H_5i, PMM-quarantine) | PR #234 (H_5j-A, mm_sem.write loop) | This PR (unified generation) |
|---------|--------------------------------|--------------------------------------|------------------------------|
| Hot-path lock change | Yes (global PMM) | Yes (write-lock across install) | **No** |
| Cost when no race | High | High | **Single AtomicU64 load** |
| Race-window detection | Implicit (frame quarantine) | Excluded by lock | Per-arm check |
| CI kernel-smoke verdict | Failed | Reproducibly fails subtle timings | **Local smoke clean** |
| Concurrent-fault throughput | Serialised globally | Serialised per VmSpace | Preserved |

PR #234's `mm_sem.write` escalation on arms E and F has been REMOVED in this PR's base commit (`map_page_in_locked` is gone, the existing `mm_sem.read` semantics in `map_page_in` are preserved).  This restores concurrent-fault throughput.

## Test plan

- [x] `qemu-harness.py check` (default) — clean
- [x] `qemu-harness.py check --features firefox-test` — clean
- [x] `qemu-harness.py check --features test-mode` — clean
- [x] Local kernel-smoke (`qemu-harness.py start --features test-mode` + `wait 'TEST SUITE|BUGCHECK'`) completes without HUNG/bugcheck; 8 pre-existing failures (missing `/disk/bin/{hello,tcc,busybox}` on `data.img`, unix socketpair EPOLLIN gating) unchanged.  No `qemu_exit` timeout.
- [ ] CI kernel-smoke green on PR
- [ ] **3-trial KVM Firefox soak** — expect zero W215 FAULT/PHYS clusters in libxul's 0x4b*-region.  Any `[PF/gen-abort]` counter incrementing confirms the new path is exercised; absence of FAULT/PHYS events confirms the race window is closed.
- [ ] 4 systemic aliasing classes from PRs #222 / #225 / #226 / #230 remain closed.

## References

- Intel SDM Vol. 3A §4.10.5 — TLB management and demand-paging
- Intel SDM Vol. 3A §8.2.3 — memory ordering on multi-processor systems
- POSIX.1-2017 §2.4 — signals and asynchronous teardown