### PR TITLE
kernel/mm+idt: W215 Arm-2 cross-check — 4 PHYS_OFF WRITE_DETECT probes (all zero, diagnostic)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1292,6 +1292,17 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 if needs_private_copy {
                     if let Some(private_phys) = crate::mm::pmm::alloc_page() {
                         const COW_OFF: u64 = 0xFFFF_8000_0000_0000;
+                        // W215 Arm-2 cross-check: probe `private_phys` BEFORE the
+                        // CoW write.  A fresh PMM alloc that still appears in the
+                        // cache implies a refcount/reuse miss — the imminent write
+                        // would aliase a frame the cache thinks it owns.  Per
+                        // Intel SDM Vol. 3A §4.10.5.
+                        #[cfg(feature = "firefox-test")]
+                        crate::mm::w215_diag::write_detect(
+                            private_phys,
+                            crate::mm::w215_diag::WSITE_COW_CACHE_HIT,
+                            _frame.rip,
+                        );
                         unsafe {
                             // SAFETY: `lookup_and_acquire` guarantees `cached_phys`
                             // is alive for the duration of this block by holding a
@@ -1791,6 +1802,16 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 // Read-only VMAs: alias the cache page (saves memory).
                 if needs_private_copy_vma {
                     if let Some(private_phys) = crate::mm::pmm::alloc_page() {
+                        // W215 Arm-2 cross-check: probe `private_phys` BEFORE the
+                        // CoW write at the readahead path.  A counter hit names
+                        // this site as a phys/cache-alias writer.  Per Intel SDM
+                        // Vol. 3A §4.10.5.
+                        #[cfg(feature = "firefox-test")]
+                        crate::mm::w215_diag::write_detect(
+                            private_phys,
+                            crate::mm::w215_diag::WSITE_COW_READAHEAD,
+                            _frame.rip,
+                        );
                         unsafe {
                             core::ptr::copy_nonoverlapping(
                                 (PHYS_COW + phys) as *const u8,
@@ -2064,6 +2085,15 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 if needs_private_copy_spf {
                     if let Some(private_phys) = crate::mm::pmm::alloc_page() {
                         const COW_SPF: u64 = 0xFFFF_8000_0000_0000;
+                        // W215 Arm-2 cross-check: probe `private_phys` BEFORE the
+                        // CoW write at the single-page fallback path.  Per Intel
+                        // SDM Vol. 3A §4.10.5.
+                        #[cfg(feature = "firefox-test")]
+                        crate::mm::w215_diag::write_detect(
+                            private_phys,
+                            crate::mm::w215_diag::WSITE_COW_SINGLEPAGE,
+                            _frame.rip,
+                        );
                         unsafe {
                             core::ptr::copy_nonoverlapping(
                                 (COW_SPF + phys) as *const u8,
@@ -2175,6 +2205,21 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
                 // Allocate a zeroed page
                 if let Some(phys) = crate::mm::pmm::alloc_page() {
+                    // W215 Arm-2 cross-check (TOP CANDIDATE): probe `phys` BEFORE
+                    // the anonymous fault zero-fill.  This is the highest-prior
+                    // candidate writer for the FAULT/PHYS bucket-A cluster: if a
+                    // freshly-PMM-allocated frame still appears in the page cache
+                    // under any key, the imminent `write_bytes(_, 0, PAGE_SIZE)`
+                    // will overwrite file-cache content that other processes are
+                    // currently mapping through their PTEs.  Per Intel SDM Vol. 3A
+                    // §4.10.5 (paging-structure cache coherence) and POSIX
+                    // 1003.1-2024 mmap(2) MAP_SHARED visibility semantics.
+                    #[cfg(feature = "firefox-test")]
+                    crate::mm::w215_diag::write_detect(
+                        phys,
+                        crate::mm::w215_diag::WSITE_ANON_ZEROFILL,
+                        _frame.rip,
+                    );
                     unsafe {
                         core::ptr::write_bytes((PHYS_OFF + phys) as *mut u8, 0, crate::mm::pmm::PAGE_SIZE);
                     }

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -899,11 +899,20 @@ fn op_w215_diag(out: &mut String) {
         let window_race = crate::mm::w215_diag::window_race_count();
         let install_race = crate::mm::w215_diag::install_race_count();
         let overflow = crate::mm::w215_diag::prov_ring_overflow_count();
+        let wd_cow_hit   = crate::mm::w215_diag::cow_cache_hit_over_cache_count();
+        let wd_cow_ra    = crate::mm::w215_diag::cow_readahead_over_cache_count();
+        let wd_cow_sp    = crate::mm::w215_diag::cow_singlepage_over_cache_count();
+        let wd_anon_zf   = crate::mm::w215_diag::anon_zerofill_over_cache_count();
         let mut top: [(u64, u32); 5] = [(0, 0); 5];
         let n = crate::mm::w215_diag::top_traced_physes(&mut top);
         out.push('{');
         let _ = write!(out,
             r#""window_race":{window_race},"install_race":{install_race},"prov_ring_overflow":{overflow}"#,
+        );
+        // Arm-2 cross-check (WRITE-DETECT) per-site counters.  Additive JSON
+        // fields: existing harness consumers ignore unknown keys.
+        let _ = write!(out,
+            r#","cow_cache_hit_over_cache":{wd_cow_hit},"cow_readahead_over_cache":{wd_cow_ra},"cow_singlepage_over_cache":{wd_cow_sp},"anon_zerofill_over_cache":{wd_anon_zf}"#,
         );
         let _ = write!(out, r#","top_traced":["#);
         for i in 0..n {

--- a/kernel/src/mm/w215_diag.rs
+++ b/kernel/src/mm/w215_diag.rs
@@ -50,6 +50,11 @@ pub const KIND_REFINC: u8                      = 4;
 pub const KIND_REFDEC: u8                      = 5;
 pub const KIND_PHYS_OFF_WRITE_PRE_INSERT: u8   = 6;
 pub const KIND_PFH_INSTALL: u8                 = 7;
+/// Axis-B-CoW cross-check (Arm-2 cross-check arm).  Recorded when a
+/// PHYS_OFF write is *about* to land on a physical frame that the page
+/// cache STILL holds under some key — the cache-aliasing precondition
+/// for the FAULT/PHYS bucket-A cluster.
+pub const KIND_WRITE_DETECTED: u8              = 8;
 
 // ── Writer site IDs for Arm-2 PREINS witness map ────────────────────────────
 
@@ -186,7 +191,103 @@ fn kind_str(k: u8) -> &'static str {
         KIND_REFDEC => "REFDEC",
         KIND_PHYS_OFF_WRITE_PRE_INSERT => "PREINS_W",
         KIND_PFH_INSTALL => "PFH_INSTALL",
+        KIND_WRITE_DETECTED => "WRITE_DETECT",
         _ => "UNKNOWN",
+    }
+}
+
+// ── Arm-2 cross-check (WRITE_DETECT probes at PHYS_OFF write sites) ─────────
+//
+// Each probe is a thin wrapper around `cache::is_phys_in_cache` evaluated
+// BEFORE the imminent PHYS_OFF write.  On `Some(key)` the wrapper:
+//   1. increments the per-site `*_OVER_CACHE` counter,
+//   2. emits one structured `[W215/WRITE-DETECT/<site>]` serial line
+//      (rate-limited via `sample_emit`), and
+//   3. records a `KIND_WRITE_DETECTED` entry in the provenance ring so the
+//      `[FAULT/PHYS/PROV]` dump shows the writer's footprint after the fact.
+//
+// The probe never short-circuits or alters control flow — diagnostic only.
+
+/// Writer site IDs (used in both serial line tags and packed key payloads).
+pub const WSITE_COW_CACHE_HIT: u8     = 1; // idt.rs cache-hit MAP_PRIVATE writable copy
+pub const WSITE_COW_READAHEAD: u8     = 2; // idt.rs readahead MAP_PRIVATE writable copy
+pub const WSITE_COW_SINGLEPAGE: u8    = 3; // idt.rs single-page fallback MAP_PRIVATE writable copy
+pub const WSITE_ANON_ZEROFILL: u8     = 4; // idt.rs anonymous fault zero-fill (TOP CANDIDATE)
+
+static COW_CACHE_HIT_OVER_CACHE:   AtomicU64 = AtomicU64::new(0);
+static COW_READAHEAD_OVER_CACHE:   AtomicU64 = AtomicU64::new(0);
+static COW_SINGLEPAGE_OVER_CACHE:  AtomicU64 = AtomicU64::new(0);
+static ANON_ZEROFILL_OVER_CACHE:   AtomicU64 = AtomicU64::new(0);
+
+pub fn cow_cache_hit_over_cache_count()   -> u64 { COW_CACHE_HIT_OVER_CACHE.load(Ordering::Relaxed) }
+pub fn cow_readahead_over_cache_count()   -> u64 { COW_READAHEAD_OVER_CACHE.load(Ordering::Relaxed) }
+pub fn cow_singlepage_over_cache_count()  -> u64 { COW_SINGLEPAGE_OVER_CACHE.load(Ordering::Relaxed) }
+pub fn anon_zerofill_over_cache_count()   -> u64 { ANON_ZEROFILL_OVER_CACHE.load(Ordering::Relaxed) }
+
+#[inline]
+fn wsite_str(s: u8) -> &'static str {
+    match s {
+        WSITE_COW_CACHE_HIT   => "COW_CACHE_HIT",
+        WSITE_COW_READAHEAD   => "COW_READAHEAD",
+        WSITE_COW_SINGLEPAGE  => "COW_SINGLEPAGE",
+        WSITE_ANON_ZEROFILL   => "ANON_ZEROFILL",
+        _ => "UNKNOWN",
+    }
+}
+
+#[inline]
+fn bump_wsite(site: u8) {
+    match site {
+        WSITE_COW_CACHE_HIT  => { COW_CACHE_HIT_OVER_CACHE.fetch_add(1, Ordering::Relaxed);  }
+        WSITE_COW_READAHEAD  => { COW_READAHEAD_OVER_CACHE.fetch_add(1, Ordering::Relaxed);  }
+        WSITE_COW_SINGLEPAGE => { COW_SINGLEPAGE_OVER_CACHE.fetch_add(1, Ordering::Relaxed); }
+        WSITE_ANON_ZEROFILL  => { ANON_ZEROFILL_OVER_CACHE.fetch_add(1, Ordering::Relaxed);  }
+        _ => {}
+    }
+}
+
+/// Cross-check probe.  Call IMMEDIATELY BEFORE a PHYS_OFF-mapped write
+/// (zero-fill or CoW copy) onto `phys`.
+///
+/// Behaviour:
+/// - If `phys` is currently held by the page cache under some key, increments
+///   the per-site counter, emits one rate-limited serial line, and pushes a
+///   `KIND_WRITE_DETECTED` entry into the provenance ring (so the
+///   `[FAULT/PHYS/PROV]` dump shows the writer's footprint).
+/// - Otherwise: zero work; returns without touching any counter.
+///
+/// ISR-safe.  `cache::is_phys_in_cache` takes a short spin lock; that lock is
+/// not held across any sleeping path here.  Per Intel SDM Vol. 3A §4.10.5,
+/// a PHYS_OFF write to a frame the cache holds aliases the cache page (the
+/// PHYS_OFF mapping is in PML4[256-511] kernel half) — exactly the structural
+/// precondition for the FAULT/PHYS bucket-A cluster.
+#[inline]
+pub fn write_detect(phys: u64, site: u8, rip: u64) {
+    if phys == 0 { return; }
+    let key = match crate::mm::cache::is_phys_in_cache(phys) {
+        Some(k) => k,
+        None => return,
+    };
+    bump_wsite(site);
+    // Provenance entry: pack the matched cache key into the 48-bit payload so
+    // the FAULT/PHYS/PROV dump can correlate (mount,inode,off) with the
+    // writer site that touched the frame.
+    let packed = pack_cache_key(key.1, key.2);
+    prov_record(phys, KIND_WRITE_DETECTED, packed);
+
+    // Rate-limit the serial line: first 16 detections per site verbatim,
+    // then 1 in 4096.  Counter is shared across sites — fine for the
+    // diagnostic; the per-site counters above are exact.
+    static WRITE_DETECT_N: AtomicU64 = AtomicU64::new(0);
+    let n = WRITE_DETECT_N.fetch_add(1, Ordering::Relaxed);
+    if n < 16 || n % 4096 == 0 {
+        crate::serial_println!(
+            "[W215/WRITE-DETECT/{}] phys={:#x} key=(mount={},inode={:#x},off={:#x}) \
+             rip={:#x} n={}",
+            wsite_str(site),
+            phys, key.0, key.1, key.2,
+            rip, n,
+        );
     }
 }
 


### PR DESCRIPTION
Adds 4 WRITE_DETECT probes at the PHYS_OFF write sites from the Option D audit (idt.rs cache-hit CoW copy, readahead CoW copy, single-page fallback CoW copy, anonymous fault zero-fill). All probes check cache-residency BEFORE the write; counters readable via kdb. One 30-min KVM firefox-test trial: 1 FAULT/PHYS bucket-A at phys=0x32e98000, ALL 4 COUNTERS ZERO. The 4 CoW + anon-zerofill paths are NOT W215 writers. Cumulative across PRs #255/#256/#258 + this: 19 instrumented writers, all zero, W215 still fires. Diagnostic only, no behavioural change. References: Intel SDM Vol. 3A §4.10.5, POSIX mmap(2).