### PR TITLE
kernel/mm/refcount: fix PR #241 boot regression — pre-init page_ref_count panic

### DIFF
--- a/kernel/src/mm/refcount.rs
+++ b/kernel/src/mm/refcount.rs
@@ -44,9 +44,28 @@ pub fn init() {
 }
 
 /// Get the refcount array, panicking if not yet initialised.
+///
+/// Internal helper for callers that must only run post-`init()`.
 #[inline]
 fn refcounts() -> &'static [AtomicU16] {
     REFCOUNTS.get().expect("refcount::init() not called")
+}
+
+/// Get the refcount array if already initialised, or `None` during early boot.
+///
+/// Used by read-only / diagnostic paths (e.g. `page_ref_count`) that can be
+/// reached before `refcount::init()` via the early-boot allocator chain:
+/// `vmm::init() → separate_higher_half_pds() → pmm::alloc_page() →
+/// alloc_page_locked() → [firefox-test diagnostic] → page_ref_count()`.
+/// At that point the heap is not yet set up, so REFCOUNTS is `None`.
+/// Returning `None` here lets the caller return a safe sentinel (0) instead
+/// of panicking with "refcount::init() not called".
+#[inline]
+fn refcounts_opt() -> Option<&'static [AtomicU16]> {
+    // REFCOUNTS stores a &'static [AtomicU16]; Once::get() returns
+    // Option<&&'static [AtomicU16]>, so one deref is needed to get the
+    // inner &'static slice back.
+    REFCOUNTS.get().copied()
 }
 
 /// Page frame number from a physical address.
@@ -91,9 +110,16 @@ pub fn page_ref_dec(phys_addr: u64) -> u16 {
 }
 
 /// Get the current reference count for a physical page.
+///
+/// Returns 0 if the refcount table has not yet been initialised (early-boot
+/// allocator calls arrive before `refcount::init()` — returning 0 is correct
+/// because no PTE references have been recorded yet).
 pub fn page_ref_count(phys_addr: u64) -> u16 {
+    let rc = match refcounts_opt() {
+        Some(r) => r,
+        None => return 0, // pre-init: no refs tracked yet
+    };
     let idx = pfn(phys_addr);
-    let rc = refcounts();
     if idx < rc.len() {
         rc[idx].load(Ordering::Relaxed)
     } else {
@@ -110,8 +136,11 @@ pub fn page_ref_count(phys_addr: u64) -> u16 {
 /// the frame is not freed, but its refcount is silently lowered, possibly
 /// below the number of live PTEs that still reference it.
 pub fn page_ref_set(phys_addr: u64, count: u16) {
+    let rc = match refcounts_opt() {
+        Some(r) => r,
+        None => return, // pre-init: table does not exist yet, silently no-op
+    };
     let idx = pfn(phys_addr);
-    let rc = refcounts();
     if idx < rc.len() {
         // H1 diagnostic: observe decreasing set-over-nonzero transitions.
         #[cfg(feature = "firefox-test")]


### PR DESCRIPTION
## Summary

- PR #241 (`fe9208e`) added a `#[cfg(feature = "firefox-test")]` diagnostic in `alloc_page_locked()` that calls `page_ref_count(phys)` to detect H1 aliasing (PMM-free frames with live refcounts).
- `page_ref_count` called the internal `refcounts()` helper which panics if `REFCOUNTS` (`spin::Once`) is not initialised.
- `vmm::init()` calls `pmm::alloc_page()` via `separate_higher_half_pds()` (vmm.rs:137) and `extend_higher_half_to_4gib()` (vmm.rs:191), both of which run **before** `refcount::init()` is called.
- Result: every KVM firefox-test boot panicked at `refcount.rs:49` with `"refcount::init() not called"`, blocking all W215 verification trials.

## Fix

Introduce `refcounts_opt() -> Option<&'static [AtomicU16]>` using `Once::get().copied()` (no panic). Switch `page_ref_count` to return 0 on `None` (correct — no refs tracked yet) and `page_ref_set` to silently no-op on `None` (also correct). `page_ref_inc`/`page_ref_dec` retain the panicking helper — they must never be called during early boot.

Diff: 1 file, +31/-2 lines (11 functional LOC, remainder doc comments).

## Why CI passed

CI kernel-smoke builds with `--features test-mode` (not `firefox-test`). The diagnostic block is `#[cfg(feature = "firefox-test")]` so it is compiled out entirely in test-mode. The `harness-smoke` job also uses `test-mode`. No CI job builds or boots with `firefox-test`; the regression was invisible to CI. Tightening CI coverage to include a `firefox-test` check build is tracked separately.

## Verification

- `cargo check` (default, `firefox-test`, `test-mode` features): all pass, zero errors.
- KVM boot with `firefox-test,kdb` features: no panic, Firefox userspace reached (LD_DEBUG link-map visible in serial log at sc≈5700). `grep` for `panic`/`BUGCHECK`/`refcount.*not called` returns empty.