### PR TITLE
kernel/mm+idt+linux: W215 H3a/H3b diagnostic counters (writable cache-alias + filebacked SHARED+WRITE mmap)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -14,6 +14,22 @@ use spin::Once;
 static PAGE_FAULT_TOTAL: AtomicU64 = AtomicU64::new(0);
 pub fn page_fault_count() -> u64 { PAGE_FAULT_TOTAL.load(Ordering::Relaxed) }
 
+/// W215 H3a diagnostic: number of times a writable PTE install aliased a
+/// physical frame that is simultaneously held as a *different* key in the page
+/// cache.  A non-zero value means some caller is installing a PAGE_WRITABLE PTE
+/// whose backing frame the cache knows under a different (mount,inode,offset)
+/// tuple — i.e., a MAP_SHARED+PROT_WRITE mapping of a cache-resident file page,
+/// where the installer's intent differs from the cache's recorded key.
+///
+/// Only armed in `firefox-test` builds; zero cost in all others.
+#[cfg(feature = "firefox-test")]
+pub(crate) static PFH_WRITABLE_ALIAS_CACHE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(feature = "firefox-test")]
+pub fn pfh_writable_alias_cache_count() -> u64 {
+    PFH_WRITABLE_ALIAS_CACHE.load(Ordering::Relaxed)
+}
+
 /// Number of IDT entries (256 vectors).
 const IDT_ENTRIES: usize = 256;
 
@@ -1369,6 +1385,38 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         let _ = crate::mm::refcount::page_ref_dec(cached_phys);
                         return false;
                     }
+                    // W215 H3a diagnostic: check whether cached_phys is held
+                    // under a different key in the cache — which would mean a
+                    // MAP_SHARED+PROT_WRITE PTE is about to alias a page the cache
+                    // knows under a different (mount,inode,offset) identity.
+                    // Only file-backed installs (is_shared && is_writable) reach
+                    // this arm; anonymous frames are never in the cache.
+                    #[cfg(feature = "firefox-test")]
+                    if is_writable {
+                        if let Some((c_mount, c_inode, c_off)) =
+                            crate::mm::cache::is_phys_in_cache(cached_phys)
+                        {
+                            // The cache key recorded at insert time should match
+                            // our installer's key.  A mismatch means the frame has
+                            // been re-inserted under a different identity since the
+                            // readahead/prepopulate inserted it, or a concurrent
+                            // cache::insert replaced our entry with a different frame
+                            // and then re-used this phys under a new key — both
+                            // are aliasing bugs.
+                            if c_mount != mount_idx || c_inode != inode || c_off != file_page_offset {
+                                PFH_WRITABLE_ALIAS_CACHE.fetch_add(1, Ordering::Relaxed);
+                                crate::serial_println!(
+                                    "[H3a] ALIAS-CACHE writable phys={:#x} \
+                                     cache_key=({},{:#x},{:#x}) installer_key=({},{:#x},{:#x}) \
+                                     rip={:#x}",
+                                    cached_phys,
+                                    c_mount, c_inode, c_off,
+                                    mount_idx, inode, file_page_offset,
+                                    _frame.rip,
+                                );
+                            }
+                        }
+                    }
                     crate::mm::vmm::map_page_in(cr3, page_addr, cached_phys, page_flags);
                     crate::mm::vmm::invlpg(page_addr);
                     // Guard ref is intentionally NOT released — it has been
@@ -1741,6 +1789,33 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 } else {
                     // MAP_SHARED writable, or any read-only mapping: alias
                     // the cache page directly.
+                    //
+                    // W215 H3a diagnostic: the cache entry for (mount,inode,foff)
+                    // was just inserted by us (cache::insert above), so under
+                    // normal operation the cache key WILL match our installer key.
+                    // A mismatch here means another CPU raced in with a different
+                    // key for the same phys between our insert and this check —
+                    // a structural aliasing bug distinct from the MAP_SHARED case
+                    // in the cache-hit arm above.
+                    #[cfg(feature = "firefox-test")]
+                    if is_writable_vma {
+                        if let Some((c_mount, c_inode, c_off)) =
+                            crate::mm::cache::is_phys_in_cache(phys)
+                        {
+                            if c_mount != mount_idx || c_inode != inode || c_off != foff {
+                                PFH_WRITABLE_ALIAS_CACHE.fetch_add(1, Ordering::Relaxed);
+                                crate::serial_println!(
+                                    "[H3a] ALIAS-CACHE readahead phys={:#x} \
+                                     cache_key=({},{:#x},{:#x}) installer_key=({},{:#x},{:#x}) \
+                                     rip={:#x}",
+                                    phys,
+                                    c_mount, c_inode, c_off,
+                                    mount_idx, inode, foff,
+                                    _frame.rip,
+                                );
+                            }
+                        }
+                    }
                     crate::mm::refcount::page_ref_inc(phys);
                     crate::mm::vmm::map_page_in(cr3, vaddr, phys, page_flags);
                     // Drop guard ref — steady state: cache(1) + PTE(1) = 2.
@@ -1963,6 +2038,30 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // MAP_SHARED writable, or any read-only mapping: alias the
                     // cache page directly.  Writes via MAP_SHARED are visible to
                     // all other mappers — required by mmap(2) MAP_SHARED contract.
+                    //
+                    // W215 H3a diagnostic: mirror the readahead-arm check.
+                    // The single-page path inserts under (mount_idx, inode,
+                    // file_page_offset); if is_phys_in_cache returns a different
+                    // key, a concurrent re-insertion race has occurred.
+                    #[cfg(feature = "firefox-test")]
+                    if is_writable_spf {
+                        if let Some((c_mount, c_inode, c_off)) =
+                            crate::mm::cache::is_phys_in_cache(phys)
+                        {
+                            if c_mount != mount_idx || c_inode != inode || c_off != file_page_offset {
+                                PFH_WRITABLE_ALIAS_CACHE.fetch_add(1, Ordering::Relaxed);
+                                crate::serial_println!(
+                                    "[H3a] ALIAS-CACHE single-page phys={:#x} \
+                                     cache_key=({},{:#x},{:#x}) installer_key=({},{:#x},{:#x}) \
+                                     rip={:#x}",
+                                    phys,
+                                    c_mount, c_inode, c_off,
+                                    mount_idx, inode, file_page_offset,
+                                    _frame.rip,
+                                );
+                            }
+                        }
+                    }
                     crate::mm::refcount::page_ref_inc(phys); // PTE reference
                     crate::mm::vmm::map_page_in(cr3, page_addr, phys, page_flags);
                     crate::mm::vmm::invlpg(page_addr);

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -279,6 +279,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "trace-status"   => op_trace_status(out),
         "bell-stats"     => op_bell_stats(out),
         "cache-audit"    => op_cache_audit(out),
+        "cache-aliasing" => op_cache_aliasing(out),
         "tlb-stats"      => op_tlb_stats(out),
         _ => {
             out.push_str(r#"{"error":"unknown op: "#);
@@ -779,6 +780,40 @@ fn op_bell_stats(out: &mut String) {
         bell_wakes, resync_wakes, bell_ratio_permille
     );
 }
+// ── cache-aliasing ────────────────────────────────────────────────────────────
+//
+// W215 H3a diagnostic: dump the two new counters that instrument the
+// "writer into cache frame" axis.
+//
+// Output (firefox-test builds):
+//   {
+//     "pfh_writable_alias_cache":      N,   -- writable installs aliasing a cache frame
+//     "sys_mmap_shared_write_filebacked": M, -- MAP_SHARED|PROT_WRITE filebacked mmaps
+//   }
+//
+// Disambiguation per W215_H3_CACHE_HIT_COW_2026-05-16.md §188-196:
+//   sys_mmap_shared_write_filebacked > 0 AND inode matches libxul  → H3a confirmed (mmap path)
+//   pfh_writable_alias_cache > 0 AND key mismatch with installer   → H3a confirmed (PFH path)
+//   both == 0 AND W215 still fires                                  → H3a dead; escalate to H3b
+//   pfh_writable_alias_cache > 0 but key matches installer          → NULL; re-frame
+
+fn op_cache_aliasing(out: &mut String) {
+    #[cfg(feature = "firefox-test")]
+    {
+        use core::fmt::Write;
+        let pfh_alias = crate::arch::x86_64::idt::pfh_writable_alias_cache_count();
+        let mmap_sw   = crate::syscall::sys_mmap_shared_write_filebacked_count();
+        out.push('{');
+        let _ = write!(out, r#""pfh_writable_alias_cache":{},"sys_mmap_shared_write_filebacked":{}"#,
+            pfh_alias, mmap_sw);
+        out.push('}');
+    }
+    #[cfg(not(feature = "firefox-test"))]
+    {
+        out.push_str(r#"{"error":"cache-aliasing requires firefox-test feature"}"#);
+    }
+}
+
 // ── tlb-stats ────────────────────────────────────────────────────────────────
 //
 // Unified TLB shootdown + PMM recent-free diagnostic readout.

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -379,6 +379,27 @@ pub fn stats() -> (usize, usize) {
     (total, dirty)
 }
 
+/// Walk the page cache and return the cache key for a given physical frame.
+///
+/// Returns `Some((mount_idx, inode, page_offset))` if any live cache entry holds
+/// `phys` as its backing physical frame; `None` otherwise.  An O(n) walk is
+/// acceptable here: this predicate is only reachable from `#[cfg(feature =
+/// "firefox-test")]` PFH instrumentation where `n` ≈ 40 K (libxul) and the
+/// call happens at most once per writable PTE install.
+///
+/// Per-entry `phys` comparison is exact — the cache holds one physical frame per
+/// key and frames are 4 KiB-aligned, so a u64 equality test is sufficient.
+#[cfg(feature = "firefox-test")]
+pub fn is_phys_in_cache(phys: u64) -> Option<(usize, u64, u64)> {
+    let cache = PAGE_CACHE.lock();
+    for ((mount_idx, inode, page_offset), entry) in cache.iter() {
+        if entry.phys == phys {
+            return Some((*mount_idx, *inode, *page_offset));
+        }
+    }
+    None
+}
+
 /// Audit the page cache for H1 invariant violations: any cached entry whose
 /// physical frame has a reference count of zero.
 ///

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -38,6 +38,28 @@ pub mod ring {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// W215 H3a diagnostic counters
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Number of `mmap(MAP_SHARED|PROT_WRITE, fd≥0)` calls on file-backed fds.
+///
+/// A non-zero count indicates that some caller created a MAP_SHARED+writable
+/// mapping of a regular file (not a memfd, not /dev/*).  If the file is the
+/// libxul binary, any write through this mapping lands directly in the page
+/// cache frame, corrupting the content every other MAP_PRIVATE reader copies
+/// from the cache — which is precisely the W215 H3a failure chain.
+///
+/// Only armed in `firefox-test` builds.  Zero cost in all others.
+#[cfg(feature = "firefox-test")]
+static SYS_MMAP_SHARED_WRITE_FILEBACKED: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+
+#[cfg(feature = "firefox-test")]
+pub fn sys_mmap_shared_write_filebacked_count() -> u64 {
+    SYS_MMAP_SHARED_WRITE_FILEBACKED.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // User pointer validation
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1991,6 +2013,29 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
         feature = "test-mode",
     )))]
     let (cr3, backing, name, base) = mmap_setup;
+
+    // W215 H3a diagnostic: count MAP_SHARED+PROT_WRITE file-backed mappings.
+    //
+    // The check is after argument decode and backing resolution (above), but
+    // before any phase-2/3 VMA edit, so the metadata is stable.  Per POSIX
+    // mmap(2), MAP_SHARED+PROT_WRITE on a regular file installs a user PTE
+    // that aliases the page-cache frame directly with PAGE_WRITABLE set — any
+    // store through the mapping writes into the cache frame itself.  If the
+    // file is a shared library (.so), subsequent MAP_PRIVATE+PROT_WRITE
+    // demand-page faults copy the already-written (e.g. relocated) content
+    // into their private frame, producing wrong code bytes at the original
+    // file offset (the W215 H3a hypothesis).
+    #[cfg(feature = "firefox-test")]
+    if (flags & MAP_SHARED as u32 != 0) && (prot & PROT_WRITE != 0) {
+        if let VmBacking::File { mount_idx: m, inode: ino, .. } = &backing {
+            SYS_MMAP_SHARED_WRITE_FILEBACKED
+                .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            crate::serial_println!(
+                "[H3a/mmap] SHARED+WRITE filebacked mount={} inode={:#x} fd={} len={:#x} off={:#x} pid={}",
+                m, ino, fd, length, offset, pid,
+            );
+        }
+    }
 
     // Emit shared-library mmap trace AFTER the PROCESS_TABLE lock is dropped
     // so a slow serial path cannot block the process table.  Format:

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2480,7 +2480,7 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
-              "bell-stats", "cache-audit", "tlb-stats"):
+              "bell-stats", "cache-audit", "cache-aliasing", "tlb-stats"):
         return {"op": op}
     if op == "proc":
         if not rest: raise ValueError("proc requires <pid>")
@@ -2766,6 +2766,65 @@ def cmd_cache_audit(args):
         resp["_verdict"] = "PROCEED-TO-FIX: at least one H1 counter non-zero"
     elif all(v == 0 for v in [orphans, pmm_nz, rc_set_ov] if isinstance(v, int)):
         resp["_verdict"] = "ABORT-OR-NULL: all H1 counters zero"
+    else:
+        resp["_verdict"] = "UNKNOWN: check for error field"
+
+    _out(resp)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# cache-aliasing — W215 H3a diagnostic: writable alias + SHARED+WRITE mmap counters
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Wraps kdb op 'cache-aliasing' (firefox-test kernel builds only).
+# The response carries:
+#   pfh_writable_alias_cache           — writable installs that aliased a cache frame
+#                                        under a different (mount,inode,offset) key
+#   sys_mmap_shared_write_filebacked   — MAP_SHARED|PROT_WRITE mmap calls on file fds
+#
+# Disambiguation table (per docs/W215_H3_CACHE_HIT_COW_2026-05-16.md §188-196):
+#   sys_mmap_shared_write_filebacked > 0   → H3a confirmed (mmap path); check inode in log
+#   pfh_writable_alias_cache > 0           → H3a confirmed (PFH path)
+#   both == 0 AND W215 still fires         → H3a dead; escalate to H3b (kalloc recycled frame)
+
+def cmd_cache_aliasing(args):
+    """W215 H3a diagnostic: writable cache-frame alias + SHARED+WRITE mmap counters.
+
+    Sends kdb op 'cache-aliasing' and returns structured JSON with
+    pfh_writable_alias_cache and sys_mmap_shared_write_filebacked counters.
+
+    Requires the session to have been started with --features firefox-test,kdb.
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"error": "session was not started with --features kdb"})
+        sys.exit(1)
+
+    req: dict = {"op": "cache-aliasing"}
+    timeout = float(getattr(args, "timeout", 10.0) or 10.0)
+    try:
+        raw = _kdb_recv(port, req, timeout=timeout)
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        _out({"error": f"kdb connect failed on 127.0.0.1:{port}: {e}"})
+        sys.exit(1)
+    try:
+        resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError) as e:
+        _out({"error": f"malformed kdb response: {e}",
+              "raw": raw.decode(errors="replace")})
+        sys.exit(1)
+
+    # Annotate with a verdict per the H3a disambiguation table.
+    pfh_alias = resp.get("pfh_writable_alias_cache", -1)
+    mmap_sw   = resp.get("sys_mmap_shared_write_filebacked", -1)
+    if isinstance(pfh_alias, int) and pfh_alias > 0:
+        resp["_verdict"] = "PROCEED-TO-FIX (H3a via PFH path): pfh_writable_alias_cache > 0"
+    elif isinstance(mmap_sw, int) and mmap_sw > 0:
+        resp["_verdict"] = ("PROCEED-TO-FIX (H3a via mmap path): sys_mmap_shared_write_filebacked > 0 "
+                            "— check [H3a/mmap] lines in serial log for inode match")
+    elif isinstance(pfh_alias, int) and isinstance(mmap_sw, int) and pfh_alias == 0 and mmap_sw == 0:
+        resp["_verdict"] = "ABORT-AND-ESCALATE: both H3a counters zero — escalate to H3b"
     else:
         resp["_verdict"] = "UNKNOWN: check for error field"
 
@@ -5565,7 +5624,7 @@ def main():
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "tframe", "user-mem", "trace-status",
-        "bell-stats", "cache-audit", "tlb-stats",
+        "bell-stats", "cache-audit", "cache-aliasing", "tlb-stats",
     ])
     p_kdb.add_argument("args", nargs="*",
                         help="Op-specific positional args: "
@@ -5614,6 +5673,18 @@ def main():
     p_cacheaudit.add_argument("sid")
     p_cacheaudit.add_argument("--timeout", type=float, default=10.0,
                                help="kdb socket timeout in seconds (default 10.0)")
+
+    # cache-aliasing — W215 H3a diagnostic: writable cache-frame alias + filebacked SHARED+WRITE mmap
+    p_cache_aliasing = sub.add_parser(
+        "cache-aliasing",
+        help="[W215 H3a diag] Dump PFH_WRITABLE_ALIAS_CACHE and "
+             "SYS_MMAP_SHARED_WRITE_FILEBACKED counters "
+             "(requires --features firefox-test,kdb). "
+             "Non-zero pfh_writable_alias_cache or sys_mmap_shared_write_filebacked "
+             "confirms H3a (MAP_SHARED+PROT_WRITE file-backed mapping aliases cache frame).")
+    p_cache_aliasing.add_argument("sid")
+    p_cache_aliasing.add_argument("--timeout", type=float, default=10.0,
+                                   help="kdb socket timeout in seconds (default 10.0)")
 
     # qga-ping / qga-info / qga-sync / qga-file-read — QEMU Guest Agent
     # bridge.  Requires --features qga at start; talks NDJSON over the
@@ -5930,7 +6001,8 @@ def main():
         "kdb":         cmd_kdb,
         "tlb-stats":   cmd_tlb_stats,
         "fd-map":      cmd_fd_map,
-        "cache-audit": cmd_cache_audit,
+        "cache-audit":     cmd_cache_audit,
+        "cache-aliasing":  cmd_cache_aliasing,
         # QGA bridge
         "qga-ping":      cmd_qga_ping,
         "qga-info":      cmd_qga_info,


### PR DESCRIPTION
## Summary

W215 FAULT/PHYS aliasing cluster persists after all six H1+H2 counters read zero across 5 dispositive KVM trials (docs/W215_DISPOSITIVE_SOAK_2026-05-16.md). The H3 audit (docs/W215_H3_CACHE_HIT_COW_2026-05-16.md) identifies H3a as the highest-confidence remaining hypothesis: a MAP_SHARED+PROT_WRITE mapping of a file-backed cache frame writes directly into the cache frame, corrupting content that subsequent MAP_PRIVATE demand-page callers copy into their private frames.

This PR adds ~200 LOC of purely additive, `cfg(feature = "firefox-test")`-gated diagnostic instrumentation to confirm or rule out H3a before implementing any fix. Per the audit's "What NOT to do" section, no fix is included — the fix (refuse or downgrade MAP_SHARED+RW on executable-bit-set files) could break Mozilla's freeze-shmem dance for non-libxul memfds if scoped incorrectly.

## Four instrumentation pieces

**1. `cache::is_phys_in_cache(phys) -> Option<(usize, u64, u64)>`** (`cache.rs`)
O(n) walk of `PAGE_CACHE`; returns `(mount_idx, inode, page_offset)` for any cached frame. Only reachable from `#[cfg(feature = "firefox-test")]` call sites. Enables PFH instrumentation to ask "is this frame in the cache under a different key than what I'm installing for?"

**2. `PFH_WRITABLE_ALIAS_CACHE` counter** (`idt.rs`)
Before every `map_page_in` in the PFH where `PAGE_WRITABLE` is set on a file-backed path (cache-hit alias arm at line 1372, readahead alias arm at line 1745, single-page alias arm at line 1967), calls `is_phys_in_cache` and increments the counter + emits a `[H3a]` serial line if the cache key differs from the installer's key. Anonymous installs (by definition not in the file cache) are excluded.

**3. `SYS_MMAP_SHARED_WRITE_FILEBACKED` counter** (`syscall/mod.rs`)
At `sys_mmap` entry, after backing resolution, when `MAP_SHARED|PROT_WRITE` is requested on a file-backed fd: increments the counter and emits a `[H3a/mmap]` serial line with mount_idx, inode, fd, and length. Per POSIX mmap(2), such mappings install a `PAGE_WRITABLE` PTE that aliases the page-cache frame directly — any store lands in the cache frame itself.

**4. `cache-aliasing` kdb op** (`kdb.rs` + `scripts/qemu-harness.py`)
New kdb subcommand that dumps both counters as structured JSON. Available as both `kdb <sid> cache-aliasing` and top-level `python3 scripts/qemu-harness.py cache-aliasing <sid>` with a structured `_verdict` field for automated soak analysis.

## Disambiguation table (from audit §188-196)

| Counter outcome | Verdict |
|---|---|
| `sys_mmap_shared_write_filebacked > 0` AND inode matches libxul | **PROCEED-TO-FIX** (H3a mmap path): refuse MAP_SHARED+PROT_WRITE on executable files |
| `pfh_writable_alias_cache > 0` AND key mismatch with installer | **PROCEED-TO-FIX** (H3a PFH path): same fix, tighten PFH alias arm |
| Both == 0 AND W215 still fires | **ABORT-AND-ESCALATE**: H3a dead; instrument H3b (kalloc-recycled-cache-frame) |
| `pfh_writable_alias_cache > 0` but key matches installer | **NULL**: installer is the legitimate cache owner; re-frame |

## Verification

- `cargo check --features firefox-test,kdb`: clean
- `cargo check --features test-mode`: clean  
- `cargo check --features firefox-test`: clean
- Boot smoke test: kernel boots, KDB initialises (`[KDB] listening on 0.0.0.0:9999` confirmed in serial log). KDB unresponsive under Firefox CPU load is a pre-existing infrastructure limitation documented in the dispositive soak report — the 30-minute KVM soak to read the counters is the next step dispatched separately.

## Next step

Run 5-trial KVM soak with `--features firefox-test,kdb`, collect `cache-aliasing` counter snapshot per trial via the harness, apply the disambiguation table.