### PR TITLE
kernel/mm+kdb: W215 axis-B per-writer cache-residency probe (diagnostic)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -281,6 +281,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "cache-audit"      => op_cache_audit(out),
         "cache-aliasing"   => op_cache_aliasing(out),
         "fault-cache-keys" => op_fault_cache_keys(out),
+        "w215-cache-residency" => op_w215_cache_residency(out),
         "tlb-stats"        => op_tlb_stats(out),
         "w215-diag"        => op_w215_diag(out),
         "coverage-flush" => op_coverage_flush(out),
@@ -852,6 +853,42 @@ fn op_fault_cache_keys(out: &mut String) {
     #[cfg(not(feature = "firefox-test"))]
     {
         out.push_str(r#"{"error":"fault-cache-keys requires firefox-test feature"}"#);
+    }
+}
+
+// ── w215-cache-residency ────────────────────────────────────────────────────
+//
+// W215 axis-B per-writer cache-residency probe readout.  Each counter
+// represents one instrumented kernel writer; the value is the number of
+// times that writer attempted to write into a user buffer whose backing
+// physical frame was at that moment resident in the page cache (i.e. a
+// W215 bucket-A in-place corruption opportunity, per Intel SDM Vol. 3A
+// §4.10.5 page-content coherence semantics).
+//
+// Decision matrix:
+//   - exactly one counter > 0  → that writer is the W215 trigger
+//   - multiple counters > 0    → multi-writer class; need copy_to_user
+//   - all counters = 0         → axis B is wrong; pivot to PHYS_OFF
+//                                kernel-internal writers
+//
+// The first hit per writer also emits a `[H_W/<name>]` serial line with
+// pid/vaddr/phys/key for provenance.  Requires --features firefox-test.
+
+fn op_w215_cache_residency(out: &mut String) {
+    #[cfg(feature = "firefox-test")]
+    {
+        use core::fmt::Write;
+        out.push('{');
+        let counts = crate::mm::w215_diag::counts();
+        for (i, (name, val)) in counts.iter().enumerate() {
+            if i > 0 { out.push(','); }
+            let _ = write!(out, r#""{name}":{val}"#);
+        }
+        out.push('}');
+    }
+    #[cfg(not(feature = "firefox-test"))]
+    {
+        out.push_str(r#"{"error":"w215-cache-residency requires firefox-test feature"}"#);
     }
 }
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -11,7 +11,6 @@ pub mod refcount;
 pub mod tlb;
 pub mod vma;
 pub mod vmm;
-
 #[cfg(feature = "firefox-test")]
 pub mod w215_diag;
 

--- a/kernel/src/mm/w215_diag.rs
+++ b/kernel/src/mm/w215_diag.rs
@@ -1,6 +1,8 @@
-//! W215 two-arm diagnostic instrumentation (firefox-test gated).
+//! W215 combined diagnostic instrumentation (firefox-test gated).
 //!
-//! ## Goal
+//! ## Arms
+//!
+//! ### Arm 1 + 2 (PROV + PREINS — from W215 H2 diagnostic, PR #255)
 //!
 //! Two structurally-isolated diagnostics that disambiguate the remaining
 //! candidate W215 corruption mechanisms after the dispositive soak
@@ -23,6 +25,23 @@
 //!   present in the map emits `[PREINS/INSTALL_RACE]` and increments
 //!   `INSTALL_RACE`.
 //!
+//! ### Axis B — per-writer cache-residency probes (PR #256)
+//!
+//! Diagnostic-only instrumentation: identifies which kernel writer is the
+//! W215 trigger by checking, before each candidate write, whether the
+//! destination user buffer's physical page is currently resident in the
+//! page cache.  A cache-resident frame being written through any path
+//! other than the cache's own write-back machinery is the W215 bucket-A
+//! corruption fingerprint (FAULT/PHYS classifier from PR #252).
+//!
+//! Decision matrix (see dispatch brief):
+//!   - exactly one counter ticks  → that writer is the W215 trigger
+//!   - multiple counters tick     → multi-writer class; need copy_to_user
+//!                                  helper migration
+//!   - none tick & W215 fires     → axis B is wrong; pivot to PHYS_OFF
+//!                                  kernel-internal writers (cache.rs,
+//!                                  elf.rs, vmm.rs zero-fill paths).
+//!
 //! ## Public spec citations
 //!
 //! - Intel SDM Vol. 3A §4.10.5 (paging-structure cache coherence) — the
@@ -39,7 +58,7 @@
 
 #![cfg(feature = "firefox-test")]
 
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 // ── Event kinds for Arm-1 provenance ring ───────────────────────────────────
 
@@ -418,7 +437,7 @@ fn op_str(o: u8) -> &'static str {
     }
 }
 
-// ── Counters readable via kdb ───────────────────────────────────────────────
+// ── Counters readable via kdb (Arm-1/2) ────────────────────────────────────
 
 static WINDOW_RACE: AtomicU64 = AtomicU64::new(0);
 static INSTALL_RACE: AtomicU64 = AtomicU64::new(0);
@@ -475,4 +494,178 @@ pub fn top_traced_physes(out: &mut [(u64, u32)]) -> usize {
         out[j] = cur;
     }
     filled
+}
+
+// ── Axis B: per-writer cache-residency counters ─────────────────────────────
+
+/// Counters — one per instrumented writer.  All `Relaxed`: read by kdb at
+/// human pace, no ordering requirement against the corruption itself.
+pub static DEVZERO_OVER_CACHE:    AtomicU64 = AtomicU64::new(0);
+pub static STATX_OVER_CACHE:      AtomicU64 = AtomicU64::new(0);
+pub static GETRANDOM_OVER_CACHE:  AtomicU64 = AtomicU64::new(0);
+pub static GETRUSAGE_OVER_CACHE:  AtomicU64 = AtomicU64::new(0);
+pub static SYSINFO_OVER_CACHE:    AtomicU64 = AtomicU64::new(0);
+pub static TIMES_OVER_CACHE:      AtomicU64 = AtomicU64::new(0);
+pub static MEMSET_OVER_CACHE:     AtomicU64 = AtomicU64::new(0);
+pub static PREADV120_OVER_CACHE:  AtomicU64 = AtomicU64::new(0);
+pub static CLEARTID_OVER_CACHE:   AtomicU64 = AtomicU64::new(0);
+pub static SIGFRAME_OVER_CACHE:   AtomicU64 = AtomicU64::new(0);
+
+/// One "first-hit serial line emitted" flag per writer, to avoid drowning
+/// the serial log when a single corrupting path fires thousands of times.
+/// The counters still tick on every hit; only the structured serial line is
+/// rate-limited to one per writer per boot.
+static FIRST_LINE_DEVZERO:   AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_STATX:     AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_GETRANDOM: AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_GETRUSAGE: AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_SYSINFO:   AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_TIMES:     AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_MEMSET:    AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_PREADV120: AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_CLEARTID:  AtomicBool = AtomicBool::new(false);
+static FIRST_LINE_SIGFRAME:  AtomicBool = AtomicBool::new(false);
+
+/// Identifies one of the ten instrumented writers.  The name is embedded
+/// in the structured serial line so a downstream parser can attribute each
+/// `[H_W/<name>]` event back to its source-of-truth callsite.
+#[derive(Copy, Clone)]
+pub enum Writer {
+    DevZero,
+    Statx,
+    Getrandom,
+    Getrusage,
+    Sysinfo,
+    Times,
+    Memset,
+    Preadv120,
+    ClearTid,
+    Sigframe,
+}
+
+impl Writer {
+    fn name(self) -> &'static str {
+        match self {
+            Writer::DevZero   => "dev-zero",
+            Writer::Statx     => "statx",
+            Writer::Getrandom => "getrandom",
+            Writer::Getrusage => "getrusage",
+            Writer::Sysinfo   => "sysinfo",
+            Writer::Times     => "times",
+            Writer::Memset    => "memset",
+            Writer::Preadv120 => "preadv120",
+            Writer::ClearTid  => "clear-tid",
+            Writer::Sigframe  => "sigframe",
+        }
+    }
+
+    fn counter(self) -> &'static AtomicU64 {
+        match self {
+            Writer::DevZero   => &DEVZERO_OVER_CACHE,
+            Writer::Statx     => &STATX_OVER_CACHE,
+            Writer::Getrandom => &GETRANDOM_OVER_CACHE,
+            Writer::Getrusage => &GETRUSAGE_OVER_CACHE,
+            Writer::Sysinfo   => &SYSINFO_OVER_CACHE,
+            Writer::Times     => &TIMES_OVER_CACHE,
+            Writer::Memset    => &MEMSET_OVER_CACHE,
+            Writer::Preadv120 => &PREADV120_OVER_CACHE,
+            Writer::ClearTid  => &CLEARTID_OVER_CACHE,
+            Writer::Sigframe  => &SIGFRAME_OVER_CACHE,
+        }
+    }
+
+    fn first_line(self) -> &'static AtomicBool {
+        match self {
+            Writer::DevZero   => &FIRST_LINE_DEVZERO,
+            Writer::Statx     => &FIRST_LINE_STATX,
+            Writer::Getrandom => &FIRST_LINE_GETRANDOM,
+            Writer::Getrusage => &FIRST_LINE_GETRUSAGE,
+            Writer::Sysinfo   => &FIRST_LINE_SYSINFO,
+            Writer::Times     => &FIRST_LINE_TIMES,
+            Writer::Memset    => &FIRST_LINE_MEMSET,
+            Writer::Preadv120 => &FIRST_LINE_PREADV120,
+            Writer::ClearTid  => &FIRST_LINE_CLEARTID,
+            Writer::Sigframe  => &FIRST_LINE_SIGFRAME,
+        }
+    }
+}
+
+/// Resolve `buf` through the current CR3 to a physical page and ask the
+/// cache whether that frame is currently resident.  Returns the first
+/// (vaddr, phys, cache_key) tuple where the cache says "yes".
+///
+/// `len == 0` is treated as `len == 1` so a zero-length buffer is still
+/// page-checked at `buf`.
+///
+/// Walks 4 KiB pages over `[buf, buf+len)` using the current process's
+/// CR3.  Caller is responsible for the buffer being in user space; this
+/// function only translates and looks up, it does not deref the buffer.
+fn check_user_buf_over_cache(
+    buf: *const u8,
+    len: usize,
+) -> Option<(u64, u64, (usize, u64, u64))> {
+    if buf.is_null() { return None; }
+    let len = if len == 0 { 1 } else { len };
+    let start = buf as u64;
+    let end   = start.checked_add(len as u64)?;
+    let first_page = start & !0xFFFu64;
+    let last_page  = (end - 1) & !0xFFFu64;
+
+    // Use the current CR3 — the writer is in syscall context, so the
+    // active CR3 is the calling process's PML4.
+    let cr3 = crate::mm::vmm::get_cr3();
+
+    let mut va = first_page;
+    loop {
+        if let Some(phys_with_offset) = crate::mm::vmm::virt_to_phys_in(cr3, va) {
+            let phys = phys_with_offset & !0xFFFu64;
+            if let Some(key) = crate::mm::cache::is_phys_in_cache(phys) {
+                return Some((va, phys, key));
+            }
+        }
+        if va == last_page { break; }
+        va += 0x1000;
+    }
+    None
+}
+
+/// Probe `[buf, buf+len)`; if any page maps to a cache-resident phys
+/// frame, bump the per-writer counter and (on the first hit per writer)
+/// emit a structured `[H_W/<name>]` serial line.
+///
+/// Observation-only: returns no value, does not alter the write.
+///
+/// ISR-safe: uses the PAGE_CACHE Mutex (spin, no sleep) and a CR3 read
+/// (asm).  Safe to call from syscall, exit-thread, and signal-delivery
+/// contexts.
+#[inline]
+pub fn probe(writer: Writer, buf: *const u8, len: usize) {
+    if let Some((vaddr, phys, (mount, inode, offset))) =
+        check_user_buf_over_cache(buf, len)
+    {
+        writer.counter().fetch_add(1, Ordering::Relaxed);
+        if !writer.first_line().swap(true, Ordering::Relaxed) {
+            let pid = crate::proc::current_pid_lockless();
+            crate::serial_println!(
+                "[H_W/{}] pid={} vaddr={:#x} phys={:#x} key=({},{:#x},{:#x})",
+                writer.name(), pid, vaddr, phys, mount, inode, offset,
+            );
+        }
+    }
+}
+
+/// Read all ten counters; used by the `kdb w215-cache-residency` op.
+pub fn counts() -> [(&'static str, u64); 10] {
+    [
+        ("dev-zero",  DEVZERO_OVER_CACHE.load(Ordering::Relaxed)),
+        ("statx",     STATX_OVER_CACHE.load(Ordering::Relaxed)),
+        ("getrandom", GETRANDOM_OVER_CACHE.load(Ordering::Relaxed)),
+        ("getrusage", GETRUSAGE_OVER_CACHE.load(Ordering::Relaxed)),
+        ("sysinfo",   SYSINFO_OVER_CACHE.load(Ordering::Relaxed)),
+        ("times",     TIMES_OVER_CACHE.load(Ordering::Relaxed)),
+        ("memset",    MEMSET_OVER_CACHE.load(Ordering::Relaxed)),
+        ("preadv120", PREADV120_OVER_CACHE.load(Ordering::Relaxed)),
+        ("clear-tid", CLEARTID_OVER_CACHE.load(Ordering::Relaxed)),
+        ("sigframe",  SIGFRAME_OVER_CACHE.load(Ordering::Relaxed)),
+    ]
 }

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -651,6 +651,16 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
             let ucontext_ptr   = (new_rsp + sigframe_size) as *mut UContext;
             let siginfo_ptr    = (new_rsp + sigframe_size + UCONTEXT_SIZE) as *mut u8;
 
+            // W215 axis-B probe: signal-frame delivery into a user stack
+            // that happens to back onto a cache-resident frame (e.g. a
+            // libxul mmap aliasing the worker thread's signal stack).
+            #[cfg(feature = "firefox-test")]
+            crate::mm::w215_diag::probe(
+                crate::mm::w215_diag::Writer::Sigframe,
+                new_rsp as *const u8,
+                total as usize,
+            );
+
             // Write the signal frame to user memory.
             unsafe {
                 (*sig_frame_ptr).restorer   = restorer_addr;
@@ -903,6 +913,16 @@ pub unsafe fn deliver_sigsegv_from_isr(
     let isr_r13 = *((frame_u64 - 112) as *const u64);
     let isr_r14 = *((frame_u64 - 120) as *const u64);
     let isr_r15 = *((frame_u64 - 128) as *const u64);
+
+    // W215 axis-B probe: SIGSEGV synth-frame delivery into a user stack
+    // backed by a cache-resident frame.  Same Writer::Sigframe counter as
+    // the regular delivery path; the per-writer first-line gate de-dupes.
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::probe(
+        crate::mm::w215_diag::Writer::Sigframe,
+        new_rsp as *const u8,
+        total as usize,
+    );
 
     // ── Write SignalFrame ─────────────────────────────────────────────────────
     (*sig_frame_ptr).restorer    = restorer_addr;

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2400,6 +2400,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 98: getrusage(who, usage) — resource usage; return zeroed struct
         98 => {
             if arg2 != 0 {
+                #[cfg(feature = "firefox-test")]
+                crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Getrusage, arg2 as *const u8, 144);
                 unsafe { core::ptr::write_bytes(arg2 as *mut u8, 0, 144); }
             }
             0
@@ -2408,6 +2410,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         99 => {
             if arg1 != 0 {
                 // struct sysinfo: 11 fields, 64 bytes total
+                #[cfg(feature = "firefox-test")]
+                crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Sysinfo, arg1 as *const u8, 64);
                 unsafe { core::ptr::write_bytes(arg1 as *mut u8, 0, 64); }
                 // uptime (seconds) at offset 0
                 let ticks = crate::arch::x86_64::irq::get_ticks();
@@ -2693,6 +2697,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 Ok(st) => {
                     // struct statx is 256 bytes; zero the whole thing first
                     let base = arg5 as *mut u8;
+                    #[cfg(feature = "firefox-test")]
+                    crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Statx, base, 256);
                     unsafe { core::ptr::write_bytes(base, 0, 256); }
                     unsafe {
                         // stx_mask (offset 0): populate BASIC_STATS fields
@@ -2752,6 +2758,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 100: times(buf) — CPU usage times; return zero struct
         100 => {
             if arg1 != 0 && crate::syscall::validate_user_ptr(arg1, 32) {
+                #[cfg(feature = "firefox-test")]
+                crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Times, arg1 as *const u8, 32);
                 unsafe { core::ptr::write_bytes(arg1 as *mut u8, 0, 32); }
             }
             0
@@ -2791,6 +2799,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 127: rt_sigpending(set, sigsetsize) — stub: no pending signals
         127 => {
             if arg1 != 0 && crate::syscall::validate_user_ptr(arg1, arg2 as usize) {
+                #[cfg(feature = "firefox-test")]
+                crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Memset, arg1 as *const u8, arg2 as usize);
                 unsafe { core::ptr::write_bytes(arg1 as *mut u8, 0, arg2 as usize); }
             }
             0
@@ -6067,6 +6077,8 @@ fn sys_fstatfs_linux(_fd: usize, buf: *mut u8) -> i64 {
 /// Write a plausible statfs structure into `buf` (120 bytes).
 fn fill_statfs_buf(buf: *mut u8) {
     // Wipe first.
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Preadv120, buf, 120);
     unsafe { core::ptr::write_bytes(buf, 0, 120); }
     // Use EXT2_SUPER_MAGIC (0xEF53) as f_type — widely recognised.
     let p = buf as *mut u64;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1441,6 +1441,29 @@ pub(crate) fn write_u32_to_user(cr3: u64, vaddr: u64, val: u32) {
     let pte = read_pte(cr3, vaddr);
     if pte & PAGE_PRESENT == 0 { return; }
     let phys = (pte & ADDR_MASK) + (vaddr & 0xFFF);
+    // W215 axis-B probe: check if the resolved phys page is cache-resident.
+    // This writer hits via PHYS_OFF direct map, bypassing user-PTE permission
+    // bits — a candidate W215 corruption path.
+    #[cfg(feature = "firefox-test")]
+    {
+        let phys_page = phys & !0xFFFu64;
+        if let Some(key) = crate::mm::cache::is_phys_in_cache(phys_page) {
+            use core::sync::atomic::Ordering;
+            crate::mm::w215_diag::CLEARTID_OVER_CACHE.fetch_add(1, Ordering::Relaxed);
+            // Per-writer first-line gate handled internally by the
+            // `probe` helper; we replicate that here because we already
+            // have the phys/key in hand and don't want to re-walk.
+            static FIRST: core::sync::atomic::AtomicBool =
+                core::sync::atomic::AtomicBool::new(false);
+            if !FIRST.swap(true, Ordering::Relaxed) {
+                let pid = crate::proc::current_pid_lockless();
+                crate::serial_println!(
+                    "[H_W/clear-tid] pid={} vaddr={:#x} phys={:#x} key=({},{:#x},{:#x})",
+                    pid, vaddr, phys_page, key.0, key.1, key.2,
+                );
+            }
+        }
+    }
     unsafe {
         core::ptr::write_volatile((PHYS_OFF + phys) as *mut u32, val);
     }
@@ -3318,6 +3341,9 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize, _flags: u32) -> i64 {
     if !validate_user_ptr(buf as u64, count) {
         return -14; // EFAULT
     }
+
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Getrandom, buf, count);
 
     let out = unsafe { core::slice::from_raw_parts_mut(buf, count) };
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1717,6 +1717,8 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
             if flags & 0x0400_0000 != 0 { return Ok(0); }
             // bit 25 = /dev/zero  → fill buffer with zeros
             if flags & 0x0200_0000 != 0 {
+                #[cfg(feature = "firefox-test")]
+                crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::DevZero, buf, count);
                 unsafe { core::ptr::write_bytes(buf, 0, count); }
                 return Ok(count);
             }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2527,7 +2527,8 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
               "bell-stats", "cache-audit", "cache-aliasing",
-              "fault-cache-keys", "tlb-stats", "w215-diag",
+              "fault-cache-keys", "w215-cache-residency",
+              "tlb-stats", "w215-diag",
               "coverage-flush"):
         return {"op": op}
     if op == "proc":
@@ -5967,7 +5968,7 @@ def main():
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "tframe", "user-mem", "trace-status",
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
-        "tlb-stats", "w215-diag",
+        "w215-cache-residency", "tlb-stats", "w215-diag",
         "coverage-flush",
     ])
     p_kdb.add_argument("args", nargs="*",


### PR DESCRIPTION
## Summary

W215 saga iteration 6 — **diagnostic only, no fix**.  Per-writer cache-residency probe to pinpoint which kernel writer corrupts a cache-resident frame and produces the FAULT/PHYS bucket-A fingerprint introduced by PR #252.

The probe wraps 10 candidate user-VA writers across the syscall and signal-delivery paths.  Each call walks the destination buffer's 4 KiB pages through the active CR3, queries `cache::is_phys_in_cache` (from PR #252), and on a hit bumps a per-writer atomic counter plus a one-shot `[H_W/<writer>] pid=... vaddr=... phys=... key=...` serial line.

Instrumented writers: `/dev/zero` zero-fill, `statx`, `getrandom`, `getrusage`, `sysinfo`, `times`, `rt_sigpending` memset, `statfs` 120-byte fill, CLEAR_TID PHYS_OFF write, and signal-frame delivery (regular + SIGSEGV-synth paths).

Per Intel SDM Vol. 3A §4.10.5 (page-content coherence), a cache citizen mutated outside the cache's coherence protocol is the W215 corruption pattern.

## Counters exposed via kdb

```
kdb w215-cache-residency
→ {\"dev-zero\":N, \"statx\":N, \"getrandom\":N, \"getrusage\":N,
   \"sysinfo\":N, \"times\":N, \"memset\":N, \"preadv120\":N,
   \"clear-tid\":N, \"sigframe\":N}
```

## Trial results (2 × 30-min KVM)

| Trial | rip_phys | vma_offset | key                       | H_W lines |
|---|---|---|---|---|
| 1 | 0x32f08000 | 0x4b30000 | (4, 0x9b, 0x5125000) | **0** |
| 2 | 0x32f10000 | 0x4b31ec0 | (4, 0x9b, 0x5126000) | **0** |

Both trials: identical bucket-A fingerprint (libxul mount=4, inode=0x9b, phys cluster 0x32f08-0x32f10, offset cluster 0x4b30-0x4b31).  **Zero H_W lines across either trial.**

## Decision matrix

Decision-matrix row 3 fires: **all counters = 0 AND W215 fires anyway** → the corrupting writer is OUTSIDE the user-VA-write class entirely.

The next dispatch should pivot from user-VA writers to PHYS_OFF / kernel-internal writers — specifically the cache-prepopulate pre-insert window (`cache::prepopulate_file` chunk_buf copy into a frame BEFORE `cache::insert` lands), the elf.rs `phys_to_virt(phys)` writes during program-header loading, and the vmm.rs zero-fill paths that hit `write_bytes(phys_to_virt(phys), 0, PAGE_SIZE)` without consulting the cache.

## Diagnostic discipline

Per the W215 saga anti-pattern (iteration 6 of \"right theory, wrong write site\"), this PR lands the probe ONLY.  No fix is dispatched until provenance-level evidence (a non-zero H_W counter with a matching cache key, or a cache-prepopulate write-window race trace) attributes the corruption to a specific writer.

## References

- Intel SDM Vol. 3A §4.10.5 — Propagation of Page Table and Page Directory Entry Changes to Multiple Processors
- PR #252 — FAULT/PHYS bucket-A classifier (`signal::FAULT_CACHE_KEY_BUCKET_A`, `cache::is_phys_in_cache`)
- POSIX.1-2017 (no direct citation; observation-only instrumentation)

## Test plan

- [x] Builds with `firefox-test,kdb`
- [x] Trial 1 (30-min KVM): W215 fired, 0 H_W lines
- [x] Trial 2 (30-min KVM): W215 fired, 0 H_W lines
- [ ] Reviewer to confirm decision-matrix row 3 verdict
- [ ] Next dispatch: PHYS_OFF kernel-internal writer audit (cache prepopulate, elf.rs phys writes, vmm.rs zero-fill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)