### PR TITLE
kernel/proc: fix exit_group STUCK_IN_NR=231 false positive + auto-reap orphan zombies

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1156,6 +1156,21 @@ pub fn exit_thread(exit_code: i64) {
         let _ = crate::signal::kill(parent_pid, crate::signal::SIGCHLD);
     }
 
+    // ── Metrics: clear last-syscall slot when this thread's exit completes
+    //               the process's teardown ────────────────────────────────
+    //
+    // Same rationale as in `exit_group_inner`: exit_thread is `-> !`, so
+    // `proc_metrics::leave_syscall` is never invoked from the normal
+    // syscall-return path.  Without this clear, the dump would report
+    // `STUCK_IN_NR=60@<N>t` (exit) for the now-zombie process every interval
+    // until it is reaped.  Only clear when this thread's exit transitioned
+    // the process to Zombie (`all_dead`); other threads in the same process
+    // may still be alive and their syscall activity will overwrite the slot
+    // normally.
+    if all_dead {
+        proc_metrics::leave_syscall(pid);
+    }
+
     // Yield to scheduler — we're dead, should never return.
     // Wrap in a loop: if the scheduler is disabled (between tests on SMP),
     // schedule() returns early.  Without the loop, exit_thread (which is -> !)
@@ -1578,21 +1593,81 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
 
     // Mark the process as Zombie, record exit code, and re-parent its live children
     // to PID 1 (orphan adoption) so they don't accumulate as un-reapable zombies.
-    let parent_pid = {
+    //
+    // Also collect any of THIS process's own Zombie children: their would-be
+    // reaper (us) is now dying, so re-parenting them to PID 1 only helps if PID 1
+    // is alive and reaping.  When PID 1 is itself the exiting process — common in
+    // the Firefox-on-AstryxOS case where firefox-bin is the only userspace
+    // process — they would orphan to "no one" and leak their PROCESS_TABLE entry
+    // and metrics slot for the rest of the kernel's lifetime.  Reap them inline
+    // before yielding so the table stays bounded.
+    //
+    // Per POSIX wait(2): "If the parent terminates without waiting for the child,
+    // the init process shall inherit the child."  Without a userspace init,
+    // we play that role here for any zombie whose adoptive parent (PID 1) is
+    // itself exiting or already a zombie.
+    let (parent_pid, orphan_zombie_pids): (Pid, alloc::vec::Vec<(Pid, alloc::vec::Vec<Tid>)>) = {
         let mut procs = PROCESS_TABLE.lock();
         let pp = procs.iter().find(|p| p.pid == pid).map(|p| p.parent_pid).unwrap_or(0);
         if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {
             proc.state = ProcessState::Zombie;
             proc.exit_code = exit_code as i32;
         }
-        // Orphan adoption: re-parent surviving children to PID 1.
+        // Determine whether the conventional adopter (PID 1) is alive and able
+        // to eventually reap: if PID 1 is the dying process, missing, or itself
+        // a Zombie, downstream zombies will never be reaped through wait4().
+        // In that case promote them to "ready to reap" right here.
+        let pid1_alive = pid != 1 && procs.iter().any(|p|
+            p.pid == 1 && p.state != ProcessState::Zombie);
+        // Re-parent surviving (non-Zombie) children to PID 1.  Their lifecycle
+        // continues normally; PID 1's exit will sweep them via the same path.
         for p in procs.iter_mut() {
             if p.parent_pid == pid && p.state != ProcessState::Zombie {
                 p.parent_pid = 1;
             }
         }
-        pp
+        // Collect Zombie children of the dying PID (and, when PID 1 cannot
+        // reap, Zombie children of PID 1 too — they are about to be doubly
+        // orphaned).  Returned to the caller as (pid, [tid, …]) and removed
+        // from PROCESS_TABLE in the same critical section to keep observers
+        // from racing against half-removed entries.
+        let mut orphans: alloc::vec::Vec<(Pid, alloc::vec::Vec<Tid>)> =
+            alloc::vec::Vec::new();
+        let mut i = 0;
+        while i < procs.len() {
+            let p = &procs[i];
+            let direct_orphan = p.parent_pid == pid && p.state == ProcessState::Zombie;
+            let pid1_orphan = !pid1_alive
+                && p.parent_pid == 1
+                && p.state == ProcessState::Zombie
+                && p.pid != pid;
+            if direct_orphan || pid1_orphan {
+                let cpid = p.pid;
+                let tids = p.threads.clone();
+                procs.swap_remove(i);
+                orphans.push((cpid, tids));
+                continue;
+            }
+            i += 1;
+        }
+        (pp, orphans)
     };
+    // Drop reaped orphans' threads + metrics outside the PROCESS_TABLE lock
+    // (lock order: PROCESS_TABLE then THREAD_TABLE — see waitpid()).
+    if !orphan_zombie_pids.is_empty() {
+        let mut threads = THREAD_TABLE.lock();
+        for (_cpid, tids) in &orphan_zombie_pids {
+            threads.retain(|t| !tids.contains(&t.tid));
+        }
+        drop(threads);
+        for (cpid, _) in &orphan_zombie_pids {
+            proc_metrics::unregister(*cpid);
+            crate::serial_println!(
+                "[PROC] auto-reaped orphan zombie PID {} (parent {} exiting)",
+                cpid, pid
+            );
+        }
+    }
 
     // Switch to the kernel page tables BEFORE freeing user page tables.
     // Only relevant when the caller is on the user CR3 of the dying process —
@@ -1652,6 +1727,25 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     if parent_pid != 0 {
         let _ = crate::signal::kill(parent_pid, crate::signal::SIGCHLD);
     }
+
+    // ── Metrics: clear the dying process's last-syscall slot ────────────────
+    //
+    // `proc_metrics::leave_syscall` is normally called at the tail of the
+    // syscall dispatcher after the match returns.  exit_group(231) never
+    // returns to the dispatcher (the caller is marked Dead and yields to
+    // `schedule()` below, which never comes back), so the slot's
+    // `last_sc_nr` would remain pinned at 231 long after teardown is
+    // complete.  The periodic dump then reports `STUCK_IN_NR=231@<N>t`
+    // for the exited process every interval until the parent reaps it
+    // (via `waitpid` → `unregister`) — and forever if no one reaps.
+    //
+    // Clear it explicitly here so the diagnostic correctly reflects the
+    // truth: teardown is done; the process is a zombie awaiting reap, not
+    // a thread stuck in a syscall.  Symmetric with `leave_syscall` from
+    // the normal return path.  `proc_metrics::leave_syscall` is wait-free
+    // and takes no locks (one atomic store), so it is safe to invoke even
+    // immediately before `schedule()` switches us off-CPU permanently.
+    proc_metrics::leave_syscall(pid);
 
     // Yield — we're dead and should never return.  Out-of-band callers
     // (yield_self == false) return normally; the caller is a healthy thread

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1670,6 +1670,21 @@ pub fn run() -> ! {
         if test_227_sigreturn_frame_base_ptr_validation() { passed += 1; }
     }
 
+    // ── Test 228: auto-reap doubly-orphaned zombie children on parent exit ─
+    // Verifies that exit_group_inner sweeps any Zombie child of the dying
+    // process from PROCESS_TABLE in-line (rather than leaving it to leak
+    // forever when the conventional adopter PID 1 is itself the dying
+    // process).  Closes the per-trial zombie / metrics-slot leak that the
+    // STUCK_IN_NR=231 investigation surfaced on 2026-05-17.  Per POSIX
+    // wait(2): "If the parent terminates without waiting for the child, the
+    // init process shall inherit the child."  AstryxOS plays that role for
+    // any zombie whose would-be reaper is itself dying.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_228_auto_reap_orphan_zombies() { passed += 1; }
+    }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -28923,5 +28938,120 @@ fn test_227_sigreturn_frame_base_ptr_validation() -> bool {
         return false;
     }
     test_pass!("validate_user_ptr rejects kernel-VA frame_base for SignalFrame size");
+    true
+}
+
+/// Test 228 — exit_group_inner auto-reaps Zombie children of the dying process.
+///
+/// Per POSIX wait(2): "If the parent terminates without waiting for the
+/// child, the init process shall inherit the child."  AstryxOS plays init
+/// for any zombie whose adoptive parent (PID 1) is itself exiting or
+/// already a zombie.  Without the sweep, the child's PROCESS_TABLE row
+/// and proc_metrics slot would leak for the rest of the kernel's lifetime,
+/// and the periodic PROC-METRICS dump would emit a misleading
+/// `STUCK_IN_NR=…` line for the zombie every interval.
+///
+/// Setup:
+///   1. Create two synthetic user processes A (parent) and C (child).
+///   2. Manually re-parent C to A in PROCESS_TABLE.
+///   3. Mark C Zombie out-of-band so it represents an unreaped exit.
+///   4. Call exit_group_pid(A, …) — A's teardown should sweep C.
+///
+/// Asserts:
+///   - PROCESS_TABLE no longer contains C after A's exit.
+///   - proc_metrics for C is unregistered (snapshot returns None).
+///   - C's threads are gone from THREAD_TABLE.
+fn test_228_auto_reap_orphan_zombies() -> bool {
+    use crate::proc::{PROCESS_TABLE, THREAD_TABLE, ProcessState};
+
+    test_header!("exit_group auto-reaps doubly-orphaned zombie children");
+
+    // ── 1. Two synthetic processes ───────────────────────────────────────
+    let parent_pid = match crate::proc::usermode::create_user_process(
+        "reap_parent", &crate::proc::hello_elf::HELLO_ELF
+    ) {
+        Ok(p) => p,
+        Err(e) => { test_fail!("auto_reap_orphan_zombies",
+            "create_user_process(parent): {:?}", e); return false; }
+    };
+    let child_pid = match crate::proc::usermode::create_user_process(
+        "reap_child", &crate::proc::hello_elf::HELLO_ELF
+    ) {
+        Ok(p) => p,
+        Err(e) => { test_fail!("auto_reap_orphan_zombies",
+            "create_user_process(child): {:?}", e); return false; }
+    };
+    if parent_pid == child_pid || parent_pid == 0 || child_pid == 0 {
+        test_fail!("auto_reap_orphan_zombies",
+            "bad pids parent={} child={}", parent_pid, child_pid);
+        return false;
+    }
+    test_println!("  parent PID {}, child PID {} ✓", parent_pid, child_pid);
+
+    // Collect the child's threads up front so the post-sweep check can
+    // confirm THREAD_TABLE is also cleaned up.
+    let child_tids: alloc::vec::Vec<u64> = {
+        let threads = THREAD_TABLE.lock();
+        threads.iter().filter(|t| t.pid == child_pid).map(|t| t.tid).collect()
+    };
+    if child_tids.is_empty() {
+        test_fail!("auto_reap_orphan_zombies",
+            "child pid {} has no threads", child_pid);
+        return false;
+    }
+    test_println!("  child has {} thread(s): {:?} ✓", child_tids.len(), child_tids);
+
+    // ── 2. Re-parent + mark child Zombie ─────────────────────────────────
+    {
+        let mut procs = PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == child_pid) {
+            p.parent_pid = parent_pid;
+            p.state = ProcessState::Zombie;
+            p.exit_code = 0x4242;
+        }
+    }
+    test_println!("  child re-parented to parent + marked Zombie ✓");
+
+    // ── 3. Trigger parent's exit_group out-of-band ───────────────────────
+    crate::proc::exit_group_pid(parent_pid, -1);
+
+    // ── 4. Post-conditions ───────────────────────────────────────────────
+    // (a) Child PROCESS_TABLE entry must be gone.
+    let child_present = {
+        let procs = PROCESS_TABLE.lock();
+        procs.iter().any(|p| p.pid == child_pid)
+    };
+    if child_present {
+        test_fail!("auto_reap_orphan_zombies",
+            "child PID {} still in PROCESS_TABLE after parent exit_group",
+            child_pid);
+        return false;
+    }
+    test_println!("  child PID {} swept from PROCESS_TABLE ✓", child_pid);
+
+    // (b) Metrics slot must be unregistered.
+    if crate::proc::proc_metrics::snapshot(child_pid).is_some() {
+        test_fail!("auto_reap_orphan_zombies",
+            "proc_metrics slot for child PID {} still registered", child_pid);
+        return false;
+    }
+    test_println!("  proc_metrics slot for child unregistered ✓");
+
+    // (c) Child threads must be gone from THREAD_TABLE.
+    {
+        let threads = THREAD_TABLE.lock();
+        let lingering: alloc::vec::Vec<u64> = child_tids.iter()
+            .filter(|&&t| threads.iter().any(|th| th.tid == t))
+            .copied().collect();
+        if !lingering.is_empty() {
+            test_fail!("auto_reap_orphan_zombies",
+                "THREAD_TABLE still contains child tids {:?} after sweep",
+                lingering);
+            return false;
+        }
+    }
+    test_println!("  child threads cleared from THREAD_TABLE ✓");
+
+    test_pass!("exit_group auto-reaps doubly-orphaned zombie children");
     true
 }


### PR DESCRIPTION
## Summary

Closes two bugs that PR #264's per-process activity metrics surfaced in firefox-test:

1. **`STUCK_IN_NR=231` false positive** — `exit_group(231)` is `-> !`, so the dispatcher's `proc_metrics::leave_syscall(pid)` is never invoked. The metrics slot's `last_sc_nr` stays pinned at 231 forever, and the periodic `[PROC-METRICS]` dump emits a misleading `STUCK_IN_NR=231@<N>t` line every 5 s until the parent reaps the zombie (or forever if no one does). Observed firing 37+ times per Firefox trial.
2. **Doubly-orphaned zombies leak** — when PID 1 itself is the dying process (the Firefox-on-AstryxOS case with no userspace init), the orphan-adoption loop re-parents children to PID 1 which is itself exiting. Any pre-existing Zombie children of PID 1 then orphan to nobody and leak their `PROCESS_TABLE` row + `proc_metrics` slot for the rest of the kernel's lifetime. Per `wait(2)`, the kernel must take over the init role here.

### Fix

- `exit_group_inner` and the `all_dead` arm of `exit_thread` call `proc_metrics::leave_syscall(pid)` right before yielding so the dump correctly distinguishes "in kernel" from "exited, awaiting reap".
- `exit_group_inner` collects Zombie children of the dying PID (and, when PID 1 cannot reap, Zombie children of PID 1 too) inline; reaps them in the same critical section under the existing `PROCESS_TABLE → THREAD_TABLE` lock order; logs `[PROC] auto-reaped orphan zombie PID X (parent Y exiting)`.

### Verification (firefox-test, KVM, single trial)

- **0** occurrences of `STUCK_IN_NR=231` (baseline: 37 lines, every 500 ticks).
- PID 2 contentproc entered `exit_group(0)` at tick 14502, and no STUCK metric ever followed in subsequent PROC-METRICS lines.
- PID 1 reached `sc=7049` + 4 KiB SQLite-journal writes to `/tmp/ff-profile/storage/` — past the previous sc~6400 plateau, progressing toward libpng16.so.16 use (8 successful opens of `/lib/x86_64-linux-gnu/libpng16.so.16` observed).
- 0 `FAULT/PHYS` aliasing fires during the trial.

### Test 228

`test_228_auto_reap_orphan_zombies` (gated `#[cfg(any(feature = "firefox-test", feature = "test-mode"))]`) builds a synthetic parent + zombie child topology, drives `exit_group_pid` on the parent, and asserts `PROCESS_TABLE` + `THREAD_TABLE` + `proc_metrics` are all swept clean.

### Diff size

97 LOC kernel + 130 LOC test = 227 total — within budget per dispatch (50-150 with burst to 250).

### Files

- `kernel/src/proc/mod.rs` (+97/-3)
- `kernel/src/test_runner.rs` (+130/-0)

## Test plan

- [x] Build with `--features firefox-test`: clean.
- [x] Build with `--features test-mode`: clean.
- [x] KVM trial: 0 `STUCK_IN_NR=231`, PID 1 deeper progress vs baseline.
- [ ] CI: confirm test_228 passes in test-mode run.

References: POSIX `wait(2)` / `_exit(2)` (parent absence → init inherits), `proc(5)` /proc/[pid]/stat for activity-class bucketing, Intel SDM Vol. 3A §8.10 (wait-free atomic-store property used by `proc_metrics::leave_syscall`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)