### PR TITLE
kernel/idt: hold mm_sem.write across PFH cache-hit install arm (W216 H_5j-C)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1193,6 +1193,88 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     return false;
                 }
 
+                // W216 H_5j-C: escalate mm_sem to write before installing the
+                // cache-hit PTE.
+                //
+                // The PR #230 revalidate above (`still_valid`) closes the case
+                // where PROCESS_TABLE reveals the VMA was already replaced before
+                // we entered this branch.  However, PROCESS_TABLE is dropped
+                // after the check, and the write lock is not yet held.  A
+                // concurrent MAP_FIXED on a sibling CPU can interleave as:
+                //
+                //   T0  CPU-A: still_valid → true  (VMA intact at check time)
+                //   T1  CPU-A: PROCESS_TABLE dropped, no write lock held
+                //   T2  CPU-B: MAP_FIXED Phase 2a — old VMA removed from VmSpace
+                //   T3  CPU-B: MAP_FIXED Phase 2b — old pages unmapped, freed
+                //   T4  CPU-B: MAP_FIXED Phase 3  — new VMA inserted (diff backing)
+                //   T5  CPU-A: map_page_in() installs cached_phys at page_addr
+                //              ↑ PTE now points at the cache frame for the OLD
+                //              (inode, file_page_offset) but the VMA at page_addr
+                //              describes a DIFFERENT backing object — aliasing.
+                //   T6  Userspace reads from page_addr → receives stale bytes
+                //              from cached_phys → SIGSEGV / #UD
+                //
+                // The fix mirrors PR #234 H_5j-A (readahead arm) and H_5j-B
+                // (single-page arm): acquire mm_sem.write() so that no MAP_FIXED
+                // unmap/remap can execute against this address space between
+                // T1 and T5.  Re-validate the VMA under the write lock; if it
+                // changed between T0 and now, free private_phys (if allocated)
+                // and release the guard ref, then return false so the faulting
+                // instruction retries against the new VMA.
+                //
+                // `map_page_in_locked` replaces `map_page_in` below because we
+                // already hold mm_sem.write() and spin::RwLock is non-reentrant
+                // — a second acquire in the same mode on the same CPU self-deadlocks.
+                //
+                // Lock ordering: PROCESS_TABLE (dropped) → MOUNTS (not held) →
+                // mm_sem.write → VMM_LOCK / PMM_LOCK / PAGE_CACHE (leaves).
+                // Per Intel SDM Vol. 3A §4.10.5 and §8.2.2, the write-lock
+                // provides the store-ordering guarantee for PTE installation.
+                let _ch_sem = crate::mm::vma::mm_sem_for_cr3(cr3);
+                let _ch_guard = _ch_sem.as_ref().map(|s| s.write());
+
+                // Re-validate under the write lock.  Between the outer
+                // `still_valid` check and this point, a concurrent MAP_FIXED
+                // Phase 2a may have replaced the VMA.
+                let still_valid_locked = {
+                    let procs = crate::proc::PROCESS_TABLE.lock();
+                    procs.iter()
+                        .find(|p| p.pid == target_pid)
+                        .and_then(|p| p.vm_space.as_ref())
+                        .and_then(|vs| vs.find_vma(faulting_addr))
+                        .map(|v| {
+                            matches!(&v.backing,
+                                crate::mm::vma::VmBacking::File {
+                                    mount_idx: m, inode: ino, offset: o, ..
+                                } if *m == mount_idx && *ino == inode && *o == file_base_offset)
+                            && v.base == vma_base
+                            && v.base + v.length == vma_end
+                        })
+                        .unwrap_or(false)
+                };
+                if !still_valid_locked {
+                    let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                    #[cfg(feature = "firefox-test")]
+                    crate::serial_println!(
+                        "[PF/revalidate] CACHE-HIT VMA stale under lock addr={:#x} \
+                         mount={} inode={} foff={:#x} — abandoning",
+                        faulting_addr, mount_idx, inode, file_page_offset);
+                    return false;
+                }
+
+                #[cfg(feature = "firefox-test")]
+                {
+                    static PF_INSTALL_LOCK_N_CH: core::sync::atomic::AtomicU64 =
+                        core::sync::atomic::AtomicU64::new(0);
+                    let nl = PF_INSTALL_LOCK_N_CH
+                        .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                    if nl < 5 || nl % 500 == 0 {
+                        crate::serial_println!(
+                            "[PF/install-lock] cache-hit #{} addr={:#x} cached_phys={:#x}",
+                            nl, page_addr, cached_phys);
+                    }
+                }
+
                 // MAP_PRIVATE + writable: give the process a private copy so
                 // writes (e.g., GOT/PLT relocations) don't corrupt the shared
                 // cache page. Without this, a second process loading the same
@@ -1224,7 +1306,9 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             );
                         }
                         crate::mm::refcount::page_ref_set(private_phys, 1);
-                        crate::mm::vmm::map_page_in(cr3, page_addr, private_phys, page_flags);
+                        // mm_sem.write is held via _ch_guard — use the locked
+                        // variant to avoid a non-reentrant re-acquire.
+                        crate::mm::vmm::map_page_in_locked(cr3, page_addr, private_phys, page_flags);
                         crate::mm::vmm::invlpg(page_addr);
                         // Release the guard ref acquired by `lookup_and_acquire`.
                         // The PTE now refers to `private_phys`, not `cached_phys`;
@@ -1264,7 +1348,9 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // reference — do NOT call `page_ref_inc` again here.
                     // Steady state after install: cache holds one ref,
                     // this PTE holds one ref (the promoted guard ref) = rc ≥ 2.
-                    crate::mm::vmm::map_page_in(cr3, page_addr, cached_phys, page_flags);
+                    //
+                    // mm_sem.write is held via _ch_guard — use the locked variant.
+                    crate::mm::vmm::map_page_in_locked(cr3, page_addr, cached_phys, page_flags);
                     crate::mm::vmm::invlpg(page_addr);
                     // Guard ref is intentionally NOT released — it has been
                     // promoted to the PTE reference.


### PR DESCRIPTION
## Summary

- **PR #234 verifier outcome**: 3-trial KVM Firefox soak showed W215 FAULT/PHYS cluster firing 3/3 with `[PF/install-lock]` counter = 0 across all trials. PR #234's readahead and single-page arms were never entered for the faulting pages — the cut-point was the cache-hit arm.

- **Cache-hit arm gap**: `cache::lookup_and_acquire` (line 1135) protects the physical frame from PMM recycling. The PR #230 `still_valid` revalidate (line ~1167) checks whether MAP_FIXED already completed before the branch executes. Neither guard covers a MAP_FIXED that races between the `still_valid` check and the subsequent `map_page_in` call — PROCESS_TABLE is dropped after the revalidate and no write lock is held across that window.

- **Race pattern (T0–T6)**:
  - T0: CPU-A: `still_valid → true` (VMA intact at snapshot time)
  - T1: CPU-A: PROCESS_TABLE dropped, `mm_sem.write` NOT yet held
  - T2: CPU-B: MAP_FIXED Phase 2a — old VMA removed from VmSpace
  - T3: CPU-B: MAP_FIXED Phase 2b — old frames unmapped, returned to PMM
  - T4: CPU-B: MAP_FIXED Phase 3 — new VMA (different backing) inserted
  - T5: CPU-A: `map_page_in()` installs `cached_phys` at `page_addr` — PTE points at cache frame for the OLD inode/offset while the VMA now describes different backing
  - T6: Userspace reads from `page_addr`, receives stale libxul bytes in a VMA backed by something else → SIGSEGV / #UD

## Fix

Mirrors the PR #234 H_5j-A escalation pattern, applied to the cache-hit arm:

1. After `still_valid` passes, acquire `mm_sem.write()` via `mm_sem_for_cr3(cr3)`.
2. Re-validate the VMA **under the write lock** (`still_valid_locked`). If MAP_FIXED Phase 2a ran between T1 and lock acquisition, release the guard ref and return false; the faulting instruction retries against the new VMA.
3. Replace `map_page_in` → `map_page_in_locked` at both install sites (private-copy and alias arms) to avoid a non-reentrant re-acquire of the `spin::RwLock`.
4. Adds `[PF/install-lock] cache-hit #N` counter under `firefox-test` feature, mirroring PR #234's readahead/single-page counters.

Lock ordering preserved: `PROCESS_TABLE` (dropped) → `MOUNTS` (not held) → `mm_sem.write` → `VMM_LOCK / PMM_LOCK / PAGE_CACHE` (leaves). Per Intel SDM Vol. 3A §4.10.5 and §8.2.2 the write-lock provides PTE store-ordering at install time.

## Verification expected

3-trial KVM Firefox soak:
- `[PF/install-lock] cache-hit` counter > 0 (confirming the path is now taken)
- W215 FAULT/PHYS cluster: 0/3

## Test plan

- [x] `scripts/qemu-harness.py check` — default features, rc=0
- [x] `scripts/qemu-harness.py check --features firefox-test` — rc=0
- [x] `scripts/qemu-harness.py start --features firefox-test,kdb --no-kvm` kernel smoke — no BUGCHECK, no HUNG, Firefox boot progressed to sc=5486
- [ ] 3-trial KVM soak with W215 verifier (coordinator to dispatch)