### PR TITLE
kernel/proc+mm: W215 follow-ups (ELF OOM cleanup + caller_rip range check)

### DIFF
--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -424,11 +424,24 @@ pub fn alloc_page() -> Option<u64> {
 /// save RBP (LTO / `-fomit-frame-pointer`) this returns 0 — the
 /// `[PMM/PTE-REFS]` line is still useful from the phys + residual count
 /// alone.  Diagnostic-only.
+///
+/// Defensive range check: kernel stacks live in the higher-half
+/// direct-map at `[KERNEL_VIRT_OFFSET, KERNEL_VIRT_OFFSET + 4 GiB)`
+/// (see `kernel/src/proc/mod.rs::alloc_kernel_stack` and
+/// `mm/pmm.rs::MAX_PAGES`).  A bare "higher-half" check accepts any
+/// VA ≥ 0xFFFF_8000_0000_0000 — including unmapped holes between the
+/// direct map, the kernel heap, and per-CPU regions.  If bookkeeping
+/// corruption ever placed RBP into one of those holes, the
+/// `read_volatile` below would page-fault in kernel mode (likely
+/// fatal during a diagnostic that exists to AID triage of a separate
+/// fault).  Restricting RBP to the direct-map range keeps the read
+/// safe: every address in `[KERNEL_VIRT_OFFSET, +4 GiB)` is mapped by
+/// the higher-half PML4 entries set up at boot.
 #[inline(never)]
 fn caller_rip() -> u64 {
     let rbp: u64;
     // SAFETY: reading the frame pointer is always safe; the subsequent
-    // dereference is guarded by alignment + higher-half checks below.
+    // dereference is guarded by alignment + range checks below.
     unsafe {
         core::arch::asm!(
             "mov {}, rbp",
@@ -436,11 +449,21 @@ fn caller_rip() -> u64 {
             options(nomem, nostack, preserves_flags),
         );
     }
-    if rbp == 0 || (rbp & 7) != 0 || rbp < 0xFFFF_8000_0000_0000 {
+    // Direct-map bounds: 4 GiB of physical RAM identity-mapped into
+    // the higher half (MAX_PAGES * PAGE_SIZE = 4 GiB).
+    const DIRECT_MAP_BASE: u64 = crate::proc::KERNEL_VIRT_OFFSET;
+    const DIRECT_MAP_END:  u64 = DIRECT_MAP_BASE + (MAX_PAGES * PAGE_SIZE) as u64;
+    if rbp == 0
+        || (rbp & 7) != 0
+        || rbp < DIRECT_MAP_BASE
+        || rbp.saturating_add(8) >= DIRECT_MAP_END
+    {
         return 0;
     }
     // [rbp+8] = saved return address into `free_page`'s caller.
-    // SAFETY: rbp has passed the higher-half + alignment guard above.
+    // SAFETY: rbp + 8 has passed the direct-map range + alignment
+    // guard above; the entire direct-map window is mapped via the
+    // higher-half PML4 entries.
     unsafe { core::ptr::read_volatile((rbp + 8) as *const u64) }
 }
 

--- a/kernel/src/proc/elf.rs
+++ b/kernel/src/proc/elf.rs
@@ -698,7 +698,18 @@ pub fn load_elf_with_args(data: &[u8], cr3: u64, argv: &[&str], envp: &[&str]) -
             if !already_mapped {
                 // Map the page into the target page table.
                 if !vmm::map_page_in(cr3, page_vaddr, phys, flags) {
+                    // Cleanup: every prior page in `allocated_pages` had
+                    // `page_ref_set(phys, 1)` applied after its successful
+                    // map_page_in.  The current iteration's page has NOT
+                    // had page_ref_set called yet (refcount==0 already), so
+                    // unconditionally clearing the refcount before free is
+                    // a no-op for it and the correct decrement for all
+                    // already-mapped predecessors.  Without this, the W215
+                    // pte_share_count free-time invariant would quarantine
+                    // every successfully-mapped frame on this OOM path,
+                    // leaking them for the rest of the boot.
                     for &page in &allocated_pages {
+                        crate::mm::refcount::page_ref_set(page, 0);
                         pmm::free_page(page);
                     }
                     return Err(ElfError::OutOfMemory);
@@ -783,7 +794,14 @@ pub fn load_elf_with_args(data: &[u8], cr3: u64, argv: &[&str], envp: &[&str]) -
 
         let flags = vmm::PAGE_PRESENT | vmm::PAGE_WRITABLE | vmm::PAGE_USER | vmm::PAGE_NO_EXECUTE;
         if !vmm::map_page_in(cr3, page_vaddr, phys, flags) {
+            // Cleanup mirrors the PT_LOAD path above: clear refcount on
+            // every page before free so the W215 pte_share_count free-time
+            // invariant does not quarantine the successfully-mapped
+            // predecessors.  The current page is still at refcount==0
+            // (page_ref_set has not yet been called) so the clear is a
+            // no-op for it.
             for &page in &allocated_pages {
+                crate::mm::refcount::page_ref_set(page, 0);
                 pmm::free_page(page);
             }
             return Err(ElfError::OutOfMemory);


### PR DESCRIPTION
## Summary

Two non-blocking review notes from PR #270
(https://github.com/me1iissa/AstryxOS/pull/270#issuecomment-4469437006),
the W215 surgical fix that landed the `pte_share_count` free-time
invariant.

### Change 1 — ELF loader OOM cleanup (`kernel/src/proc/elf.rs`)

`load_elf_with_args` has two `vmm::map_page_in` failure paths (PT_LOAD
loop and user-stack loop).  Each one cleans up by iterating over
`allocated_pages` and calling `pmm::free_page` on every frame.  After
PR #270 the cleanup is wrong: every successfully-mapped page has had
`page_ref_set(phys, 1)` applied, and `pmm::free_page` now refuses to
recycle any frame whose `pte_share_count` is non-zero.  The OOM
rollback therefore quarantined every mapped frame for the rest of the
boot — a slow leak triggered by any ELF that hit OOM mid-load.

The fix mirrors the test-runner cleanup pattern PR #270 introduced
(Test 229 and the 8 test-side fixes): drop the share-ref to 0 before
freeing each page.  The current-iteration page is already at 0 (the
failure happened before `page_ref_set` was called), so the
unconditional clear is a no-op for it and the correct decrement for
all already-mapped predecessors.

### Change 2 — `caller_rip` defensive range check (`kernel/src/mm/pmm.rs`)

The current implementation accepts any RBP ≥ `0xFFFF_8000_0000_0000`
and then `read_volatile`s at `rbp + 8`.  That higher-half check
accepts addresses in unmapped holes between the direct map, the
kernel heap, and per-CPU regions; if bookkeeping corruption ever
placed RBP into one of those holes the diagnostic itself would
page-fault in kernel mode — fatal during a path that exists to
**aid** triage of a separate fault.

RBP is now restricted to the direct-map range
`[KERNEL_VIRT_OFFSET, KERNEL_VIRT_OFFSET + 4 GiB)`, the
contiguously-mapped window in which all kernel stacks live
(`alloc_kernel_stack` returns `KERNEL_VIRT_OFFSET + phys` with `phys`
bounded by `MAX_PAGES * PAGE_SIZE`).  Every address in that window is
covered by the higher-half PML4 entries set up at boot, so the
`read_volatile` cannot fault.  Intel SDM Vol. 3A §4.10.5 (paging
structure coherence) is the relevant invariant: a diagnostic that
exists to surface the consequences of a coherence violation must
itself be safe under the bookkeeping corruption it triages.

### Diff size

44 lines added, 3 removed across 2 files (target ~20, soft cap 30,
ok-with-justification 50).  The overshoot is comment density — both
sites now carry a paragraph explaining the W215 interaction so future
readers do not re-introduce the bug.  The mechanical edits are 4
lines (two `page_ref_set(page, 0)` insertions, one range-check
condition, one constant declaration).

## Test plan

- [x] `python3 scripts/qemu-harness.py check --features ""`                  → ok rc=0
- [x] `python3 scripts/qemu-harness.py check --features "firefox-test"`       → ok rc=0
- [x] `python3 scripts/qemu-harness.py check --features "firefox-test,w215-diag"` → ok rc=0
- [x] Firefox-test boot: BSP boot → Phase 10f (GUI input init) → init
      thread → libxul making syscalls (`[FF/write] pid=1 fd=3 bytes=14
      body="calling init: "`).  Zero `PANIC`, zero `BUGCHECK`, zero
      `[PMM/PTE-REFS]` lines — the W215 clean signature from master
      `b1059e0` is preserved.

Cross-link: PR #270 https://github.com/me1iissa/AstryxOS/pull/270

🤖 Generated with [Claude Code](https://claude.com/claude-code)