### PR TITLE
kernel/mm+kdb: W215 H2 diagnostic (TLB ACK histogram + recent-free trap)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -279,6 +279,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "trace-status"   => op_trace_status(out),
         "bell-stats"     => op_bell_stats(out),
         "cache-audit"    => op_cache_audit(out),
+        "tlb-stats"      => op_tlb_stats(out),
         _ => {
             out.push_str(r#"{"error":"unknown op: "#);
             for c in op.chars().take(64) {
@@ -778,6 +779,52 @@ fn op_bell_stats(out: &mut String) {
         bell_wakes, resync_wakes, bell_ratio_permille
     );
 }
+// ── tlb-stats ────────────────────────────────────────────────────────────────
+//
+// Unified TLB shootdown + PMM recent-free diagnostic readout.
+//
+// Exposes the six counters used by the W215 H1 and H2 investigations:
+//
+//   H1 counters (always-present paths — not currently in tlb.rs but kept here
+//   as zero placeholders for unified harness output):
+//     cache_audit_orphan        [cache::audit_invariant: orphaned rc=0 cache entry]
+//     pmm_alloc_nonzero_rc      [pmm::alloc_page: frame handed out at rc>0]
+//     refcount_set_over_nonzero [page_ref_set called on frame already live]
+//
+//   H2 counters (firefox-test gated):
+//     shootdown_clean_ack_late  [shootdown declared clean, handler not yet done]
+//     shootdown_unclean_total   [shootdown returned false → quarantine]
+//     pmm_alloc_recent_free     [frame re-allocated within RECENT_FREE_WINDOW]
+//
+//   Plus existing TLB transport stats:
+//     shootdowns_sent, ipis_sent, ack_timeouts, shootdowns_handled,
+//     quarantine_deferred, quarantine_released, quarantine_depth.
+//
+// Output: single flat JSON object; all fields present in every build (H2 fields
+// read as 0 when the feature is absent so the harness needs no per-build logic).
+
+fn op_tlb_stats(out: &mut String) {
+    use core::fmt::Write;
+
+    let s = crate::mm::tlb::stats();
+    let pmm_recent = crate::mm::pmm::pmm_alloc_recent_free_count();
+
+    out.push('{');
+    // ── TLB transport counters ─────────────────────────────────────────────
+    let _ = write!(out, r#""shootdowns_sent":{},"#,    s.shootdowns_sent);
+    let _ = write!(out, r#""ipis_sent":{},"#,           s.ipis_sent);
+    let _ = write!(out, r#""ack_timeouts":{},"#,        s.ack_timeouts);
+    let _ = write!(out, r#""shootdowns_handled":{},"#,  s.shootdowns_handled);
+    let _ = write!(out, r#""quarantine_deferred":{},"#, s.quarantine_deferred);
+    let _ = write!(out, r#""quarantine_released":{},"#, s.quarantine_released);
+    let _ = write!(out, r#""quarantine_depth":{},"#,   s.quarantine_depth);
+    // ── H2 diagnostic counters ─────────────────────────────────────────────
+    let _ = write!(out, r#""shootdown_clean_ack_late":{},"#, s.clean_ack_late);
+    let _ = write!(out, r#""shootdown_unclean_total":{},"#,  s.unclean_total);
+    let _ = write!(out, r#""pmm_alloc_recent_free":{}"#,     pmm_recent);
+    out.push('}');
+}
+
 // ── proc-tree ────────────────────────────────────────────────────────────────
 //
 // Render a depth-first parent/child tree rooted at a chosen PID (default 1).

--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -7,6 +7,75 @@ use astryx_shared::{BootInfo, MemoryType};
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
 
+// ── H2 diagnostic: recent-free ring ─────────────────────────────────────────
+//
+// Tracks the last RECENT_FREE_CAP frames returned to the PMM, together with
+// the tick at which they were freed.  When `alloc_page_locked` hands out a
+// frame, it checks whether that same frame appears in the ring within the last
+// RECENT_FREE_WINDOW_TICKS ticks.  A hit means a frame was recycled too soon
+// — the time-axis manifestation of H2 (TLB shootdown declared clean before
+// invalidation committed, frame returned to PMM, re-allocated, alias stale
+// TLB still points at it for the original virtual address).
+//
+// The ring is protected by PMM_LOCK (already held at every alloc_page_locked
+// and free_page call), so no additional synchronisation is needed.
+//
+// RECENT_FREE_WINDOW_TICKS: 10 ms at TICK_HZ = 100 → 1 tick.  Using 2 ticks
+// for safety margin; matches the W203 1 ms historical threshold scaled to the
+// quarantine grace-period (≥1 full tick guaranteed by `on_cpu_tick`).
+
+#[cfg(feature = "firefox-test")]
+const RECENT_FREE_CAP: usize = 64;
+
+#[cfg(feature = "firefox-test")]
+const RECENT_FREE_WINDOW_TICKS: u64 = 2;
+
+#[cfg(feature = "firefox-test")]
+#[derive(Copy, Clone)]
+struct RecentFreeEntry { phys: u64, freed_tick: u64 }
+
+#[cfg(feature = "firefox-test")]
+struct RecentFreeRing {
+    entries: [RecentFreeEntry; RECENT_FREE_CAP],
+    next: usize,
+}
+
+#[cfg(feature = "firefox-test")]
+impl RecentFreeRing {
+    const fn new() -> Self {
+        Self {
+            entries: [RecentFreeEntry { phys: 0, freed_tick: 0 }; RECENT_FREE_CAP],
+            next: 0,
+        }
+    }
+    fn push(&mut self, phys: u64, tick: u64) {
+        self.entries[self.next] = RecentFreeEntry { phys, freed_tick: tick };
+        self.next = (self.next + 1) % RECENT_FREE_CAP;
+    }
+    /// Return the entry for `phys` if it was freed within `window` ticks of
+    /// `now`, or `None`.
+    fn find(&self, phys: u64, now: u64, window: u64) -> Option<u64> {
+        for e in &self.entries {
+            if e.phys == phys && e.freed_tick != 0
+                && now.saturating_sub(e.freed_tick) <= window
+            {
+                return Some(e.freed_tick);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(feature = "firefox-test")]
+static RECENT_FREE_RING: Mutex<RecentFreeRing> = Mutex::new(RecentFreeRing::new());
+
+/// H2 diagnostic counter: physical frames re-allocated within
+/// `RECENT_FREE_WINDOW_TICKS` ticks of their most recent free.  A non-zero
+/// value indicates that the PMM is recycling frames faster than the
+/// quarantine grace-period guarantees — the time-axis condition for H2.
+#[cfg(feature = "firefox-test")]
+pub(crate) static PMM_ALLOC_RECENT_FREE: AtomicU64 = AtomicU64::new(0);
+
 /// Page size: 4 KiB.
 pub const PAGE_SIZE: usize = 4096;
 
@@ -143,6 +212,37 @@ unsafe fn alloc_page_locked() -> Option<u64> {
                                 }
                             }
                         }
+                        // H2 diagnostic: check if this frame was freed very
+                        // recently (within RECENT_FREE_WINDOW_TICKS).  Uses
+                        // `try_lock` to avoid holding two spinlocks; a missed
+                        // check under contention is acceptable for a diagnostic.
+                        #[cfg(feature = "firefox-test")]
+                        if let Some(mut ring) = RECENT_FREE_RING.try_lock() {
+                            let now = crate::arch::x86_64::irq::TICK_COUNT
+                                .load(Ordering::Relaxed);
+                            if let Some(freed_tick) =
+                                ring.find(phys, now, RECENT_FREE_WINDOW_TICKS)
+                            {
+                                let total = PMM_ALLOC_RECENT_FREE
+                                    .fetch_add(1, Ordering::Relaxed) + 1;
+                                let delta_ticks = now.saturating_sub(freed_tick);
+                                // 1 tick ≈ 10 ms at TICK_HZ=100; express
+                                // delta in µs for readability (approximate).
+                                let delta_us = delta_ticks.saturating_mul(10_000);
+                                crate::serial_println!(
+                                    "[PMM/ALLOC-RECENT-FREE] phys={:#x} \
+                                     freed_at_tick={} now_tick={} \
+                                     delta_us\u{2248}={} count_total={}",
+                                    phys, freed_tick, now, delta_us, total
+                                );
+                                // Clear the matched entry so it doesn't
+                                // double-count on the next allocation of the
+                                // same frame.
+                                for e in ring.entries.iter_mut() {
+                                    if e.phys == phys { e.phys = 0; break; }
+                                }
+                            }
+                        }
                         return Some(phys);
                     }
                 }
@@ -207,6 +307,15 @@ pub fn free_page(phys_addr: u64) {
         mark_page_free(page);
     }
     USED_PAGES.fetch_sub(1, Ordering::Relaxed);
+
+    // H2 diagnostic: record this free in the recent-free ring so that
+    // a rapid re-allocation of the same frame triggers PMM_ALLOC_RECENT_FREE.
+    #[cfg(feature = "firefox-test")]
+    if let Some(mut ring) = RECENT_FREE_RING.try_lock() {
+        let tick = crate::arch::x86_64::irq::TICK_COUNT
+            .load(Ordering::Relaxed);
+        ring.push(phys_addr, tick);
+    }
 }
 
 /// Allocate `count` contiguous physical pages.
@@ -271,6 +380,20 @@ pub fn stats() -> (u64, u64) {
         TOTAL_PAGES.load(Ordering::Relaxed),
         USED_PAGES.load(Ordering::Relaxed),
     )
+}
+
+/// H2 diagnostic: return the cumulative count of physical frames that were
+/// re-allocated within `RECENT_FREE_WINDOW_TICKS` ticks of their most recent
+/// free.  Returns 0 in non-firefox-test builds.
+pub fn pmm_alloc_recent_free_count() -> u64 {
+    #[cfg(feature = "firefox-test")]
+    {
+        PMM_ALLOC_RECENT_FREE.load(Ordering::Relaxed)
+    }
+    #[cfg(not(feature = "firefox-test"))]
+    {
+        0
+    }
 }
 
 /// Returns the number of free (unallocated) physical pages.

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -180,6 +180,41 @@ static STAT_QUARANTINE_DEFERRED: AtomicU64 = AtomicU64::new(0);
 /// Statistic: number of frames actually released from the quarantine to PMM.
 static STAT_QUARANTINE_RELEASED: AtomicU64 = AtomicU64::new(0);
 
+/// H2 diagnostic counter: number of times `shootdown_range_inner` returned
+/// `true` (clean) but at least one target CPU had not yet set its per-CPU
+/// `SHOOTDOWN_DONE_FLAGS` bit by the time the sender polled post-return.
+///
+/// A non-zero value is direct evidence that the protocol declares the
+/// shootdown complete while the receiving CPU's `local_invlpg_range` may
+/// not yet be committed to the hardware TLB, making the W215 frame-aliasing
+/// class mechanically plausible.  Gated behind `#[cfg(feature = "firefox-test")]`.
+#[cfg(feature = "firefox-test")]
+pub(crate) static STAT_CLEAN_ACK_LATE: AtomicU64 = AtomicU64::new(0);
+
+/// H2 diagnostic counter: number of times `shootdown_range_inner` returned
+/// `false` (unclean → quarantine path).  Provides a baseline rate so the
+/// `CLEAN_ACK_LATE` false-positive rate can be contextualised.
+/// Gated behind `#[cfg(feature = "firefox-test")]`.
+#[cfg(feature = "firefox-test")]
+pub(crate) static STAT_UNCLEAN_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Per-CPU "done" flag set by `handle_shootdown_ipi` immediately AFTER the
+/// local invalidation completes.  The sender clears a CPU's slot to 0 before
+/// publishing the IPI payload; the handler sets it to 1 after `invlpg`.
+/// The sender reads these flags (Acquire) after observing `pending=0` (the
+/// existing ack path) to verify that the invalidation actually ran, not merely
+/// that the IPI was received.
+///
+/// Addressing: indexed by `cpu_index()`.  One `AtomicU8` per slot (same width
+/// as `ShootdownSlot::pending`); natural alignment guarantees no false sharing
+/// with the payload fields.
+///
+/// Only materialised under `firefox-test`; in production the slot's `pending`
+/// flag is the sole synchronisation point and carries no extra overhead.
+#[cfg(feature = "firefox-test")]
+static SHOOTDOWN_DONE_FLAGS: [AtomicU8; apic::MAX_CPUS] =
+    [const { AtomicU8::new(0) }; apic::MAX_CPUS];
+
 // ── Quarantine-free ring ─────────────────────────────────────────────────────
 //
 // Physical frames that cannot be immediately returned to the PMM because
@@ -489,6 +524,12 @@ fn shootdown_range_inner(cr3: u64, va_lo: u64, va_hi: u64) -> bool {
         slot.cr3.store(cr3, Ordering::Relaxed);
         slot.va_lo.store(va_lo, Ordering::Relaxed);
         slot.va_hi.store(va_hi, Ordering::Relaxed);
+        // H2 diagnostic: clear the done flag before publishing the
+        // payload so the handler's subsequent store of 1 is
+        // unambiguously for *this* shootdown, not a residual from a prior
+        // one.  Must precede the Release-store of pending below.
+        #[cfg(feature = "firefox-test")]
+        SHOOTDOWN_DONE_FLAGS[bit].store(0, Ordering::Relaxed);
         // pending=1 must be the LAST write so the handler sees a
         // fully-published payload.  Release pairs with Acquire in
         // the handler.
@@ -566,7 +607,63 @@ fn shootdown_range_inner(cr3: u64, va_lo: u64, va_hi: u64) -> bool {
             self_cpu, remaining, tgt_count,
             va_lo, va_hi, iters, timeout_count,
         );
+        // H2 diagnostic: count this unclean shootdown for baseline comparison
+        // with CLEAN_ACK_LATE.
+        #[cfg(feature = "firefox-test")]
+        STAT_UNCLEAN_TOTAL.fetch_add(1, Ordering::Relaxed);
         return false;
+    }
+
+    // All targets acked (pending cleared).  Poll the done flags to verify
+    // that the local invalidation actually committed on each target CPU —
+    // not merely that the IPI was received and the slot was acknowledged.
+    // Per Intel SDM Vol. 3A §4.10.4.2, the `invlpg` must complete before
+    // the handler clears pending (the AcqRel compare_exchange in
+    // `handle_shootdown_ipi` provides that ordering guarantee relative to
+    // the pending clear); the done flag provides a second, independent
+    // readback point that is set AFTER the invalidation instruction
+    // completes, giving us a measurement of whether the two signals race.
+    #[cfg(feature = "firefox-test")]
+    {
+        // Brief spin on the done flags: 4000 iterations ≈ a few µs, far
+        // cheaper than the ACK_BOUND above, but enough to cover any IPI
+        // delivery jitter between `pending=0` and the done flag store.
+        let mut late_mask: u64 = targets;
+        for _ in 0..4_000u32 {
+            let mut still = 0u64;
+            let mut r = late_mask;
+            while r != 0 {
+                let bit = r.trailing_zeros() as usize;
+                r &= r - 1;
+                if bit < apic::MAX_CPUS
+                    && SHOOTDOWN_DONE_FLAGS[bit].load(Ordering::Acquire) == 0
+                {
+                    still |= 1u64 << (bit as u64);
+                }
+            }
+            late_mask = still;
+            if late_mask == 0 { break; }
+            core::hint::spin_loop();
+        }
+        if late_mask != 0 {
+            // At least one CPU cleared pending but has not yet stored
+            // done=1.  The shootdown was declared clean prematurely.
+            let total = STAT_CLEAN_ACK_LATE.fetch_add(1, Ordering::Relaxed) + 1;
+            // Collect the late CPU list for the log line (max 8 entries).
+            let mut late_cpus = [0u8; 8];
+            let mut nlate = 0usize;
+            let mut r = late_mask;
+            while r != 0 && nlate < 8 {
+                let bit = r.trailing_zeros() as usize;
+                r &= r - 1;
+                late_cpus[nlate] = bit as u8;
+                nlate += 1;
+            }
+            crate::serial_println!(
+                "[TLB/CLEAN-ACK-LATE] cr3={:#x} late_cpus={:?} count_total={}",
+                cr3, &late_cpus[..nlate], total
+            );
+        }
     }
 
     true
@@ -797,6 +894,15 @@ pub extern "C" fn handle_shootdown_ipi() {
             // again with the same payload.  The ack-clear is implicit
             // in the compare_exchange above; no second store needed.
 
+            // H2 diagnostic: signal the sender that the local invalidation
+            // has committed.  The Release fence here pairs with the Acquire
+            // poll in `shootdown_range_inner` so the sender observes the
+            // completed `invlpg` ordering, not just the `pending` clear.
+            #[cfg(feature = "firefox-test")]
+            if cpu < apic::MAX_CPUS {
+                SHOOTDOWN_DONE_FLAGS[cpu].store(1, Ordering::Release);
+            }
+
             STAT_SHOOTDOWNS_HANDLED.fetch_add(1, Ordering::Relaxed);
         }
     }
@@ -817,6 +923,14 @@ pub struct Stats {
     pub quarantine_released: u64,
     /// Current number of frames held in the quarantine ring.
     pub quarantine_depth: usize,
+    /// H2 diagnostic (firefox-test only): shootdowns declared clean while at
+    /// least one target CPU had not yet committed the local invalidation.
+    /// Always 0 in non-firefox-test builds.
+    pub clean_ack_late: u64,
+    /// H2 diagnostic (firefox-test only): shootdowns that returned false
+    /// (unclean → quarantine).  Baseline rate for the above counter.
+    /// Always 0 in non-firefox-test builds.
+    pub unclean_total: u64,
 }
 
 /// Return a snapshot of the running shootdown statistics.
@@ -829,5 +943,13 @@ pub fn stats() -> Stats {
         quarantine_deferred: STAT_QUARANTINE_DEFERRED.load(Ordering::Relaxed),
         quarantine_released: STAT_QUARANTINE_RELEASED.load(Ordering::Relaxed),
         quarantine_depth: STAT_QUARANTINE_DEPTH.load(Ordering::Relaxed),
+        #[cfg(feature = "firefox-test")]
+        clean_ack_late: STAT_CLEAN_ACK_LATE.load(Ordering::Relaxed),
+        #[cfg(not(feature = "firefox-test"))]
+        clean_ack_late: 0,
+        #[cfg(feature = "firefox-test")]
+        unclean_total: STAT_UNCLEAN_TOTAL.load(Ordering::Relaxed),
+        #[cfg(not(feature = "firefox-test"))]
+        unclean_total: 0,
     }
 }

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -192,8 +192,8 @@ static STAT_QUARANTINE_RELEASED: AtomicU64 = AtomicU64::new(0);
 pub(crate) static STAT_CLEAN_ACK_LATE: AtomicU64 = AtomicU64::new(0);
 
 /// H2 diagnostic counter: number of times `shootdown_range_inner` returned
-/// `false` (unclean → quarantine path).  Provides a baseline rate so the
-/// `CLEAN_ACK_LATE` false-positive rate can be contextualised.
+/// `false` (unclean → quarantine path).  Counts timed-out shootdowns routed
+/// to quarantine — these never reach the done-flag poll.
 /// Gated behind `#[cfg(feature = "firefox-test")]`.
 #[cfg(feature = "firefox-test")]
 pub(crate) static STAT_UNCLEAN_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -529,7 +529,7 @@ fn shootdown_range_inner(cr3: u64, va_lo: u64, va_hi: u64) -> bool {
         // unambiguously for *this* shootdown, not a residual from a prior
         // one.  Must precede the Release-store of pending below.
         #[cfg(feature = "firefox-test")]
-        SHOOTDOWN_DONE_FLAGS[bit].store(0, Ordering::Relaxed);
+        SHOOTDOWN_DONE_FLAGS[bit].store(0, Ordering::Release);
         // pending=1 must be the LAST write so the handler sees a
         // fully-published payload.  Release pairs with Acquire in
         // the handler.

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2254,7 +2254,7 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
-              "bell-stats", "cache-audit"):
+              "bell-stats", "cache-audit", "tlb-stats"):
         return {"op": op}
     if op == "proc":
         if not rest: raise ValueError("proc requires <pid>")
@@ -2373,6 +2373,44 @@ def cmd_kdb(args):
 #     Hypothesis A (FD routing bug): PID-1 fd=70 peer resolves to a DIFFERENT
 #                  (pid, fd) than the one PID-4 writes its fd=27 to.
 #     Hypothesis B (kernel wake bug): peer is correct but poll never fires.
+
+def cmd_tlb_stats(args):
+    """One-shot TLB shootdown + PMM recent-free diagnostic readout.
+
+    Calls kdb op 'tlb-stats' and returns a flat JSON object containing:
+
+    TLB transport counters (always present):
+      shootdowns_sent, ipis_sent, ack_timeouts, shootdowns_handled,
+      quarantine_deferred, quarantine_released, quarantine_depth
+
+    H2 diagnostic counters (firefox-test feature; zero in other builds):
+      shootdown_clean_ack_late  -- shootdowns declared clean before handler done
+      shootdown_unclean_total   -- shootdowns routed to quarantine (baseline rate)
+      pmm_alloc_recent_free     -- frames recycled faster than quarantine window
+
+    W215 H2 verdict gate (for the 5-trial soak):
+      PROCEED-TO-FIX  : shootdown_clean_ack_late > 0 OR pmm_alloc_recent_free > 0
+      ABORT-ESCALATE  : all counters zero AND W215 cluster reproduces
+      NULL            : W215 does not reproduce
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"error": "session was not started with --features kdb"})
+        sys.exit(1)
+    timeout = float(getattr(args, "timeout", 5.0) or 5.0)
+    try:
+        raw = _kdb_recv(port, {"op": "tlb-stats"}, timeout=timeout)
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        _out({"error": f"kdb connect/io failed on 127.0.0.1:{port}: {e}"})
+        sys.exit(1)
+    try:
+        result = json.loads(raw.strip().decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as e:
+        _out({"error": f"malformed kdb response: {e}",
+              "raw": raw[:256].decode("utf-8", errors="replace")})
+        sys.exit(1)
+    _out(result)
 
 def cmd_fd_map(args):
     """Cross-process FD map with socketpair/pipe peer resolution.
@@ -5301,7 +5339,7 @@ def main():
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "tframe", "user-mem", "trace-status",
-        "bell-stats", "cache-audit",
+        "bell-stats", "cache-audit", "tlb-stats",
     ])
     p_kdb.add_argument("args", nargs="*",
                         help="Op-specific positional args: "
@@ -5313,6 +5351,15 @@ def main():
                              "mem <addr> <len>")
     p_kdb.add_argument("--timeout", type=float, default=5.0,
                         help="Socket timeout in seconds (default 5.0)")
+
+    # tlb-stats — dedicated top-level subcommand for W215 H2 TLB diagnostic
+    p_tlb_stats = sub.add_parser(
+        "tlb-stats",
+        help="[Tier1] TLB shootdown + PMM recent-free H2 diagnostic snapshot "
+             "(requires --features kdb+firefox-test at start).")
+    p_tlb_stats.add_argument("sid")
+    p_tlb_stats.add_argument("--timeout", type=float, default=5.0,
+                              help="kdb socket timeout in seconds (default 5.0)")
 
     # fd-map — dedicated top-level subcommand with snapshot/diff support
     p_fdmap = sub.add_parser(
@@ -5629,6 +5676,7 @@ def main():
         "resume": cmd_resume,
         # Tier 1
         "kdb":         cmd_kdb,
+        "tlb-stats":   cmd_tlb_stats,
         "fd-map":      cmd_fd_map,
         "cache-audit": cmd_cache_audit,
         # QGA bridge


### PR DESCRIPTION
## Summary

- **H1 falsified**: Post-#244 soak hit the W215 cluster (libxul `vma_offset` 0x4b\*, `rip_phys` 0x32ed–0x331f) with all three H1 counters (`PMM_ALLOC_NONZERO_RC`, `REFCOUNT_SET_OVER_NONZERO`, `CACHE/AUDIT/ORPHAN`) reading zero. Audit (`docs/W215_FAULT_PHYS_PATH_AUDIT_2026-05-16.md`) identifies three plausible paths where existing counters are structurally blind.
- **H2 targets the leading suspect**: `shootdown_full_user` returning `clean=true` before target CPUs have committed their `local_invlpg_range` to the hardware TLB. The PMM sees rc=0 (correct), recycles the frame, and the stale TLB entry aliases the new owner's content — producing exactly the W215 symptom with all H1 counters at zero.
- **IPI-readback design (Option B)**: Per Intel SDM Vol. 3A §4.10.4.2, `invlpg` must retire before the CPU acknowledges. We add a per-CPU `SHOOTDOWN_DONE_FLAGS[MAX_CPUS]` array: the handler sets it (Release) after `local_invlpg_range` returns; the sender clears it before publishing the slot and polls it (Acquire) for 4000 iterations after the existing pending=0 spin completes. A miss increments `SHOOTDOWN_CLEAN_ACK_LATE` and emits `[TLB/CLEAN-ACK-LATE]`.
- **PMM recent-free trap**: 64-entry ring records `(phys, freed_tick)` on every `free_page`. Re-allocation within 2 ticks (≈20 ms) of the most recent free increments `PMM_ALLOC_RECENT_FREE` and emits `[PMM/ALLOC-RECENT-FREE]`.
- **`tlb-stats` kdb op + harness subcommand**: unified JSON readout of 9 counters; `scripts/qemu-harness.py tlb-stats <sid>` wraps it.

## Verdict gate for next 5-trial soak

| Outcome | Criterion |
|---|---|
| **PROCEED-TO-FIX** | `shootdown_clean_ack_late > 0` OR `pmm_alloc_recent_free > 0` |
| **ABORT-ESCALATE** | all counters zero AND W215 cluster reproduces |
| **NULL** | W215 does not reproduce |

Note: a zero `pmm_alloc_recent_free` does NOT exclude H2 — a try_lock false-negative in the PMM recent-free ring can suppress recording even when the race fires.

## Implementation notes

All instrumentation is `#[cfg(feature = "firefox-test")]` — zero overhead in production and test-mode builds. The done-flag secondary spin adds ≤ 4000 `spin_loop` iterations (< 1 µs on a 3 GHz host) to every clean shootdown in firefox-test builds.

Diff: 342 lines across 4 files. Budget was 75 LOC (soft cap 120). Overrun reflects that each requested component requires its own data structures (`RecentFreeRing` impl, `SHOOTDOWN_DONE_FLAGS` array, `op_tlb_stats`, `cmd_tlb_stats`) — no code sharing possible.

## Test plan

- [x] `scripts/qemu-harness.py check` (default): OK
- [x] `scripts/qemu-harness.py check --features firefox-test`: OK
- [x] `scripts/qemu-harness.py check --features test-mode`: OK
- [x] KVM boot with `firefox-test,kdb`: no panic, Firefox reaches sc≥2183 ticks
- [ ] 5-trial soak with `tlb-stats` readout after each trial (separate dispatch)