### PR TITLE
kernel/mm+arch: gate W215 Arm-1 diagnostic behind w215-diag (fix PR #260 demo regression)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,6 +8,19 @@ default = []
 test-mode = []
 gui-test = []
 firefox-test = []
+# W215 Arm-1 diagnostic infrastructure: the page-cache CRC walker
+# (`mm/w215_crc.rs`, ~2 MiB BSS shadow table), the cross-CPU DR0
+# write-watchpoint plumbing (`arch/x86_64/debug_reg.rs`, IPI vector 0xF1),
+# and the matching `record_insert`/`record_evict` hooks in
+# `mm/cache.rs`.  Opt-in because the shadow table alone adds ~2 MiB of
+# BSS that the bootloader-side `kernel_size = file_size` accounting does
+# not reserve (the flat-binary `kernel.bin` excludes BSS), exposing a
+# latent PMM-vs-BSS overlap that can corrupt kernel page tables during
+# the firefox-test page-cache prepopulate burst.  Gating the diagnostic
+# behind its own feature keeps the demo path's BSS small while
+# preserving on-demand investigative access.  Implies `firefox-test`
+# because the diagnostic shares the firefox-test cache instrumentation.
+w215-diag = ["firefox-test"]
 # W133: opt-out for cross-CPU TLB shootdown.  Default builds run the full
 # shootdown protocol (IPI vector 0xF0, per-CPU active-CR3 mask).  Enable
 # this feature only for bisect/baseline runs where you want to compare

--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1071,7 +1071,7 @@ pub extern "C" fn ap_rust_entry() -> ! {
     // DR0 write-watchpoint before this AP came online, apply it now.
     // Per Intel SDM Vol. 3B §17.2.4, DR0–DR3 are per-CPU and must be
     // programmed on every CPU that should participate in the trap.
-    #[cfg(feature = "firefox-test")]
+    #[cfg(feature = "w215-diag")]
     crate::arch::x86_64::debug_reg::apply_pending_to_this_cpu();
 
     // Enable interrupts and enter scheduling loop.

--- a/kernel/src/arch/x86_64/debug_reg.rs
+++ b/kernel/src/arch/x86_64/debug_reg.rs
@@ -45,7 +45,7 @@
 //! `docs/W215_DISPOSITIVE_SOAK_2026-05-16.md` for the soak context that
 //! motivates this approach.
 
-#![cfg(feature = "firefox-test")]
+#![cfg(feature = "w215-diag")]
 
 use core::sync::atomic::{AtomicBool, AtomicU64, AtomicU32, Ordering};
 

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -182,8 +182,11 @@ pub fn init() {
             // Vol. 3B §17.2.4, DR0–DR3 are per-CPU; this vector lets the
             // sender CPU publish a new (addr, ctrl) pair and have every
             // online CPU pick it up by reprogramming its own DRs.
-            // Diagnostic-only; gated on `firefox-test`.
-            #[cfg(feature = "firefox-test")]
+            // Diagnostic-only; gated on `w215-diag` (superset of
+            // `firefox-test`).  When the feature is off the vector
+            // stays unassigned and the spurious-IRQ handler catches any
+            // stray IPI — see the IPI-broadcast `cpu_count` invariant.
+            #[cfg(feature = "w215-diag")]
             IDT[0xF1].set_handler(fix(super::irq::irq_w215_dr_sync_handler as *const () as u64), kernel_cs, 0, 0);
 
             // Syscall interrupt (vector 0x80) — for int 0x80 style syscalls
@@ -240,8 +243,8 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
     // interrupted RIP without printing any further diagnostics.  Per
     // Intel SDM Vol. 3B §17.2.5 (Debug Status Register DR6), B0..B3
     // identify which DRn triggered.  Diagnostic-only; gated on
-    // `firefox-test`.
-    #[cfg(feature = "firefox-test")]
+    // `w215-diag` so non-diagnostic builds carry no DR0 dispatch.
+    #[cfg(feature = "w215-diag")]
     if vector == 1 {
         if crate::arch::x86_64::debug_reg::handle_db_exception(
             frame.rip, frame.rsp, frame.rflags, frame.cs,

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -503,8 +503,10 @@ extern "C" fn timer_tick() {
     // `arch::x86_64::debug_reg::arm_write_watchpoint` so the offending
     // kernel write site self-identifies through `#DB`.  Per Intel SDM
     // Vol. 3B §17.2.4 (Debug Address Registers).  Diagnostic-only;
-    // does nothing without the `firefox-test` feature.
-    #[cfg(feature = "firefox-test")]
+    // gated behind `w215-diag` (a superset of `firefox-test`) because
+    // the walker's shadow table is a ~2 MiB BSS static that exposes a
+    // latent PMM-vs-BSS reservation gap on the demo path.
+    #[cfg(feature = "w215-diag")]
     crate::mm::w215_crc::crc_walk_tick(cpu as u32);
 
     // Notify the scheduler about the tick.
@@ -537,13 +539,13 @@ irq_stub!(irq_e1000_handler, e1000_interrupt);
 irq_stub!(irq_virtio_blk_handler, virtio_blk_interrupt);
 irq_stub!(irq_virtio_serial_handler, virtio_serial_interrupt);
 irq_stub!(irq_tlb_shootdown_handler, tlb_shootdown_interrupt);
-#[cfg(feature = "firefox-test")]
+#[cfg(feature = "w215-diag")]
 irq_stub!(irq_w215_dr_sync_handler, w215_dr_sync_interrupt);
 
 /// W215 Arm-1 DR0/DR7 sync IPI body.  Programs this CPU's DR0/DR7 from
 /// the values published by `arch::x86_64::debug_reg::arm_write_watchpoint`.
-/// EOIs the LAPIC.  Diagnostic-only.
-#[cfg(feature = "firefox-test")]
+/// EOIs the LAPIC.  Diagnostic-only; gated behind `w215-diag`.
+#[cfg(feature = "w215-diag")]
 extern "C" fn w215_dr_sync_interrupt() {
     crate::arch::x86_64::debug_reg::handle_w215_dr_sync_ipi();
 }

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -1,7 +1,9 @@
 //! x86_64 architecture-specific code.
 
 pub mod apic;
-#[cfg(feature = "firefox-test")]
+// DR0 W-watchpoint plumbing for the W215 Arm-1 CRC walker.
+// Gated behind `w215-diag` together with the walker itself.
+#[cfg(feature = "w215-diag")]
 pub mod debug_reg;
 pub mod gdt;
 pub mod idt;

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -136,6 +136,7 @@ pub fn insert(mount_idx: usize, inode: u64, page_offset: u64, phys: u64) {
                     crate::mm::w215_diag::KIND_EVICT,
                     crate::mm::w215_diag::pack_cache_key(inode, page_offset),
                 );
+                #[cfg(feature = "w215-diag")]
                 crate::mm::w215_crc::record_evict(old_entry.phys);
             }
         } else {
@@ -155,7 +156,10 @@ pub fn insert(mount_idx: usize, inode: u64, page_offset: u64, phys: u64) {
         let _ = crate::mm::w215_diag::preins_clear_on_insert(phys);
         // Arm-1 CRC walker shadow-table snapshot.  Done AFTER the cache
         // lock is released so we do not hold two locks at once; the
-        // shadow-table mutex is the only lock involved.
+        // shadow-table mutex is the only lock involved.  Gated behind
+        // `w215-diag` so the demo path does not perform the per-insert
+        // 4 KiB CRC scan that touches the ~2 MiB shadow table.
+        #[cfg(feature = "w215-diag")]
         crate::mm::w215_crc::record_insert(phys, inode, page_offset);
     }
 
@@ -197,6 +201,7 @@ pub fn evict(mount_idx: usize, inode: u64, page_offset: u64) -> Option<u64> {
                 crate::mm::w215_diag::OP_EVICT,
                 ((page_offset >> 12) & 0xFFFF_FFFF) as u32,
             );
+            #[cfg(feature = "w215-diag")]
             crate::mm::w215_crc::record_evict(entry.phys);
         }
         Some(entry.phys)
@@ -445,6 +450,7 @@ pub fn evict_if_phys(
                 crate::mm::w215_diag::KIND_EVICT,
                 crate::mm::w215_diag::pack_cache_key(inode, page_offset),
             );
+            #[cfg(feature = "w215-diag")]
             crate::mm::w215_crc::record_evict(expected_phys);
         }
         true

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -11,7 +11,11 @@ pub mod refcount;
 pub mod tlb;
 pub mod vma;
 pub mod vmm;
-#[cfg(feature = "firefox-test")]
+// W215 Arm-1 diagnostic (CRC walker + DR plumbing).  Gated behind
+// `w215-diag` (a strict superset of `firefox-test`) so the 2 MiB
+// shadow-table BSS is only present when the diagnostic is requested.
+// See `Cargo.toml` for the underlying PMM-vs-BSS rationale.
+#[cfg(feature = "w215-diag")]
 pub mod w215_crc;
 #[cfg(feature = "firefox-test")]
 pub mod w215_diag;

--- a/kernel/src/mm/w215_crc.rs
+++ b/kernel/src/mm/w215_crc.rs
@@ -19,7 +19,7 @@
 //!
 //! Diagnostic-only.  No fix-it logic.
 
-#![cfg(feature = "firefox-test")]
+#![cfg(feature = "w215-diag")]
 
 use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 


### PR DESCRIPTION
## Summary

PR #260 introduced a ~2 MiB BSS shadow table (`CRC_TABLE` in
`mm/w215_crc.rs`) gated on `firefox-test`.  That growth pushed kernel
BSS into physical RAM that PMM thinks is free (because
`kernel_size` passed by the bootloader equals the flat-binary
`objcopy -O binary` file size, which excludes BSS).  The page-cache
prepopulate burst then handed out frames aliasing kernel page tables
in the higher-half PD copies; the resulting write through
`PHYS_OFF + phys` cleared the present bit on the PDE covering
`CRC_TABLE`, producing `BUGCHECK 0xdead0006 KERNEL_PAGE_FAULT` in
`record_insert` at `CR2=0xffff800000600098 NOT-PRESENT READ` on the
very next walker iteration.

Fix (Option C — feature-flag separation): introduce a new opt-in
`w215-diag = ["firefox-test"]` feature and move all PR #260 surface
behind it — CRC walker, DR0 watchpoint + IPI vector 0xF1, IDT
registration, `#DB` dispatcher, AP late-arrival apply, and the cache
`record_insert`/`record_evict` hooks.  The `w215_diag` provenance
infrastructure stays under `firefox-test` (its ~104 KiB of statics
do not stress the BSS overlap).

The underlying bootloader-PMM reservation gap (`kernel_size` =
flat-binary file size, omitting BSS) is a separate latent bug that
should be fixed in `bootloader/src/main.rs` or `mm/pmm::init` —
tracked separately so the demo path is unblocked today.

## Test plan

- [x] `cargo +nightly check --features firefox-test` — green.
- [x] `cargo +nightly check --features firefox-test,w215-diag` — green.
- [x] 1×30-min KVM `firefox-test` trial (no `w215-diag`):
  - PID 1 progressed past the pre-fix bugcheck.
  - libxul prepopulate completed all 36 000 pages.
  - Dynamic linker resolved libcairo, libpng16, etc.
  - `[FAULT/PHYS] pid=1 rip_phys=0x32ed8000 vma_offset=0x4b2c5f0` —
    same W215 bucket-A cluster observed pre-PR-#260 (sc=7119 /
    pf=17775).
  - `exit_group(11)` after bucket-A — demo depth restored.
- [ ] Optional follow-up: trial under `firefox-test,w215-diag` to
      confirm the diagnostic still arms; expected behaviour unchanged
      from PR #260's own verification but with a smaller failure
      blast-radius (the BSS overlap still exists but is now opt-in).

## Citations

- Intel SDM Vol. 3B §17.2.4 (Debug Address Registers DR0–DR3) — DRs
  are per-CPU; vector 0xF1 broadcast preserved under `w215-diag`.
- Intel SDM Vol. 3A §4.10.5 (paging-structure coherence) — frames
  must remain reserved against PMM recycling for the lifetime of
  mappings that use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)