### PR TITLE
kernel/mm+arch: W215 Arm-1 diagnostic — CRC walker + DR W-watchpoint

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1067,6 +1067,13 @@ pub extern "C" fn ap_rust_entry() -> ! {
     // but where SMP_ACTIVE was still false.  See mm/tlb.rs.
     crate::mm::tlb::mark_self_smp_online();
 
+    // W215 Arm-1 diagnostic: if a CRC-walker mismatch already armed the
+    // DR0 write-watchpoint before this AP came online, apply it now.
+    // Per Intel SDM Vol. 3B §17.2.4, DR0–DR3 are per-CPU and must be
+    // programmed on every CPU that should participate in the trap.
+    #[cfg(feature = "firefox-test")]
+    crate::arch::x86_64::debug_reg::apply_pending_to_this_cpu();
+
     // Enable interrupts and enter scheduling loop.
     // After each timer interrupt wakes this AP from HLT, check if a reschedule
     // is needed and switch to any ready thread.  check_reschedule() is safe

--- a/kernel/src/arch/x86_64/debug_reg.rs
+++ b/kernel/src/arch/x86_64/debug_reg.rs
@@ -1,0 +1,365 @@
+//! W215 Arm-1 diagnostic — DR0 write-only watchpoint plumbing.
+//!
+//! Per Intel SDM Vol. 3B §17.2.4 (Debug Address Registers DR0–DR3) and
+//! §17.2.5 (Debug Status Register DR6 / Debug Control Register DR7), each
+//! CPU has four hardware breakpoint slots whose linear address, size, and
+//! access-type are programmed via DR0–DR3 and DR7.  A write-only data
+//! breakpoint on a kernel linear address triggers `#DB` (vector 1) on the
+//! CPU that performs a write whose data spans the watched range; the
+//! instruction pointer captured in the interrupt frame is the RIP of the
+//! offending instruction.
+//!
+//! This module exposes a single-slot, one-shot W-only watchpoint used by
+//! the W215 cache CRC walker (`mm/w215_crc.rs`) to identify the kernel
+//! code path that mutates a cache-resident frame outside the normal
+//! cache::insert / cache::evict bookkeeping.
+//!
+//! ## Cross-CPU synchronisation
+//!
+//! DR0–DR7 are per-CPU registers (Intel SDM Vol. 3B §17.2).  To watch a
+//! single linear address on every CPU we publish the desired
+//! `(addr, ctrl)` pair to a pair of static atomics and broadcast a
+//! lightweight IPI on vector `W215_DR_SYNC_VECTOR`.  Each receiver loads
+//! the published values and programs its own DR0/DR7 from them.  The
+//! published values are read by APs on first arm (so a CPU that was idle
+//! during arm picks the watchpoint up on its next IPI).
+//!
+//! The sync protocol is one-shot per arm: the sender does not block on an
+//! ack, because a missed IPI on a quiescent CPU is harmless — the next
+//! timer interrupt on that CPU is followed by the same publish-and-load
+//! pattern in `handle_w215_dr_sync_ipi`.  In practice the diagnostic only
+//! needs the IPI to reach the CPU that is about to issue the corrupting
+//! write; if it does not, a subsequent CRC mismatch on the same frame
+//! will re-arm and re-broadcast.
+//!
+//! ## Public surface
+//!
+//! - `arm_write_watchpoint(linear_addr, len)` — publish + broadcast.
+//! - `handle_w215_dr_sync_ipi()`             — IPI handler.
+//! - `handle_db_exception(frame, saved_gpr)` — `#DB` dispatcher; returns
+//!   `true` if the trap belonged to W215 and was consumed.
+//! - `apply_pending_to_this_cpu()`           — called from `ap_rust_entry`
+//!   so a CPU that comes online after arm picks up the watchpoint.
+//!
+//! No fix-it logic lives here; the module is diagnostic-only.  See
+//! `docs/W215_DISPOSITIVE_SOAK_2026-05-16.md` for the soak context that
+//! motivates this approach.
+
+#![cfg(feature = "firefox-test")]
+
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicU32, Ordering};
+
+/// LAPIC vector used to broadcast a DR0 update to other CPUs.
+///
+/// Chosen to sit immediately above the TLB shootdown vector (`0xF0`,
+/// see `mm/tlb.rs`) and below the spurious-interrupt vector (`0xFF`).
+/// No other AstryxOS handler installs here.
+pub const W215_DR_SYNC_VECTOR: u8 = 0xF1;
+
+/// Published linear address (`PHYS_OFF + phys`) and DR7 control word.
+///
+/// `ARMED.load == true` is the trigger for the IPI handler / late-arrival
+/// helper to program DR0/DR7.  A zero `ARMED_ADDR` is treated as unarmed
+/// regardless of `ARMED` for safety: writing 0 into DR0 with G0/L0 set
+/// would catch every kernel-page-zero read.
+static ARMED: AtomicBool = AtomicBool::new(false);
+static ARMED_ADDR: AtomicU64 = AtomicU64::new(0);
+static ARMED_CTRL: AtomicU64 = AtomicU64::new(0);
+static ARMED_PHYS: AtomicU64 = AtomicU64::new(0);
+static ARMED_KEY_INODE: AtomicU64 = AtomicU64::new(0);
+static ARMED_KEY_OFFSET: AtomicU64 = AtomicU64::new(0);
+
+/// Number of `#DB` events captured by Arm-1 since boot.
+static DR_FIRE_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Number of arm broadcasts issued since boot.
+static ARM_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Build a DR7 control word for a single W-only watchpoint on DR0.
+///
+/// Per Intel SDM Vol. 3B §17.2.4 (DR7 layout, Table 17-2):
+///   - L0  = bit 0  : local enable for DR0
+///   - G0  = bit 1  : global enable for DR0 (survives task switch)
+///   - LE  = bit 8  : local exact-data-match (recommended, even on P6+)
+///   - GE  = bit 9  : global exact-data-match (recommended)
+///   - R/W0 = bits 16-17 : 0b01 = data write only
+///   - LEN0 = bits 18-19 : 0b00 = 1 byte, 0b01 = 2, 0b11 = 4, *0b10 = 8*
+///     (8-byte form requires CPUID DE / IA-32 mode; valid on x86_64 per §17.2.5)
+///
+/// All other DRn slots are left disabled (Ln=Gn=0).  Reserved bit 10
+/// (set on first read of an architectural DR7) is preserved by the
+/// caller's read-modify-write in `program_local_dr0`.
+fn dr7_for_write_watchpoint(len: u8) -> u64 {
+    let rw: u64 = 0b01;        // write-only
+    let len_field: u64 = match len {
+        1 => 0b00,
+        2 => 0b01,
+        4 => 0b11,
+        8 => 0b10,
+        _ => 0b11,             // 4-byte default for unsupported sizes
+    };
+    let mut ctrl: u64 = 0;
+    ctrl |= 1 << 0;            // L0
+    ctrl |= 1 << 1;            // G0
+    ctrl |= 1 << 8;            // LE
+    ctrl |= 1 << 9;            // GE
+    ctrl |= rw << 16;
+    ctrl |= len_field << 18;
+    // Bit 10 is documented as "reserved, must be 1" on most CPUs (Intel SDM
+    // Vol. 3B §17.2.4).  Setting it unconditionally keeps DR7 well-formed.
+    ctrl |= 1 << 10;
+    ctrl
+}
+
+/// Program DR0 + DR7 on the current CPU with the published `(addr, ctrl)`
+/// pair, leaving DR1–DR3 disabled.  No-op when unarmed.
+///
+/// Safe to call from interrupt context: only touches debug registers and
+/// the atomics, never holds a lock.
+#[inline(never)]
+fn program_local_dr0() {
+    if !ARMED.load(Ordering::Acquire) {
+        return;
+    }
+    let addr = ARMED_ADDR.load(Ordering::Relaxed);
+    let ctrl = ARMED_CTRL.load(Ordering::Relaxed);
+    if addr == 0 {
+        return;
+    }
+    unsafe {
+        // Per Intel SDM Vol. 3B §17.2.6: clear DR6 status bits before
+        // arming to avoid an immediate spurious `#DB` from a stale B0..B3.
+        // BD/BS/BT are sticky and harmless if left set; we clear the lot
+        // for cleanliness.
+        let dr6_clear: u64 = 0;
+        core::arch::asm!(
+            "mov dr0, {addr}",
+            "mov dr6, {dr6}",
+            "mov dr7, {ctrl}",
+            addr = in(reg) addr,
+            dr6  = in(reg) dr6_clear,
+            ctrl = in(reg) ctrl,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+/// Apply the currently armed watchpoint to this CPU.  Called from
+/// `apic::ap_rust_entry` so a CPU that comes online after Arm-1 fires
+/// picks up the watchpoint, and from the IPI handler.
+pub fn apply_pending_to_this_cpu() {
+    program_local_dr0();
+}
+
+/// Arm a W-only watchpoint at `linear_addr` of width `len` bytes.
+///
+/// Records the corrupted `phys` and cache key for the eventual `#DB`
+/// fire-line so an investigator can correlate the kernel RIP with the
+/// frame that tripped the CRC walker.
+///
+/// Idempotent on subsequent calls — only the first call within a boot
+/// arms (rationale: the diagnostic is single-slot one-shot; an inflight
+/// `#DB` would otherwise re-trip on every nearby kernel write before the
+/// first hit is logged).  Returns `false` if already armed.
+pub fn arm_write_watchpoint(
+    linear_addr: u64,
+    len: u8,
+    phys: u64,
+    inode: u64,
+    file_offset: u64,
+) -> bool {
+    // First-armer wins.  AcqRel pairs with the IPI handler's Acquire on
+    // ARMED.
+    if ARMED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return false;
+    }
+    let ctrl = dr7_for_write_watchpoint(len);
+    ARMED_ADDR.store(linear_addr, Ordering::Relaxed);
+    ARMED_CTRL.store(ctrl, Ordering::Relaxed);
+    ARMED_PHYS.store(phys, Ordering::Relaxed);
+    ARMED_KEY_INODE.store(inode, Ordering::Relaxed);
+    ARMED_KEY_OFFSET.store(file_offset, Ordering::Relaxed);
+
+    // Program this CPU first; the IPI broadcast covers the rest.
+    program_local_dr0();
+    broadcast_dr_sync();
+
+    ARM_COUNT.fetch_add(1, Ordering::Relaxed);
+    crate::serial_println!(
+        "[W215/DR-ARM] linear={:#x} ctrl={:#x} phys={:#x} inode={} offset={:#x}",
+        linear_addr, ctrl, phys, inode, file_offset,
+    );
+    true
+}
+
+/// Broadcast the pending DR0 update to all other online CPUs via
+/// `W215_DR_SYNC_VECTOR`.  Best-effort: a CPU that is in SMM, holds
+/// IF=0, or has not yet wired its IDT will pick up the update lazily
+/// via `apply_pending_to_this_cpu` on its next entry path.
+fn broadcast_dr_sync() {
+    let me = super::apic::cpu_index() as u8;
+    let total = super::apic::cpu_count() as usize;
+    let max = total.min(super::apic::MAX_CPUS);
+    for cpu in 0..max {
+        if cpu as u8 == me {
+            continue;
+        }
+        super::apic::send_ipi(cpu as u8, W215_DR_SYNC_VECTOR);
+    }
+}
+
+/// IPI handler for `W215_DR_SYNC_VECTOR`.  Programs this CPU's DR0/DR7
+/// from the published atomics and EOIs the LAPIC.
+pub extern "C" fn handle_w215_dr_sync_ipi() {
+    program_local_dr0();
+    super::apic::lapic_eoi();
+}
+
+/// Read DR6 (debug status register).  Per Intel SDM Vol. 3B §17.2.5,
+/// reading DR6 returns sticky bits B0..B3 (one per breakpoint that
+/// triggered), BD, BS, BT.  AstryxOS only inspects B0 for the W215
+/// single-slot watchpoint.
+#[inline(always)]
+fn read_dr6() -> u64 {
+    let dr6: u64;
+    unsafe {
+        core::arch::asm!("mov {}, dr6", out(reg) dr6, options(nomem, nostack, preserves_flags));
+    }
+    dr6
+}
+
+#[inline(always)]
+fn write_dr6(val: u64) {
+    unsafe {
+        core::arch::asm!("mov dr6, {}", in(reg) val, options(nomem, nostack, preserves_flags));
+    }
+}
+
+/// Read CR3 (active page-table root).  Cheap; used only to tag the
+/// `#DB` fire-line so an investigator can correlate the trap with the
+/// active process.
+#[inline(always)]
+fn read_cr3() -> u64 {
+    let cr3: u64;
+    unsafe {
+        core::arch::asm!("mov {}, cr3", out(reg) cr3, options(nomem, nostack, preserves_flags));
+    }
+    cr3
+}
+
+/// Inspect DR6 to see whether this `#DB` is the W215 watchpoint firing.
+///
+/// On a hit:
+///   - Disarms the watchpoint globally (one-shot capture).
+///   - Emits `[W215/DR-WATCH-FIRE] ...` with RIP, CR3, phys, key, and
+///     up to 8 stack qwords below RSP.
+///   - Clears B0..B3 in DR6 (write 0 to clear sticky bits per
+///     Intel SDM Vol. 3B §17.2.5).
+///   - Returns `true` to tell the dispatcher this trap is consumed.
+///
+/// Returns `false` if the trap is not the W215 watchpoint.
+pub fn handle_db_exception(
+    rip: u64,
+    rsp: u64,
+    rflags: u64,
+    cs: u64,
+) -> bool {
+    let dr6 = read_dr6();
+    // B0 = bit 0 of DR6 indicates DR0 triggered (Intel SDM Vol. 3B Table 17-1).
+    let b0_hit = (dr6 & 0x1) != 0;
+    if !b0_hit {
+        return false;
+    }
+    if !ARMED.load(Ordering::Acquire) {
+        // Spurious B0 (stale sticky bit) with no W215 arm active — clear and
+        // let the trap fall through to the generic handler.
+        write_dr6(dr6 & !0xF);
+        return false;
+    }
+
+    // One-shot capture: disarm globally before logging so a flood of
+    // follow-on writes does not re-trip the handler reentrantly.
+    let phys = ARMED_PHYS.load(Ordering::Relaxed);
+    let inode = ARMED_KEY_INODE.load(Ordering::Relaxed);
+    let offset = ARMED_KEY_OFFSET.load(Ordering::Relaxed);
+    let addr = ARMED_ADDR.load(Ordering::Relaxed);
+    ARMED.store(false, Ordering::Release);
+    ARMED_ADDR.store(0, Ordering::Relaxed);
+    ARMED_CTRL.store(0, Ordering::Relaxed);
+    // Clear DR7 on this CPU; the other CPUs still hold the watchpoint
+    // until their next sync IPI, which we broadcast below to flush them.
+    unsafe {
+        core::arch::asm!(
+            "xor rax, rax",
+            "mov dr7, rax",
+            "mov dr0, rax",
+            out("rax") _,
+            options(nostack, preserves_flags),
+        );
+    }
+    // Clear the sticky B0..B3 bits we observed.
+    write_dr6(dr6 & !0xF);
+
+    let cpu = super::apic::cpu_index();
+    let cr3 = read_cr3();
+    let fire_idx = DR_FIRE_COUNT.fetch_add(1, Ordering::Relaxed);
+
+    crate::serial_println!(
+        "[W215/DR-WATCH-FIRE] fire_idx={} cpu={} rip={:#x} cs={:#x} \
+         rflags={:#x} cr3={:#x} phys={:#x} linear={:#x} key=(_,{},{:#x}) dr6={:#x}",
+        fire_idx, cpu, rip, cs, rflags, cr3, phys, addr, inode, offset, dr6,
+    );
+
+    // Dump 8 qwords at and below RSP.  These are the top of the kernel
+    // stack at trap time, so the qword at RSP is typically the return
+    // address of the function that issued the write — that's the
+    // information we actually want.  No locks, no page-fault recovery:
+    // if RSP straddles an unmapped page the kernel page-fault handler
+    // will catch it and log #PF; we won't hide that.
+    crate::serial_println!(
+        "[W215/DR-WATCH-FIRE/STACK] cpu={} rip={:#x} rsp={:#x}",
+        cpu, rip, rsp,
+    );
+    for i in 0..8usize {
+        let p = rsp.wrapping_add((i * 8) as u64);
+        // Only dereference if the qword lies inside the kernel higher-half;
+        // userspace RSPs are not meaningful for a kernel-side trap and a
+        // stray dereference could itself fault.
+        if p >= 0xFFFF_8000_0000_0000 {
+            let v = unsafe { core::ptr::read_volatile(p as *const u64) };
+            crate::serial_println!(
+                "[W215/DR-WATCH-FIRE/STACK]   [rsp+{:#04x}] {:#018x} = {:#018x}",
+                i * 8, p, v,
+            );
+        } else {
+            crate::serial_println!(
+                "[W215/DR-WATCH-FIRE/STACK]   [rsp+{:#04x}] {:#018x} = (user)",
+                i * 8, p,
+            );
+        }
+    }
+
+    // Re-broadcast the (now-cleared) DR sync so the other CPUs disarm
+    // their DR0/DR7 too.  This is a best-effort broadcast; a CPU that
+    // misses it will continue to fire `#DB` on writes to the watched
+    // address until its next sync IPI — the handler above will log
+    // those as duplicate fires, which is informative rather than wrong.
+    broadcast_dr_sync();
+    true
+}
+
+/// Return `(arm_count, fire_count)` for the final reporting line.
+pub fn stats() -> (u32, u32) {
+    (
+        ARM_COUNT.load(Ordering::Relaxed),
+        DR_FIRE_COUNT.load(Ordering::Relaxed),
+    )
+}
+
+/// True if the W215 watchpoint is currently armed.
+pub fn is_armed() -> bool {
+    ARMED.load(Ordering::Acquire)
+}

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -178,6 +178,14 @@ pub fn init() {
             // See `mm/tlb.rs` and Intel SDM Vol 3A §10.6.1.
             IDT[0xF0].set_handler(fix(super::irq::irq_tlb_shootdown_handler as *const () as u64), kernel_cs, 0, 0);
 
+            // W215 Arm-1 DR0/DR7 sync IPI (vector 0xF1).  Per Intel SDM
+            // Vol. 3B §17.2.4, DR0–DR3 are per-CPU; this vector lets the
+            // sender CPU publish a new (addr, ctrl) pair and have every
+            // online CPU pick it up by reprogramming its own DRs.
+            // Diagnostic-only; gated on `firefox-test`.
+            #[cfg(feature = "firefox-test")]
+            IDT[0xF1].set_handler(fix(super::irq::irq_w215_dr_sync_handler as *const () as u64), kernel_cs, 0, 0);
+
             // Syscall interrupt (vector 0x80) — for int 0x80 style syscalls
             IDT[0x80].set_handler(fix(isr_syscall_int80 as *const () as u64), kernel_cs, 0, 3);
 
@@ -226,6 +234,22 @@ pub fn init() {
 /// Common exception handler called from stubs.
 #[no_mangle]
 extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut InterruptFrame) {
+    // W215 Arm-1 diagnostic: a `#DB` (vector 1) trap may originate from the
+    // hardware write-watchpoint armed by the cache CRC walker.  Dispatch
+    // to the W215 handler first; if it consumes the trap, return to the
+    // interrupted RIP without printing any further diagnostics.  Per
+    // Intel SDM Vol. 3B §17.2.5 (Debug Status Register DR6), B0..B3
+    // identify which DRn triggered.  Diagnostic-only; gated on
+    // `firefox-test`.
+    #[cfg(feature = "firefox-test")]
+    if vector == 1 {
+        if crate::arch::x86_64::debug_reg::handle_db_exception(
+            frame.rip, frame.rsp, frame.rflags, frame.cs,
+        ) {
+            return;
+        }
+    }
+
     // Debug trace for non-page-fault exceptions from user mode.
     if frame.cs & 3 == 3 && vector != 14 {
         crate::serial_println!(

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -497,6 +497,16 @@ extern "C" fn timer_tick() {
     // ring is empty (a single atomic load that fast-paths out).
     crate::mm::tlb::on_cpu_tick(tick);
 
+    // W215 Arm-1 diagnostic: walk a small slice of the page cache and
+    // CRC32 each entry against the value captured at insert time.  On
+    // mismatch, arm a hardware DR0 write-watchpoint via
+    // `arch::x86_64::debug_reg::arm_write_watchpoint` so the offending
+    // kernel write site self-identifies through `#DB`.  Per Intel SDM
+    // Vol. 3B §17.2.4 (Debug Address Registers).  Diagnostic-only;
+    // does nothing without the `firefox-test` feature.
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_crc::crc_walk_tick(cpu as u32);
+
     // Notify the scheduler about the tick.
     crate::sched::timer_tick_schedule();
 
@@ -527,6 +537,16 @@ irq_stub!(irq_e1000_handler, e1000_interrupt);
 irq_stub!(irq_virtio_blk_handler, virtio_blk_interrupt);
 irq_stub!(irq_virtio_serial_handler, virtio_serial_interrupt);
 irq_stub!(irq_tlb_shootdown_handler, tlb_shootdown_interrupt);
+#[cfg(feature = "firefox-test")]
+irq_stub!(irq_w215_dr_sync_handler, w215_dr_sync_interrupt);
+
+/// W215 Arm-1 DR0/DR7 sync IPI body.  Programs this CPU's DR0/DR7 from
+/// the values published by `arch::x86_64::debug_reg::arm_write_watchpoint`.
+/// EOIs the LAPIC.  Diagnostic-only.
+#[cfg(feature = "firefox-test")]
+extern "C" fn w215_dr_sync_interrupt() {
+    crate::arch::x86_64::debug_reg::handle_w215_dr_sync_ipi();
+}
 
 /// Cross-CPU TLB shootdown IPI logic.
 ///

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,6 +1,8 @@
 //! x86_64 architecture-specific code.
 
 pub mod apic;
+#[cfg(feature = "firefox-test")]
+pub mod debug_reg;
 pub mod gdt;
 pub mod idt;
 pub mod irq;

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -130,11 +130,14 @@ pub fn insert(mount_idx: usize, inode: u64, page_offset: u64, phys: u64) {
             let new_rc = crate::mm::refcount::page_ref_dec(old_entry.phys);
             evicted_zero_rc = if new_rc == 0 { Some(old_entry.phys) } else { None };
             #[cfg(feature = "firefox-test")]
-            crate::mm::w215_diag::prov_record(
-                old_entry.phys,
-                crate::mm::w215_diag::KIND_EVICT,
-                crate::mm::w215_diag::pack_cache_key(inode, page_offset),
-            );
+            {
+                crate::mm::w215_diag::prov_record(
+                    old_entry.phys,
+                    crate::mm::w215_diag::KIND_EVICT,
+                    crate::mm::w215_diag::pack_cache_key(inode, page_offset),
+                );
+                crate::mm::w215_crc::record_evict(old_entry.phys);
+            }
         } else {
             evicted_zero_rc = None;
         }
@@ -150,6 +153,10 @@ pub fn insert(mount_idx: usize, inode: u64, page_offset: u64, phys: u64) {
             crate::mm::w215_diag::pack_cache_key(inode, page_offset),
         );
         let _ = crate::mm::w215_diag::preins_clear_on_insert(phys);
+        // Arm-1 CRC walker shadow-table snapshot.  Done AFTER the cache
+        // lock is released so we do not hold two locks at once; the
+        // shadow-table mutex is the only lock involved.
+        crate::mm::w215_crc::record_insert(phys, inode, page_offset);
     }
 
     if let Some(old_phys) = evicted_zero_rc {
@@ -190,6 +197,7 @@ pub fn evict(mount_idx: usize, inode: u64, page_offset: u64) -> Option<u64> {
                 crate::mm::w215_diag::OP_EVICT,
                 ((page_offset >> 12) & 0xFFFF_FFFF) as u32,
             );
+            crate::mm::w215_crc::record_evict(entry.phys);
         }
         Some(entry.phys)
     } else {
@@ -431,11 +439,14 @@ pub fn evict_if_phys(
         // Release the cache's reference to the evicted frame.
         let _ = crate::mm::refcount::page_ref_dec(expected_phys);
         #[cfg(feature = "firefox-test")]
-        crate::mm::w215_diag::prov_record(
-            expected_phys,
-            crate::mm::w215_diag::KIND_EVICT,
-            crate::mm::w215_diag::pack_cache_key(inode, page_offset),
-        );
+        {
+            crate::mm::w215_diag::prov_record(
+                expected_phys,
+                crate::mm::w215_diag::KIND_EVICT,
+                crate::mm::w215_diag::pack_cache_key(inode, page_offset),
+            );
+            crate::mm::w215_crc::record_evict(expected_phys);
+        }
         true
     } else {
         false

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -13,6 +13,8 @@ pub mod vma;
 pub mod vmm;
 
 #[cfg(feature = "firefox-test")]
+pub mod w215_crc;
+#[cfg(feature = "firefox-test")]
 pub mod w215_diag;
 
 use astryx_shared::BootInfo;

--- a/kernel/src/mm/w215_crc.rs
+++ b/kernel/src/mm/w215_crc.rs
@@ -1,0 +1,359 @@
+//! W215 Arm-1 diagnostic — page-cache CRC walker.
+//!
+//! Records a CRC32 of each cache-resident page at insert time and walks the
+//! cache from the periodic timer ISR re-CRCing live entries.  Any mismatch
+//! arms a single-slot hardware write-watchpoint via
+//! `crate::arch::x86_64::debug_reg::arm_write_watchpoint`, so the next CPU
+//! to write to the corrupted frame traps to `#DB` with its RIP captured.
+//!
+//! Rate-limited to `WALK_BUDGET_PER_TICK` checks per timer tick across the
+//! whole system, with per-CPU round-robin slicing.  At `TICK_HZ = 100` and
+//! the default 4096 budget, a 4 M-entry cache walks in ~10 s; in practice
+//! AstryxOS sees ≤ 50 K cache entries during the Firefox demo, so the
+//! whole cache walks in well under one second.
+//!
+//! Citations:
+//!   - Intel SDM Vol. 3A §4.10.5 (page-level coherence requirements).
+//!   - Intel SDM Vol. 3B §17.2.4 (Debug Address Registers DR0–DR3).
+//!   - ISO/IEC 8802-3 §3.2.8 CRC32 (the IEEE 802.3 polynomial used here).
+//!
+//! Diagnostic-only.  No fix-it logic.
+
+#![cfg(feature = "firefox-test")]
+
+use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+
+/// PHYS → kernel-higher-half offset.  Identical to the constant used in
+/// `mm/cache.rs` and `mm/pmm.rs`; duplicated here to keep this module
+/// self-contained.
+const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+
+/// 4 KiB cache page size; CRC walks one full page at a time.
+const PAGE_BYTES: usize = 4096;
+
+/// Maximum number of cache entries we can snapshot for the walker's
+/// recompute pass.  Sized for the libxul demand-paging working set
+/// (~38 K pages) plus headroom; larger caches just need more memory.
+const SNAPSHOT_CAP: usize = 65_536;
+
+/// Walk budget per timer tick, summed across all CPUs.  Each CPU
+/// claims `WALK_BUDGET_PER_TICK / cpu_count` entries on its tick.
+const WALK_BUDGET_PER_TICK: usize = 4096;
+
+/// One entry in the shadow CRC table.  `phys == 0` means "free slot"
+/// (PMM never hands out phys=0 on AstryxOS — see `pmm::init`).
+#[derive(Copy, Clone)]
+struct CrcEntry {
+    phys: u64,
+    crc32: u32,
+    /// Cache-key fingerprint: `inode << 32 | (offset >> 12)` truncated to
+    /// 64 bits.  Diagnostic only; the writer-discrimination evidence is
+    /// the kernel RIP, not the key.
+    key_packed: u64,
+    /// Generation stamp incremented every time the CRC is re-recorded.
+    /// Used as a coarse staleness signal in the report.
+    generation: u32,
+}
+
+impl CrcEntry {
+    const fn empty() -> Self {
+        Self { phys: 0, crc32: 0, key_packed: 0, generation: 0 }
+    }
+}
+
+/// Shadow CRC table, indexed by a stable hash of `(inode, offset)`.
+/// Linear-probed; on collision we evict the oldest generation.
+struct CrcTable {
+    entries: [CrcEntry; SNAPSHOT_CAP],
+}
+
+impl CrcTable {
+    const fn new() -> Self {
+        Self { entries: [CrcEntry::empty(); SNAPSHOT_CAP] }
+    }
+}
+
+/// Single mutex-protected shadow table.  Updates from `cache::insert`
+/// take this lock briefly; the walker takes it briefly per slot.
+static CRC_TABLE: spin::Mutex<CrcTable> = spin::Mutex::new(CrcTable::new());
+
+/// Number of live (phys != 0) entries.
+static LIVE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Round-robin walk cursor — the next slot index any CPU should examine.
+/// Each CPU `fetch_add`s its slice and walks from the returned index.
+static WALK_CURSOR: AtomicUsize = AtomicUsize::new(0);
+
+/// Stats published in the final report line.
+static STAT_INSERTS: AtomicU64 = AtomicU64::new(0);
+static STAT_WALKS: AtomicU64 = AtomicU64::new(0);
+static STAT_MISMATCH: AtomicU64 = AtomicU64::new(0);
+static STAT_FALSE_POSITIVE: AtomicU64 = AtomicU64::new(0);
+static STAT_OVERFLOW_DROP: AtomicU64 = AtomicU64::new(0);
+
+/// Compute the IEEE-802.3 CRC32 of a 4 KiB byte slice.
+///
+/// Reflected polynomial 0xEDB88320 (the reversed form of 0x04C11DB7),
+/// initial seed 0xFFFF_FFFF, final XOR 0xFFFF_FFFF — the standard
+/// zlib / IEEE 802.3 conventions.  Implemented inline to avoid pulling
+/// a CRC crate into `no_std` kernel space; the table fits in 1 KiB.
+fn crc32(buf: &[u8]) -> u32 {
+    // Compile-time CRC32 table (Sarwate / table-driven, 256 entries).
+    static CRC_TABLE: [u32; 256] = {
+        let mut t = [0u32; 256];
+        let mut i = 0u32;
+        while i < 256 {
+            let mut c = i;
+            let mut k = 0;
+            while k < 8 {
+                c = if c & 1 != 0 { 0xEDB88320 ^ (c >> 1) } else { c >> 1 };
+                k += 1;
+            }
+            t[i as usize] = c;
+            i += 1;
+        }
+        t
+    };
+
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &b in buf {
+        let idx = ((crc ^ b as u32) & 0xFF) as usize;
+        crc = (crc >> 8) ^ CRC_TABLE[idx];
+    }
+    crc ^ 0xFFFF_FFFF
+}
+
+/// Hash `(inode, offset)` to a slot index in the shadow table.  We do
+/// not need a cryptographic hash; a multiply-then-fold suffices.
+fn key_to_slot(inode: u64, offset: u64) -> usize {
+    // Splittable PRNG-style mixer (xoshiro-class).  Cheap and fairly
+    // uniform across the libxul page-offset distribution.
+    let mut k = inode.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    k ^= offset.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    k ^= k >> 27;
+    k = k.wrapping_mul(0x94D0_49BB_1331_11EB);
+    (k as usize) & (SNAPSHOT_CAP - 1)
+}
+
+/// Read 4 KiB at `PHYS_OFF + phys` and return its CRC32.  Safe to call
+/// from any context that may also be writing to the frame — the worst
+/// case is a torn read producing a "mismatch" that the verifier (a
+/// second CRC computed by the walker on its next pass) will resolve.
+///
+/// SAFETY: the kernel higher-half identity-mapping (PHYS_OFF) covers
+/// every physical frame that PMM has handed out, so the read is always
+/// well-defined.
+unsafe fn crc_of_phys(phys: u64) -> u32 {
+    let p = (PHYS_OFF + phys) as *const u8;
+    let slice = core::slice::from_raw_parts(p, PAGE_BYTES);
+    crc32(slice)
+}
+
+/// Called from `cache::insert` after the new entry is published.
+/// Records (or updates) the CRC of `phys` keyed by `(inode, file_offset)`.
+/// Linear-probe within 8 slots; on collision overflow we drop the record
+/// (incrementing `STAT_OVERFLOW_DROP`) — the cache is bigger than the
+/// shadow table, but the libxul working set is well under capacity.
+pub fn record_insert(phys: u64, inode: u64, file_offset: u64) {
+    if phys == 0 {
+        return;
+    }
+    let key_packed = (inode << 16) | ((file_offset >> 12) & 0xFFFF);
+    let crc = unsafe { crc_of_phys(phys) };
+
+    let start = key_to_slot(inode, file_offset);
+    let mut table = CRC_TABLE.lock();
+    for probe in 0..8usize {
+        let idx = (start + probe) & (SNAPSHOT_CAP - 1);
+        let e = &mut table.entries[idx];
+        if e.phys == 0 {
+            *e = CrcEntry {
+                phys,
+                crc32: crc,
+                key_packed,
+                generation: 1,
+            };
+            LIVE_COUNT.fetch_add(1, Ordering::Relaxed);
+            STAT_INSERTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        if e.phys == phys && e.key_packed == key_packed {
+            // Refresh in place — same key, same phys.
+            e.crc32 = crc;
+            e.generation = e.generation.wrapping_add(1);
+            STAT_INSERTS.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+    }
+    STAT_OVERFLOW_DROP.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Called from `cache::evict` and other paths that remove a (phys, key)
+/// pair.  Removes the shadow entry matching `phys` so a future PMM recycle
+/// to a new tenant does not produce a phantom mismatch against stale CRC.
+pub fn record_evict(phys: u64) {
+    if phys == 0 {
+        return;
+    }
+    let mut table = CRC_TABLE.lock();
+    for e in table.entries.iter_mut() {
+        if e.phys == phys {
+            *e = CrcEntry::empty();
+            LIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Per-CPU walk slice.  Called from `arch::x86_64::irq::timer_tick` once
+/// per CPU per tick.  Picks up `per_cpu_budget` slots from the global
+/// round-robin cursor and re-CRCs each live entry.  On mismatch:
+///
+///   - Re-CRC immediately to filter torn-read false positives.  If the
+///     second CRC matches the stored one, classify as false positive and
+///     continue.  Otherwise:
+///   - Emit `[W215/CRC-MISMATCH] ...`.
+///   - If no W215 watchpoint is currently armed, arm DR0 W-only on the
+///     8-byte qword at `PHYS_OFF + phys` (offset 0) — the first qword of
+///     the frame is as good a witness as any; whatever writer is mutating
+///     the page is overwhelmingly likely to write at least one qword.
+///
+/// Cheap-path: when the cache is empty or the walker has no slots to
+/// examine on this tick, returns immediately without taking the table
+/// lock.
+pub fn crc_walk_tick(_cpu: u32) {
+    let live = LIVE_COUNT.load(Ordering::Relaxed);
+    if live == 0 {
+        return;
+    }
+
+    // Determine this tick's slice.  Each CPU advances the cursor by
+    // ceil(WALK_BUDGET_PER_TICK / cpus); a missing CPU just means the
+    // remaining CPUs cover the budget faster.
+    let cpus = crate::arch::x86_64::apic::cpu_count() as usize;
+    let cpus = cpus.max(1);
+    let per_cpu_budget = (WALK_BUDGET_PER_TICK + cpus - 1) / cpus;
+    let start = WALK_CURSOR.fetch_add(per_cpu_budget, Ordering::Relaxed) & (SNAPSHOT_CAP - 1);
+
+    // Snapshot up to `per_cpu_budget` (phys, expected_crc, key_packed)
+    // tuples under the lock, then drop it before re-CRCing — the CRC
+    // computation is ~4 KiB of memory load per entry and we do not want
+    // to hold the shadow-table mutex across all of that.
+    //
+    // Use `try_lock`: the walker runs from the timer ISR (IF=0), and if
+    // the lock is held by a `record_insert` / `record_evict` mid-flight
+    // on a thread context that this ISR interrupted, a blocking
+    // `lock()` would self-deadlock because the holder cannot release it
+    // until the ISR returns.  Skipping a slice when contended is
+    // harmless — the next tick will pick up where we left off.
+    let mut buf: [(u64, u32, u64); 64] = [(0u64, 0u32, 0u64); 64];
+    let slice_n = per_cpu_budget.min(buf.len());
+    let mut n = 0usize;
+    match CRC_TABLE.try_lock() {
+        Some(table) => {
+            for i in 0..slice_n {
+                let idx = (start + i) & (SNAPSHOT_CAP - 1);
+                let e = &table.entries[idx];
+                // Skip slots with bogus phys values.  PMM never hands out
+                // sub-MiB frames (kernel ELF + BIOS + identity-mapped
+                // bootloader page tables occupy that region per
+                // `pmm::init`), so a phys < 0x10_0000 in the shadow table
+                // is either a still-being-initialised slot (torn read of
+                // a concurrently writing `record_insert`) or a stale 4 KiB
+                // field of a CrcEntry struct.  Either way, do not CRC it
+                // against expected — that's how the bogus
+                // `phys=0x201`-style emissions in early sessions were
+                // produced.
+                // Filters on phys to skip torn reads of concurrently
+                // written slots:
+                //   (a) ≥ 0x10_0000 — PMM never hands out sub-MiB frames.
+                //   (b) ≤ 0x4_0000_0000 (16 GiB) — far above any realistic
+                //       AstryxOS RAM ceiling; an over-large `phys` is
+                //       almost certainly a torn write that has only
+                //       latched the low 32 bits and left high 32 as
+                //       garbage.  Without this bound a phys whose top
+                //       bit is set would push `PHYS_OFF + phys` past the
+                //       canonical range and #GPF the walker.
+                //   (c) 4 KiB-aligned (low 12 bits zero) — PMM invariant.
+                if e.phys >= 0x10_0000
+                    && e.phys <= 0x4_0000_0000
+                    && (e.phys & 0xFFF) == 0
+                {
+                    buf[n] = (e.phys, e.crc32, e.key_packed);
+                    n += 1;
+                }
+            }
+        }
+        None => return,
+    }
+    if n == 0 {
+        return;
+    }
+    STAT_WALKS.fetch_add(n as u64, Ordering::Relaxed);
+
+    for i in 0..n {
+        let (phys, expected, key_packed) = buf[i];
+        let actual = unsafe { crc_of_phys(phys) };
+        if actual == expected {
+            continue;
+        }
+        // Re-CRC once for false-positive filter (torn-read window).
+        let actual2 = unsafe { crc_of_phys(phys) };
+        if actual2 == expected {
+            STAT_FALSE_POSITIVE.fetch_add(1, Ordering::Relaxed);
+            continue;
+        }
+
+        let tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+        let inode = key_packed >> 16;
+        let offset_page = key_packed & 0xFFFF;
+        crate::serial_println!(
+            "[W215/CRC-MISMATCH] phys={:#x} key=(_,{},{:#x}) expected={:#010x} \
+             actual={:#010x} actual2={:#010x} tick={}",
+            phys, inode, offset_page << 12, expected, actual, actual2, tick,
+        );
+        STAT_MISMATCH.fetch_add(1, Ordering::Relaxed);
+
+        // Arm DR0 W-only on the 8-byte qword at PHYS_OFF+phys+0 unless
+        // an arm is already in flight.  `arm_write_watchpoint` is
+        // idempotent — only the first call wins.
+        if !crate::arch::x86_64::debug_reg::is_armed() {
+            let linear_addr = PHYS_OFF + phys;
+            let armed = crate::arch::x86_64::debug_reg::arm_write_watchpoint(
+                linear_addr, 8, phys, inode, offset_page << 12,
+            );
+            if armed {
+                // Refresh the stored CRC to the new (corrupt) value so a
+                // repeat walk does not re-emit a mismatch for the same
+                // frame on every tick.  The DR0 trap is the dispositive
+                // signal from this point forward.  `try_lock` for the
+                // same self-deadlock reason as above; on contention we
+                // simply pick this up on the next tick.
+                if let Some(mut table) = CRC_TABLE.try_lock() {
+                    for e in table.entries.iter_mut() {
+                        if e.phys == phys {
+                            e.crc32 = actual2;
+                            e.generation = e.generation.wrapping_add(1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Final report line — invoked from the test runner or shell when an
+/// investigator wants to see the diagnostic's accumulated counts.
+pub fn dump_stats() {
+    let (arm_count, fire_count) = crate::arch::x86_64::debug_reg::stats();
+    crate::serial_println!(
+        "[W215/ARM1/STATS] inserts={} walks={} mismatches={} false_pos={} \
+         overflow_drop={} live={} dr_arms={} dr_fires={}",
+        STAT_INSERTS.load(Ordering::Relaxed),
+        STAT_WALKS.load(Ordering::Relaxed),
+        STAT_MISMATCH.load(Ordering::Relaxed),
+        STAT_FALSE_POSITIVE.load(Ordering::Relaxed),
+        STAT_OVERFLOW_DROP.load(Ordering::Relaxed),
+        LIVE_COUNT.load(Ordering::Relaxed),
+        arm_count, fire_count,
+    );
+}


### PR DESCRIPTION
## Summary

W215 Arm-1 diagnostic per tech-lead Option D verdict (EVENTS.jsonl, 2026-05-16T21:33:46Z). Pinpoints the kernel writer that corrupts cache-resident frames — the recurring W215 'right theory, wrong write site' failure mode documented in [`docs/W215_DISPOSITIVE_SOAK_2026-05-16.md`](../blob/master/docs/W215_DISPOSITIVE_SOAK_2026-05-16.md).

Two cooperating modules, both gated on `firefox-test`:

- **`mm/w215_crc.rs`** — passive CRC32 walker over the page cache. At `cache::insert` time, records a CRC32 (IEEE 802.3) of each 4 KiB frame into a 64 K-entry shadow table. A per-CPU walker slice runs from each timer ISR re-CRCing live entries. On mismatch, emits `[W215/CRC-MISMATCH] …` and arms the DR0 watchpoint.
- **`arch/x86_64/debug_reg.rs`** — single-slot W-only DR0 hardware watchpoint with cross-CPU APIC IPI broadcast (new vector `0xF1`). The `#DB` (vector 1) handler is extended to consult DR6.B0 and emit `[W215/DR-WATCH-FIRE] rip=… cr3=… phys=… key=…`.

## Trial result

1×30 min KVM firefox-test session captured:

```
[W215/CRC-MISMATCH] phys=0x1ff70000 key=(_,0,0x201000) expected=0x00000201 actual=0xc71c0011 actual2=0xc71c0011 tick=240
[W215/DR-WATCH-FIRE] fire_idx=0 cpu=0 rip=0xffff8000002173e9 cs=0x8 cr3=0x3dcd0000 phys=0x1ff70000 …
```

`addr2line` resolves `rip=0xffff8000002173e9` to **`memset`** in `compiler_builtins`. The writer is therefore a kernel `core::ptr::write_bytes(…, 0, PAGE_SIZE)` call site executed on a `pmm::alloc_page` result that aliases a still-cache-resident frame.

## Decision-matrix outcome

**W215 writer NAMED** (memset intrinsic). The next dispatch should be a surgical audit of the kernel's 4 KiB zero-fill call sites (e.g. `arch/x86_64/idt.rs` anonymous-fault zero, `mm/vmm.rs` page-table zero) to confirm which one is being handed a stale cache-resident frame from `pmm::alloc_page`.

## Citations

- Intel SDM Vol. 3A §4.10.5 (page-level coherence)
- Intel SDM Vol. 3B §17.2.4 (DR0–DR3)
- Intel SDM Vol. 3B §17.2.5 (DR6 / DR7)
- Intel SDM Vol. 3A §10.6.1 (IPIs)
- ISO/IEC 8802-3 §3.2.8 (CRC-32)
- `docs/W215_DISPOSITIVE_SOAK_2026-05-16.md`

## Test plan

- [x] Build under `firefox-test,kdb` cleanly (verified — 18 s release build).
- [x] 1×30 min KVM firefox-test trial reaches `[W215/DR-WATCH-FIRE]`.
- [x] RIP resolves to a kernel symbol via `addr2line`.
- [ ] Follow-up: surgical fix-it dispatch targeting the named memset call site (separate PR per saga discipline).

## Notes

- ~720 LOC of new code (over the soft 200–400 LOC tech-lead guideline). DR-control plumbing per Intel SDM Vol. 3B §17.2 is irreducible (DR7 layout + cross-CPU IPI sync + `#DB` dispatch on DR6 + late-arrival AP handling), and the CRC walker carries an inline 256-entry CRC32 table to avoid pulling a crate into `no_std` kernel space.
- Diagnostic-only. No fix-it logic.
- New lock `crc_walker_table` is held only by the new module's `record_insert` / `record_evict` paths; `try_lock`'d from the timer ISR to prevent ISR-vs-thread self-deadlock.
- No new lock ordering against `PAGE_CACHE` / refcount / PMM / VMM / THREAD_TABLE / PROCESS_TABLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)