### PR TITLE
kernel/mm+kdb: W215 diagnostic instrumentation (audit_invariant + nonzero-rc counters)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -278,6 +278,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "mem"            => op_mem(req, out),
         "trace-status"   => op_trace_status(out),
         "bell-stats"     => op_bell_stats(out),
+        "cache-audit"    => op_cache_audit(out),
         _ => {
             out.push_str(r#"{"error":"unknown op: "#);
             for c in op.chars().take(64) {
@@ -1310,4 +1311,50 @@ fn op_syscall_trend(req: &str, out: &mut String) {
         out.push_str(r#","more":true"#);
     }
     out.push('}');
+}
+
+// ── cache-audit ───────────────────────────────────────────────────────────────
+//
+// Run `cache::audit_invariant()` (firefox-test only) and return structured
+// JSON.  Also reads the PMM and refcount diagnostic counters accumulated since
+// boot.
+//
+// Output (firefox-test builds):
+//   {
+//     "total_entries": N,
+//     "orphan_count":  M,
+//     "pmm_alloc_nonzero_rc": P,
+//     "refcount_set_over_nonzero": Q,
+//     "orphans": [ {"key":"(m,i,0xoff)", "phys":"0x...", "rc":0}, ... ]
+//   }
+//
+// On non-firefox-test builds the op returns a capabilities note instead.
+
+fn op_cache_audit(out: &mut String) {
+    #[cfg(feature = "firefox-test")]
+    {
+        use core::fmt::Write;
+
+        // Run the audit — also emits serial lines for grep.
+        let (total, orphan_count) = crate::mm::cache::audit_invariant();
+
+        // Read the PMM and refcount counters.
+        let pmm_nonzero = crate::mm::pmm::pmm_alloc_nonzero_rc_count();
+        let rc_set_over = crate::mm::refcount::refcount_set_over_nonzero_count();
+
+        // We already logged individual orphans via serial in audit_invariant.
+        // The JSON response carries the aggregate numbers plus a note that
+        // full orphan detail is in the serial log.
+        out.push('{');
+        let _ = write!(out, r#""total_entries":{},"orphan_count":{},"pmm_alloc_nonzero_rc":{},"refcount_set_over_nonzero":{}"#,
+            total, orphan_count, pmm_nonzero, rc_set_over,
+        );
+        // Indicate where to find per-orphan detail.
+        out.push_str(r#","note":"per-orphan detail in serial log [CACHE/AUDIT/ORPHAN] lines""#);
+        out.push('}');
+    }
+    #[cfg(not(feature = "firefox-test"))]
+    {
+        out.push_str(r#"{"error":"cache-audit requires firefox-test feature"}"#);
+    }
 }

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -378,3 +378,54 @@ pub fn stats() -> (usize, usize) {
     let dirty = cache.values().filter(|e| e.dirty).count();
     (total, dirty)
 }
+
+/// Audit the page cache for H1 invariant violations: any cached entry whose
+/// physical frame has a reference count of zero.
+///
+/// A zero-refcount entry indicates the cache holds a pointer to a physical
+/// frame that has no live PTE covering it.  If the PMM later recycles that
+/// frame via `alloc_page`, the next cache-hit demand fault installs a PTE to
+/// the wrong physical page — the aliasing class under investigation (W215).
+///
+/// This is a purely read-only walk; it never modifies cache or refcount state.
+/// The serial output format is structured for `qemu-harness.py grep` / `wait`:
+///
+///   `[CACHE/AUDIT] total_entries=N orphan_count=M`
+///   `[CACHE/AUDIT/ORPHAN] key=(mount,inode,0xOFFSET) phys=0xPHYS rc=0`
+///
+/// At most 16 orphan lines are emitted per call to avoid serial flood.
+///
+/// Returns `(total_entries, orphan_count)`.
+#[cfg(feature = "firefox-test")]
+pub fn audit_invariant() -> (usize, usize) {
+    use crate::mm::refcount::page_ref_count;
+    use core::fmt::Write as _;
+
+    let cache = PAGE_CACHE.lock();
+    let total = cache.len();
+    let mut orphan_count = 0usize;
+    let mut logged = 0usize;
+
+    for ((mount_idx, inode, page_offset), entry) in cache.iter() {
+        let rc = page_ref_count(entry.phys);
+        if rc == 0 {
+            orphan_count += 1;
+            if logged < 16 {
+                let mut buf = alloc::string::String::with_capacity(128);
+                let _ = write!(
+                    buf,
+                    "[CACHE/AUDIT/ORPHAN] key=({},{},{:#x}) phys={:#x} rc=0",
+                    mount_idx, inode, page_offset, entry.phys,
+                );
+                crate::serial_println!("{}", buf);
+                logged += 1;
+            }
+        }
+    }
+
+    crate::serial_println!(
+        "[CACHE/AUDIT] total_entries={} orphan_count={}",
+        total, orphan_count,
+    );
+    (total, orphan_count)
+}

--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -32,6 +32,15 @@ static USED_PAGES: AtomicU64 = AtomicU64::new(0);
 /// Avoids O(N) scans from 0 when low physical frames are all in use.
 static NEXT_FIT_BYTE: AtomicU64 = AtomicU64::new(0);
 
+/// Diagnostic counter (firefox-test only): number of times `alloc_page`
+/// returned a frame whose refcount was already non-zero at the moment of
+/// allocation.  A non-zero count is a direct indicator of H1 (cache-vs-PMM
+/// bitmap drift): the PMM believes a frame is free (bitmap bit clear) but
+/// the refcount table still holds a live reference — indicating the previous
+/// owner never called `page_ref_dec` before the frame was recycled.
+#[cfg(feature = "firefox-test")]
+static PMM_ALLOC_NONZERO_RC: AtomicU64 = AtomicU64::new(0);
+
 /// Initialize the PMM from the UEFI memory map.
 pub fn init(boot_info: &BootInfo) {
     let _lock = PMM_LOCK.lock();
@@ -113,7 +122,28 @@ unsafe fn alloc_page_locked() -> Option<u64> {
                         // Advance cursor past this byte for next call.
                         let next = (byte_idx + 1) % BITMAP_SIZE;
                         NEXT_FIT_BYTE.store(next as u64, Ordering::Relaxed);
-                        return Some((page * PAGE_SIZE) as u64);
+                        let phys = (page * PAGE_SIZE) as u64;
+                        // H1 diagnostic: check whether this frame still
+                        // carries a live refcount — a mismatch between the
+                        // PMM bitmap (free) and the refcount table (in-use).
+                        // Gated on firefox-test to keep production builds
+                        // identical.
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            let rc = crate::mm::refcount::page_ref_count(phys);
+                            if rc != 0 {
+                                let total = PMM_ALLOC_NONZERO_RC
+                                    .fetch_add(1, Ordering::Relaxed) + 1;
+                                // Log first 8, then every 1000th occurrence.
+                                if total <= 8 || total % 1000 == 0 {
+                                    crate::serial_println!(
+                                        "[PMM/ALLOC-NONZERO-RC] pfn={} phys={:#x} rc_at_alloc={} count_total={}",
+                                        page, phys, rc, total,
+                                    );
+                                }
+                            }
+                        }
+                        return Some(phys);
                     }
                 }
             }
@@ -248,6 +278,17 @@ pub fn free_page_count() -> u64 {
     let total = TOTAL_PAGES.load(Ordering::Relaxed);
     let used = USED_PAGES.load(Ordering::Relaxed);
     total.saturating_sub(used)
+}
+
+/// Read the cumulative `PMM_ALLOC_NONZERO_RC` counter.
+///
+/// Returns the number of times an `alloc_page` call returned a frame whose
+/// refcount was already non-zero.  Always 0 on non-firefox-test builds.
+pub fn pmm_alloc_nonzero_rc_count() -> u64 {
+    #[cfg(feature = "firefox-test")]
+    { PMM_ALLOC_NONZERO_RC.load(Ordering::Relaxed) }
+    #[cfg(not(feature = "firefox-test"))]
+    { 0 }
 }
 
 /// Mark a page as used in the bitmap.

--- a/kernel/src/mm/refcount.rs
+++ b/kernel/src/mm/refcount.rs
@@ -12,8 +12,16 @@
 
 extern crate alloc;
 
-use core::sync::atomic::{AtomicU16, Ordering};
+use core::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 use spin::Once;
+
+/// Diagnostic counter (firefox-test only): number of times `page_ref_set` was
+/// called with `val < existing_rc` on a frame that already had a non-zero
+/// refcount.  A decreasing set-over-nonzero is the H1 signature for a caller
+/// that resets a live frame's refcount without going through `page_ref_dec`,
+/// bypassing the zero-check that would trigger `pmm::free_page`.
+#[cfg(feature = "firefox-test")]
+static REFCOUNT_SET_OVER_NONZERO: AtomicU64 = AtomicU64::new(0);
 
 /// Maximum physical pages we track (same as PMM: 4 GiB / 4 KiB = 1M pages).
 const MAX_PAGES: usize = 1024 * 1024;
@@ -94,10 +102,43 @@ pub fn page_ref_count(phys_addr: u64) -> u16 {
 }
 
 /// Set the reference count for a physical page (used during initialization).
+///
+/// Under the `firefox-test` feature gate, this function observes any case
+/// where `count` is less than the existing non-zero refcount.  Such a
+/// decreasing set-over-nonzero bypasses the zero-transition that would
+/// normally trigger `pmm::free_page`, which is a potential H1 aliasing path:
+/// the frame is not freed, but its refcount is silently lowered, possibly
+/// below the number of live PTEs that still reference it.
 pub fn page_ref_set(phys_addr: u64, count: u16) {
     let idx = pfn(phys_addr);
     let rc = refcounts();
     if idx < rc.len() {
+        // H1 diagnostic: observe decreasing set-over-nonzero transitions.
+        #[cfg(feature = "firefox-test")]
+        {
+            let existing = rc[idx].load(Ordering::Relaxed);
+            if existing > 0 && count != existing && count < existing {
+                let total = REFCOUNT_SET_OVER_NONZERO
+                    .fetch_add(1, Ordering::Relaxed) + 1;
+                if total <= 8 || total % 1000 == 0 {
+                    crate::serial_println!(
+                        "[REFCOUNT/SET-OVER-NONZERO] phys={:#x} existing_rc={} new_rc={} count_total={}",
+                        phys_addr, existing, count, total,
+                    );
+                }
+            }
+        }
         rc[idx].store(count, Ordering::Relaxed);
     }
+}
+
+/// Read the cumulative `REFCOUNT_SET_OVER_NONZERO` counter.
+///
+/// Returns the number of times `page_ref_set` decreased a non-zero refcount.
+/// Always 0 on non-firefox-test builds.
+pub fn refcount_set_over_nonzero_count() -> u64 {
+    #[cfg(feature = "firefox-test")]
+    { REFCOUNT_SET_OVER_NONZERO.load(Ordering::Relaxed) }
+    #[cfg(not(feature = "firefox-test"))]
+    { 0 }
 }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2253,7 +2253,8 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> fd-table 6
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
-    if op in ("ping", "proc-list", "vfs-mounts", "trace-status", "bell-stats"):
+    if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
+              "bell-stats", "cache-audit"):
         return {"op": op}
     if op == "proc":
         if not rest: raise ValueError("proc requires <pid>")
@@ -2448,6 +2449,61 @@ def cmd_fd_map(args):
             "changed": changed,
             "snapshot": resp,
         }
+
+    _out(resp)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# cache-audit — W215 H1 diagnostic: page-cache refcount invariant walker
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Wraps kdb op 'cache-audit' (firefox-test kernel builds only) and pretty-
+# prints the result.  The response carries:
+#   total_entries           — number of entries currently in PAGE_CACHE
+#   orphan_count            — entries with page_ref_count == 0 (H1 smoke gun)
+#   pmm_alloc_nonzero_rc    — times alloc_page returned a frame with rc > 0
+#   refcount_set_over_nonzero — times page_ref_set decreased a non-zero rc
+#
+# PROCEED-TO-FIX (per PM verdict) iff any of the three counters are non-zero.
+
+def cmd_cache_audit(args):
+    """W215 H1 diagnostic: audit page-cache vs refcount table invariants.
+
+    Sends kdb op 'cache-audit' and returns structured JSON with orphan_count,
+    pmm_alloc_nonzero_rc, and refcount_set_over_nonzero counters.
+
+    Requires the session to have been started with --features firefox-test,kdb.
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"error": "session was not started with --features kdb"})
+        sys.exit(1)
+
+    req: dict = {"op": "cache-audit"}
+    timeout = float(getattr(args, "timeout", 10.0) or 10.0)
+    try:
+        raw = _kdb_recv(port, req, timeout=timeout)
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        _out({"error": f"kdb connect failed on 127.0.0.1:{port}: {e}"})
+        sys.exit(1)
+    try:
+        resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError) as e:
+        _out({"error": f"malformed kdb response: {e}",
+              "raw": raw.decode(errors="replace")})
+        sys.exit(1)
+
+    # Annotate with a human-readable verdict for the PM's classification rules.
+    orphans    = resp.get("orphan_count", -1)
+    pmm_nz     = resp.get("pmm_alloc_nonzero_rc", -1)
+    rc_set_ov  = resp.get("refcount_set_over_nonzero", -1)
+    if any(v > 0 for v in [orphans, pmm_nz, rc_set_ov] if isinstance(v, int)):
+        resp["_verdict"] = "PROCEED-TO-FIX: at least one H1 counter non-zero"
+    elif all(v == 0 for v in [orphans, pmm_nz, rc_set_ov] if isinstance(v, int)):
+        resp["_verdict"] = "ABORT-OR-NULL: all H1 counters zero"
+    else:
+        resp["_verdict"] = "UNKNOWN: check for error field"
 
     _out(resp)
 
@@ -5245,7 +5301,7 @@ def main():
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "tframe", "user-mem", "trace-status",
-        "bell-stats",
+        "bell-stats", "cache-audit",
     ])
     p_kdb.add_argument("args", nargs="*",
                         help="Op-specific positional args: "
@@ -5273,6 +5329,18 @@ def main():
                           help="Diff current snapshot against a previously --save'd NAME")
     p_fdmap.add_argument("--timeout", type=float, default=5.0,
                           help="kdb socket timeout in seconds (default 5.0)")
+
+    # cache-audit — W215 H1 diagnostic: walk the page cache checking for
+    # zero-refcount entries.  Requires --features firefox-test,kdb at start.
+    p_cacheaudit = sub.add_parser(
+        "cache-audit",
+        help="[W215 diag] Audit page-cache refcount invariants via kdb op "
+             "cache-audit (requires --features firefox-test,kdb). Reports "
+             "total_entries, orphan_count (rc=0 entries), and the cumulative "
+             "PMM_ALLOC_NONZERO_RC and REFCOUNT_SET_OVER_NONZERO counters.")
+    p_cacheaudit.add_argument("sid")
+    p_cacheaudit.add_argument("--timeout", type=float, default=10.0,
+                               help="kdb socket timeout in seconds (default 10.0)")
 
     # qga-ping / qga-info / qga-sync / qga-file-read — QEMU Guest Agent
     # bridge.  Requires --features qga at start; talks NDJSON over the
@@ -5560,8 +5628,9 @@ def main():
         "pause":  cmd_pause,
         "resume": cmd_resume,
         # Tier 1
-        "kdb":    cmd_kdb,
-        "fd-map": cmd_fd_map,
+        "kdb":         cmd_kdb,
+        "fd-map":      cmd_fd_map,
+        "cache-audit": cmd_cache_audit,
         # QGA bridge
         "qga-ping":      cmd_qga_ping,
         "qga-info":      cmd_qga_info,


### PR DESCRIPTION
## Summary

- Adds four read-only diagnostic counters (all `#[cfg(feature = "firefox-test")]`) to measure the H1 hypothesis for the W215 page-aliasing cluster: the PMM bitmap and refcount table have no cross-validation gate, so bitmap-free + refcount-live can coexist and cause `alloc_page` to recycle an in-use frame.
- `cache::audit_invariant()` walks `PAGE_CACHE` and reports orphan entries (entries where `page_ref_count == 0`).
- `PMM_ALLOC_NONZERO_RC` counter in `alloc_page_locked`: incremented when a freshly allocated frame has a non-zero refcount at the moment the bitmap marks it used.
- `REFCOUNT_SET_OVER_NONZERO` counter in `page_ref_set`: incremented when a decreasing set-over-nonzero transition is observed (existing > 0 and new_val < existing), indicating a caller bypassed the normal dec→free path.
- `kdb` op `cache-audit` + harness subcommand `cache-audit <sid>`: invokes `audit_invariant()` and returns structured JSON with `orphan_count`, `pmm_alloc_nonzero_rc`, `refcount_set_over_nonzero`, and a `_verdict` annotation.

## This is a MEASUREMENT PR — no MM behaviour is changed

No logic in `alloc_page`, `page_ref_set`, `cache::insert`, or any other MM path is modified. The probes are purely observational.

## Verification gate (per PM verdict)

After merge, a 5-trial KVM soak will classify as:
- **PROCEED-TO-FIX**: any counter non-zero AND W215 reproduces ≥2/5 → targeted fix in a separate PR.
- **ABORT-AND-ESCALATE**: all counters zero AND W215 still reproduces → escalate to F-5/F-3.
- **NULL RESULT**: no reproduce, all counters zero → re-run.

## Test plan

- [x] `scripts/qemu-harness.py check` — default build: pass
- [x] `scripts/qemu-harness.py check --features firefox-test,kdb` — pass
- [x] `scripts/qemu-harness.py check --features test-mode` — pass
- [x] Kernel smoke: test-mode ran 3+ minutes with no BUGCHECK or HUNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)