### PR TITLE
scripts/agent-context + harness: live shared-context infra for cross-agent state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# AstryxOS — project instructions for Claude Code agents
+
+## Live session context (read on entry, update on exit)
+
+**Before doing any non-trivial work, read `.claude/session/CURRENT.md`** for the
+current goal, active investigations, recent decisions, and known gates.
+
+```
+python3 scripts/agent-context.py read-current
+# Or through the harness front-end:
+python3 scripts/qemu-harness.py context read-current
+```
+
+On completion, register your outcome so downstream agents start informed:
+
+```
+python3 scripts/agent-context.py register-completion \
+    --agent-id <YOUR-AGENT-ID> \
+    --outcome "<one-liner summary>" \
+    --commits <sha1,sha2>       \   # omit if no commits
+    --pr "#NNN"                      # omit if no PR
+```
+
+If dispatching sub-agents, register their launch too:
+
+```
+python3 scripts/agent-context.py register-dispatch \
+    --agent-id <CHILD-AGENT-ID> \
+    --role <role> \
+    --task "<what it's doing>" \
+    --parent <YOUR-AGENT-ID>
+```
+
+### Context helper subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `read-current [--section S] [--json]` | Print CURRENT.md or one section |
+| `summary` | One-paragraph session state |
+| `digest-since <ISO-ts>` | Events since timestamp |
+| `register-dispatch ...` | Record launch + update Active investigations |
+| `register-completion ...` | Record finish + move to Recent findings |
+| `append-event <kind> ...` | Append arbitrary event to EVENTS.jsonl |
+| `prune-current [--max-lines N]` | Trim CURRENT.md to ≤N lines |
+
+All subcommands are also accessible as `python3 scripts/qemu-harness.py context <subcommand>`.
+
+---
+
+## Test harness
+
+For **all** kernel / Firefox-port testing use `scripts/qemu-harness.py` — NOT
+the shell wrappers (`run-test.sh`, `run-firefox-test.sh`, etc.).
+
+```
+python3 scripts/qemu-harness.py start [--features FLAGS] [--no-build]
+python3 scripts/qemu-harness.py wait <sid> <regex> [--ms MS]
+python3 scripts/qemu-harness.py grep <sid> <regex>
+python3 scripts/qemu-harness.py stop <sid>
+```
+
+KVM is used by default when `/dev/kvm` is available (recommended — see W139
+soak results in harness docstring). Pass `--no-kvm` only for explicit TCG runs.
+
+GDB stub: add `--gdb-port N` to `start`, then use `regs`, `mem`, `bp`, `step`.
+
+Snapshot/restore: `snap <sid> save <name>` / `snap <sid> load <name>`.
+
+### Hard-banned tools (for kernel testing)
+
+- `scripts/run-test.sh`
+- `scripts/run-firefox-test.sh`
+- `scripts/run-qemu.sh`
+- `scripts/run-test-gdb.sh`
+- `scripts/run-gui-test.sh`
+- Direct `scripts/watch-test.py` invocation
+- Manually composed `cargo +nightly build` for testing
+
+Every step goes through `scripts/qemu-harness.py`. If a subcommand is missing,
+**extend the harness** — don't fall back to shell scripts.
+
+---
+
+## Architectural invariants
+
+- **Never edit upstream binaries.** The Linux personality layer runs upstream
+  Linux binaries (libxul, glibc, GTK, X11) as shipped. Build scripts wrap
+  upstream — they do not patch it. If a wrap requires patching, fix the
+  kernel/ABI instead.
+- **All tools must be non-interactive and agent-friendly.** One-shot argv
+  invocations, structured JSON output, no REPLs, no interactive prompts. If
+  state must persist between calls, write it to disk.
+- **Harness changes are additive.** New JSON fields are fine; field renames
+  break downstream dispatches. Call out breaking changes in commit messages.
+
+---
+
+## Session files
+
+| File | Purpose |
+|---|---|
+| `.claude/session/CURRENT.md` | Live state of the world (coordinator-maintained) |
+| `.claude/session/EVENTS.jsonl` | Append-only event stream (one JSON per line) |
+| `~/.astryx-harness/<sid>.json` | Per-QEMU-session state |
+| `~/.astryx-harness/<sid>.events.jsonl` | Per-QEMU-session event stream |
+| `~/.astryx-harness/<sid>.serial.log` | Serial log for grep/wait/tail |

--- a/scripts/agent-context.py
+++ b/scripts/agent-context.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""
+agent-context.py — Live shared-context helper for AstryxOS agent sessions.
+
+Non-interactive, one-shot argv, JSON output. All subcommands exit cleanly with
+structured output. File locking ensures safe concurrent appends from parallel
+agents.
+
+Session files:
+  .claude/session/CURRENT.md   — coordinator-maintained live state (≤200 lines)
+  .claude/session/EVENTS.jsonl — append-only event stream (one JSON per line)
+
+Subcommands:
+
+  read-current [--section SECTION] [--json]
+      Print CURRENT.md (or a named section) to stdout.
+      --json wraps output in {"ok": true, "content": "..."}.
+
+  append-event <kind> --agent-id <id> --payload '<json>'
+      Atomically append one event line to EVENTS.jsonl.
+      kind: dispatch|completion|decision|finding|pivot|pr_merged|pr_opened
+
+  digest-since <ts>
+      Emit a compact summary of events since ISO timestamp.
+      Output: {"ok": true, "events": [...], "count": N}
+
+  register-dispatch --agent-id <id> --role <role> --task <task>
+                    [--parent <parent>]
+      Append a `dispatch` event AND update CURRENT.md "Active investigations".
+
+  register-completion --agent-id <id> --outcome <text>
+                      [--commits <sha,sha>] [--pr <#NNN>]
+      Append a `completion` event AND move entry from "Active investigations"
+      to "Recent findings" in CURRENT.md. Prunes old entries to keep ≤200 lines.
+
+  prune-current [--max-lines N]
+      Trim CURRENT.md to ≤N lines (default 200) by dropping oldest list entries
+      in each rolling section.
+
+  summary
+      Print a one-paragraph plain-text summary of current session state.
+      Output: {"ok": true, "summary": "..."}
+"""
+
+import argparse
+import datetime
+import fcntl
+import json
+import os
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SESSION_DIR = _REPO_ROOT / ".claude" / "session"
+_CURRENT_MD = _SESSION_DIR / "CURRENT.md"
+_EVENTS_JSONL = _SESSION_DIR / "EVENTS.jsonl"
+
+_SECTION_MAX = {
+    "Active investigations": 10,
+    "Open PRs": 20,
+    "Recent decisions": 10,
+    "Known gates / not-yet-investigated": 20,
+    "Recent findings": 10,
+    "Quick links": 30,
+}
+_DEFAULT_MAX_LINES = 200
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _out(obj: dict) -> None:
+    print(json.dumps(obj))
+
+
+def _err(msg: str, code: int = 1) -> None:
+    print(json.dumps({"ok": False, "error": msg}))
+    sys.exit(code)
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ensure_session_dir() -> None:
+    _SESSION_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _lock_file(path: Path):
+    """Open + exclusive-lock path for atomic read-modify-write; returns file obj."""
+    fh = open(path, "a+")  # 'a+' creates if missing, positions at end for appends
+    fcntl.flock(fh, fcntl.LOCK_EX)
+    fh.seek(0)
+    return fh
+
+
+# ---------------------------------------------------------------------------
+# CURRENT.md section parsing
+# ---------------------------------------------------------------------------
+
+_SECTION_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+
+
+def _parse_sections(text: str) -> dict[str, tuple[int, int, str]]:
+    """Return {section_name: (header_idx, end_idx, body_text)}.
+
+    All indices are 0-based into text.splitlines(keepends=True).
+    header_idx   — index of the '## ...' header line.
+    end_idx      — exclusive end of this section's content (= next header or EOF).
+    body_text    — stripped body text (excluding the header line itself).
+    """
+    lines = text.splitlines(keepends=True)
+    sections: dict[str, tuple[int, int, str]] = {}
+    headers: list[tuple[str, int]] = []  # (name, 0-based-line-index)
+
+    for i, line in enumerate(lines):
+        m = _SECTION_RE.match(line.rstrip())
+        if m:
+            headers.append((m.group(1), i))
+
+    for idx, (name, start) in enumerate(headers):
+        end = headers[idx + 1][1] if idx + 1 < len(headers) else len(lines)
+        body = "".join(lines[start + 1:end])
+        sections[name] = (start, end, body.strip())
+
+    return sections
+
+
+def _read_current_md() -> str:
+    if not _CURRENT_MD.exists():
+        return ""
+    return _CURRENT_MD.read_text(encoding="utf-8")
+
+
+def _write_current_md(text: str) -> None:
+    _ensure_session_dir()
+    _CURRENT_MD.write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Rolling-section append helper
+# ---------------------------------------------------------------------------
+
+def _prepend_to_section(md_text: str, section: str, new_entry: str,
+                         max_entries: int) -> str:
+    """
+    Prepend `new_entry` (a bullet line, no leading newline) to the named section.
+    Trims old entries beyond max_entries. Returns updated markdown text.
+    """
+    lines = md_text.splitlines(keepends=True)
+    sections = _parse_sections(md_text)
+
+    if section not in sections:
+        # Append a new section
+        tail = f"\n## {section}\n- {new_entry}\n"
+        return md_text + tail
+
+    header_idx, end_idx, _ = sections[section]
+    # header_idx is the ## header line (0-based); body starts at header_idx+1
+    body_start = header_idx + 1  # 0-based index of first body line
+    body_end = end_idx           # 0-based exclusive
+
+    # Collect current bullet lines in the body
+    body_lines = lines[body_start:body_end]
+    bullets = [l for l in body_lines if l.strip().startswith("-")]
+    non_bullets = [l for l in body_lines if not l.strip().startswith("-")]
+
+    # Insert new bullet at front, trim to max
+    new_bullets = [f"- {new_entry}\n"] + bullets
+    if len(new_bullets) > max_entries:
+        new_bullets = new_bullets[:max_entries]
+
+    new_body = non_bullets + new_bullets
+
+    new_lines = lines[:body_start] + new_body + lines[body_end:]
+    return "".join(new_lines)
+
+
+def _remove_from_section(md_text: str, section: str, pattern: str) -> str:
+    """Remove bullet lines matching pattern (substring) from section."""
+    lines = md_text.splitlines(keepends=True)
+    sections = _parse_sections(md_text)
+    if section not in sections:
+        return md_text
+
+    header_idx, end_idx, _ = sections[section]
+    body_start = header_idx + 1  # first body line
+    body_end = end_idx           # exclusive
+
+    new_lines = []
+    for i, line in enumerate(lines):
+        if body_start <= i < body_end and line.strip().startswith("-") and pattern in line:
+            continue
+        new_lines.append(line)
+    return "".join(new_lines)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: read-current
+# ---------------------------------------------------------------------------
+
+def cmd_read_current(args) -> None:
+    text = _read_current_md()
+    if not text:
+        if args.json:
+            _out({"ok": True, "content": "", "exists": False})
+        else:
+            print("(CURRENT.md not found — run coordinator to seed it)")
+        return
+
+    if args.section:
+        sections = _parse_sections(text)
+        name = args.section
+        if name not in sections:
+            available = list(sections.keys())
+            if args.json:
+                _out({"ok": False, "error": f"section '{name}' not found",
+                      "available": available})
+            else:
+                print(f"Section '{name}' not found. Available: {available}",
+                      file=sys.stderr)
+            sys.exit(1)
+        content = f"## {name}\n{sections[name][2]}"
+    else:
+        content = text
+
+    if args.json:
+        _out({"ok": True, "content": content})
+    else:
+        print(content, end="" if content.endswith("\n") else "\n")
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: append-event
+# ---------------------------------------------------------------------------
+
+def cmd_append_event(args) -> None:
+    _ensure_session_dir()
+    try:
+        payload = json.loads(args.payload)
+    except json.JSONDecodeError as exc:
+        _err(f"payload is not valid JSON: {exc}")
+
+    event = {
+        "ts": _now_iso(),
+        "kind": args.kind,
+        "agent_id": args.agent_id,
+        **payload,
+    }
+    line = json.dumps(event) + "\n"
+
+    with open(_EVENTS_JSONL, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        fh.write(line)
+        fcntl.flock(fh, fcntl.LOCK_UN)
+
+    _out({"ok": True, "event": event})
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: digest-since
+# ---------------------------------------------------------------------------
+
+def cmd_digest_since(args) -> None:
+    since_ts = args.ts
+    if not _EVENTS_JSONL.exists():
+        _out({"ok": True, "events": [], "count": 0, "since": since_ts})
+        return
+
+    events = []
+    with open(_EVENTS_JSONL, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if ev.get("ts", "") >= since_ts:
+                events.append(ev)
+
+    _out({"ok": True, "events": events, "count": len(events), "since": since_ts})
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: register-dispatch
+# ---------------------------------------------------------------------------
+
+def cmd_register_dispatch(args) -> None:
+    _ensure_session_dir()
+    ts = _now_iso()
+
+    # Append dispatch event
+    event = {
+        "ts": ts,
+        "kind": "dispatch",
+        "agent_id": args.agent_id,
+        "role": args.role,
+        "task": args.task,
+        "parent": args.parent or "coordinator",
+    }
+    with open(_EVENTS_JSONL, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        fh.write(json.dumps(event) + "\n")
+        fcntl.flock(fh, fcntl.LOCK_UN)
+
+    # Update CURRENT.md
+    entry = f"`{args.agent_id[:8]}` ({args.role}) — {args.task}"
+    with _lock_file(_CURRENT_MD) as fh:
+        text = fh.read()
+        text = _prepend_to_section(text, "Active investigations", entry,
+                                   _SECTION_MAX["Active investigations"])
+        fh.seek(0)
+        fh.truncate()
+        fh.write(text)
+
+    _out({"ok": True, "event": event,
+          "current_updated": True,
+          "section": "Active investigations"})
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: register-completion
+# ---------------------------------------------------------------------------
+
+def cmd_register_completion(args) -> None:
+    _ensure_session_dir()
+    ts = _now_iso()
+    commits = [c.strip() for c in args.commits.split(",") if c.strip()] if args.commits else []
+
+    event = {
+        "ts": ts,
+        "kind": "completion",
+        "agent_id": args.agent_id,
+        "outcome_summary": args.outcome,
+        "commits": commits,
+        "pr": args.pr or "",
+    }
+    with open(_EVENTS_JSONL, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        fh.write(json.dumps(event) + "\n")
+        fcntl.flock(fh, fcntl.LOCK_UN)
+
+    # Update CURRENT.md: remove from Active investigations, add to Recent findings
+    pr_tag = f" ({args.pr})" if args.pr else ""
+    commit_tag = f" [{commits[0][:8]}]" if commits else ""
+    finding_entry = (
+        f"`{args.agent_id[:8]}` — {args.outcome}{pr_tag}{commit_tag}"
+    )
+    with _lock_file(_CURRENT_MD) as fh:
+        text = fh.read()
+        # Remove matching active-investigations entry (match by agent_id prefix)
+        text = _remove_from_section(text, "Active investigations", args.agent_id[:8])
+        # Add to Recent findings
+        text = _prepend_to_section(text, "Recent findings", finding_entry,
+                                   _SECTION_MAX["Recent findings"])
+        # Prune overall length
+        text = _do_prune(text, _DEFAULT_MAX_LINES)
+        fh.seek(0)
+        fh.truncate()
+        fh.write(text)
+
+    _out({"ok": True, "event": event,
+          "current_updated": True,
+          "sections": ["Active investigations", "Recent findings"]})
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: prune-current
+# ---------------------------------------------------------------------------
+
+def _do_prune(text: str, max_lines: int) -> str:
+    """
+    Prune rolling sections so the total line count stays under max_lines.
+    For each section that has a defined max-entries cap, trim oldest bullets first.
+    Then hard-trim overall document if still over max_lines.
+    """
+    # Per-section entry caps
+    for section, cap in _SECTION_MAX.items():
+        lines = text.splitlines(keepends=True)
+        sections = _parse_sections(text)
+        if section not in sections:
+            continue
+        header_idx, end_idx, _ = sections[section]
+        body_lines = lines[header_idx + 1:end_idx]
+        bullets = [l for l in body_lines if l.strip().startswith("-")]
+        if len(bullets) > cap:
+            # Remove oldest (last) bullets beyond cap
+            to_remove = bullets[cap:]
+            for b in to_remove:
+                text = text.replace(b, "", 1)
+
+    # Hard line cap: drop trailing lines from last section if still over
+    all_lines = text.splitlines(keepends=True)
+    if len(all_lines) > max_lines:
+        text = "".join(all_lines[:max_lines])
+
+    return text
+
+
+def cmd_prune_current(args) -> None:
+    max_lines = args.max_lines
+    if not _CURRENT_MD.exists():
+        _out({"ok": True, "pruned": False, "reason": "CURRENT.md not found"})
+        return
+
+    with _lock_file(_CURRENT_MD) as fh:
+        text = fh.read()
+        before = len(text.splitlines())
+        text = _do_prune(text, max_lines)
+        after = len(text.splitlines())
+        fh.seek(0)
+        fh.truncate()
+        fh.write(text)
+
+    _out({"ok": True, "pruned": True, "lines_before": before,
+          "lines_after": after, "max_lines": max_lines})
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: summary
+# ---------------------------------------------------------------------------
+
+def cmd_summary(args) -> None:
+    text = _read_current_md()
+    if not text:
+        _out({"ok": True, "summary": "No session context found (CURRENT.md missing)."})
+        return
+
+    sections = _parse_sections(text)
+
+    goal = sections.get("Goal", (0, 0, "(unknown)"))[2]
+    active = sections.get("Active investigations", (0, 0, ""))[2]
+    findings = sections.get("Recent findings", (0, 0, ""))[2]
+    gates = sections.get("Known gates / not-yet-investigated", (0, 0, ""))[2]
+
+    active_count = len([l for l in active.splitlines() if l.strip().startswith("-")])
+    findings_count = len([l for l in findings.splitlines() if l.strip().startswith("-")])
+    gate_count = len([l for l in gates.splitlines() if l.strip().startswith("-")])
+
+    # Event counts
+    event_count = 0
+    if _EVENTS_JSONL.exists():
+        with open(_EVENTS_JSONL, "r", encoding="utf-8") as fh:
+            event_count = sum(1 for l in fh if l.strip())
+
+    summary = (
+        f"Goal: {goal.strip()}. "
+        f"{active_count} active investigation(s) in flight. "
+        f"{findings_count} recent finding(s) recorded. "
+        f"{gate_count} known gate(s) / backlog item(s). "
+        f"{event_count} total events in EVENTS.jsonl."
+    )
+    _out({"ok": True, "summary": summary,
+          "active_count": active_count,
+          "findings_count": findings_count,
+          "gate_count": gate_count,
+          "event_count": event_count})
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="agent-context.py",
+        description="Live shared-context helper for AstryxOS agent sessions.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    # read-current
+    p_rc = sub.add_parser("read-current",
+                           help="Print CURRENT.md (or a named section)")
+    p_rc.add_argument("--section", metavar="NAME",
+                      help="Only print this section (e.g. 'Goal')")
+    p_rc.add_argument("--json", action="store_true",
+                      help="Wrap output in JSON envelope")
+
+    # append-event
+    p_ae = sub.add_parser("append-event",
+                           help="Append one event to EVENTS.jsonl")
+    p_ae.add_argument("kind",
+                      choices=["dispatch", "completion", "decision",
+                               "finding", "pivot", "pr_merged", "pr_opened"])
+    p_ae.add_argument("--agent-id", required=True)
+    p_ae.add_argument("--payload", required=True,
+                      help="JSON object to merge into event (must be valid JSON)")
+
+    # digest-since
+    p_ds = sub.add_parser("digest-since",
+                           help="Summarize events since ISO timestamp")
+    p_ds.add_argument("ts", metavar="TIMESTAMP",
+                      help="ISO 8601 timestamp (e.g. 2026-05-16T00:00:00Z)")
+
+    # register-dispatch
+    p_rd = sub.add_parser("register-dispatch",
+                           help="Record dispatch event + update CURRENT.md")
+    p_rd.add_argument("--agent-id", required=True)
+    p_rd.add_argument("--role", required=True)
+    p_rd.add_argument("--task", required=True)
+    p_rd.add_argument("--parent", default="coordinator")
+
+    # register-completion
+    p_rco = sub.add_parser("register-completion",
+                            help="Record completion event + update CURRENT.md")
+    p_rco.add_argument("--agent-id", required=True)
+    p_rco.add_argument("--outcome", required=True)
+    p_rco.add_argument("--commits", default="",
+                       metavar="SHA,SHA",
+                       help="Comma-separated commit SHAs")
+    p_rco.add_argument("--pr", default="",
+                       help="PR reference e.g. #238")
+
+    # prune-current
+    p_pc = sub.add_parser("prune-current",
+                           help="Trim CURRENT.md to max lines")
+    p_pc.add_argument("--max-lines", type=int, default=_DEFAULT_MAX_LINES,
+                      metavar="N")
+
+    # summary
+    sub.add_parser("summary",
+                   help="One-paragraph summary of session state")
+
+    args = parser.parse_args()
+
+    dispatch = {
+        "read-current":       cmd_read_current,
+        "append-event":       cmd_append_event,
+        "digest-since":       cmd_digest_since,
+        "register-dispatch":  cmd_register_dispatch,
+        "register-completion": cmd_register_completion,
+        "prune-current":      cmd_prune_current,
+        "summary":            cmd_summary,
+    }
+    dispatch[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -1155,6 +1155,44 @@ def _regen_data_img(root_dir: Path) -> dict:
 
 # ══════════════════════════════════════════════════════════════════════════════
 
+def cmd_context(args):
+    """
+    Front-end for scripts/agent-context.py — shared session-context management.
+
+    Delegates directly to agent-context.py with the supplied sub-subcommand and
+    arguments.  Agents that already know to use qemu-harness.py can access the
+    context layer through this single entry point without needing to remember a
+    separate script path.
+
+    Usage:
+      python3 scripts/qemu-harness.py context read-current [--section S] [--json]
+      python3 scripts/qemu-harness.py context summary
+      python3 scripts/qemu-harness.py context register-dispatch --agent-id ID \\
+                                                                 --role ROLE \\
+                                                                 --task TASK
+      python3 scripts/qemu-harness.py context register-completion --agent-id ID \\
+                                                                   --outcome TEXT \\
+                                                                   [--commits SHAs]\\
+                                                                   [--pr #NNN]
+      python3 scripts/qemu-harness.py context append-event KIND \\
+                                                             --agent-id ID \\
+                                                             --payload JSON
+      python3 scripts/qemu-harness.py context digest-since TIMESTAMP
+      python3 scripts/qemu-harness.py context prune-current [--max-lines N]
+    """
+    import subprocess as _sp
+    agent_ctx = Path(__file__).parent / "agent-context.py"
+    if not agent_ctx.exists():
+        _out({"ok": False, "error": f"agent-context.py not found at {agent_ctx}"})
+        return 1
+    # Pass everything after "context" directly to the helper script.
+    cmd = [sys.executable, str(agent_ctx)] + (args.context_args or [])
+    result = _sp.run(cmd)
+    return result.returncode
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+
 def cmd_check(args):
     """
     Run `cargo +nightly check` against the kernel package and emit a JSON
@@ -5480,6 +5518,19 @@ def main():
                           help="Feature flags passed VERBATIM to cargo. "
                                "Empty string → default desktop kernel.")
 
+    # context — shared session-context management (delegates to agent-context.py)
+    p_ctx = sub.add_parser(
+        "context",
+        help="Shared session-context management: read CURRENT.md, register "
+             "dispatch/completion events, append arbitrary events, summarise. "
+             "All subcommands are forwarded verbatim to scripts/agent-context.py. "
+             "Example: context read-current --section Goal",
+    )
+    p_ctx.add_argument(
+        "context_args", nargs=argparse.REMAINDER,
+        help="Subcommand + arguments forwarded to agent-context.py",
+    )
+
     # _watch: private subcommand used internally by `start` to run the
     # background watcher in a detached process. Not shown in help.
     p_watch = sub.add_parser("_watch")
@@ -5532,6 +5583,8 @@ def main():
         "qmp-xp":   cmd_qmp_xp,
         "rip-walk": cmd_rip_walk,
         "read-png": cmd_read_png,
+        # Shared session context
+        "context": cmd_context,
         "_watch":  cmd_run_watcher,
     }
     rc = dispatch[args.cmd](args)


### PR DESCRIPTION
## Motivation

Each subagent dispatch currently re-establishes 1-3K tokens of session context in its prompt. The coordinator is the only persistent context window, which is expensive, brittle (context drifts), and bottlenecks parallelization.

This PR introduces a structured shared-context layer so agents read current state from one cheap file read (~few hundred bytes) and register their outcomes on exit. Dispatch prompts drop to ~300 tokens of task-specific direction plus a standing preamble.

## Four pieces

**1. `scripts/agent-context.py`** (new, ~550 LOC)

Non-interactive one-shot argv tool with JSON output. Subcommands:
- `read-current [--section S] [--json]` — print CURRENT.md or one named section
- `append-event <kind> ...` — atomically append to EVENTS.jsonl (fcntl lock)
- `digest-since <ts>` — events since ISO timestamp (for orchestrator integration)
- `register-dispatch` — append dispatch event + update "Active investigations" in CURRENT.md
- `register-completion` — append completion event + move entry to "Recent findings" + prune
- `prune-current [--max-lines N]` — trim CURRENT.md to ≤N lines
- `summary` — one-paragraph session state (JSON)

File locking (`fcntl.LOCK_EX`) on all CURRENT.md write paths for safe concurrent use from parallel agents.

Session files live under `.claude/session/` (gitignored — runtime state, not repo state):
- `CURRENT.md` — coordinator-maintained live state (≤200 lines), seeded with current goal, active investigations, open PRs, recent decisions, known gates, recent findings
- `EVENTS.jsonl` — append-only event stream, backfilled with ~37 events from last 20 dispatches

**2. `scripts/qemu-harness.py`: `context` subcommand** (new, ~50 LOC)

Delegates all args to `agent-context.py` via REMAINDER forwarding. Agents that only know the harness surface get the full context layer without a separate script path:
```
python3 scripts/qemu-harness.py context read-current --section Goal
python3 scripts/qemu-harness.py context summary
python3 scripts/qemu-harness.py context register-completion --agent-id ... --outcome "..."
```

**3. `CLAUDE.md`** (new project-level instructions, ~100 LOC)

Standing dispatch preamble baked into every agent's context window via the project CLAUDE.md. Every agent reads `.claude/session/CURRENT.md` on entry and calls `register-completion` on exit. Also codifies: harness usage rules, hard-banned shell wrappers, architectural invariants, session file map.

**4. Seeded runtime files** (gitignored, created at `.claude/session/`)

`CURRENT.md` bootstrapped with current session state. `EVENTS.jsonl` backfilled with ~37 events from `claudemon-dispatched.csv` (marked `backfilled: true`).

## Build verification

```
python3 scripts/qemu-harness.py check            # ok, rc=0
python3 scripts/qemu-harness.py check --features firefox-test  # ok, rc=0
```

## Next session expectation

An engineering-historian agent (once created) will own ongoing `CURRENT.md` curation. Until then, the coordinator updates via `register-dispatch` / `register-completion` calls on each dispatch. The preamble in `CLAUDE.md` ensures every agent picks up the current state without coordinator intervention.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)