### PR TITLE
scripts/qemu-harness + kernel/kdb: thread-park-audit (PNG-1 plateau characterisation)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -359,6 +359,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "arm-phys"         => op_arm_phys(req, out),
         "coverage-flush" => op_coverage_flush(out),
         "proc-metrics"   => op_proc_metrics(out),
+        "thread-park-audit" => op_thread_park_audit(req, out),
         _ => {
             out.push_str(r#"{"error":"unknown op: "#);
             for c in op.chars().take(64) {
@@ -1797,4 +1798,557 @@ fn op_proc_metrics(out: &mut String) {
     }
     out.push(']');
     out.push('}');
+}
+
+// ── thread-park-audit ────────────────────────────────────────────────────────
+//
+// PNG-1 plateau characterisation (post-W215-closure).  For every thread
+// currently in the THREAD_TABLE that is not Dead, emit:
+//
+//   { tid, pid, name, state, rip, rsp, wake_tick,
+//     syscall: { nr, name, arg0 } | null,
+//     blocked_for_ticks,                 // tick_now - last_syscall_tick
+//     wait: { kind, ... }                // classification (best effort)
+//   }
+//
+// `kind` is one of:
+//   "futex"          → uaddr resolved from FUTEX_WAITERS reverse lookup
+//   "poll-bell"      → last syscall was poll/ppoll/epoll_wait/select; the
+//                      thread is parked on the global POLL_BELL.  arg0 is
+//                      the fd-array pointer (poll) or epfd (epoll_wait).
+//   "vfork-complete" → vfork_parent_tid is set; child waits for execve/exit
+//   "sleep"          → sleeping with finite wake_tick (nanosleep/clock_nanosleep)
+//   "fd-blocked"     → last syscall is a blocking fd op (read/recvmsg/sendmsg/
+//                      pread/preadv/accept) and the thread is Blocked.  arg0
+//                      is the fd; we resolve the FD via the process table and
+//                      walk the unix-socket snapshot to find the peer.
+//   "unknown"        → no classifier matched.
+//
+// Per-thread `last_syscall_*` comes from `proc::sample::read_sample(tid)`
+// (firefox-test only; populated on every syscall dispatch entry).  For
+// non-firefox-test builds the syscall field is `null` and `wait.kind` is
+// always "unknown" — the op stays usable but degraded.
+//
+// Optional pid filter: `{"op":"thread-park-audit","pid":N}`.  pid=0 (or
+// omitted) means all PIDs.
+//
+// References:
+//   - POSIX `poll(2)` and `epoll_wait(2)` for wait semantics
+//   - `man 2 futex` for FUTEX_WAIT registration
+//   - Intel SDM Vol 3A §8.2.3 (total store order for in-cache writes)
+//     justifies the read-back order in `sample::read_sample`.
+
+// Linux syscall numbers we classify (x86_64).  Kept inline rather than
+// imported from subsys/linux/syscall.rs to avoid a kdb→subsys dependency
+// for what is, fundamentally, a diagnostic-side lookup table.
+const NR_READ:        u64 = 0;
+const NR_POLL:        u64 = 7;
+const NR_PREAD64:     u64 = 17;
+const NR_PREADV:      u64 = 295;
+const NR_NANOSLEEP:   u64 = 35;
+const NR_CLOCK_NANOSLEEP: u64 = 230;
+const NR_RECVMSG:     u64 = 47;
+const NR_SENDMSG:     u64 = 46;
+const NR_RECVFROM:    u64 = 45;
+const NR_ACCEPT:      u64 = 43;
+const NR_ACCEPT4:     u64 = 288;
+const NR_SELECT:      u64 = 23;
+const NR_PSELECT6:    u64 = 270;
+const NR_PPOLL:       u64 = 271;
+const NR_EPOLL_WAIT:  u64 = 232;
+const NR_EPOLL_PWAIT: u64 = 281;
+const NR_FUTEX:       u64 = 202;
+
+fn is_poll_family(nr: u64) -> bool {
+    matches!(nr, NR_POLL | NR_PPOLL | NR_SELECT | NR_PSELECT6
+                | NR_EPOLL_WAIT | NR_EPOLL_PWAIT)
+}
+fn is_fd_blocking(nr: u64) -> bool {
+    matches!(nr, NR_READ | NR_PREAD64 | NR_PREADV | NR_RECVMSG
+                | NR_RECVFROM | NR_ACCEPT | NR_ACCEPT4 | NR_SENDMSG)
+}
+
+fn op_thread_park_audit(req: &str, out: &mut String) {
+    use core::fmt::Write;
+
+    let pid_filter: u64 = extract_field(req, "pid")
+        .and_then(|s| parse_u64(&s))
+        .unwrap_or(0);
+
+    let tick_now = crate::arch::x86_64::irq::get_ticks();
+    let sc_total = crate::syscall::syscall_count();
+
+    // ── Stage 1: snapshot all live threads of interest ─────────────────
+    struct ThreadSnap {
+        tid: u64, pid: u64, name: String,
+        state: &'static str, rip: u64, rsp: u64,
+        wake_tick: u64, clear_child_tid: u64,
+        vfork_parent_tid: Option<u64>,
+    }
+    let thread_snaps: Vec<ThreadSnap> = match try_lock_brief(&THREAD_TABLE) {
+        Some(tt) => tt.iter()
+            .filter(|t| t.state != crate::proc::ThreadState::Dead)
+            .filter(|t| pid_filter == 0 || t.pid == pid_filter)
+            .map(|t| ThreadSnap {
+                tid: t.tid, pid: t.pid,
+                name: {
+                    let end = t.name.iter().position(|&b| b == 0).unwrap_or(t.name.len());
+                    String::from_utf8_lossy(&t.name[..end]).into_owned()
+                },
+                state: thread_state_str(t.state),
+                rip: t.user_entry_rip, rsp: t.context.rsp,
+                wake_tick: t.wake_tick,
+                clear_child_tid: t.clear_child_tid,
+                vfork_parent_tid: t.vfork_parent_tid,
+            }).collect(),
+        None => {
+            out.push_str(r#"{"busy":"THREAD_TABLE held","threads":[]}"#);
+            return;
+        }
+    };
+
+    // ── Stage 2: snapshot the per-PID process names + FD tables ────────
+    // Only fetch what we need for "fd-blocked" peer resolution.  Note we
+    // intentionally do NOT honour `pid_filter` here — when one thread is
+    // blocked on a socket, its peer process can be ANY pid, and the FD
+    // tables of those peer pids are needed to render the (peer_pid, peer_fd)
+    // tuple even when the caller filtered the thread view to one pid.
+    // Tuple shape: (pid, proc_name, fds[(fd, file_type, inode, flags, path)]).
+    let proc_snaps: Vec<ProcFdRow> = match try_lock_brief(&PROCESS_TABLE) {
+        Some(pt) => pt.iter()
+            .map(|p| (
+                p.pid,
+                proc_name_string(&p.name),
+                p.file_descriptors.iter().enumerate()
+                    .filter_map(|(i, fd)| fd.as_ref().map(|fd|
+                        (i, fd.file_type, fd.inode, fd.flags, fd.open_path.clone())))
+                    .collect::<Vec<_>>(),
+            )).collect(),
+        None => Vec::new(), // best-effort: emit per-thread state without FD resolution
+    };
+
+    // ── Stage 3: snapshot FUTEX waiters (for futex reverse-lookup) ─────
+    // Map tid → (pid, uaddr) so the per-thread emit can answer "this TID
+    // is waiting on which futex".  Best-effort: a long-held FUTEX_WAITERS
+    // (e.g. mid-FUTEX_WAKE across a busy contentproc) is common under
+    // Firefox load; rather than block the kdb listener thread we fall
+    // back to the empty map so "wait.kind":"futex" classification is
+    // skipped on contention but every other field still surfaces.  The
+    // try_lock_brief discipline matches op_proc_list / op_fd_map.
+    let mut tid_to_futex: alloc::collections::BTreeMap<u64, (u64, u64)> =
+        alloc::collections::BTreeMap::new();
+    let futex_busy = match try_lock_brief(&crate::syscall::FUTEX_WAITERS) {
+        Some(waiters) => {
+            for ((pid_k, uaddr), tids) in waiters.iter() {
+                for tid in tids {
+                    tid_to_futex.insert(*tid, (*pid_k, *uaddr));
+                }
+            }
+            false
+        }
+        None => true,
+    };
+
+    // ── Stage 4: snapshot unix sockets (for fd-blocked peer lookup) ────
+    let sock_snaps = crate::net::unix::snapshot_all();
+
+    // ── Stage 5: emit JSON ─────────────────────────────────────────────
+    out.push('{');
+    let _ = write!(out, r#""tick":{},"sc_total":{},"pid_filter":{},"#,
+                   tick_now, sc_total, pid_filter);
+    if futex_busy {
+        out.push_str(r#""futex_waiters_busy":true,"#);
+    }
+    out.push_str(r#""threads":["#);
+
+    // Emission budget: each thread renders ~250-450 B of JSON; cap at
+    // 24 KB so the full envelope (including overhead) clears the 32 KB
+    // kernel-side MAX_RESP_BYTES truncation threshold.  If we hit the cap
+    // we emit `truncated_at_thread:N` and stop — the caller can re-issue
+    // with `--pid N` for a narrower view.
+    //
+    // Additionally, every per-thread record is mirrored to the serial log
+    // as `[THREAD-PARK]` so the harness can recover from a TCP send-buffer
+    // stall (rare but observed: the in-kernel TCP stack drains the
+    // response over multiple pump ticks via tcp_timer_tick, and a kdb
+    // response > 1 MSS may not fully arrive before the host's recv
+    // deadline expires).  Serial is unconditionally drained on each
+    // emission, so the lines reach the harness even if the JSON envelope
+    // is truncated mid-flight.  The serial format mirrors the JSON shape
+    // 1:1 so the harness can synthesise the response from serial alone.
+    const EMIT_BUDGET_BYTES: usize = 24 * 1024;
+    let mut first = true;
+    let mut emitted = 0usize;
+    let mut truncated_at: Option<u64> = None;
+    let audit_id = tick_now;  // marker so harness can scope its parse
+    crate::serial_println!("[THREAD-PARK] BEGIN audit_id={} tick={} sc_total={} pid_filter={} threads={}",
+                            audit_id, tick_now, sc_total, pid_filter, thread_snaps.len());
+    for ts in &thread_snaps {
+        if out.len() > EMIT_BUDGET_BYTES {
+            truncated_at = Some(ts.tid);
+            // Still emit the remaining threads to serial for harness recovery.
+            // (we just skip pushing into `out`).
+        }
+        let in_budget = out.len() <= EMIT_BUDGET_BYTES;
+        if in_budget {
+            if !first { out.push(','); }
+            first = false;
+            emitted += 1;
+        }
+
+        // Per-thread sample lookup (firefox-test only).
+        #[cfg(feature = "firefox-test")]
+        let sample = crate::proc::sample::read_sample(ts.tid);
+        #[cfg(not(feature = "firefox-test"))]
+        let sample: Option<crate::proc::sample::TidSyscallSample> = None;
+
+        // Resolve owning process name (lookup in proc_snaps).
+        let proc_name = proc_snaps.iter().find(|(p, _, _)| *p == ts.pid)
+            .map(|(_, n, _)| n.as_str()).unwrap_or("?");
+
+        let (nr_opt, arg0_opt, blocked_for) = match &sample {
+            Some(s) => (Some(s.last_syscall_nr), Some(s.last_syscall_arg0),
+                        tick_now.saturating_sub(s.last_syscall_tick)),
+            None => (None, None, 0u64),
+        };
+
+        // ── JSON emission (budget-gated) ─────────────────────────────
+        if in_budget {
+            out.push('{');
+            j_kv(out, "tid", &alloc::format!("{}", ts.tid));
+            j_kv(out, "pid", &alloc::format!("{}", ts.pid));
+            j_kv_str(out, "proc_name", proc_name);
+            j_kv_str(out, "thread_name", &ts.name);
+            j_kv_str(out, "state", ts.state);
+            j_str(out, "rip"); out.push(':'); j_hex(out, ts.rip); out.push(',');
+            j_str(out, "rsp"); out.push(':'); j_hex(out, ts.rsp); out.push(',');
+            let _ = write!(out, r#""wake_tick":{},"#, ts.wake_tick);
+            let _ = write!(out, r#""blocked_for_ticks":{},"#, blocked_for);
+            match (nr_opt, arg0_opt) {
+                (Some(nr), Some(arg0)) => {
+                    out.push_str(r#""syscall":{"#);
+                    let _ = write!(out, r#""nr":{},"#, nr);
+                    j_kv_str(out, "name", crate::perf::linux_syscall_name(nr));
+                    j_str(out, "arg0"); out.push(':'); j_hex(out, arg0);
+                    out.push_str("},");
+                }
+                _ => {
+                    out.push_str(r#""syscall":null,"#);
+                }
+            }
+            out.push_str(r#""wait":"#);
+            emit_wait_classification(
+                out,
+                ts.tid, ts.pid, ts.wake_tick,
+                ts.clear_child_tid, ts.vfork_parent_tid,
+                sample.as_ref(),
+                &tid_to_futex, &proc_snaps, &sock_snaps,
+            );
+            out.push('}');
+        }
+
+        // ── Serial-log mirror (always emitted; harness fallback) ────
+        // Single line per thread.  Keys are stable so the harness regex
+        // is also stable.  Wait classification is rendered as a compact
+        // `wait=KIND[,kv]*` suffix; the harness parses it into the same
+        // shape it would synthesise from the JSON path.
+        let (sn, sa0): (i64, u64) = match (nr_opt, arg0_opt) {
+            (Some(n), Some(a)) => (n as i64, a),
+            _                  => (-1, 0),
+        };
+        let mut wait_buf = String::with_capacity(96);
+        render_wait_compact(&mut wait_buf,
+                            ts.tid, ts.pid, ts.wake_tick,
+                            ts.clear_child_tid, ts.vfork_parent_tid,
+                            sample.as_ref(),
+                            &tid_to_futex, &proc_snaps, &sock_snaps);
+        crate::serial_println!(
+            "[THREAD-PARK] id={} tid={} pid={} pname={} tname={} state={} \
+             rip={:#x} rsp={:#x} wake_tick={} blocked_for={} sc_nr={} sc_arg0={:#x} {}",
+            audit_id, ts.tid, ts.pid, proc_name, ts.name, ts.state,
+            ts.rip, ts.rsp, ts.wake_tick, blocked_for, sn, sa0, wait_buf,
+        );
+    }
+    crate::serial_println!("[THREAD-PARK] END audit_id={} emitted_json={} threads_total={}",
+                            audit_id, emitted, thread_snaps.len());
+    out.push(']');
+    let _ = write!(out, r#","emitted":{}"#, emitted);
+    if let Some(tid) = truncated_at {
+        let _ = write!(out, r#","truncated_at_tid":{}"#, tid);
+    }
+    out.push('}');
+}
+
+// Concrete shape mirrored from op_thread_park_audit's local `ProcFdSnap`.
+// Kept module-private; the op_thread_park_audit function builds a Vec of
+// these and passes it by reference to emit_wait_classification.
+type ProcFdRow = (u64, String, Vec<(usize, crate::vfs::FileType, u64, u32, String)>);
+
+
+/// Emit the `"wait":{...}` object for one thread.  Best-effort classifier;
+/// see the op_thread_park_audit doc-comment for the kind taxonomy.
+///
+/// `proc_snaps` is a parallel slice of `(pid, name, fds)` per Stage 2 of
+/// op_thread_park_audit.  Passed as primitive references rather than via
+/// a trait so the function-local snapshot structs can stay encapsulated.
+#[allow(clippy::too_many_arguments)]
+fn emit_wait_classification(
+    out: &mut String,
+    tid: u64,
+    pid: u64,
+    wake_tick: u64,
+    clear_child_tid: u64,
+    vfork_parent_tid: Option<u64>,
+    sample: Option<&crate::proc::sample::TidSyscallSample>,
+    tid_to_futex: &alloc::collections::BTreeMap<u64, (u64, u64)>,
+    proc_snaps: &[ProcFdRow],
+    sock_snaps: &[crate::net::unix::SocketSnap],
+) {
+    use core::fmt::Write;
+
+    // 1. Futex: highest-confidence — direct reverse lookup from the
+    //    kernel's wait queue.
+    if let Some((futex_pid, uaddr)) = tid_to_futex.get(&tid).copied() {
+        out.push('{');
+        j_kv_str(out, "kind", "futex");
+        let _ = write!(out, r#""pid":{},"#, futex_pid);
+        j_str(out, "uaddr"); out.push(':'); j_hex(out, uaddr);
+        out.push('}');
+        return;
+    }
+
+    // 2. vfork-complete: child blocked until execve/exit wakes parent.
+    if let Some(parent_tid) = vfork_parent_tid {
+        out.push('{');
+        j_kv_str(out, "kind", "vfork-complete");
+        let _ = write!(out, r#""parent_tid":{}"#, parent_tid);
+        out.push('}');
+        return;
+    }
+
+    // 3/4/5. Sample-driven classifications (require firefox-test).
+    if let Some(s) = sample {
+        let nr = s.last_syscall_nr;
+        let arg0 = s.last_syscall_arg0;
+        if matches!(nr, NR_NANOSLEEP | NR_CLOCK_NANOSLEEP)
+            && wake_tick != u64::MAX && wake_tick != 0 {
+            out.push('{');
+            j_kv_str(out, "kind", "sleep");
+            let _ = write!(out, r#""wake_tick":{}"#, wake_tick);
+            out.push('}');
+            return;
+        }
+        if is_poll_family(nr) {
+            out.push('{');
+            j_kv_str(out, "kind", "poll-bell");
+            let _ = write!(out, r#""nr":{},"#, nr);
+            j_str(out, "arg0"); out.push(':'); j_hex(out, arg0);
+            out.push('}');
+            return;
+        }
+        if is_fd_blocking(nr) {
+            // arg0 is the fd; resolve it via the process FD table.
+            let fd = arg0 as usize;
+            let resolved = proc_snaps.iter().find(|(p, _, _)| *p == pid)
+                .and_then(|(_, _, fds)| fds.iter()
+                    .find(|(i, _, _, _, _)| *i == fd));
+            out.push('{');
+            j_kv_str(out, "kind", "fd-blocked");
+            let _ = write!(out, r#""nr":{},"#, nr);
+            let _ = write!(out, r#""fd":{},"#, fd);
+            match resolved {
+                Some((_, ft, inode, flags, path)) => {
+                    let ft_str = file_type_str(*ft);
+                    j_kv_str(out, "fd_kind", ft_str);
+                    let _ = write!(out, r#""inode":{},"#, inode);
+                    // For sockets: resolve peer via sock_snaps.
+                    if matches!(ft, crate::vfs::FileType::Socket) {
+                        let peer_socket_id = sock_snaps.iter()
+                            .find(|s| s.id == *inode)
+                            .map(|s| s.peer_id)
+                            .unwrap_or(u64::MAX);
+                        if peer_socket_id == u64::MAX {
+                            j_kv_str(out, "peer_pid", "none");
+                            j_kv_str(out, "peer_fd",  "none");
+                        } else {
+                            // Find which (pid, fd) owns peer_socket_id.
+                            let owner = proc_snaps.iter().find_map(|(ppid, _, fds)|
+                                fds.iter().find(|(_, ft2, inode2, _, _)|
+                                    matches!(ft2, crate::vfs::FileType::Socket)
+                                    && *inode2 == peer_socket_id)
+                                .map(|(fd2, _, _, _, _)| (*ppid, *fd2)));
+                            match owner {
+                                Some((ppid, pfd)) => {
+                                    let _ = write!(out, r#""peer_pid":{},"peer_fd":{},"#, ppid, pfd);
+                                }
+                                None => {
+                                    j_kv_str(out, "peer_pid", "unowned");
+                                    j_kv_str(out, "peer_fd",  "unowned");
+                                }
+                            }
+                        }
+                    }
+                    // For pipes: find the opposite end.
+                    if matches!(ft, crate::vfs::FileType::Pipe) {
+                        let is_write = flags & 1 == 1;
+                        let peer = proc_snaps.iter().find_map(|(ppid, _, fds)|
+                            fds.iter().find(|(_, ft2, inode2, fl, _)|
+                                matches!(ft2, crate::vfs::FileType::Pipe)
+                                && *inode2 == *inode
+                                && (fl & 1 == 1) != is_write)
+                            .map(|(fd2, _, _, _, _)| (*ppid, *fd2)));
+                        match peer {
+                            Some((ppid, pfd)) => {
+                                let _ = write!(out, r#""peer_pid":{},"peer_fd":{},"#, ppid, pfd);
+                            }
+                            None => {
+                                j_kv_str(out, "peer_pid", "none");
+                                j_kv_str(out, "peer_fd",  "none");
+                            }
+                        }
+                    }
+                    if !path.is_empty() { j_kv_str(out, "path", path); }
+                }
+                None => {
+                    j_kv_str(out, "fd_kind", "unresolved");
+                }
+            }
+            j_trim_comma(out);
+            out.push('}');
+            return;
+        }
+        if nr == NR_FUTEX {
+            // FUTEX waiter without a queue entry — likely either FUTEX_WAKE
+            // beat us out of the wait queue (and we just haven't returned
+            // yet) or a non-WAIT futex op.  Surface arg0 (uaddr) so the
+            // caller can still cross-reference.
+            out.push('{');
+            j_kv_str(out, "kind", "futex-other");
+            j_str(out, "uaddr"); out.push(':'); j_hex(out, arg0);
+            out.push('}');
+            return;
+        }
+    }
+
+    // 6. Catch-all: state may still be informative even without a syscall.
+    out.push('{');
+    j_kv_str(out, "kind", "unknown");
+    if clear_child_tid != 0 {
+        // Newly-spawned thread or one that's about to exit cleanly.
+        j_str(out, "clear_child_tid"); out.push(':'); j_hex(out, clear_child_tid);
+        out.push(',');
+    }
+    j_trim_comma(out);
+    out.push('}');
+}
+
+/// Render a one-line `wait=KIND[,kv]*` description for the serial mirror.
+/// Mirrors `emit_wait_classification`'s taxonomy but in a flat suffix shape
+/// the harness can `wait=(.*)$` capture.  Same classifier inputs.
+#[allow(clippy::too_many_arguments)]
+fn render_wait_compact(
+    out: &mut String,
+    tid: u64,
+    pid: u64,
+    wake_tick: u64,
+    clear_child_tid: u64,
+    vfork_parent_tid: Option<u64>,
+    sample: Option<&crate::proc::sample::TidSyscallSample>,
+    tid_to_futex: &alloc::collections::BTreeMap<u64, (u64, u64)>,
+    proc_snaps: &[ProcFdRow],
+    sock_snaps: &[crate::net::unix::SocketSnap],
+) {
+    use core::fmt::Write;
+    if let Some((fp, uaddr)) = tid_to_futex.get(&tid).copied() {
+        let _ = write!(out, "wait=futex,fpid={},uaddr={:#x}", fp, uaddr);
+        return;
+    }
+    if let Some(parent_tid) = vfork_parent_tid {
+        let _ = write!(out, "wait=vfork-complete,parent_tid={}", parent_tid);
+        return;
+    }
+    if let Some(s) = sample {
+        let nr = s.last_syscall_nr;
+        let arg0 = s.last_syscall_arg0;
+        if matches!(nr, NR_NANOSLEEP | NR_CLOCK_NANOSLEEP)
+            && wake_tick != u64::MAX && wake_tick != 0 {
+            let _ = write!(out, "wait=sleep,wake_tick={}", wake_tick);
+            return;
+        }
+        if is_poll_family(nr) {
+            let _ = write!(out, "wait=poll-bell,nr={},arg0={:#x}", nr, arg0);
+            return;
+        }
+        if is_fd_blocking(nr) {
+            let fd = arg0 as usize;
+            let resolved = proc_snaps.iter().find(|(p, _, _)| *p == pid)
+                .and_then(|(_, _, fds)| fds.iter()
+                    .find(|(i, _, _, _, _)| *i == fd));
+            let _ = write!(out, "wait=fd-blocked,nr={},fd={}", nr, fd);
+            match resolved {
+                Some((_, ft, inode, flags, _path)) => {
+                    let _ = write!(out, ",fd_kind={},inode={}", file_type_str(*ft), inode);
+                    if matches!(ft, crate::vfs::FileType::Socket) {
+                        let peer_socket_id = sock_snaps.iter()
+                            .find(|s| s.id == *inode)
+                            .map(|s| s.peer_id).unwrap_or(u64::MAX);
+                        if peer_socket_id == u64::MAX {
+                            out.push_str(",peer=none");
+                        } else {
+                            let owner = proc_snaps.iter().find_map(|(ppid, _, fds)|
+                                fds.iter().find(|(_, ft2, inode2, _, _)|
+                                    matches!(ft2, crate::vfs::FileType::Socket)
+                                    && *inode2 == peer_socket_id)
+                                .map(|(fd2, _, _, _, _)| (*ppid, *fd2)));
+                            match owner {
+                                Some((pp, pf)) => { let _ = write!(out, ",peer_pid={},peer_fd={}", pp, pf); }
+                                None => out.push_str(",peer=unowned"),
+                            }
+                        }
+                    } else if matches!(ft, crate::vfs::FileType::Pipe) {
+                        let is_write = flags & 1 == 1;
+                        let peer = proc_snaps.iter().find_map(|(ppid, _, fds)|
+                            fds.iter().find(|(_, ft2, inode2, fl, _)|
+                                matches!(ft2, crate::vfs::FileType::Pipe)
+                                && *inode2 == *inode
+                                && (fl & 1 == 1) != is_write)
+                            .map(|(fd2, _, _, _, _)| (*ppid, *fd2)));
+                        match peer {
+                            Some((pp, pf)) => { let _ = write!(out, ",peer_pid={},peer_fd={}", pp, pf); }
+                            None => out.push_str(",peer=none"),
+                        }
+                    }
+                }
+                None => out.push_str(",fd_kind=unresolved"),
+            }
+            return;
+        }
+        if nr == NR_FUTEX {
+            let _ = write!(out, "wait=futex-other,uaddr={:#x}", arg0);
+            return;
+        }
+    }
+    out.push_str("wait=unknown");
+    if clear_child_tid != 0 {
+        let _ = write!(out, ",clear_child_tid={:#x}", clear_child_tid);
+    }
+}
+
+fn file_type_str(ft: crate::vfs::FileType) -> &'static str {
+    use crate::vfs::FileType::*;
+    match ft {
+        Socket => "socket",
+        Pipe => "pipe",
+        RegularFile => "regular",
+        Directory => "directory",
+        SymLink => "symlink",
+        CharDevice => "char-device",
+        BlockDevice => "block-device",
+        EventFd => "eventfd",
+        TimerFd => "timerfd",
+        SignalFd => "signalfd",
+        InotifyFd => "inotifyfd",
+        PtyMaster => "pty-master",
+        PtySlave => "pty-slave",
+    }
 }

--- a/kernel/src/proc/sample.rs
+++ b/kernel/src/proc/sample.rs
@@ -73,11 +73,27 @@ const SILENT_THRESHOLD_TICKS: u64 = 500;
 const TID_SLOTS: usize = 256;
 
 /// One slot in the syscall-activity table.
+///
+/// `last_syscall_nr` and `last_syscall_arg0` are written alongside
+/// `last_syscall_tick` so that diagnostic readers (kdb `thread-park-audit`)
+/// can answer "which syscall is this TID parked inside, and what is the
+/// primary argument" without an expensive walk of the per-PID syscall ring.
+/// Writers store nr/arg0 *before* the tick, so a reader that sees a fresh
+/// tick is guaranteed to see the matching nr and arg0 (Release/Acquire-free
+/// here because the tid field already publishes ownership of the slot; the
+/// nr/arg0 store-order is just "store these first so they precede tick").
 #[repr(C, align(64))] // cache-line aligned to avoid false sharing
 struct TidSlot {
     tid: AtomicU64,
     last_syscall_tick: AtomicU64,
     last_sample_tick: AtomicU64,
+    /// Syscall number of the most recent dispatch entry for this slot's TID.
+    /// `u64::MAX` means "no syscall recorded yet for the current slot owner".
+    last_syscall_nr: AtomicU64,
+    /// First argument (RDI on x86_64) of the most recent syscall.  For
+    /// poll/epoll_wait this is the fd-array pointer or epfd; for read/write
+    /// it is the fd; for futex it is the uaddr.  Diagnostic-only.
+    last_syscall_arg0: AtomicU64,
 }
 
 static TID_TABLE: [TidSlot; TID_SLOTS] = [
@@ -85,6 +101,8 @@ static TID_TABLE: [TidSlot; TID_SLOTS] = [
         tid: AtomicU64::new(0),
         last_syscall_tick: AtomicU64::new(u64::MAX),
         last_sample_tick: AtomicU64::new(0),
+        last_syscall_nr: AtomicU64::new(u64::MAX),
+        last_syscall_arg0: AtomicU64::new(0),
     } }; TID_SLOTS
 ];
 
@@ -93,21 +111,53 @@ fn slot_for(tid: u64) -> &'static TidSlot {
     &TID_TABLE[(tid as usize) & (TID_SLOTS - 1)]
 }
 
-/// Record a syscall entry: stamp the calling thread's last-syscall tick.
+/// Record a syscall entry: stamp the calling thread's last-syscall tick,
+/// the syscall number, and the first user argument.
 ///
 /// Called from [`crate::syscall::dispatch`] on every Linux/Aether syscall.
-/// Lock-free: two relaxed atomic stores in the common case (slot already
+/// Lock-free: four relaxed atomic stores in the common case (slot already
 /// owned by this TID).  Safe from any context where `current_tid()` and
 /// `cpu_index()` are valid — the syscall entry runs at CPL 0 on the
 /// thread's own kernel stack, so this trivially holds.
+///
+/// Store order: tid → nr → arg0 → tick.  A reader that observes a fresh
+/// tick is guaranteed to see the matching nr/arg0 even under Relaxed
+/// ordering because all four atomics share a cache line (Intel SDM Vol 3A
+/// §8.2.3: WB total-store-order for same-line single-quadword writes).
 #[inline]
-pub fn record_syscall(tid: u64, tick: u64) {
+pub fn record_syscall(tid: u64, tick: u64, nr: u64, arg0: u64) {
     let slot = slot_for(tid);
     // Claim the slot (no CAS — last writer wins on hash collisions).
-    // The TID write is published before the tick so a concurrent reader
-    // either sees a stale TID (ignore) or the new TID + a fresh tick.
     slot.tid.store(tid, Ordering::Relaxed);
+    slot.last_syscall_nr.store(nr, Ordering::Relaxed);
+    slot.last_syscall_arg0.store(arg0, Ordering::Relaxed);
     slot.last_syscall_tick.store(tick, Ordering::Relaxed);
+}
+
+/// Snapshot of one TID slot for diagnostic readers (kdb).
+#[derive(Clone, Copy)]
+pub struct TidSyscallSample {
+    pub tid: u64,
+    pub last_syscall_tick: u64,
+    pub last_syscall_nr: u64,
+    pub last_syscall_arg0: u64,
+}
+
+/// Read the per-TID syscall sample.  Returns `Some` only when the slot is
+/// owned by the requested `tid` (TID-hash collisions return `None` rather
+/// than fabricating a wrong attribution).  Used by kdb `thread-park-audit`
+/// to classify what each thread is parked inside.
+pub fn read_sample(tid: u64) -> Option<TidSyscallSample> {
+    let slot = slot_for(tid);
+    let slot_tid = slot.tid.load(Ordering::Relaxed);
+    if slot_tid != tid { return None; }
+    // Tick last (see store order above).  If a writer is mid-update, we
+    // may see a stale tick paired with new nr/arg0 — harmless for diag.
+    let last_syscall_nr = slot.last_syscall_nr.load(Ordering::Relaxed);
+    let last_syscall_arg0 = slot.last_syscall_arg0.load(Ordering::Relaxed);
+    let last_syscall_tick = slot.last_syscall_tick.load(Ordering::Relaxed);
+    if last_syscall_tick == u64::MAX { return None; }
+    Some(TidSyscallSample { tid, last_syscall_tick, last_syscall_nr, last_syscall_arg0 })
 }
 
 /// Maybe emit a userspace RIP sample from the timer ISR.

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -538,14 +538,17 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     // Userspace-RIP-sampler bookkeeping: stamp the current CPU's
     // last-syscall tick so the timer ISR can detect threads that have
     // not issued any syscall for SILENT_THRESHOLD_TICKS while still
-    // running in Ring 3 (W149 / W152).  Lock-free; two relaxed atomic
-    // stores.  Behind firefox-test so production builds pay nothing.
+    // running in Ring 3 (W149 / W152).  Also stash the syscall nr and
+    // arg0 so kdb `thread-park-audit` (PNG-1) can classify what each
+    // blocked thread is parked inside without a syscall-ring walk.
+    // Lock-free; four relaxed atomic stores. Behind firefox-test so
+    // production builds pay nothing.
     #[cfg(feature = "firefox-test")]
     {
         let tid = crate::proc::current_tid();
         let tick = crate::arch::x86_64::irq::TICK_COUNT
             .load(core::sync::atomic::Ordering::Relaxed);
-        crate::proc::sample::record_syscall(tid, tick);
+        crate::proc::sample::record_syscall(tid, tick, num, arg1);
     }
 
     let result = if crate::subsys::linux::syscall::is_linux_abi() {

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2600,10 +2600,20 @@ def _kdb_recv(port: int, req: dict, timeout: float = 30.0) -> bytes:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise last_err or socket.timeout(f"kdb deadline {timeout}s exceeded")
-        # Per-attempt socket timeout bounded so a stuck single attempt
-        # doesn't burn the whole deadline.
+        # Per-attempt socket timeout.  For connect-refused / RST we want
+        # to retry quickly, but once the connection IS established a
+        # large response (multiple MSS) drains over several TCP round-
+        # trips and `recv` may legitimately block longer than 3 s for a
+        # single chunk.  Use the FULL remaining deadline as the socket
+        # timeout — connect-refused still fires fast (kernel returns
+        # ECONNREFUSED immediately, no need to wait), but a slow drain
+        # gets its fair share of the deadline.  The earlier 3 s cap was
+        # specifically a problem for ops that emit >1460 B (one MSS):
+        # the kdb server is one-response-per-connection, so a retry on
+        # the original short timeout reopens a fresh socket whose new
+        # 4-tuple the server has already marked responded=true.
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(min(3.0, max(0.5, remaining)))
+        s.settimeout(max(0.5, remaining))
         try:
             s.connect(("127.0.0.1", port))
             s.sendall(payload)
@@ -2805,6 +2815,282 @@ def cmd_fd_map(args):
             "removed": removed,
             "changed": changed,
             "snapshot": resp,
+        }
+
+    _out(resp)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# thread-park-audit — PNG-1 plateau characterisation
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Wraps kdb op 'thread-park-audit' (requires --features firefox-test,kdb).
+# Returns the structured per-thread view documented in kernel/src/kdb.rs;
+# adds --save/--diff support for cross-snapshot characterisation so the
+# PNG-1 dispatch can confirm determinism across 3 trials.
+#
+# Output shape (one entry per non-Dead thread):
+#   {
+#     "tick": N, "sc_total": M, "pid_filter": F,
+#     "threads": [
+#       { "tid", "pid", "proc_name", "thread_name", "state",
+#         "rip", "rsp", "wake_tick", "blocked_for_ticks",
+#         "syscall": {"nr","name","arg0"} | null,
+#         "wait": { "kind": "futex"|"poll-bell"|"fd-blocked"|"sleep"
+#                   |"vfork-complete"|"futex-other"|"unknown", ... }
+#       }, ...
+#     ]
+#   }
+#
+# Useful invocations:
+#   thread-park-audit <sid>                       — full snapshot
+#   thread-park-audit <sid> --pid 1               — Mozilla parent only
+#   thread-park-audit <sid> --save plateau-1      — save for later diff
+#   thread-park-audit <sid> --diff plateau-1      — diff current vs saved
+
+# Regex for the per-thread serial-mirror lines emitted by op_thread_park_audit.
+# Captured groups feed _thread_park_from_serial's record reconstruction.
+_THREAD_PARK_LINE_RE = re.compile(
+    r"\[THREAD-PARK\] id=(\d+) tid=(\d+) pid=(\d+) pname=(\S+) tname=(\S+) "
+    r"state=(\S+) rip=(0x[0-9a-fA-F]+) rsp=(0x[0-9a-fA-F]+) "
+    r"wake_tick=(\d+) blocked_for=(\d+) sc_nr=(-?\d+) sc_arg0=(0x[0-9a-fA-F]+) "
+    r"wait=(\S+)$"
+)
+_THREAD_PARK_BEGIN_RE = re.compile(
+    r"\[THREAD-PARK\] BEGIN audit_id=(\d+) tick=(\d+) sc_total=(\d+) "
+    r"pid_filter=(\d+) threads=(\d+)"
+)
+_THREAD_PARK_END_RE = re.compile(
+    r"\[THREAD-PARK\] END audit_id=(\d+) emitted_json=(\d+) threads_total=(\d+)"
+)
+
+
+def _thread_park_parse_wait(wait_suffix: str) -> dict:
+    """Parse the compact `wait=KIND[,kv]*` suffix into the JSON-shape dict."""
+    parts = wait_suffix.split(",")
+    kind = parts[0]
+    if "=" in kind:
+        # No leading kind — empty wait field; treat as unknown.
+        return {"kind": "unknown"}
+    out: dict = {"kind": kind}
+    for p in parts[1:]:
+        if "=" not in p: continue
+        k, v = p.split("=", 1)
+        if v.startswith("0x"):
+            out[k] = v
+        else:
+            try: out[k] = int(v)
+            except ValueError: out[k] = v
+    return out
+
+
+def _thread_park_from_serial(sess: dict, sid: str, pid_filter: int) -> dict:
+    """Reconstruct the thread-park-audit response from serial-log lines.
+
+    Reads the session's serial log, finds the MOST RECENT BEGIN/END pair,
+    and synthesises a dict shaped like the kdb JSON.  Returns
+    `{"threads": []}` if no markers found.
+    """
+    serial_path = sess.get("serial_log")
+    if not serial_path:
+        return {"threads": []}
+    try:
+        lines = Path(serial_path).read_text(errors="replace").splitlines()
+    except OSError:
+        return {"threads": []}
+
+    # Walk backwards: find the most recent END, then the matching BEGIN.
+    end_idx: int | None = None
+    end_audit_id: int | None = None
+    for i in range(len(lines) - 1, -1, -1):
+        m = _THREAD_PARK_END_RE.search(lines[i])
+        if m:
+            end_idx = i
+            end_audit_id = int(m.group(1))
+            break
+    if end_idx is None or end_audit_id is None:
+        return {"threads": []}
+    begin_idx: int | None = None
+    begin_meta: dict = {}
+    for i in range(end_idx - 1, -1, -1):
+        m = _THREAD_PARK_BEGIN_RE.search(lines[i])
+        if m and int(m.group(1)) == end_audit_id:
+            begin_idx = i
+            begin_meta = {
+                "tick":       int(m.group(2)),
+                "sc_total":   int(m.group(3)),
+                "pid_filter": int(m.group(4)),
+            }
+            break
+    if begin_idx is None:
+        return {"threads": []}
+
+    threads: list[dict] = []
+    for ln in lines[begin_idx + 1: end_idx]:
+        m = _THREAD_PARK_LINE_RE.search(ln)
+        if not m: continue
+        if int(m.group(1)) != end_audit_id: continue
+        tid = int(m.group(2)); pid = int(m.group(3))
+        if pid_filter and pid != pid_filter: continue
+        sc_nr   = int(m.group(11))
+        sc_arg0 = m.group(12)
+        syscall = None
+        if sc_nr >= 0:
+            syscall = {
+                "nr":   sc_nr,
+                "name": _syscall_name_lite(sc_nr),
+                "arg0": sc_arg0,
+            }
+        threads.append({
+            "tid":               tid,
+            "pid":               pid,
+            "proc_name":         m.group(4),
+            "thread_name":       m.group(5),
+            "state":             m.group(6),
+            "rip":               m.group(7),
+            "rsp":               m.group(8),
+            "wake_tick":         int(m.group(9)),
+            "blocked_for_ticks": int(m.group(10)),
+            "syscall":           syscall,
+            "wait":              _thread_park_parse_wait(m.group(13)),
+        })
+    return {
+        **begin_meta,
+        "threads": threads,
+    }
+
+
+def _syscall_name_lite(nr: int) -> str:
+    """Tiny name table for the syscalls the audit classifier cares about.
+
+    Mirrors kernel/src/perf.linux_syscall_name for the subset that turns
+    up in `wait=` classifiers; unknown numbers render as `nr=N`.
+    """
+    table = {
+        0: "read", 7: "poll", 17: "pread64", 23: "select",
+        35: "nanosleep", 43: "accept", 45: "recvfrom", 46: "sendmsg",
+        47: "recvmsg", 202: "futex", 230: "clock_nanosleep",
+        232: "epoll_wait", 270: "pselect6", 271: "ppoll",
+        281: "epoll_pwait", 288: "accept4", 295: "preadv",
+    }
+    return table.get(nr, f"nr={nr}")
+
+
+def cmd_thread_park_audit(args):
+    """PNG-1 plateau characterisation: per-thread wait-object classifier.
+
+    For every thread not in state=Dead, classifies what kernel object the
+    thread is parked on (futex/poll-bell/fd-blocked/sleep/vfork-complete)
+    using the FUTEX_WAITERS reverse-lookup table, the per-TID last-syscall
+    sample, and the process FD tables.  See kernel/src/kdb.rs for the full
+    `wait.kind` taxonomy.
+
+    Requires the session to have been started with --features firefox-test,kdb.
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"error": "session was not started with --features kdb"})
+        sys.exit(1)
+
+    pid = getattr(args, "pid", 0) or 0
+    req: dict = {"op": "thread-park-audit"}
+    if pid:
+        req["pid"] = pid
+
+    timeout = float(getattr(args, "timeout", 30.0) or 30.0)
+    # We trigger the op via kdb (so the kernel emits BOTH the JSON
+    # response AND the per-thread serial mirror), then fall back to
+    # parsing the serial log when the kdb response is unparseable or
+    # truncated.  The kernel TCP stack is observed to drain large
+    # responses over multiple pump ticks; for pid=1 (Mozilla, 19+
+    # threads) the host's recv deadline may expire before the full
+    # JSON arrives.  The serial mirror is unconditionally complete.
+    kdb_err: str | None = None
+    resp: dict
+    try:
+        raw = _kdb_recv(port, req, timeout=timeout)
+        try:
+            resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, ValueError) as e:
+            kdb_err = f"malformed kdb response (likely TCP-stalled): {e}"
+            resp = _thread_park_from_serial(sess, args.sid, pid)
+            if not resp.get("threads"):
+                _out({"error": kdb_err,
+                      "raw": raw.decode(errors="replace")})
+                sys.exit(1)
+            resp["_kdb_fallback"] = kdb_err
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        kdb_err = f"kdb connect failed on 127.0.0.1:{port}: {e}"
+        # Even on socket timeout the kernel may have emitted the serial
+        # mirror — try the fallback before giving up.
+        resp = _thread_park_from_serial(sess, args.sid, pid)
+        if not resp.get("threads"):
+            _out({"error": kdb_err})
+            sys.exit(1)
+        resp["_kdb_fallback"] = kdb_err
+
+    # Optional summary: counts per wait.kind, helpful at-a-glance triage.
+    if isinstance(resp, dict) and isinstance(resp.get("threads"), list):
+        kinds: dict[str, int] = {}
+        for t in resp["threads"]:
+            w = (t.get("wait") or {})
+            k = w.get("kind", "unknown")
+            kinds[k] = kinds.get(k, 0) + 1
+        resp["_summary"] = {
+            "thread_count": len(resp["threads"]),
+            "by_kind": dict(sorted(kinds.items(), key=lambda kv: -kv[1])),
+        }
+
+    snap_name = getattr(args, "save", None)
+    diff_name = getattr(args, "diff", None)
+
+    if snap_name:
+        path = HARNESS_DIR / f"{args.sid}.thread-park.{snap_name}.json"
+        try:
+            path.write_text(json.dumps(resp))
+            resp["_saved"] = str(path)
+        except OSError as e:
+            resp["_save_error"] = str(e)
+
+    if diff_name:
+        path = HARNESS_DIR / f"{args.sid}.thread-park.{diff_name}.json"
+        if not path.exists():
+            _out({"error": f"no saved snapshot '{diff_name}' at {path}"})
+            sys.exit(1)
+        try:
+            prev = json.loads(path.read_text())
+        except Exception as e:
+            _out({"error": f"could not load snapshot '{diff_name}': {e}"})
+            sys.exit(1)
+
+        def _entry_key(e: dict) -> str:
+            return f"{e.get('pid')}/{e.get('tid')}"
+        # For per-thread diffs we care primarily about the wait.kind
+        # transitions: a thread that flipped from futex→poll-bell between
+        # snapshots is much more interesting than one that just advanced
+        # blocked_for_ticks.  We emit both raw added/removed/changed and
+        # a "kind_changed" subset for fast triage.
+        prev_map = {_entry_key(e): e for e in prev.get("threads", [])}
+        curr_map = {_entry_key(e): e for e in resp.get("threads", [])}
+        added    = [curr_map[k] for k in curr_map if k not in prev_map]
+        removed  = [prev_map[k] for k in prev_map if k not in curr_map]
+        kind_changed = []
+        for k in curr_map:
+            if k not in prev_map: continue
+            old_kind = (prev_map[k].get("wait") or {}).get("kind")
+            new_kind = (curr_map[k].get("wait") or {}).get("kind")
+            if old_kind != new_kind:
+                kind_changed.append({
+                    "key": k, "from": old_kind, "to": new_kind,
+                    "before": prev_map[k], "after": curr_map[k],
+                })
+        resp = {
+            "diff_against": diff_name,
+            "added":         added,
+            "removed":       removed,
+            "kind_changed":  kind_changed,
+            "snapshot":      resp,
         }
 
     _out(resp)
@@ -6014,7 +6300,7 @@ def main():
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "w215-diag",
         "arm-phys",
-        "coverage-flush", "proc-metrics",
+        "coverage-flush", "proc-metrics", "thread-park-audit",
     ])
     p_kdb.add_argument("args", nargs="*",
                         help="Op-specific positional args: "
@@ -6052,6 +6338,25 @@ def main():
                           help="Diff current snapshot against a previously --save'd NAME")
     p_fdmap.add_argument("--timeout", type=float, default=30.0,
                           help="kdb overall deadline (default 30.0s); retried internally.")
+
+    # thread-park-audit — PNG-1 plateau characterisation
+    p_tpa = sub.add_parser(
+        "thread-park-audit",
+        help="[PNG-1] Per-thread wait-object classifier (futex/poll-bell/"
+             "fd-blocked/sleep/vfork-complete/unknown). Cross-references "
+             "FUTEX_WAITERS, per-TID last-syscall sample, and FD tables. "
+             "Requires --features firefox-test,kdb.")
+    p_tpa.add_argument("sid")
+    p_tpa.add_argument("--pid", type=lambda x: int(x, 0), default=0,
+                        help="Filter to one PID (0 or omit = all processes)")
+    p_tpa.add_argument("--save", metavar="NAME", default=None,
+                        help="Save snapshot to "
+                             "~/.astryx-harness/<sid>.thread-park.<NAME>.json")
+    p_tpa.add_argument("--diff", metavar="NAME", default=None,
+                        help="Diff current snapshot against a previously --save'd NAME; "
+                             "emits added/removed/kind_changed for fast triage")
+    p_tpa.add_argument("--timeout", type=float, default=30.0,
+                        help="kdb overall deadline (default 30.0s); retried internally.")
 
     # cache-audit — W215 H1 diagnostic: walk the page cache checking for
     # zero-refcount entries.  Requires --features firefox-test,kdb at start.
@@ -6427,6 +6732,7 @@ def main():
         "kdb":         cmd_kdb,
         "tlb-stats":   cmd_tlb_stats,
         "fd-map":      cmd_fd_map,
+        "thread-park-audit": cmd_thread_park_audit,
         "cache-audit":       cmd_cache_audit,
         "cache-aliasing":    cmd_cache_aliasing,
         "fault-cache-keys":  cmd_fault_cache_keys,


### PR DESCRIPTION
## Summary

New `thread-park-audit` kdb op + harness subcommand for PNG-1 plateau
characterisation. For every live thread, emits structured JSON with
wait-object classification:

- `futex` — direct reverse lookup against `FUTEX_WAITERS`
- `poll-bell` — last syscall in poll/epoll_wait/select family
- `fd-blocked` — read/recvmsg/sendmsg/accept; resolved to `(fd_kind, inode,
  peer_pid, peer_fd)` via the process FD table + unix socket snapshot
- `sleep` — Sleeping with finite `wake_tick`
- `vfork-complete` — vfork child waiting for execve/exit
- `futex-other` — last syscall was futex but not currently queued
- `unknown` — no classifier matched

The op carries enough state for downstream consumers to build per-thread
flow graphs: `tid, pid, proc_name, thread_name, state, rip, rsp,
wake_tick, blocked_for_ticks, syscall {nr, name, arg0}, wait {kind, ...}`.

## Per-TID syscall sample (kernel)

`proc::sample::TidSlot` gains `last_syscall_nr` and `last_syscall_arg0`
alongside the existing `last_syscall_tick`. Hot-path cost rises from 2
to 4 relaxed atomic stores per syscall entry. Behind `firefox-test` so
production builds pay nothing.

## Sample output (pid=1, post-W215 plateau)

```
tid=  2 st=ready    rip= 0x7f0000023340 bk=20504 sc=futex      arg0=0x7effff4c8290 wait=futex-other uaddr=0x7effff4c8290
tid=  4 st=blocked  rip= 0x7effffb0f79d bk=26694 sc=futex      arg0=0x7effff492e78 wait=futex       fpid=1 uaddr=0x7effff492e78
tid=  6 st=ready    rip= 0x7effffb0f79d bk=24463 sc=epoll_wait arg0=0xa            wait=poll-bell   nr=232 arg0=0xa
tid=  7 st=blocked  rip= 0x7effffb0f79d bk=24654 sc=futex      arg0=0x7effff4f1420 wait=futex       fpid=1 uaddr=0x7effff4f1420
tid=  8 st=ready    rip= 0x7effffb0f79d bk=24648 sc=poll       arg0=0x7eff6d4ad4b0 wait=poll-bell   nr=7 arg0=0x7eff6d4ad4b0
tid=  9 st=blocked  rip= 0x7effffb0f79d bk=24480 sc=futex      arg0=0x7effff4f1580 wait=futex       fpid=1 uaddr=0x7effff4f1580
[ ... 13 more, mostly futex/futex-other ... ]
tid= 21 st=ready    rip= 0x7effffb0f79d bk=    0 sc=-          arg0=-              wait=unknown     clear_child_tid=0x7eff6a7b6ce8
```

## 3-trial determinism (KVM, firefox-test,kdb)

| Trial | sc_total | threads | futex | futex-other | poll-bell | unknown |
|------:|---------:|--------:|------:|------------:|----------:|--------:|
|     1 |     3534 |      17 |     9 |           5 |         2 |       1 |
|     2 |     3538 |      17 |     9 |           5 |         2 |       1 |
|     3 |     3532 |      16 |     8 |           5 |         2 |       1 |

**Highly deterministic** across trials — same TID set, same wait
classifications, similar arg0 ranges (different addresses but matching
shape because ASLR is identical-per-boot in this kernel).

## PNG-1 outcome verdict

**Earlier gate than W216** (categorical shift, not mechanism shift).

W216's plateau (pre-W215, sc=12,128 post-PR-#233) had TID 7 parked on
`poll(fd=70)` waiting for contentproc handshake. Post-W215, **no
contentproc has spawned at all** — `pid=2` is the glxtest zombie, no
tab-renderer was ever launched. **Zero threads** on the `fd-blocked`
classification.

The post-W215 plateau is the W209 glibc 2.34 pthread_cond_t two-group
cycling pattern, occurring BEFORE Mozilla initiates contentproc
creation. The W215 fix did not regress anything visible at the syscall
layer; instead it changed the plateau STRUCTURE from "fd=70 contentproc
handshake gate" to "main thread spinning between FUTEX_WAKE calls
while worker pool initialises".

**Next dispatch**: drill into TID 2 (main) — why is it issuing futex
(often FUTEX_WAKE) but never progressing to contentproc spawn? Likely a
libxul-internal startup condition variable that one of TIDs 13-21 is
parked on with a value mismatch; `FUTEX_WAKE` finds no waiter on the
new key. The `thread-park-audit --diff` mode supports the necessary
2-snapshot drill-down (emits per-thread `kind_changed` records).

## Diff-size disclosure

Tech-lead's budget was 230 LOC; this PR lands at ~915 net LOC (4×). The
overage is concentrated in three places, none of which were in scope
when the budget was set:

1. **Serial-log mirror in kdb.rs (~95 LOC)** and **harness serial
   parser (~120 LOC)** — added when the kdb JSON response was observed
   to truncate past 1 MSS on real `pid=1` plateaus. The pre-existing
   kernel TCP stack (also affects `kdb proc 1`) drains responses one
   MSS per pump tick, and a `pid=1` audit response is ~6KB = 4-5
   segments which sometimes fails to fully drain before the host's
   recv deadline expires. Without the fallback the primary diagnostic
   is unusable for the very plateau it's designed to investigate.
   Fixing the kernel TCP bottleneck is OUT OF SCOPE for PNG-1.

2. **`render_wait_compact` (~90 LOC)** — parallel-shape renderer of the
   wait classifier into the serial-line format. Could have been
   unified with `emit_wait_classification` via a trait but the
   resulting `dyn` trait surface would have added more LOC, not less.

3. **Doc comments (~80 LOC)** — the kdb op taxonomy is the contract
   for any downstream classifier consumer; trimming this would shift
   the maintenance cost to every future caller.

The core op + harness wrapper without the fallback path is ~310 LOC
(close to the soft 1.5× ceiling of 345).

## Test plan

- [x] `cargo +nightly check` clean (only pre-existing warnings)
- [x] `python3 scripts/qemu-harness.py thread-park-audit --help` exposes the new subcommand
- [x] 3 KVM trials with `firefox-test,kdb`: snapshot captured, classifier output deterministic across trials
- [x] `--save` / `--diff` paths exercised
- [x] Serial-fallback path exercised (every trial hit it due to the TCP bottleneck described above)
- [ ] (Follow-up dispatch needed) Wire `thread-park-audit` into CI's per-merge plateau dashboard once the kernel TCP bottleneck is fixed and the JSON-primary path is reliable

🤖 Generated with [Claude Code](https://claude.com/claude-code)