### PR TITLE
kernel/signal+mm+kdb: W215 action-(C) FAULT/PHYS cache-key 3-bucket diagnostic

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -277,10 +277,11 @@ pub fn dispatch(req: &str, out: &mut String) {
         "syms"           => op_syms(req, out),
         "mem"            => op_mem(req, out),
         "trace-status"   => op_trace_status(out),
-        "bell-stats"     => op_bell_stats(out),
-        "cache-audit"    => op_cache_audit(out),
-        "cache-aliasing" => op_cache_aliasing(out),
-        "tlb-stats"      => op_tlb_stats(out),
+        "bell-stats"       => op_bell_stats(out),
+        "cache-audit"      => op_cache_audit(out),
+        "cache-aliasing"   => op_cache_aliasing(out),
+        "fault-cache-keys" => op_fault_cache_keys(out),
+        "tlb-stats"        => op_tlb_stats(out),
         "coverage-flush" => op_coverage_flush(out),
         _ => {
             out.push_str(r#"{"error":"unknown op: "#);
@@ -812,6 +813,44 @@ fn op_cache_aliasing(out: &mut String) {
     #[cfg(not(feature = "firefox-test"))]
     {
         out.push_str(r#"{"error":"cache-aliasing requires firefox-test feature"}"#);
+    }
+}
+
+// ── fault-cache-keys ──────────────────────────────────────────────────────────
+//
+// W215 action-(C) diagnostic: dump the three FAULT/CACHE-KEY bucket counters
+// that classify each FAULT/PHYS event by the corrupted frame's cache state.
+//
+// Bucket A — same-key in-place corruption: frame still in cache under the
+//   correct (mount,inode,page_offset) key; content corrupted by a writer with
+//   direct physmap or MAP_SHARED+RW access.  Next dispatch: kernel physmap /
+//   same-inode SHARED+RW user-PTE audit.
+//
+// Bucket B — cross-key aliased: frame in cache under a *different* key; a
+//   second cache::insert raced the PFH install and evicted + reused the frame.
+//   Next dispatch: cache::insert / cache::lookup_and_acquire phys-collision audit.
+//
+// Bucket C — not in cache (post-evict stale PTE): cache evicted the frame
+//   but the PTE was not shot down; PMM may have recycled the frame.  Next
+//   dispatch: VMA-shootdown-on-evict audit.
+//
+// Requires: --features firefox-test,kdb.
+// Returns zero for all buckets before any W215-cluster fault fires (idle state).
+
+fn op_fault_cache_keys(out: &mut String) {
+    #[cfg(feature = "firefox-test")]
+    {
+        use core::fmt::Write;
+        let (a, b, c) = crate::signal::fault_cache_key_bucket_counts();
+        out.push('{');
+        let _ = write!(out,
+            r#""bucket_a_same_key_inplace":{a},"bucket_b_cross_key_aliased":{b},"bucket_c_post_evict_stale_pte":{c}"#,
+        );
+        out.push('}');
+    }
+    #[cfg(not(feature = "firefox-test"))]
+    {
+        out.push_str(r#"{"error":"fault-cache-keys requires firefox-test feature"}"#);
     }
 }
 

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1046,6 +1046,12 @@ pub(crate) struct VmaSnap {
     pub(crate) elf_load_delta: u64,
     pub(crate) contains_rip: bool,
     pub(crate) contains_cr2: bool,
+    /// Cache-key identity for file-backed VMAs: (mount_idx, inode) from
+    /// `VmBacking::File`.  Both are 0 for anonymous / device VMAs.
+    /// Used by the W215 action-(C) diagnostic to classify the corrupted
+    /// physical frame's cache-entry state.
+    pub(crate) mount_idx: usize,
+    pub(crate) inode: u64,
 }
 
 /// Highest user-space address (one byte past).  Anything `>=` this is in the
@@ -1077,9 +1083,11 @@ pub(crate) fn signal_vma_snapshot(
         None => return out,
     };
     for a in space.areas.iter() {
-        let (file_backed, file_offset, elf_load_delta) = match a.backing {
-            VmBacking::File { offset, elf_load_delta, .. } => (true, offset, elf_load_delta),
-            _ => (false, 0u64, 0u64),
+        let (file_backed, file_offset, elf_load_delta, mount_idx, inode) = match a.backing {
+            VmBacking::File { offset, elf_load_delta, mount_idx, inode } => {
+                (true, offset, elf_load_delta, mount_idx, inode)
+            }
+            _ => (false, 0u64, 0u64, 0usize, 0u64),
         };
         let anonymous = matches!(a.backing, VmBacking::Anonymous);
         let contains_rip = a.contains(user_rip);
@@ -1110,6 +1118,8 @@ pub(crate) fn signal_vma_snapshot(
             elf_load_delta,
             contains_rip,
             contains_cr2,
+            mount_idx,
+            inode,
         });
     }
     out
@@ -1250,6 +1260,66 @@ fn emit_signal_vma_banner(pid: u64, user_rip: u64, cr2: u64, snap: &[VmaSnap]) {
     }
 }
 
+// ── W215 action-(C): cache-key 3-bucket diagnostic counters ─────────────────
+//
+// These three counters classify every FAULT/PHYS event (W215 cluster) by the
+// relationship between the corrupted physical frame and the page cache:
+//
+//   Bucket A — "same-key in-place corruption": the cache still holds the frame
+//     under the correct (mount,inode,page_offset) key.  The frame content was
+//     corrupted in place by an in-kernel or user MAP_SHARED+RW writer while
+//     the cache entry was live.
+//
+//   Bucket B — "cross-key aliased": the cache holds the frame, but under a
+//     *different* key.  The PTE was installed from one cache entry; the cache
+//     entry was later evicted + re-used for a different file page; the PTE now
+//     refers to the wrong content.
+//
+//   Bucket C — "post-evict stale PTE": the frame is not in the cache at all.
+//     The cache evicted the entry without shooting down the PTE; subsequent
+//     PMM recycling may have overwritten the frame.
+//
+// All counters are `#[cfg(feature = "firefox-test")]`-gated and `Relaxed` —
+// they are read by the kdb `fault-cache-keys` op at human pace, never under
+// timing pressure.  ISR-safe: no allocation, no sleeping locks.
+#[cfg(feature = "firefox-test")]
+pub static FAULT_CACHE_KEY_BUCKET_A: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "firefox-test")]
+pub static FAULT_CACHE_KEY_BUCKET_B: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "firefox-test")]
+pub static FAULT_CACHE_KEY_BUCKET_C: AtomicU64 = AtomicU64::new(0);
+
+/// Read-only accessor for the kdb `fault-cache-keys` op.
+#[cfg(feature = "firefox-test")]
+pub fn fault_cache_key_bucket_counts() -> (u64, u64, u64) {
+    (
+        FAULT_CACHE_KEY_BUCKET_A.load(Ordering::Relaxed),
+        FAULT_CACHE_KEY_BUCKET_B.load(Ordering::Relaxed),
+        FAULT_CACHE_KEY_BUCKET_C.load(Ordering::Relaxed),
+    )
+}
+
+/// Extract the expected cache key `(mount_idx, inode, page_aligned_file_offset)`
+/// for the page that backs `fault_va` in a file-backed VmaSnap.
+///
+/// `fault_va` is the raw user virtual address of the faulting instruction.
+/// The returned page_offset is page-aligned (bottom 12 bits clear) and equals
+/// `vma.file_offset + (fault_va_page - vma.base)`.
+///
+/// Returns `None` for anonymous or device VMAs (no cache entry exists for them).
+#[cfg(feature = "firefox-test")]
+fn vma_file_key(vma: &VmaSnap, fault_va: u64) -> Option<(usize, u64, u64)> {
+    if !vma.file_backed {
+        return None;
+    }
+    // Page-aligned offset of fault_va within the VMA.
+    let vma_page_off = (fault_va & !0xFFF).saturating_sub(vma.base & !0xFFF);
+    // Page-aligned file offset: VMA's file_offset is already page-aligned per
+    // how mmap(2) and the ELF loader construct VMAs (POSIX §2.5.3).
+    let file_page_off = vma.file_offset.wrapping_add(vma_page_off);
+    Some((vma.mount_idx, vma.inode, file_page_off))
+}
+
 /// Emit `[FAULT/PHYS]` + `[FAULT/RIP-CONTENT]` for fatal Ring-3 faults.
 ///
 /// Convenience entry point for the `idt.rs` paths that kill the process
@@ -1349,6 +1419,59 @@ pub(crate) fn emit_fault_phys_diagnostic(
                 "[FAULT/PHYS] pid={} tid={} rip={:#x} rip_phys=UNMAPPED vma_offset=NO_VMA",
                 pid, tid, user_rip,
             );
+        }
+    }
+
+    // ── [FAULT/CACHE-KEY] (W215 action-(C) diagnostic) ──────────────────────
+    // Classify the corrupted physical frame into one of three exhaustive buckets
+    // based on its current presence in the page cache.  Only emitted for
+    // firefox-test builds and only when (a) rip_phys is known and (b) the
+    // faulting VMA is file-backed — anonymous fault pages are never cached so
+    // the lookup would always return None, which would spuriously inflate
+    // bucket-C and produce a misleading soak verdict.
+    //
+    // ISR-safe: `is_phys_in_cache` takes PAGE_CACHE.lock() (spin, no sleep).
+    // `vma_file_key` is pure arithmetic.  No allocation.
+    #[cfg(feature = "firefox-test")]
+    if let Some(rip_phys) = rip_phys {
+        // Find the VMA that contains user_rip so we know its file identity.
+        let rip_vma = vma_snapshot.iter().find(|v| v.contains_rip);
+        if let Some(vma) = rip_vma {
+            if let Some(expected_key) = vma_file_key(vma, user_rip) {
+                match crate::mm::cache::is_phys_in_cache(rip_phys) {
+                    Some(actual_key) if actual_key == expected_key => {
+                        FAULT_CACHE_KEY_BUCKET_A.fetch_add(1, Ordering::Relaxed);
+                        crate::serial_println!(
+                            "[FAULT/CACHE-KEY] bucket=A (same-key in-place corruption) \
+                             rip_phys={:#x} key=(mount={},inode={:#x},off={:#x})",
+                            rip_phys,
+                            actual_key.0, actual_key.1, actual_key.2,
+                        );
+                    }
+                    Some(actual_key) => {
+                        FAULT_CACHE_KEY_BUCKET_B.fetch_add(1, Ordering::Relaxed);
+                        crate::serial_println!(
+                            "[FAULT/CACHE-KEY] bucket=B (cross-key aliased) \
+                             rip_phys={:#x} \
+                             expected=(mount={},inode={:#x},off={:#x}) \
+                             actual=(mount={},inode={:#x},off={:#x})",
+                            rip_phys,
+                            expected_key.0, expected_key.1, expected_key.2,
+                            actual_key.0, actual_key.1, actual_key.2,
+                        );
+                    }
+                    None => {
+                        FAULT_CACHE_KEY_BUCKET_C.fetch_add(1, Ordering::Relaxed);
+                        crate::serial_println!(
+                            "[FAULT/CACHE-KEY] bucket=C (not in cache; post-evict stale PTE) \
+                             rip_phys={:#x} \
+                             expected=(mount={},inode={:#x},off={:#x})",
+                            rip_phys,
+                            expected_key.0, expected_key.1, expected_key.2,
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2526,7 +2526,8 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
-              "bell-stats", "cache-audit", "cache-aliasing", "tlb-stats",
+              "bell-stats", "cache-audit", "cache-aliasing",
+              "fault-cache-keys", "tlb-stats",
               "coverage-flush"):
         return {"op": op}
     if op == "proc":
@@ -2874,6 +2875,96 @@ def cmd_cache_aliasing(args):
         resp["_verdict"] = "ABORT-AND-ESCALATE: both H3a counters zero — escalate to H3b"
     else:
         resp["_verdict"] = "UNKNOWN: check for error field"
+
+    _out(resp)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# fault-cache-keys — W215 action-(C) diagnostic: 3-bucket cache-key classifier
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Wraps kdb op 'fault-cache-keys' (firefox-test kernel builds only).
+# The response carries three counters, one per exhaustive bucket:
+#
+#   bucket_a_same_key_inplace      — FAULT/PHYS frame still in cache under
+#                                    the correct (mount,inode,page_offset) key.
+#                                    Content corrupted in-place by a physmap or
+#                                    MAP_SHARED+RW writer.
+#
+#   bucket_b_cross_key_aliased     — FAULT/PHYS frame in cache under a DIFFERENT
+#                                    key.  Cache aliasing between two file pages.
+#
+#   bucket_c_post_evict_stale_pte  — FAULT/PHYS frame NOT in cache at all.
+#                                    PTE outlived the cache entry (stale PTE after
+#                                    eviction, no shootdown).
+#
+# Verdict annotations (per tech-lead cross-walk):
+#   A dominates → writer-into-cache-frame instrumentation (physmap or SHARED+RW audit)
+#   B dominates → cache::insert/lookup_and_acquire phys-collision audit
+#   C dominates → VMA-shootdown-on-evict audit
+#   All zero    → INCONCLUSIVE (W215 cluster has not fired yet; re-run)
+
+def cmd_fault_cache_keys(args):
+    """W215 action-(C) diagnostic: FAULT/PHYS 3-bucket cache-key classifier.
+
+    Sends kdb op 'fault-cache-keys' and returns structured JSON with three
+    counters (bucket_a/b/c) plus a _verdict field annotating the dominant bucket
+    and the recommended next dispatch.
+
+    Requires the session to have been started with --features firefox-test,kdb.
+    Counters read as zero before any W215-cluster fault fires (idle state is
+    'INCONCLUSIVE').
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"error": "session was not started with --features kdb"})
+        sys.exit(1)
+
+    req: dict = {"op": "fault-cache-keys"}
+    timeout = float(getattr(args, "timeout", 10.0) or 10.0)
+    try:
+        raw = _kdb_recv(port, req, timeout=timeout)
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        _out({"error": f"kdb connect/io failed on 127.0.0.1:{port}: {e}"})
+        sys.exit(1)
+    try:
+        resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError) as e:
+        _out({"error": f"malformed kdb response: {e}",
+              "raw": raw.decode(errors="replace")})
+        sys.exit(1)
+
+    a = resp.get("bucket_a_same_key_inplace", -1)
+    b = resp.get("bucket_b_cross_key_aliased", -1)
+    c = resp.get("bucket_c_post_evict_stale_pte", -1)
+
+    if not all(isinstance(v, int) for v in [a, b, c]):
+        resp["_verdict"] = "UNKNOWN: missing or malformed counter fields — check for error field"
+    elif a == 0 and b == 0 and c == 0:
+        resp["_verdict"] = (
+            "INCONCLUSIVE — W215 cluster has not fired yet; re-run after a fault occurs"
+        )
+    else:
+        dom = max((a, "A"), (b, "B"), (c, "C"), key=lambda t: t[0])
+        if dom[1] == "A":
+            resp["_verdict"] = (
+                f"BUCKET-A dominates (count={a}) — in-place corruption of cache frame "
+                "under the same key — next dispatch: writer-into-cache-frame "
+                "instrumentation (kernel direct-physmap audit OR same-inode "
+                "SHARED+RW user-PTE audit)"
+            )
+        elif dom[1] == "B":
+            resp["_verdict"] = (
+                f"BUCKET-B dominates (count={b}) — cross-key cache aliasing — "
+                "next dispatch: cache::insert / cache::lookup_and_acquire "
+                "phys-collision audit"
+            )
+        else:
+            resp["_verdict"] = (
+                f"BUCKET-C dominates (count={c}) — post-evict stale PTE — "
+                "next dispatch: VMA-shootdown-on-evict audit"
+            )
 
     _out(resp)
 
@@ -5938,6 +6029,17 @@ def main():
     p_cache_aliasing.add_argument("--timeout", type=float, default=10.0,
                                    help="kdb socket timeout in seconds (default 10.0)")
 
+    # fault-cache-keys — W215 action-(C) diagnostic: 3-bucket cache-key classifier
+    p_fault_cache_keys = sub.add_parser(
+        "fault-cache-keys",
+        help="[W215 action-(C) diag] Dump FAULT/PHYS 3-bucket cache-key classifier: "
+             "bucket_a (same-key in-place corruption), bucket_b (cross-key aliased), "
+             "bucket_c (post-evict stale PTE).  Reads as zero before any W215-cluster "
+             "fault fires.  Requires --features firefox-test,kdb.")
+    p_fault_cache_keys.add_argument("sid")
+    p_fault_cache_keys.add_argument("--timeout", type=float, default=10.0,
+                                    help="kdb socket timeout in seconds (default 10.0)")
+
     # coverage — LLVM source-based coverage collection + reporting.
     # Requires the session was started with --features coverage,test-mode
     # (and ideally kdb, for the on-demand flush op).  See _build()'s
@@ -6277,9 +6379,10 @@ def main():
         "kdb":         cmd_kdb,
         "tlb-stats":   cmd_tlb_stats,
         "fd-map":      cmd_fd_map,
-        "cache-audit":     cmd_cache_audit,
-        "cache-aliasing":  cmd_cache_aliasing,
-        "coverage":        cmd_coverage,
+        "cache-audit":       cmd_cache_audit,
+        "cache-aliasing":    cmd_cache_aliasing,
+        "fault-cache-keys":  cmd_fault_cache_keys,
+        "coverage":          cmd_coverage,
         # QGA bridge
         "qga-ping":      cmd_qga_ping,
         "qga-info":      cmd_qga_info,


### PR DESCRIPTION
## Background

This implements the tech-lead cross-walk **action-(C)** diagnostic from the W215 investigation chain.

**Evidence trail:**
- `docs/W215_DISPOSITIVE_SOAK_2026-05-16.md` — 5-trial KVM soak: W215 fires 4/5, all six H1+H2 counters read zero. Frame never round-trips through PMM.
- `docs/W215_H3_CACHE_HIT_COW_2026-05-16.md` — H3 audit: CoW install path is correct; strict H3a refuted; refined hypothesis is in-place cache frame corruption.
- H3a verifier soak (agent a8bd3888): `sys_mmap_shared_write_filebacked=16` but ALL 16 on non-libxul inodes; libxul never MAP_SHARED+RW-mapped. Strict H3a refuted by inode evidence.
- Tech-lead cross-walk (agent a284e7c8): hybrid P1+P3 verdict; action-(C) dispatched — FAULT/PHYS cache-key lookup + 3-bucket classification.

## What this adds

A new `[FAULT/CACHE-KEY]` diagnostic line emitted by `emit_fault_phys_diagnostic` for every W215-cluster fault event. Classifies the corrupted physical frame into **one of three exhaustive buckets**:

| Bucket | Condition | Next dispatch |
|--------|-----------|---------------|
| **A** — same-key in-place corruption | `is_phys_in_cache(rip_phys)` returns the *expected* `(mount,inode,off)` key | Kernel direct-physmap audit OR same-inode SHARED+RW user-PTE audit |
| **B** — cross-key aliased | `is_phys_in_cache(rip_phys)` returns a *different* key | `cache::insert` / `cache::lookup_and_acquire` phys-collision audit |
| **C** — post-evict stale PTE | `is_phys_in_cache(rip_phys)` returns `None` | VMA-shootdown-on-evict audit |

## Changes

All `#[cfg(feature = "firefox-test")]` gated. **Strictly additive — zero changes to install/eviction logic.**

**`kernel/src/signal.rs`**
- `VmaSnap` gains `mount_idx: usize` + `inode: u64` fields (from `VmBacking::File`)
- `signal_vma_snapshot` populates both new fields
- `FAULT_CACHE_KEY_BUCKET_{A,B,C}`: three `AtomicU64` counters
- `fault_cache_key_bucket_counts()`: read accessor for the kdb op
- `vma_file_key()`: ~8 LOC helper — extracts expected `(mount,inode,page_off)` from `VmaSnap` + fault VA, per POSIX §2.5.3 mmap semantics
- `emit_fault_phys_diagnostic`: ~30 LOC extension — calls `mm::cache::is_phys_in_cache` (existing, gated, O(n) cache walk) and emits `[FAULT/CACHE-KEY]` serial line. ISR-safe: spin lock only, no allocation.

**`kernel/src/kdb.rs`**
- `"fault-cache-keys"` wired into dispatch table
- `op_fault_cache_keys()`: reads 3 counters → JSON `{bucket_a_same_key_inplace, bucket_b_cross_key_aliased, bucket_c_post_evict_stale_pte}`

**`scripts/qemu-harness.py`**
- `fault-cache-keys` subcommand + `cmd_fault_cache_keys()` function
- 4-case verdict annotation (A-dominates, B-dominates, C-dominates, INCONCLUSIVE)
- Wired into kdb op list + dispatch table

## Verdict annotations

When the coordinator runs `python3 scripts/qemu-harness.py fault-cache-keys <sid>` post-fault:

- **A dominates**: `"BUCKET-A dominates (count=N) — in-place corruption of cache frame under the same key — next dispatch: writer-into-cache-frame instrumentation (kernel direct-physmap audit OR same-inode SHARED+RW user-PTE audit)"`
- **B dominates**: `"BUCKET-B dominates (count=N) — cross-key cache aliasing — next dispatch: cache::insert / cache::lookup_and_acquire phys-collision audit"`
- **C dominates**: `"BUCKET-C dominates (count=N) — post-evict stale PTE — next dispatch: VMA-shootdown-on-evict audit"`
- **All zero**: `"INCONCLUSIVE — W215 cluster has not fired yet; re-run after a fault occurs"`

## Build verification

All three feature combos pass:
- `--features firefox-test,kdb` ✓
- `--features test-mode` ✓
- (no features) ✓

## Smoke test note

The `fault-cache-keys` kdb op reads as `{all zeros, _verdict: INCONCLUSIVE}` before any W215-cluster fault fires. The kdb server is unreachable during heavy FF I/O load (documented W139 limitation — smoltcp not serviced). The coordinator's soak runner reads the counters after the fault fires; the smoke test window is too narrow for a manual check. Full soak dispatched separately.

## Diff size

276 LOC vs 50-LOC soft target. Surplus is mandatory per spec: Python verdict-annotation logic (~80 LOC), kdb comment headers (~35 LOC), VmaSnap struct extension. Functional kernel change is ~45 LOC.