### PR TITLE
kernel/arch+syscall+subsys: H1-SMAP — STAC/CLAC bracketing + CR4.SMAP enable

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -938,8 +938,9 @@ pub extern "C" fn ap_rust_entry() -> ! {
 
     // Enable SSE on this AP (BSP does it in arch::x86_64::init)
     crate::arch::x86_64::enable_sse();
-    // Enable CR4.SMEP on this AP. Each CPU has its own CR4, so the BSP's
-    // setting does not propagate. Per Intel SDM Vol. 3A §2.5.
+    // Enable CR4.SMEP and CR4.SMAP on this AP.  Each CPU has its own CR4,
+    // so the BSP's setting does not propagate.  Per Intel SDM Vol. 3A
+    // §2.5 (CR4 fields) and §4.6 (SMAP semantics).
     crate::arch::x86_64::enable_cpu_security_features();
 
     // Enable local APIC

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -8,6 +8,7 @@ pub mod debug_reg;
 pub mod gdt;
 pub mod idt;
 pub mod irq;
+pub mod smap;
 
 /// Initialize all x86_64 architecture components.
 pub fn init() {
@@ -16,7 +17,7 @@ pub fn init() {
     irq::init();
     enable_sse();
     enable_cpu_security_features();
-    crate::serial_println!("[x86_64] Architecture initialized (GDT, IDT, IRQ, SSE, SMEP)");
+    crate::serial_println!("[x86_64] Architecture initialized (GDT, IDT, IRQ, SSE, SMEP, SMAP)");
 }
 
 /// Enable SSE/SSE2 support on the current CPU.
@@ -55,24 +56,32 @@ pub fn enable_sse() {
 /// not advertise the feature raises #GP, so the bit is gated on the
 /// CPUID probe.
 ///
-/// SMAP (CR4 bit 21, CPUID 7:0 EBX[20]) is intentionally NOT enabled
-/// here. Enabling SMAP requires every legitimate kernel access to user
-/// memory to be bracketed by STAC/CLAC (EFLAGS.AC=1) per Intel SDM
-/// Vol. 3A §4.6.1; the current `validate_user_ptr` family performs raw
-/// dereferences without that bracketing, so enabling SMAP without first
-/// refactoring those helpers would cause a #PF on every legitimate user
-/// copy. SMAP enablement is deferred to a follow-up that introduces
-/// `stac()`/`clac()` wrappers and audits every unsafe user pointer
-/// dereference.
+/// Also enables CR4.SMAP (bit 21) when CPUID.(EAX=07H,ECX=00H):EBX[bit
+/// 20] advertises support and after the STAC/CLAC bracketing in the
+/// syscall layer has been audited (see `arch::x86_64::smap` module).
+/// With SMAP set, the CPU raises #PF on any supervisor-mode access to
+/// a user-mapped page (PTE.U/S=1) unless EFLAGS.AC=1.  Per Intel SDM
+/// Vol. 3A §4.6, this defeats the class of kernel bugs that
+/// inadvertently dereference an attacker-controlled user pointer —
+/// converting an arbitrary-write primitive into a fail-stop fault.
+///
+/// SMAP enablement publishes `smap::SMAP_ENABLED = true`; every
+/// legitimate user-pointer access in the kernel goes through a
+/// `UserGuard` (or `stac_if_smap`/`clac_if_smap`) which reads that
+/// atomic and issues STAC/CLAC accordingly.  Tests / kernel paths that
+/// drive a syscall handler with a kernel-VA buffer are unaffected:
+/// SMAP only fires on user-mapped pages.
 ///
 /// Called on the BSP from `init()` and on each AP from `apic::ap_main`.
 ///
 /// Mitigates: CVE-2017-7308-class kernel-pointer-corruption exploits
 /// (CWE-119 / CWE-269) by removing the user-mapped-page execution
 /// primitive even when a kernel UAF or vtable confusion gives the
-/// attacker control of an indirect-branch target.
+/// attacker control of an indirect-branch target.  SMAP additionally
+/// closes the BadIRET / ret2usr-data class (CVE-2014-9322) by
+/// converting unintentional user-pointer dereferences into faults.
 pub fn enable_cpu_security_features() {
-    let (smep_supported, _smap_supported) = unsafe {
+    let (smep_supported, smap_supported) = unsafe {
         let ebx: u32;
         // CPUID leaf 7, sub-leaf 0: structured extended feature flags.
         // EBX bit 7 = SMEP, EBX bit 20 = SMAP (Intel SDM Vol. 2A §3.2).
@@ -96,9 +105,27 @@ pub fn enable_cpu_security_features() {
     }
 
     unsafe {
-        let cr4: u64;
+        let mut cr4: u64;
         core::arch::asm!("mov {}, cr4", out(reg) cr4, options(nomem, nostack));
-        let cr4 = cr4 | (1u64 << 20); // CR4.SMEP
+        cr4 |= 1u64 << 20; // CR4.SMEP
+        if smap_supported {
+            cr4 |= 1u64 << 21; // CR4.SMAP
+        }
         core::arch::asm!("mov cr4, {}", in(reg) cr4, options(nostack));
+    }
+
+    if smap_supported {
+        // Publish AFTER CR4 has actually been written so any STAC issued
+        // through a UserGuard cannot precede the SMAP-on transition.
+        // `Relaxed` is sufficient: bracketing helpers do their own
+        // dependent loads on the same atomic, and the publication
+        // happens once per CPU, on that CPU, before any user pointer is
+        // dereferenced — there is no cross-thread visibility ordering
+        // to enforce (the atomic exists to gate runtime instruction
+        // emission, not to synchronise data).
+        smap::SMAP_ENABLED.store(true, core::sync::atomic::Ordering::Relaxed);
+        crate::serial_println!("[x86_64] SMAP enabled (CR4.SMAP=1, EFLAGS.AC gated by STAC/CLAC)");
+    } else {
+        crate::serial_println!("[x86_64] SMAP not advertised by CPU — skipping");
     }
 }

--- a/kernel/src/arch/x86_64/smap.rs
+++ b/kernel/src/arch/x86_64/smap.rs
@@ -1,0 +1,196 @@
+//! Supervisor Mode Access Prevention (SMAP) — STAC/CLAC plumbing.
+//!
+//! SMAP (CR4 bit 21) causes the CPU to raise #PF on any supervisor-mode
+//! access to a user-mapped page (PTE.U/S=1) unless EFLAGS.AC (bit 18) is
+//! set.  The STAC instruction sets AC; CLAC clears it.  Per Intel SDM
+//! Vol. 3A §4.6 and Vol. 2A (CLAC/STAC entries).
+//!
+//! # Threat model
+//!
+//! Without SMAP, a kernel bug that dereferences an attacker-controlled
+//! user pointer (e.g. a confused-deputy write through a corrupted
+//! function pointer the attacker steered at a user address) executes
+//! silently, giving the attacker an arbitrary-kernel-write primitive
+//! mediated by their own user pages.  With SMAP enabled, any such
+//! unguarded access faults immediately and the page-fault handler can
+//! cleanly terminate the offending process — converting an arbitrary-
+//! write primitive into a fail-stop.  See CVE-2014-9322 (BadIRET) and
+//! CWE-269 / CWE-119 / CWE-823 for the bug-class catalogue.
+//!
+//! Crucially, SMAP is *additive* to validation: every legitimate
+//! kernel→user dereference must still range-check via
+//! [`crate::syscall::validate_user_ptr`] to reject kernel-VA pointers
+//! (which SMAP does NOT cover — those pages have PTE.U=0) and to bound
+//! the access length.  STAC/CLAC merely enable the *intentional* access
+//! once the pointer has been validated.
+//!
+//! # Runtime gating
+//!
+//! Older CPUs (and TCG without `-cpu Haswell-v4` or newer) do not
+//! advertise SMAP.  The [`SMAP_ENABLED`] atomic is set by
+//! [`crate::arch::x86_64::enable_cpu_security_features`] only when the
+//! CPUID probe succeeds AND CR4.SMAP is actually set.  The gated
+//! [`stac_if_smap`] / [`clac_if_smap`] wrappers (and the [`UserGuard`]
+//! RAII) check this flag, so on a non-SMAP CPU the bracketing collapses
+//! to a single relaxed load + branch — no #UD from issuing STAC on
+//! hardware that does not implement it.
+//!
+//! Once `SMAP_ENABLED` is set, it never clears — there is no legitimate
+//! reason to disable SMAP at runtime, and a one-way transition lets
+//! the compiler hoist the check out of tight loops once the BSP has
+//! finished bring-up.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Set by [`crate::arch::x86_64::enable_cpu_security_features`] after
+/// CR4.SMAP is asserted.  Cleared at boot.  One-way transition (never
+/// re-cleared) so callers can treat it as monotonic.
+///
+/// Tests / kernel paths that drive a syscall handler with a kernel-VA
+/// buffer must NOT set this flag — those accesses do not target user
+/// pages and SMAP is silent for them.  The flag is set exactly once,
+/// from BSP and from every AP, after the CPU has actually committed
+/// CR4.SMAP.
+pub static SMAP_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Raw STAC — set EFLAGS.AC.  Allows subsequent supervisor accesses
+/// to user-mapped pages without a #PF.  Must be paired with a
+/// matching [`clac()`] on every exit path including faults.
+///
+/// # Safety
+///
+/// Unconditional on the underlying CPU supporting SMAP.  Issuing STAC
+/// on a non-SMAP CPU raises #UD per Intel SDM Vol. 2A (STAC).  Callers
+/// should prefer [`stac_if_smap`] / [`UserGuard`] instead.
+///
+/// IMPORTANT: we deliberately omit `nomem` here.  The default (memory
+/// clobber) tells LLVM that any memory access could happen as a side
+/// effect of this asm block, which prevents the optimiser from hoisting
+/// user-memory reads (e.g. inlined `copy_nonoverlapping` word loads)
+/// past the STAC instruction.  Without the memory clobber, LLVM
+/// previously rewrote `let _g = UserGuard::new(); copy_nonoverlapping(p, buf, 32); use buf`
+/// into direct reads from `p` AFTER the CLAC fired — faulting with
+/// AC=0.  Same rationale applies to CLAC below.
+#[inline(always)]
+pub unsafe fn stac() {
+    core::arch::asm!("stac", options(nostack));
+}
+
+/// Raw CLAC — clear EFLAGS.AC.  Re-arms SMAP enforcement for any
+/// subsequent supervisor access to user-mapped pages.  Must be
+/// executed before returning from any STAC scope.
+///
+/// # Safety
+///
+/// See [`stac`] — same #UD hazard on non-SMAP CPUs.  Prefer
+/// [`clac_if_smap`] / [`UserGuard`].  See `stac` for the
+/// memory-clobber rationale.
+#[inline(always)]
+pub unsafe fn clac() {
+    core::arch::asm!("clac", options(nostack));
+}
+
+/// Issue STAC iff SMAP has been enabled on this CPU.  Safe to call from
+/// any kernel context; collapses to a single relaxed load + branch when
+/// SMAP is not advertised (e.g. early boot before
+/// [`crate::arch::x86_64::enable_cpu_security_features`], or on TCG
+/// without `+smap`).
+///
+/// # Safety
+///
+/// Caller must pair this with [`clac_if_smap`] (or use [`UserGuard`]
+/// which does that on drop).  Holding AC=1 across an unrelated kernel
+/// codepath would silently bypass SMAP for any user-pointer deref that
+/// path performs.
+#[inline(always)]
+pub unsafe fn stac_if_smap() {
+    if SMAP_ENABLED.load(Ordering::Relaxed) {
+        stac();
+    }
+}
+
+/// Issue CLAC iff SMAP has been enabled on this CPU.  Pair with
+/// [`stac_if_smap`].
+///
+/// # Safety
+///
+/// Idempotent: clearing an already-clear AC is a no-op.  The danger
+/// runs the other way — failing to call this after [`stac_if_smap`]
+/// leaves SMAP disabled for the remainder of the kernel path.
+#[inline(always)]
+pub unsafe fn clac_if_smap() {
+    if SMAP_ENABLED.load(Ordering::Relaxed) {
+        clac();
+    }
+}
+
+/// RAII bracket for a user-pointer access region.  Sets AC on
+/// construction (when SMAP is active) and clears it on drop, including
+/// on a panic / fault unwind exit path.
+///
+/// # Usage
+///
+/// ```ignore
+/// // Pointer must already have been range-validated.
+/// let val = unsafe {
+///     let _g = UserGuard::new();
+///     core::ptr::read_volatile(user_ptr)
+/// }; // CLAC fires on `_g` drop here.
+/// ```
+///
+/// # Safety
+///
+/// Constructing a `UserGuard` is unsafe because it lifts SMAP
+/// enforcement for the current CPU until drop.  The caller must:
+///
+/// 1. Have range-validated the pointer (`validate_user_ptr`) so a
+///    kernel-VA cannot slip through this guard.
+/// 2. Confine the guard's scope to the minimum needed for the user
+///    access — anything else risks an unintended bypass.
+/// 3. NOT recurse into a kernel-only path while holding the guard, for
+///    the same reason.
+pub struct UserGuard {
+    /// `true` if construction actually issued STAC.  Drop only issues
+    /// the matching CLAC in that case, so a nested guard on a non-SMAP
+    /// CPU collapses to two relaxed loads.
+    armed: bool,
+}
+
+impl UserGuard {
+    /// # Safety
+    ///
+    /// See type-level docs.  The caller assumes responsibility for
+    /// ensuring the about-to-be-dereferenced pointer is a validated
+    /// user-VA, not a kernel-VA.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        let armed = SMAP_ENABLED.load(Ordering::Relaxed);
+        if armed {
+            stac();
+        }
+        // SeqCst compiler fence: prevents LLVM from reordering
+        // user-memory accesses across this point.  Without this fence
+        // the optimiser can hoist `copy_nonoverlapping`'s individual
+        // word loads PAST the UserGuard scope (a literal observed
+        // failure mode: `let _g = UserGuard::new(); copy_nonoverlapping(p, buf, 32); ... use buf` was
+        // rewritten by LLVM to read directly from `p` AFTER `_g`
+        // dropped, faulting with AC=0).  The fence forces the
+        // user-memory access ordering to match source order.
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+        UserGuard { armed }
+    }
+}
+
+impl Drop for UserGuard {
+    #[inline(always)]
+    fn drop(&mut self) {
+        // Matching fence to seal the AC=1 region before CLAC.  Same
+        // rationale as the constructor fence — LLVM must not move
+        // user-memory accesses past the drop boundary.
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+        if self.armed {
+            // Safety: paired with the STAC issued in `new`.
+            unsafe { clac() };
+        }
+    }
+}

--- a/kernel/src/drivers/tty.rs
+++ b/kernel/src/drivers/tty.rs
@@ -384,13 +384,20 @@ impl Tty {
             return 0;
         }
 
+        // SMAP bracket — `buf` is typically a user-VA slice forwarded
+        // from sys_read_linux (stdin path).  Copies through `buf` run
+        // with AC=1; the surrounding cooked_buf / input_buf mutation
+        // is kernel-only and lives outside the bracket.
         if self.termios.c_lflag & ICANON != 0 {
             // Canonical mode: wait for a complete line
             if !self.input_ready {
                 return 0;
             }
             let avail = self.cooked_buf.len().min(n);
-            buf[..avail].copy_from_slice(&self.cooked_buf[..avail]);
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                buf[..avail].copy_from_slice(&self.cooked_buf[..avail]);
+            }
             self.cooked_buf.drain(..avail);
             if self.cooked_buf.is_empty() {
                 self.input_ready = false;
@@ -404,7 +411,10 @@ impl Tty {
                 return 0;
             }
             let to_read = available.min(n);
-            buf[..to_read].copy_from_slice(&self.input_buf[..to_read]);
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                buf[..to_read].copy_from_slice(&self.input_buf[..to_read]);
+            }
             self.input_buf.drain(..to_read);
             to_read
         }
@@ -417,20 +427,34 @@ impl Tty {
         let opost = self.termios.c_oflag & OPOST != 0;
         let onlcr = self.termios.c_oflag & ONLCR != 0;
 
-        if opost && onlcr {
-            // Convert \n to \r\n
-            for &b in data {
-                if b == b'\n' {
-                    write_console_byte(b'\r');
-                    write_console_byte(b'\n');
-                } else {
+        // SMAP bracket — `data` is typically a user-VA slice forwarded
+        // from sys_write_linux (stdout/stderr fallback).  Snapshot into
+        // a kernel stack buffer in bounded chunks so the console-write
+        // loop runs from kernel memory.  Per Intel SDM Vol. 3A §4.6.
+        let mut chunk = [0u8; 256];
+        let mut off = 0usize;
+        while off < data.len() {
+            let take = (data.len() - off).min(chunk.len());
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::copy_nonoverlapping(
+                    data.as_ptr().add(off), chunk.as_mut_ptr(), take);
+            }
+            if opost && onlcr {
+                for &b in &chunk[..take] {
+                    if b == b'\n' {
+                        write_console_byte(b'\r');
+                        write_console_byte(b'\n');
+                    } else {
+                        write_console_byte(b);
+                    }
+                }
+            } else {
+                for &b in &chunk[..take] {
                     write_console_byte(b);
                 }
             }
-        } else {
-            for &b in data {
-                write_console_byte(b);
-            }
+            off += take;
         }
     }
 

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -64,6 +64,12 @@ impl Pipe {
     /// Read up to `buf.len()` bytes from the pipe. Returns bytes read.
     pub fn read(&mut self, buf: &mut [u8]) -> usize {
         let to_read = buf.len().min(self.count);
+        // SMAP bracket — `buf` typically points to user memory (the
+        // syscall layer passes user `buf_ptr` through `from_raw_parts_mut`).
+        // The bounded copy below runs synchronously under the PIPE_TABLE
+        // lock, so AC=1 cannot leak past `to_read` iterations.  When
+        // SMAP is not enabled, UserGuard collapses to a relaxed load.
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for i in 0..to_read {
             buf[i] = self.buffer[self.read_pos];
             self.read_pos = (self.read_pos + 1) % PIPE_BUF_SIZE;
@@ -76,6 +82,8 @@ impl Pipe {
     pub fn write(&mut self, data: &[u8]) -> usize {
         let space = PIPE_BUF_SIZE - self.count;
         let to_write = data.len().min(space);
+        // SMAP bracket — `data` typically points to user memory.
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for i in 0..to_write {
             self.buffer[self.write_pos] = data[i];
             self.write_pos = (self.write_pos + 1) % PIPE_BUF_SIZE;

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -169,6 +169,12 @@ impl UnixSocket {
 
     fn push(&mut self, data: &[u8]) -> usize {
         let n = data.len().min(self.recv_space());
+        // SMAP bracket — `data` is typically a user-VA slice forwarded
+        // from the syscall layer (sys_write_linux / sendmsg / sendto).
+        // The bounded loop runs under the TABLE lock with no schedule
+        // points, so AC=1 cannot leak.  Collapses to a relaxed load on
+        // CPUs without SMAP.
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for &b in &data[..n] {
             self.recv_buf[self.recv_tail] = b;
             self.recv_tail = (self.recv_tail + 1) % RECV_BUF_CAP;
@@ -178,6 +184,8 @@ impl UnixSocket {
 
     fn pop(&mut self, buf: &mut [u8]) -> usize {
         let n = buf.len().min(self.recv_available());
+        // SMAP bracket — `buf` is typically a user-VA slice.
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for byte in &mut buf[..n] {
             *byte = self.recv_buf[self.recv_head];
             self.recv_head = (self.recv_head + 1) % RECV_BUF_CAP;

--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -13,6 +13,8 @@
 //! Implementation bodies live here; the forwarding stub in
 //! `crate::subsys::aether::dispatch()` delegates to this function.
 
+extern crate alloc;
+
 use astryx_shared::syscall::*;
 
 /// Aether native syscall dispatch.
@@ -37,10 +39,21 @@ pub fn dispatch(
 
             if count == 0 { return 0; }
 
-            let slice = match unsafe { crate::syscall::user_slice(arg2, count) } {
-                Some(s) => s,
-                None => return -14, // EFAULT
+            // Snapshot user buffer into a kernel Vec under a single SMAP
+            // bracket.  Per Intel SDM Vol. 3A §4.6 a supervisor read of a
+            // user page (PTE.U=1) requires EFLAGS.AC=1; UserGuard's RAII
+            // issues STAC/CLAC.  Downstream consumers (pipe_write, TTY
+            // write, the optional UTF-8 debug formatter) all read every
+            // byte of the data after the guard would drop, so snapshot
+            // first instead of borrowing the user page.
+            if !crate::syscall::validate_user_ptr(arg2, count) {
+                return -14; // EFAULT
+            }
+            let snapshot: alloc::vec::Vec<u8> = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::slice::from_raw_parts(arg2 as *const u8, count).to_vec()
             };
+            let slice: &[u8] = &snapshot;
 
             // Special fd types take priority over fd-number shortcuts
             let pid = crate::proc::current_pid();
@@ -54,6 +67,8 @@ pub fn dispatch(
                 // Try VFS first; fall back to TTY for fd 1/2 if no file open.
                 #[cfg(feature = "firefox-test")]
                 if fd == 2 {
+                    // `slice` is a kernel-resident snapshot — from_utf8 is
+                    // safe outside any SMAP bracket.
                     let s = core::str::from_utf8(slice).unwrap_or("<binary>");
                     crate::serial_println!("[FF/stderr] pid={} {:?}", pid, s);
                 }
@@ -71,15 +86,27 @@ pub fn dispatch(
             let fd = arg1;
             let count = arg3 as usize;
 
-            let buf = match unsafe { crate::syscall::user_slice_mut(arg2, count) } {
-                Some(s) => s,
-                None => return -14, // EFAULT
-            };
+            if count == 0 { return 0; }
+
+            // Validate the user buffer up front so EFAULT is reported
+            // before any I/O is performed.  The downstream paths bracket
+            // their own kernel→user writes (pipe_read / tty::read / VFS
+            // fd_read), so we don't need to hold a UserGuard here — they
+            // each acquire one when actually touching user memory.
+            if !crate::syscall::validate_user_ptr(arg2, count) {
+                return -14; // EFAULT
+            }
 
             // Special fd types take priority over fd-number shortcuts
             let pid = crate::proc::current_pid();
             if crate::syscall::is_pipe_fd(pid, fd as usize) {
                 let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
+                // pipe_read does not bracket — it writes through the
+                // supplied &mut [u8].  Bracket the entire call so the
+                // writes execute with AC=1.  The borrow stays inside
+                // the guard scope.
+                let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                let buf = unsafe { core::slice::from_raw_parts_mut(arg2 as *mut u8, count) };
                 match crate::ipc::pipe::pipe_read(pipe_id, buf) {
                     Some(n) => n as i64,
                     None => -9, // EBADF
@@ -89,12 +116,16 @@ pub fn dispatch(
                 match crate::vfs::fd_read(pid, fd as usize, arg2 as *mut u8, count) {
                     Ok(n) => n as i64,
                     Err(_) if fd == 0 => {
-                        // stdin — read through TTY line discipline
+                        // stdin — read through TTY line discipline.
+                        // tty.read writes directly into the supplied
+                        // &mut [u8] so we bracket each spin iteration.
                         let mut attempts = 0u32;
                         loop {
                             {
                                 let mut tty = crate::drivers::tty::TTY0.lock();
                                 crate::drivers::tty::pump_keyboard(&mut tty);
+                                let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                                let buf = unsafe { core::slice::from_raw_parts_mut(arg2 as *mut u8, count) };
                                 let n = tty.read(buf, count);
                                 if n > 0 {
                                     return n as i64;
@@ -116,10 +147,20 @@ pub fn dispatch(
             let path_len = arg2 as usize;
             let flags = arg3 as u32;
 
-            let path = match unsafe { crate::syscall::user_slice(arg1, path_len) } {
-                Some(s) => core::str::from_utf8(s).unwrap_or(""),
-                None => return -14, // EFAULT
+            // Snapshot the path into a kernel Vec under one SMAP bracket.
+            // `core::str::from_utf8` walks every byte for validation, so
+            // calling it on a `&[u8]` that still borrows the user page
+            // would fault under SMAP after the materialisation's internal
+            // UserGuard drops.  See Intel SDM Vol. 3A §4.6.  Use
+            // user_slice_snapshot in new code (this site predates it).
+            if !crate::syscall::validate_user_ptr(arg1, path_len) {
+                return -14; // EFAULT
+            }
+            let path_buf: alloc::vec::Vec<u8> = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::slice::from_raw_parts(arg1 as *const u8, path_len).to_vec()
             };
+            let path = core::str::from_utf8(&path_buf).unwrap_or("");
 
             let pid = crate::proc::current_pid();
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3165,8 +3165,19 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 if !crate::syscall::validate_user_ptr(arg1, 8) {
                     return -14; // EFAULT
                 }
-                let buf = unsafe { core::slice::from_raw_parts_mut(arg1 as *mut u8, 8) };
-                buf.copy_from_slice(&wall_secs.to_le_bytes());
+                // SMAP bracket — the slice materialisation and the
+                // copy_from_slice write below both touch a user page
+                // (PTE.U=1).  Per Intel SDM Vol. 3A §4.6 the supervisor
+                // must hold EFLAGS.AC=1 to issue these stores.  UserGuard
+                // RAII issues STAC on construction and CLAC on drop, so
+                // the bracket covers the write regardless of fault unwind.
+                // glibc's `time(t)` vDSO fallback (man 2 time) takes this
+                // path whenever a userspace caller passes a non-NULL tloc.
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    let buf = core::slice::from_raw_parts_mut(arg1 as *mut u8, 8);
+                    buf.copy_from_slice(&wall_secs.to_le_bytes());
+                }
             }
             wall_secs
         }
@@ -3184,8 +3195,23 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         437 => {
             // openat2 struct how: { flags: u64, mode: u64, resolve: u64 }
             // arg1=dirfd, arg2=path, arg3=*how, arg4=sizeof(how)
-            let how_flags = if arg3 != 0 { unsafe { *(arg3 as *const u64) } } else { 0 };
-            let how_mode  = if arg3 != 0 { unsafe { *((arg3 + 8) as *const u64) } } else { 0o644 };
+            //
+            // SMAP bracket — both reads target user memory.  Validate the
+            // range up front (16 B covers flags+mode), then dereference
+            // under a single UserGuard.  Per Intel SDM Vol. 3A §4.6 and
+            // openat2(2) man page (which specifies a `struct open_how`).
+            let (how_flags, how_mode) = if arg3 != 0 {
+                if !crate::syscall::validate_user_ptr(arg3, 16) {
+                    return -14; // EFAULT
+                }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    (core::ptr::read_unaligned(arg3 as *const u64),
+                     core::ptr::read_unaligned((arg3 + 8) as *const u64))
+                }
+            } else {
+                (0, 0o644)
+            };
             dispatch(257, arg1, arg2, how_flags, how_mode, 0, 0) // openat
         }
         // 316: renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
@@ -4129,42 +4155,75 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     // Must check these BEFORE the `fd == 1/2` stdout/stderr branch because
     // kernel tests and user processes may allocate pipe/socket/eventfd at fd 1.
     let pid = crate::proc::current_pid_lockless();
-    if crate::syscall::is_pipe_fd(pid, fd as usize) {
-        let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
-        let slice = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
-        return match crate::ipc::pipe::pipe_write(pipe_id, slice) {
-            Some(n) => {
-                // Per `man 7 pipe`: writes that deposit data MUST wake any
-                // readers parked on this pipe (the matching wait list lives
-                // in `crate::ipc::pipe::PIPE_READ_WAITERS`).  Skip the wake
-                // on a zero-byte write — the buffer state did not change.
-                if n > 0 {
-                    crate::ipc::pipe::wake_readers_all(pipe_id);
+
+    // Decide once whether the destination is a kernel-internal fd type that
+    // will hold the slice past the UserGuard scope (pipe/socket/unix/eventfd
+    // queue the bytes into kernel buffers; UDP packetises into its own Vec;
+    // TCP enqueues into the send window).  For all of these we must snapshot
+    // the user buffer into a kernel Vec BEFORE invoking the downstream code,
+    // otherwise the downstream's `extend_from_slice` / queue copy reads user
+    // memory with AC=0 and faults under SMAP (Intel SDM Vol. 3A §4.6).
+    //
+    // The VFS fd_write path below threads the raw user pointer through into
+    // its own STAC/CLAC-bracketed copy helpers, so we don't need to snapshot
+    // for that case — keeping the zero-copy fast path intact.
+    let is_pipe   = crate::syscall::is_pipe_fd(pid, fd as usize);
+    let is_unix   = !is_pipe && crate::syscall::is_unix_socket_fd(pid, fd as usize);
+    let is_inet   = !is_pipe && !is_unix && crate::syscall::is_socket_fd(pid, fd as usize);
+    let is_evfd   = !is_pipe && !is_unix && !is_inet
+                    && crate::syscall::is_eventfd_fd(pid, fd as usize);
+
+    if is_pipe || is_unix || is_inet || is_evfd {
+        if !crate::syscall::validate_user_ptr(buf as u64, count) {
+            return -14; // EFAULT
+        }
+        // Snapshot the entire buffer to kernel memory under one bracket.
+        // Bracket-scope is tight: STAC fires, the snapshot copies bytes
+        // through `to_vec`, then CLAC fires before any downstream call.
+        let snapshot: alloc::vec::Vec<u8> = unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::slice::from_raw_parts(buf_ptr, count).to_vec()
+        };
+        let data: &[u8] = &snapshot;
+
+        if is_pipe {
+            let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
+            return match crate::ipc::pipe::pipe_write(pipe_id, data) {
+                Some(n) => {
+                    // Per `man 7 pipe`: writes that deposit data MUST wake
+                    // any readers parked on this pipe (the matching wait
+                    // list lives in `crate::ipc::pipe::PIPE_READ_WAITERS`).
+                    // Skip the wake on a zero-byte write — the buffer state
+                    // did not change.
+                    if n > 0 {
+                        crate::ipc::pipe::wake_readers_all(pipe_id);
+                    }
+                    n as i64
                 }
-                n as i64
-            }
-            None => -9,
-        };
-    } else if crate::syscall::is_unix_socket_fd(pid, fd as usize) {
-        let data = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
-        let unix_id = crate::syscall::get_unix_socket_id(pid, fd as usize);
-        return crate::net::unix::write(unix_id, data);
-    } else if crate::syscall::is_socket_fd(pid, fd as usize) {
-        let socket_id = crate::syscall::get_socket_id(pid, fd as usize);
-        let data = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
-        return match crate::net::socket::socket_send(socket_id, data) {
-            Ok(n) => n as i64,
-            Err("EPIPE") => -32, // EPIPE — caller did SHUT_WR
-            Err(_) => -104, // ECONNRESET
-        };
-    } else if crate::syscall::is_eventfd_fd(pid, fd as usize) {
+                None => -9,
+            };
+        }
+        if is_unix {
+            let unix_id = crate::syscall::get_unix_socket_id(pid, fd as usize);
+            return crate::net::unix::write(unix_id, data);
+        }
+        if is_inet {
+            let socket_id = crate::syscall::get_socket_id(pid, fd as usize);
+            return match crate::net::socket::socket_send(socket_id, data) {
+                Ok(n) => n as i64,
+                Err("EPIPE") => -32, // EPIPE — caller did SHUT_WR
+                Err(_) => -104, // ECONNRESET
+            };
+        }
+        // is_evfd
         if count < 8 { return -22; } // EINVAL
         let efd_id = crate::syscall::get_eventfd_id(pid, fd as usize);
-        let val = unsafe {
-            let _g = crate::arch::x86_64::smap::UserGuard::new();
-            core::ptr::read_unaligned(buf_ptr as *const u64)
-        };
-        return match crate::ipc::eventfd::write(efd_id, u64::from_le(val)) {
+        let val_bytes: [u8; 8] = [
+            data[0], data[1], data[2], data[3],
+            data[4], data[5], data[6], data[7],
+        ];
+        let val = u64::from_le_bytes(val_bytes);
+        return match crate::ipc::eventfd::write(efd_id, val) {
             Ok(()) => {
                 // Per `man 2 eventfd`: a write that bumps the counter must
                 // wake any reader parked on a zero counter (see the per-
@@ -4184,9 +4243,18 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
         Err(_) => return -9, // EBADF for other fds
     }
 
-    // fd 1/2 with no VFS file → TTY stdout/stderr.
-    let slice = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
-    crate::drivers::tty::TTY0.lock().write(slice);
+    // fd 1/2 with no VFS file → TTY stdout/stderr.  Same SMAP discipline as
+    // the special-fd paths above: TTY's write() reads every byte of the slice
+    // into the line buffer, holding the read past the UserGuard would risk a
+    // mismatched bracket.  Snapshot first.
+    if !crate::syscall::validate_user_ptr(buf as u64, count) {
+        return -14; // EFAULT
+    }
+    let tty_snap: alloc::vec::Vec<u8> = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::slice::from_raw_parts(buf_ptr, count).to_vec()
+    };
+    crate::drivers::tty::TTY0.lock().write(&tty_snap);
     count as i64
 }
 
@@ -5159,8 +5227,20 @@ fn sys_sendfile(out_fd: usize, in_fd: usize, offset_ptr: u64, count: usize) -> i
             None => return -9,
         }
     };
+    // Per sendfile(2): if `offset` is non-NULL, kernel reads the starting
+    // offset from `*offset` and writes the post-read offset back on success.
+    // Validate the 8-byte range and bracket the read with STAC/CLAC so the
+    // supervisor access to a user page does not raise #PF when SMAP is
+    // active (Intel SDM Vol. 3A §4.6).  An invalid pointer must surface as
+    // EFAULT (errno 14), per the man page.
     let read_offset: u64 = if offset_ptr != 0 {
-        unsafe { core::ptr::read_unaligned(offset_ptr as *const u64) }
+        if !crate::syscall::validate_user_ptr(offset_ptr, 8) {
+            return -14; // EFAULT
+        }
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::read_unaligned(offset_ptr as *const u64)
+        }
     } else {
         in_offset_cur
     };
@@ -5219,9 +5299,16 @@ fn sys_sendfile(out_fd: usize, in_fd: usize, offset_ptr: u64, count: usize) -> i
         }
     }
 
-    // Update the read offset.
+    // Update the read offset.  Per sendfile(2): on a non-NULL offset
+    // pointer the kernel writes back the post-read offset.  validate_user_ptr
+    // already passed at the top of the function (we never NULL it between
+    // there and here), but we re-bracket with STAC/CLAC because the write
+    // touches a user page (Intel SDM Vol. 3A §4.6).
     if offset_ptr != 0 {
-        unsafe { core::ptr::write_unaligned(offset_ptr as *mut u64, read_offset + n as u64); }
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::write_unaligned(offset_ptr as *mut u64, read_offset + n as u64);
+        }
     } else {
         let mut procs = crate::proc::PROCESS_TABLE.lock();
         if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -161,9 +161,9 @@ pub(crate) fn user_path_ptr_ok(ptr: u64) -> bool {
 /// pathname-reading syscall (open, openat, access, stat, statx,
 /// readlink, rename, link, mkdir, mount, execve, …) against malicious
 /// userspace without breaking the in-kernel test API.
-fn read_cstring_from_user(ptr: u64) -> &'static [u8] {
+fn read_cstring_from_user(ptr: u64) -> alloc::vec::Vec<u8> {
     if ptr == 0 {
-        return b"";
+        return alloc::vec::Vec::new();
     }
     // The user/kernel boundary check is enforced at dispatch (see
     // `user_path_ptr_ok` and the per-syscall dispatch arms in
@@ -172,14 +172,35 @@ fn read_cstring_from_user(ptr: u64) -> &'static [u8] {
     // the kernel-mapped read-only string table; rejecting those would
     // break the test-runner and early-boot code.  We keep the bounded
     // 4096-byte read as the only defensive limit here.
+    //
+    // SMAP bracket — every iteration below derefs through `start` which
+    // backs the user pointer in the syscall path.  Per Intel SDM Vol. 3A
+    // §4.6 the supervisor must hold AC=1 to touch a user page; the
+    // UserGuard issues STAC/CLAC accordingly when SMAP is active and
+    // collapses to a load + branch otherwise.
+    //
+    // We return an owned Vec<u8> rather than a `&[u8]` borrow because
+    // every downstream consumer of the result holds it past the bracket
+    // — formatting it through serial_println, passing it to VFS, etc.
+    // A user-page borrow would re-fault on access outside the guard.
+    // Stage into a kernel-resident stack buffer under one SMAP guard,
+    // then push into the (allocating) Vec outside the guard.  Holding
+    // AC=1 across a heap allocation would be incorrect because the
+    // allocator path may take locks and is unrelated to user memory.
     let start = ptr as *const u8;
-    let mut len = 0usize;
-    unsafe {
-        while len < 4096 && *start.add(len) != 0 {
+    let mut staging = [0u8; 4096];
+    let n = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        let mut len = 0usize;
+        while len < 4096 {
+            let b = *start.add(len);
+            if b == 0 { break; }
+            staging[len] = b;
             len += 1;
         }
-        core::slice::from_raw_parts(start, len)
-    }
+        len
+    };
+    staging[..n].to_vec()
 }
 
 /// Read a null-terminated array of C string pointers (char *argv[]) from user memory.
@@ -191,12 +212,21 @@ pub(crate) fn read_user_argv(ptr: u64) -> alloc::vec::Vec<alloc::string::String>
     }
     let array = ptr as *const u64;
     for i in 0..256usize {
-        let str_ptr = unsafe { *array.add(i) };
+        // SMAP bracket the pointer-array read only.  Each iteration's
+        // `read_cstring_from_user` opens its own UserGuard internally —
+        // we cannot hold a single guard across the whole loop because
+        // `String::from_utf8_lossy` allocates, and the allocator is a
+        // kernel-only path; holding AC=1 across it would defeat the
+        // SMAP invariant ("AC=1 only while reading user memory").
+        let str_ptr = unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            *array.add(i)
+        };
         if str_ptr == 0 {
             break;
         }
         let bytes = read_cstring_from_user(str_ptr);
-        let s = alloc::string::String::from_utf8_lossy(bytes).into_owned();
+        let s = alloc::string::String::from_utf8_lossy(&bytes).into_owned();
         result.push(s);
     }
     result
@@ -226,7 +256,9 @@ fn write_sockaddr_in(addr_ptr: u64, addrlen_ptr: *mut u32,
     buf[6] = ip[2]; buf[7] = ip[3];          // sin_addr
     // sin_zero already zero.
     let n = cap.min(16);
+    // SMAP bracket — both writes target user buffers in the syscall path.
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         core::ptr::copy_nonoverlapping(buf.as_ptr(), addr_ptr as *mut u8, n);
         core::ptr::write(addrlen_ptr, 16u32);
     }
@@ -635,22 +667,36 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
 
             // Inner check: evaluate all pollfds, write revents, return ready count.
             // struct pollfd { int fd; short events; short revents; } = 8 bytes
+            //
+            // SMAP discipline: bracket each pollfd access individually
+            // because crate::syscall::poll_revents is a kernel-only path
+            // (waitlist + fd table) — holding AC=1 across it would defeat
+            // SMAP's purpose of confining user-page access.
             let do_check = |clear: bool, log: bool| -> i64 {
                 let mut ready = 0i64;
                 for i in 0..nfds as u64 {
                     let base = (arg1 + i * 8) as *mut u8;
                     let (fd_val, events) = unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
                         (core::ptr::read_unaligned(base as *const i32),
                          core::ptr::read_unaligned(base.add(4) as *const u16))
                     };
                     if fd_val < 0 {
-                        if clear { unsafe { core::ptr::write_unaligned(base.add(6) as *mut u16, 0); } }
+                        if clear {
+                            unsafe {
+                                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                core::ptr::write_unaligned(base.add(6) as *mut u16, 0);
+                            }
+                        }
                         continue;
                     }
                     let revents = crate::syscall::poll_revents(pid, fd_val as usize, events);
                     // Per-fd poll logging disabled to reduce kernel stack pressure.
                     let _ = log;
-                    unsafe { core::ptr::write_unaligned(base.add(6) as *mut u16, revents); }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::write_unaligned(base.add(6) as *mut u16, revents);
+                    }
                     if revents != 0 { ready += 1; }
                 }
                 ready
@@ -838,15 +884,24 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let addr_ptr = arg2;
             let addrlen = arg3 as usize;
             if addrlen < 2 || addr_ptr == 0 { return -22; }
-            let family = unsafe { core::ptr::read_unaligned(addr_ptr as *const u16) };
+            // SMAP bracket — the family read derefs a user pointer.
+            let family = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::read_unaligned(addr_ptr as *const u16)
+            };
 
             if family == 1 {
                 // AF_UNIX — sockaddr_un { sa_family: u16, sun_path: [u8; 108] }
                 if !crate::syscall::is_unix_socket_fd(pid, fd) { return -9; }
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
-                let path_bytes = if addrlen > 2 {
-                    unsafe { core::slice::from_raw_parts((addr_ptr + 2) as *const u8, (addrlen - 2).min(108)) }
+                // SMAP bracket — copy the path bytes into a kernel Vec so the
+                // downstream IPC work doesn't hold AC=1.
+                let path_owned: alloc::vec::Vec<u8> = if addrlen > 2 {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    let s = unsafe { core::slice::from_raw_parts((addr_ptr + 2) as *const u8, (addrlen - 2).min(108)) };
+                    s.to_vec()
                 } else { return -22; };
+                let path_bytes: &[u8] = &path_owned;
                 // Strip trailing NUL
                 let plen = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
                 #[cfg(feature = "firefox-test")]
@@ -866,8 +921,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
                 if family == 2 && addrlen >= 16 {
-                    // sockaddr_in
-                    let bytes = unsafe { core::slice::from_raw_parts(addr_ptr as *const u8, 16) };
+                    // sockaddr_in — SMAP-bracketed copy into kernel-local
+                    // bytes so the connect / wait loop below runs without
+                    // AC=1.
+                    let mut bytes = [0u8; 16];
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(addr_ptr as *const u8, bytes.as_mut_ptr(), 16);
+                    }
                     let port = u16::from_be_bytes([bytes[2], bytes[3]]);
                     let ip = [bytes[4], bytes[5], bytes[6], bytes[7]];
                     match crate::net::socket::socket_connect(socket_id, ip, port) {
@@ -932,7 +993,17 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let fd = arg1 as usize;
             let buf_ptr = arg2 as *const u8;
             let len = arg3 as usize;
-            let data = unsafe { core::slice::from_raw_parts(buf_ptr, len) };
+            // SMAP bracket — slice materialised under AC=1 because every
+            // path below copies (unix::write / socket_send / socket_sendto)
+            // reads through `data`.  The downstream net code is kernel-only
+            // and will copy the bytes into its own buffers; we don't hold
+            // the guard across those calls.  Materialise + immediately
+            // copy into a kernel Vec to keep AC=1 scope tight.
+            let data_owned: alloc::vec::Vec<u8> = {
+                let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                unsafe { core::slice::from_raw_parts(buf_ptr, len) }.to_vec()
+            };
+            let data: &[u8] = &data_owned;
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 crate::net::unix::write(unix_id, data)
@@ -942,7 +1013,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let addr_ptr = arg5;
                 let addrlen = arg6 as usize;
                 if addr_ptr != 0 && addrlen >= 16 {
-                    let bytes = unsafe { core::slice::from_raw_parts(addr_ptr as *const u8, 16) };
+                    let mut bytes = [0u8; 16];
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(addr_ptr as *const u8, bytes.as_mut_ptr(), 16);
+                    }
                     let family = u16::from_le_bytes([bytes[0], bytes[1]]);
                     if family == 2 {
                         let port = u16::from_be_bytes([bytes[2], bytes[3]]);
@@ -983,6 +1058,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let addrlen_ptr  = arg6 as *mut u32;
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
+                // SMAP bracket — `buf` is a user slice; unix::read writes
+                // into it.  Bracket spans the call so the writes inside
+                // unix::read run with AC=1.
+                let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
                 let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr, len) };
                 crate::net::unix::read(unix_id, buf)
             } else {
@@ -992,7 +1071,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     Ok((data, src_ip, src_port)) => {
                         let n = data.len().min(len);
                         if n > 0 {
-                            unsafe { core::ptr::copy_nonoverlapping(data.as_ptr(), buf_ptr, n); }
+                            unsafe {
+                                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                core::ptr::copy_nonoverlapping(data.as_ptr(), buf_ptr, n);
+                            }
                         }
                         // Only marshal the source address when the caller
                         // asked for it (both pointers non-NULL) AND we
@@ -1001,7 +1083,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         // the contents of the sockaddr buffer are
                         // unspecified when no message was received.
                         if n > 0 && addr_ptr != 0 && !addrlen_ptr.is_null() {
-                            let cap = unsafe { core::ptr::read(addrlen_ptr) } as usize;
+                            let cap = unsafe {
+                                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                core::ptr::read(addrlen_ptr)
+                            } as usize;
+                            // write_sockaddr_in opens its own UserGuard
+                            // for the marshalled writes.
                             write_sockaddr_in(addr_ptr, addrlen_ptr, src_ip, src_port, cap);
                         }
                         n as i64
@@ -1021,20 +1108,38 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // ending at msg_flags (offset 48–52); ctrl writes touch up to
             // ctrl_ptr + ctrl_len which is validated separately below.
             if !crate::syscall::validate_user_ptr(arg2, 56) { return -14; }
-            let iov_ptr = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(2)) }; // offset 16
-            let iov_len = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(3)) }; // offset 24
+            // SMAP bracket the msghdr field reads (iov_ptr, iov_len).
+            let (iov_ptr, iov_len) = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                (core::ptr::read_unaligned(msghdr_ptr.add(2)),  // offset 16
+                 core::ptr::read_unaligned(msghdr_ptr.add(3)))  // offset 24
+            };
             if iov_ptr == 0 || iov_len == 0 { return 0; }
             if iov_len > 1024 { return -22; } // IOV_MAX per POSIX sendmsg(2)
             if !crate::syscall::validate_user_ptr(iov_ptr, (iov_len as usize).saturating_mul(16)) {
                 return -14;
             }
-            let iovecs = unsafe { core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iov_len as usize) };
+            // Copy the iovec array into kernel memory so the per-iov
+            // base/len reads do not need to re-enter user space; this
+            // also defangs any TOCTOU between validate and use.
+            let iovecs_owned: alloc::vec::Vec<[u64; 2]> = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iov_len as usize).to_vec()
+            };
             let mut total = 0usize;
-            for iov in iovecs {
+            for iov in &iovecs_owned {
                 let base = iov[0] as *const u8;
                 let slen = iov[1] as usize;
                 if slen == 0 { continue; }
-                let data = unsafe { core::slice::from_raw_parts(base, slen) };
+                // SMAP bracket — slice materialises against the user iov
+                // buffer; copy into a kernel Vec immediately so the net
+                // layer's send (which may take locks / queue) runs
+                // outside AC=1.
+                let data_owned: alloc::vec::Vec<u8> = {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    unsafe { core::slice::from_raw_parts(base, slen) }.to_vec()
+                };
+                let data: &[u8] = &data_owned;
                 if crate::syscall::is_unix_socket_fd(pid, fd) {
                     let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                     match crate::net::unix::write(unix_id, data) {
@@ -1055,14 +1160,23 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // msghdr layout (x86_64): msg_control at byte-offset 32 (u64 index 4),
             // msg_controllen at byte-offset 40 (u64 index 5).
             if crate::syscall::is_unix_socket_fd(pid, fd) {
-                let ctrl_ptr = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(4)) };
-                let ctrl_len = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(5)) } as usize;
+                // SMAP bracket — read msghdr.msg_control / msg_controllen
+                // and the cmsghdr fields under a single guard.
+                let (ctrl_ptr, ctrl_len, cmsg_len, cmsg_level, cmsg_type) = unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    let cp = core::ptr::read_unaligned(msghdr_ptr.add(4));
+                    let cl = core::ptr::read_unaligned(msghdr_ptr.add(5)) as usize;
+                    if cp != 0 && cl >= 16 {
+                        let ctrl = cp as *const u8;
+                        (cp, cl,
+                         core::ptr::read_unaligned(ctrl as *const u64) as usize,
+                         core::ptr::read_unaligned((cp + 8)  as *const i32),
+                         core::ptr::read_unaligned((cp + 12) as *const i32))
+                    } else {
+                        (cp, cl, 0usize, 0i32, 0i32)
+                    }
+                };
                 if ctrl_ptr != 0 && ctrl_len >= 16 {
-                    let ctrl = ctrl_ptr as *const u8;
-                    // cmsghdr: cmsg_len(u64@0), cmsg_level(i32@8), cmsg_type(i32@12)
-                    let cmsg_len   = unsafe { core::ptr::read_unaligned(ctrl as *const u64) } as usize;
-                    let cmsg_level = unsafe { core::ptr::read_unaligned((ctrl_ptr + 8)  as *const i32) };
-                    let cmsg_type  = unsafe { core::ptr::read_unaligned((ctrl_ptr + 12) as *const i32) };
                     const SOL_SOCKET_I32: i32 = 1;
                     const SCM_RIGHTS_I32: i32 = 1;
                     if cmsg_level == SOL_SOCKET_I32 && cmsg_type == SCM_RIGHTS_I32 && cmsg_len > 16 {
@@ -1072,7 +1186,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             let procs = crate::proc::PROCESS_TABLE.lock();
                             if let Some(p) = procs.iter().find(|p| p.pid == pid) {
                                 (0..nfds).filter_map(|i| {
-                                    let fd_n = unsafe { core::ptr::read_unaligned(fd_arr.add(i)) } as usize;
+                                    // SMAP bracket each fd read.  The
+                                    // PROCESS_TABLE lock is held — keep
+                                    // the AC=1 region as narrow as
+                                    // possible.
+                                    let fd_n = unsafe {
+                                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                        core::ptr::read_unaligned(fd_arr.add(i))
+                                    } as usize;
                                     if fd_n < p.file_descriptors.len() {
                                         p.file_descriptors[fd_n].clone()
                                     } else { None }
@@ -1099,8 +1220,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if msghdr_ptr.is_null() { return -22; }
             // CWE-823: validate msghdr is in user space (see sendmsg above).
             if !crate::syscall::validate_user_ptr(arg2, 56) { return -14; }
-            let iov_ptr = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(2)) };
-            let iov_len = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(3)) };
+            // SMAP bracket the msghdr field reads.
+            let (iov_ptr, iov_len) = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                (core::ptr::read_unaligned(msghdr_ptr.add(2)),
+                 core::ptr::read_unaligned(msghdr_ptr.add(3)))
+            };
             if iov_ptr == 0 || iov_len == 0 { return -22; }
             if iov_len > 1024 { return -22; } // IOV_MAX per POSIX recvmsg(2)
             // Only iov[0] is consumed below, but validate the full iovec array
@@ -1110,36 +1235,34 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if !crate::syscall::validate_user_ptr(iov_ptr, (iov_len as usize).saturating_mul(16)) {
                 return -14;
             }
-            let iov = unsafe { core::slice::from_raw_parts(iov_ptr as *const [u64; 2], 1) };
-            let dst = iov[0][0] as *mut u8;
-            let cap = iov[0][1] as usize;
+            // SMAP-bracketed iov[0] read; we only consume the first element.
+            let (dst, cap) = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                let iov = core::slice::from_raw_parts(iov_ptr as *const [u64; 2], 1);
+                (iov[0][0] as *mut u8, iov[0][1] as usize)
+            };
             let bytes_read: i64;
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
-                let buf = unsafe { core::slice::from_raw_parts_mut(dst, cap) };
-                // Use read_msg so SOCK_SEQPACKET callers see one message per
-                // recvmsg and can observe MSG_TRUNC (msghdr.msg_flags bit 0x20)
-                // when the receiver buffer was shorter than the sender message.
-                // msghdr.msg_flags lives at byte-offset 48 (i32) per the Linux
-                // x86_64 ABI for `struct msghdr`.
-                //
-                // Per recvmsg(2): "The msg_flags field in the msghdr is set on
-                // return of recvmsg()" — the kernel OVERWRITES the field on
-                // return; it does not OR into whatever the caller left there.
-                // Callers that zero the struct see the same result, but any
-                // sentinel the caller placed in msg_flags must not survive.
+                // SMAP bracket — read_msg writes through `buf` into user
+                // memory.  Held for the call duration; we drop it before
+                // the subsequent allocations / table walks below.
                 const MSG_TRUNC: u32 = 0x20;
-                bytes_read = match crate::net::unix::read_msg(unix_id, buf) {
-                    Ok((n, discarded)) => {
-                        // Overwrite (not OR) msg_flags — recvmsg(2) man page.
-                        let computed: u32 = if discarded > 0 { MSG_TRUNC } else { 0 };
-                        unsafe {
-                            let flags_ptr = (arg2 + 48) as *mut u32;
-                            core::ptr::write_unaligned(flags_ptr, computed);
+                bytes_read = {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    let buf = unsafe { core::slice::from_raw_parts_mut(dst, cap) };
+                    match crate::net::unix::read_msg(unix_id, buf) {
+                        Ok((n, discarded)) => {
+                            // Overwrite (not OR) msg_flags — recvmsg(2) man page.
+                            let computed: u32 = if discarded > 0 { MSG_TRUNC } else { 0 };
+                            unsafe {
+                                let flags_ptr = (arg2 + 48) as *mut u32;
+                                core::ptr::write_unaligned(flags_ptr, computed);
+                            }
+                            n as i64
                         }
-                        n as i64
+                        Err(e) => e,
                     }
-                    Err(e) => e,
                 };
                 // Deliver pending SCM_RIGHTS fds into receiver's fd table.
                 if bytes_read >= 0 {
@@ -1162,29 +1285,35 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                 }).collect()
                             } else { Vec::new() }
                         };
-                        // Write SCM_RIGHTS cmsghdr into msg_control.
-                        let ctrl_ptr = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(4)) };
-                        let ctrl_len = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(5)) } as usize;
-                        if ctrl_ptr != 0 && ctrl_len >= 16 + new_fd_nums.len() * 4 {
-                            let needed = 16 + new_fd_nums.len() * 4;
-                            unsafe {
+                        // Write SCM_RIGHTS cmsghdr into msg_control.  All
+                        // reads/writes here target user memory — single
+                        // SMAP guard spanning the whole block.
+                        unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            let ctrl_ptr = core::ptr::read_unaligned(msghdr_ptr.add(4));
+                            let ctrl_len = core::ptr::read_unaligned(msghdr_ptr.add(5)) as usize;
+                            if ctrl_ptr != 0 && ctrl_len >= 16 + new_fd_nums.len() * 4 {
+                                let needed = 16 + new_fd_nums.len() * 4;
                                 core::ptr::write_unaligned(ctrl_ptr as *mut u64, needed as u64);
                                 core::ptr::write_unaligned((ctrl_ptr + 8)  as *mut i32, 1i32); // SOL_SOCKET
                                 core::ptr::write_unaligned((ctrl_ptr + 12) as *mut i32, 1i32); // SCM_RIGHTS
                                 for (i, &new_fd) in new_fd_nums.iter().enumerate() {
                                     core::ptr::write_unaligned((ctrl_ptr + 16 + i as u64 * 4) as *mut i32, new_fd);
                                 }
+                                core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, needed as u64);
+                            } else if ctrl_ptr != 0 {
+                                // No room — zero out msg_controllen.
+                                core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, 0u64);
                             }
-                            unsafe { core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, needed as u64); }
-                        } else if ctrl_ptr != 0 {
-                            // No room — zero out msg_controllen.
-                            unsafe { core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, 0u64); }
                         }
                     } else {
                         // No SCM to deliver — set msg_controllen to 0.
-                        let ctrl_ptr = unsafe { core::ptr::read_unaligned(msghdr_ptr.add(4)) };
-                        if ctrl_ptr != 0 {
-                            unsafe { core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, 0u64); }
+                        unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            let ctrl_ptr = core::ptr::read_unaligned(msghdr_ptr.add(4));
+                            if ctrl_ptr != 0 {
+                                core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, 0u64);
+                            }
                         }
                     }
                 }
@@ -1196,7 +1325,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         if data.is_empty() { 0 }
                         else {
                             let n = data.len().min(cap);
-                            unsafe { core::ptr::copy_nonoverlapping(data.as_ptr(), dst, n); }
+                            unsafe {
+                                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                core::ptr::copy_nonoverlapping(data.as_ptr(), dst, n);
+                            }
                             n as i64
                         }
                     }
@@ -1233,20 +1365,31 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let addr_ptr = arg2;
             let addrlen = arg3 as usize;
             if addrlen < 2 || addr_ptr == 0 { return -22; }
-            let family = unsafe { core::ptr::read_unaligned(addr_ptr as *const u16) };
+            // SMAP bracket family read.
+            let family = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::read_unaligned(addr_ptr as *const u16)
+            };
             if family == 1 {
                 // AF_UNIX — sockaddr_un
                 if !crate::syscall::is_unix_socket_fd(pid, fd) { return -9; }
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
-                let path_bytes = if addrlen > 2 {
-                    unsafe { core::slice::from_raw_parts((addr_ptr + 2) as *const u8, (addrlen - 2).min(108)) }
+                // SMAP-bracketed copy into kernel Vec.
+                let path_owned: alloc::vec::Vec<u8> = if addrlen > 2 {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    unsafe { core::slice::from_raw_parts((addr_ptr + 2) as *const u8, (addrlen - 2).min(108)) }.to_vec()
                 } else { return -22; };
+                let path_bytes: &[u8] = &path_owned;
                 let plen = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
                 crate::net::unix::bind(unix_id, &path_bytes[..plen])
             } else if family == 2 && addrlen >= 8 {
                 if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
-                let bytes = unsafe { core::slice::from_raw_parts(addr_ptr as *const u8, 8) };
+                let mut bytes = [0u8; 8];
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::copy_nonoverlapping(addr_ptr as *const u8, bytes.as_mut_ptr(), 8);
+                }
                 let port = u16::from_be_bytes([bytes[2], bytes[3]]);
                 match crate::net::socket::socket_bind(socket_id, port) {
                     Ok(()) => 0,
@@ -1280,7 +1423,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let addr_ptr = arg2;
             let addrlen_ptr = arg3 as *mut u32;
             if addr_ptr == 0 || addrlen_ptr.is_null() { return -22; }
-            let cap = unsafe { core::ptr::read(addrlen_ptr) } as usize;
+            let cap = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::read(addrlen_ptr)
+            } as usize;
 
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 // AF_UNIX sockaddr_un — minimal: family=1, empty path.
@@ -1292,6 +1438,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 tmp[0] = 1; // AF_UNIX
                 let n = cap.min(want);
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
                     core::ptr::copy_nonoverlapping(tmp.as_ptr(), addr_ptr as *mut u8, n);
                     core::ptr::write(addrlen_ptr, want as u32);
                 }
@@ -1315,7 +1462,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let addr_ptr = arg2;
             let addrlen_ptr = arg3 as *mut u32;
             if addr_ptr == 0 || addrlen_ptr.is_null() { return -22; }
-            let cap = unsafe { core::ptr::read(addrlen_ptr) } as usize;
+            let cap = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::read(addrlen_ptr)
+            } as usize;
 
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 // Unconnected AF_UNIX → ENOTCONN.  Connected AF_UNIX
@@ -1330,6 +1480,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 tmp[0] = 1;
                 let n = cap.min(want);
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
                     core::ptr::copy_nonoverlapping(tmp.as_ptr(), addr_ptr as *mut u8, n);
                     core::ptr::write(addrlen_ptr, want as u32);
                 }
@@ -1416,6 +1567,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 return fd_b;
             }
             unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
                 core::ptr::write(sv_ptr,       fd_a as u32);
                 core::ptr::write(sv_ptr.add(1), fd_b as u32);
             }
@@ -1427,7 +1579,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let fd    = arg1 as usize;
             let level = arg2;
             let opt   = arg3;
-            let val   = if arg4 != 0 { unsafe { core::ptr::read_unaligned(arg4 as *const u32) } }
+            let val   = if arg4 != 0 { unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::read_unaligned(arg4 as *const u32)
+            } }
                         else         { 0u32 };
             if crate::syscall::is_socket_fd(pid, fd) {
                 let sid = crate::syscall::get_socket_id(pid, fd);
@@ -1482,6 +1637,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             return -14; // EFAULT
                         }
                         unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
                             let p = optval as *mut u8;
                             core::ptr::write_unaligned(p as *mut u32, peer.pid as u32);
                             core::ptr::write_unaligned(p.add(4) as *mut u32, peer.uid);
@@ -1491,7 +1647,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             if !crate::syscall::validate_user_ptr(optlen as u64, 4) {
                                 return -14;
                             }
-                            unsafe { core::ptr::write_unaligned(optlen, 12u32); }
+                            unsafe {
+                                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                core::ptr::write_unaligned(optlen, 12u32);
+                            }
                         }
                         return 0i64;
                     }
@@ -1513,8 +1672,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     _ => 0,
                 }
             };
-            if !optval.is_null() { unsafe { core::ptr::write(optval, val); } }
-            if !optlen.is_null() { unsafe { core::ptr::write(optlen, 4u32); } }
+            // SMAP bracket — both writes target user pointers.
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                if !optval.is_null() { core::ptr::write(optval, val); }
+                if !optlen.is_null() { core::ptr::write(optlen, 4u32); }
+            }
             0
         }
         // 56: clone(flags, stack, parent_tid, child_tid, tls)
@@ -1727,7 +1890,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let bytes = target_str.as_bytes();
             let len = bytes.len().min(bufsiz);
             if len > 0 {
-                unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len);
+                }
             }
             len as i64
         }
@@ -1752,7 +1918,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 PR_GET_NAME => {
                     let buf = arg2 as *mut u8;
                     let name = b"astryx\0";
-                    unsafe { core::ptr::copy_nonoverlapping(name.as_ptr(), buf, name.len()); }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(name.as_ptr(), buf, name.len());
+                    }
                     0
                 }
                 PR_SET_DUMPABLE          => 0,
@@ -1762,7 +1931,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 PR_GET_CHILD_SUBREAPER   => {
                     // Report "not a subreaper"
                     if arg2 != 0 {
-                        unsafe { core::ptr::write_unaligned(arg2 as *mut u32, 0); }
+                        unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            core::ptr::write_unaligned(arg2 as *mut u32, 0);
+                        }
                     }
                     0
                 }
@@ -1828,6 +2000,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let ncpus = ncpus.max(1); // always at least 1
                 // Zero the buffer, then set one bit per online CPU.
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
                     core::ptr::write_bytes(buf, 0, written);
                     // Set bits 0..ncpus-1 in the cpuset bitmask (little-endian).
                     // Each byte covers 8 CPUs.  We support up to written*8 CPUs.
@@ -1883,12 +2056,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let len  = t.robust_list_len;
                 drop(threads);
                 // Write head pointer into *head_ptr (arg2 is **robust_list_head)
-                if arg2 != 0 {
-                    unsafe { core::ptr::write(arg2 as *mut u64, head); }
-                }
-                // Write length into *len_ptr
-                if arg3 != 0 {
-                    unsafe { core::ptr::write(arg3 as *mut usize, len); }
+                // and length into *len_ptr — both user pointers.
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    if arg2 != 0 { core::ptr::write(arg2 as *mut u64, head); }
+                    if arg3 != 0 { core::ptr::write(arg3 as *mut usize, len); }
                 }
                 0
             } else {
@@ -1903,8 +2075,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         291 => sys_epoll_create1(arg1 as u32),
         // 309: getcpu(cpu, node, cache) — stub
         309 => {
-            if arg1 != 0 { unsafe { core::ptr::write(arg1 as *mut u32, 0); } }
-            if arg2 != 0 { unsafe { core::ptr::write(arg2 as *mut u32, 0); } }
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                if arg1 != 0 { core::ptr::write(arg1 as *mut u32, 0); }
+                if arg2 != 0 { core::ptr::write(arg2 as *mut u32, 0); }
+            }
             0
         }
         // 59: execve(pathname, argv, envp) — pathname is C string
@@ -1947,8 +2122,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         88 => {
             let old_raw = read_cstring_from_user(arg1);
             let new_raw = read_cstring_from_user(arg2);
-            let old_str = core::str::from_utf8(old_raw).unwrap_or("");
-            let new_str = core::str::from_utf8(new_raw).unwrap_or("");
+            let old_str = core::str::from_utf8(&old_raw).unwrap_or("");
+            let new_str = core::str::from_utf8(&new_raw).unwrap_or("");
             match crate::vfs::symlink(old_str, new_str) {
                 Ok(()) => 0,
                 Err(e) => -(e as usize as i64),
@@ -2009,6 +2184,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     .unwrap_or((!0u32, !0u32));
                 drop(procs);
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
                     let p = arg2 as *mut u32;
                     // struct 0: effective, permitted, inheritable
                     core::ptr::write_unaligned(p,         eff);
@@ -2030,8 +2206,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let mut procs = crate::proc::PROCESS_TABLE.lock();
                 if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
                     let dp = arg2 as *const u32;
-                    let eff  = unsafe { core::ptr::read_unaligned(dp) };
-                    let perm = unsafe { core::ptr::read_unaligned(dp.add(1)) };
+                    let (eff, perm) = unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        (core::ptr::read_unaligned(dp),
+                         core::ptr::read_unaligned(dp.add(1)))
+                    };
                     p.cap_effective  = eff  as u64;
                     p.cap_permitted  = perm as u64;
                 }
@@ -2043,7 +2222,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let resource = arg1 as usize;
             if resource >= 16 { return -22; } // EINVAL
             if !crate::syscall::validate_user_ptr(arg2, 16) { return -14; } // EFAULT
-            let soft = unsafe { core::ptr::read_unaligned(arg2 as *const u64) };
+            let soft = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::ptr::read_unaligned(arg2 as *const u64)
+            };
             let pid = crate::proc::current_pid_lockless();
             let mut procs = crate::proc::PROCESS_TABLE.lock();
             if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
@@ -2124,6 +2306,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // si_code=CLD_EXITED(1), si_pid=child_pid, si_status=exit_code
                 // siginfo_t is 128 bytes; we only fill the first 20 bytes.
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
                     core::ptr::write_bytes(infop, 0, 128);
                     core::ptr::write_unaligned(infop.add(0)  as *mut i32, 17); // si_signo = SIGCHLD
                     core::ptr::write_unaligned(infop.add(8)  as *mut i32, 1);  // si_code  = CLD_EXITED
@@ -2151,7 +2334,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             }
             // SET new limit if provided
             if arg3 != 0 && (arg2 as usize) < 16 && crate::syscall::validate_user_ptr(arg3, 16) {
-                let soft = unsafe { core::ptr::read_unaligned(arg3 as *const u64) };
+                let soft = unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::read_unaligned(arg3 as *const u64)
+                };
                 let pid  = crate::proc::current_pid_lockless();
                 let mut procs = crate::proc::PROCESS_TABLE.lock();
                 if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
@@ -2211,8 +2397,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         266 => {
             let old_raw = read_cstring_from_user(arg1);
             let new_raw = read_cstring_from_user(arg3);
-            let old_str = core::str::from_utf8(old_raw).unwrap_or("");
-            let new_str = core::str::from_utf8(new_raw).unwrap_or("");
+            let old_str = core::str::from_utf8(&old_raw).unwrap_or("");
+            let new_str = core::str::from_utf8(&new_raw).unwrap_or("");
             match crate::vfs::symlink(old_str, new_str) {
                 Ok(()) => 0,
                 Err(e) => -(e as usize as i64),
@@ -2240,12 +2426,16 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // CLONE_ARGS_SIZE_VER0 = 64 bytes (covers flags..tls).  Anything
             // smaller cannot supply a tls offset; reject per clone(2).
             if arg2 < 64 || arg1 == 0 { return -22i64; } // EINVAL: struct too small
-            let clone_flags   = unsafe { *(arg1 as *const u64) };
-            let stack_ptr     = unsafe { *((arg1 + 40) as *const u64) };
-            let stack_size    = unsafe { *((arg1 + 48) as *const u64) };
-            let tls           = unsafe { *((arg1 + 56) as *const u64) };
-            let child_tidptr  = unsafe { *((arg1 + 16) as *const u64) };
-            let parent_tidptr = unsafe { *((arg1 + 24) as *const u64) };
+            // SMAP bracket the struct clone_args reads.
+            let (clone_flags, stack_ptr, stack_size, tls, child_tidptr, parent_tidptr) = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                (*(arg1 as *const u64),
+                 *((arg1 + 40) as *const u64),
+                 *((arg1 + 48) as *const u64),
+                 *((arg1 + 56) as *const u64),
+                 *((arg1 + 16) as *const u64),
+                 *((arg1 + 24) as *const u64))
+            };
             #[cfg(feature = "firefox-test")]
             crate::serial_println!(
                 "[CLONE3] flags={:#x} child_tid={:#x} parent_tid={:#x} arg2_size={}",
@@ -2457,7 +2647,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if arg2 != 0 {
                 #[cfg(feature = "firefox-test")]
                 crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Getrusage, arg2 as *const u8, 144);
-                unsafe { core::ptr::write_bytes(arg2 as *mut u8, 0, 144); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_bytes(arg2 as *mut u8, 0, 144);
+                }
             }
             0
         }
@@ -2467,13 +2660,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // struct sysinfo: 11 fields, 64 bytes total
                 #[cfg(feature = "firefox-test")]
                 crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Sysinfo, arg1 as *const u8, 64);
-                unsafe { core::ptr::write_bytes(arg1 as *mut u8, 0, 64); }
                 // uptime (seconds) at offset 0
                 let ticks = crate::arch::x86_64::irq::get_ticks();
                 let uptime = (ticks / 100) as i64; // 100 Hz
-                unsafe { *(arg1 as *mut i64) = uptime; }
-                // totalram / freeram at offsets 8 / 16 (u64 each)
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_bytes(arg1 as *mut u8, 0, 64);
+                    *(arg1 as *mut i64) = uptime;
+                    // totalram / freeram at offsets 8 / 16 (u64 each)
                     let p = arg1 as *mut u64;
                     *p.add(1) = 256 * 1024 * 1024; // 256 MiB totalram
                     *p.add(2) = 128 * 1024 * 1024; // 128 MiB freeram
@@ -2486,6 +2680,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         229 => {
             if arg2 != 0 {
                 unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
                     let ts = arg2 as *mut u64;
                     *ts       = 0; // tv_sec = 0
                     *ts.add(1) = 1; // tv_nsec = 1 (nanosecond resolution)
@@ -2497,7 +2692,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         267 => {
             const AT_FDCWD: i64 = -100;
             let raw = read_cstring_from_user(arg2);
-            let path_str = core::str::from_utf8(raw).unwrap_or("");
+            let path_str = core::str::from_utf8(&raw).unwrap_or("");
             // If AT_FDCWD or absolute path, delegate to readlink logic
             let full_path: alloc::string::String = if arg1 as i64 == AT_FDCWD || path_str.starts_with('/') {
                 alloc::string::String::from(path_str)
@@ -2572,7 +2767,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             };
             let bytes = target.as_bytes();
             let len = bytes.len().min(bufsiz);
-            if len > 0 { unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len); } }
+            if len > 0 {
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len);
+                }
+            }
             len as i64
         }
         // 271: ppoll(fds, nfds, tmo_p, sigmask, sigsetsize) — poll with timeout+mask
@@ -2633,7 +2833,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 76: truncate(path, length)
         76 => {
             let path_bytes = read_cstring_from_user(arg1);
-            let path_str = core::str::from_utf8(path_bytes).unwrap_or("");
+            let path_str = core::str::from_utf8(&path_bytes).unwrap_or("");
             match crate::vfs::truncate_path(path_str, arg2) {
                 Ok(()) => 0,
                 Err(e) => crate::subsys::linux::errno::vfs_err(e),
@@ -2642,7 +2842,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 90: chmod(pathname, mode)
         90 => {
             let path_bytes = read_cstring_from_user(arg1);
-            let path_str = core::str::from_utf8(path_bytes).unwrap_or("");
+            let path_str = core::str::from_utf8(&path_bytes).unwrap_or("");
             match crate::vfs::chmod(path_str, arg2 as u32) {
                 Ok(()) => 0,
                 Err(e) => crate::subsys::linux::errno::vfs_err(e),
@@ -2743,7 +2943,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         //   offset 56: stx_attributes_mask u64
         332 => {
             let path_bytes = read_cstring_from_user(arg2);
-            let path       = match core::str::from_utf8(path_bytes) { Ok(s) => s, Err(_) => return -22 };
+            let path       = match core::str::from_utf8(&path_bytes) { Ok(s) => s, Err(_) => return -22 };
             if arg5 == 0 { return -14; } // EFAULT
             // arg4 = requested mask; we always fill all fields we have.
             // STATX_BASIC_STATS = 0x7ff covers mode, nlink, uid, gid, ino, size, etc.
@@ -2754,8 +2954,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     let base = arg5 as *mut u8;
                     #[cfg(feature = "firefox-test")]
                     crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Statx, base, 256);
-                    unsafe { core::ptr::write_bytes(base, 0, 256); }
+                    let mode: u16 = match st.file_type {
+                        crate::vfs::FileType::Directory => 0o040_755,
+                        crate::vfs::FileType::SymLink   => 0o120_777,
+                        _                               => 0o100_644,
+                    };
                     unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::write_bytes(base, 0, 256);
                         // stx_mask (offset 0): populate BASIC_STATS fields
                         core::ptr::write(base.add(0) as *mut u32, 0x7ff_u32);
                         // stx_blksize (offset 4)
@@ -2763,11 +2969,6 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         // stx_nlink (offset 16)
                         core::ptr::write(base.add(16) as *mut u32, 1_u32);
                         // stx_mode (offset 28): file type bits + permission bits
-                        let mode: u16 = match st.file_type {
-                            crate::vfs::FileType::Directory => 0o040_755,
-                            crate::vfs::FileType::SymLink   => 0o120_777,
-                            _                               => 0o100_644,
-                        };
                         core::ptr::write(base.add(28) as *mut u16, mode);
                         // stx_ino (offset 32)
                         core::ptr::write(base.add(32) as *mut u64, st.inode);
@@ -2804,7 +3005,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         27 => {
             let pages = ((arg2 + 0xFFF) / 0x1000) as usize;
             if arg3 != 0 && crate::syscall::validate_user_ptr(arg3, pages) {
-                unsafe { core::ptr::write_bytes(arg3 as *mut u8, 1, pages); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_bytes(arg3 as *mut u8, 1, pages);
+                }
             }
             0
         }
@@ -2815,7 +3019,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if arg1 != 0 && crate::syscall::validate_user_ptr(arg1, 32) {
                 #[cfg(feature = "firefox-test")]
                 crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Times, arg1 as *const u8, 32);
-                unsafe { core::ptr::write_bytes(arg1 as *mut u8, 0, 32); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_bytes(arg1 as *mut u8, 0, 32);
+                }
             }
             0
         }
@@ -2835,7 +3042,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         118 => {
             for ptr in [arg1, arg2, arg3] {
                 if ptr != 0 && crate::syscall::validate_user_ptr(ptr, 4) {
-                    unsafe { core::ptr::write(ptr as *mut u32, 0u32); }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::write(ptr as *mut u32, 0u32);
+                    }
                 }
             }
             0
@@ -2846,7 +3056,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         120 => {
             for ptr in [arg1, arg2, arg3] {
                 if ptr != 0 && crate::syscall::validate_user_ptr(ptr, 4) {
-                    unsafe { core::ptr::write(ptr as *mut u32, 0u32); }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::write(ptr as *mut u32, 0u32);
+                    }
                 }
             }
             0
@@ -2856,7 +3069,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if arg1 != 0 && crate::syscall::validate_user_ptr(arg1, arg2 as usize) {
                 #[cfg(feature = "firefox-test")]
                 crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Memset, arg1 as *const u8, arg2 as usize);
-                unsafe { core::ptr::write_bytes(arg1 as *mut u8, 0, arg2 as usize); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_bytes(arg1 as *mut u8, 0, arg2 as usize);
+                }
             }
             0
         }
@@ -2887,16 +3103,16 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let fstype_raw = read_cstring_from_user(arg3);
             let flags = arg4;
             let data_raw  = read_cstring_from_user(arg5);
-            let source = core::str::from_utf8(source_raw).unwrap_or("");
-            let target = core::str::from_utf8(target_raw).unwrap_or("");
-            let fstype = core::str::from_utf8(fstype_raw).unwrap_or("");
-            let data   = core::str::from_utf8(data_raw).unwrap_or("");
+            let source = core::str::from_utf8(&source_raw).unwrap_or("");
+            let target = core::str::from_utf8(&target_raw).unwrap_or("");
+            let fstype = core::str::from_utf8(&fstype_raw).unwrap_or("");
+            let data   = core::str::from_utf8(&data_raw).unwrap_or("");
             crate::vfs::sys_mount(source, target, fstype, flags, data)
         }
         // 166: umount(target)
         166 => {
             let target_raw = read_cstring_from_user(arg1);
-            let target = core::str::from_utf8(target_raw).unwrap_or("");
+            let target = core::str::from_utf8(&target_raw).unwrap_or("");
             crate::vfs::sys_umount(target, 0)
         }
         // 167: swapon — stub ENOSYS (no swap on AstryxOS)
@@ -2910,7 +3126,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 169: umount2(target, flags)
         169 => {
             let target_raw = read_cstring_from_user(arg1);
-            let target = core::str::from_utf8(target_raw).unwrap_or("");
+            let target = core::str::from_utf8(&target_raw).unwrap_or("");
             let flags  = arg2;
             crate::vfs::sys_umount(target, flags)
         }
@@ -2976,8 +3192,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         316 => {
             let old_raw = read_cstring_from_user(arg2);
             let new_raw = read_cstring_from_user(arg4);
-            let old_str = core::str::from_utf8(old_raw).unwrap_or("");
-            let new_str = core::str::from_utf8(new_raw).unwrap_or("");
+            let old_str = core::str::from_utf8(&old_raw).unwrap_or("");
+            let new_str = core::str::from_utf8(&new_raw).unwrap_or("");
             match crate::vfs::rename(old_str, new_str) {
                 Ok(()) => 0,
                 Err(e) => crate::subsys::linux::errno::vfs_err(e),
@@ -3011,7 +3227,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         322 => {
             // If path is empty and AT_EMPTY_PATH (0x1000) set, exec fd directly — unsupported
             let path_bytes = read_cstring_from_user(arg2);
-            let path_str   = core::str::from_utf8(path_bytes).unwrap_or("");
+            let path_str   = core::str::from_utf8(&path_bytes).unwrap_or("");
             if path_str.is_empty() {
                 return -38; // ENOSYS — fd-based execveat not supported
             }
@@ -3117,6 +3333,7 @@ fn sys_nanosleep_linux(req_ptr: u64, _rem_ptr: u64) -> i64 {
     }
     if !crate::syscall::validate_user_ptr(req_ptr, 16) { return -14; } // EFAULT
     let (tv_sec, tv_nsec) = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         let p = req_ptr as *const i64;
         (core::ptr::read_unaligned(p), core::ptr::read_unaligned(p.add(1)))
     };
@@ -3157,6 +3374,7 @@ fn sys_getrlimit(resource: u64, rlim_ptr: u64) -> i64 {
         RLIM_INFINITY
     };
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         let p = rlim_ptr as *mut u64;
         core::ptr::write_unaligned(p,        soft);
         core::ptr::write_unaligned(p.add(1), hard);
@@ -3180,12 +3398,19 @@ fn sys_select_linux(
         let byte_off = (fd / 8) as u64;
         let bit      = 1u8 << (fd % 8);
 
+        // SMAP-bracketed reads of user fd_set bits.
         let r_req = readfds  != 0
             && crate::syscall::validate_user_ptr(readfds  + byte_off, 1)
-            && unsafe { *((readfds  + byte_off) as *const u8) & bit != 0 };
+            && unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                *((readfds  + byte_off) as *const u8) & bit != 0
+            };
         let w_req = writefds != 0
             && crate::syscall::validate_user_ptr(writefds + byte_off, 1)
-            && unsafe { *((writefds + byte_off) as *const u8) & bit != 0 };
+            && unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                *((writefds + byte_off) as *const u8) & bit != 0
+            };
 
         if !r_req && !w_req { continue; }
 
@@ -3222,13 +3447,19 @@ fn sys_select_linux(
             if can_read { ready += 1; }
             else {
                 // Clear unready bit
-                unsafe { *((readfds + byte_off) as *mut u8) &= !bit; }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    *((readfds + byte_off) as *mut u8) &= !bit;
+                }
             }
         }
         if w_req {
             if can_write { ready += 1; }
             else {
-                unsafe { *((writefds + byte_off) as *mut u8) &= !bit; }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    *((writefds + byte_off) as *mut u8) &= !bit;
+                }
             }
         }
     }
@@ -3240,10 +3471,16 @@ fn sys_select_linux(
             let bit      = 1u8 << (fd % 8);
             let r_req = readfds != 0
                 && crate::syscall::validate_user_ptr(readfds + byte_off, 1)
-                && unsafe { *((readfds + byte_off) as *const u8) & bit != 0 };
+                && unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    *((readfds + byte_off) as *const u8) & bit != 0
+                };
             let w_req = writefds != 0
                 && crate::syscall::validate_user_ptr(writefds + byte_off, 1)
-                && unsafe { *((writefds + byte_off) as *const u8) & bit != 0 };
+                && unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    *((writefds + byte_off) as *const u8) & bit != 0
+                };
             if !r_req && !w_req { continue; }
             let revents = crate::syscall::poll_revents(pid, fd, if r_req { 0x0001 } else { 0x0004 });
             // Per POSIX `select(2)`: a hung-up pipe read-end is reported
@@ -3252,9 +3489,19 @@ fn sys_select_linux(
             // addition to POLLIN (0x0001).
             const READABLE_MASK: u16 = 0x0001 | 0x0010;
             if r_req && revents & READABLE_MASK != 0 { *ready += 1; }
-            else if r_req { unsafe { *((readfds + byte_off) as *mut u8) &= !bit; } }
+            else if r_req {
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    *((readfds + byte_off) as *mut u8) &= !bit;
+                }
+            }
             if w_req && revents & 0x0004 != 0 { *ready += 1; }
-            else if w_req { unsafe { *((writefds + byte_off) as *mut u8) &= !bit; } }
+            else if w_req {
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    *((writefds + byte_off) as *mut u8) &= !bit;
+                }
+            }
         }
     };
 
@@ -3271,8 +3518,11 @@ fn sys_select_linux(
             -1 // bad pointer — treat as infinite to be conservative
         } else {
             // struct timeval { tv_sec: i64, tv_usec: i64 } on x86_64.
-            let tv_sec  = unsafe { core::ptr::read_unaligned(timeout as *const i64) };
-            let tv_usec = unsafe { core::ptr::read_unaligned((timeout + 8) as *const i64) };
+            let (tv_sec, tv_usec) = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                (core::ptr::read_unaligned(timeout as *const i64),
+                 core::ptr::read_unaligned((timeout + 8) as *const i64))
+            };
             if tv_sec == 0 && tv_usec == 0 {
                 0
             } else {
@@ -3546,6 +3796,7 @@ fn sys_mremap(old_addr: u64, old_size: u64, new_size: u64, flags: u64, new_addr:
             let dest = crate::syscall::sys_mmap(0, new_size, 0x3, MAP_ANONYMOUS, u64::MAX, 0);
             if dest < 0 { return -12; } // ENOMEM
             unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
                 core::ptr::copy_nonoverlapping(
                     old_addr as *const u8, dest as *mut u8, old_size as usize);
             }
@@ -3559,6 +3810,7 @@ fn sys_mremap(old_addr: u64, old_size: u64, new_size: u64, flags: u64, new_addr:
             MAP_ANONYMOUS | MAP_FIXED, u64::MAX, 0);
         if dest < 0 { return dest; }
         unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
             core::ptr::copy_nonoverlapping(
                 old_addr as *const u8, dest as *mut u8, old_size.min(new_size) as usize);
         }
@@ -3638,7 +3890,10 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
         return match crate::net::socket::socket_recv(socket_id) {
             Ok(data) => {
                 let n = data.len().min(count);
-                unsafe { core::ptr::copy_nonoverlapping(data.as_ptr(), buf_ptr, n); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::copy_nonoverlapping(data.as_ptr(), buf_ptr, n);
+                }
                 n as i64
             }
             Err(_) => -11, // EAGAIN
@@ -3661,7 +3916,10 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
             match crate::ipc::eventfd::try_read(efd_id) {
                 Ok(val) => {
                     let bytes = val.to_le_bytes();
-                    unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf_ptr, 8); }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf_ptr, 8);
+                    }
                     return 8;
                 }
                 Err(-11) if nonblock => return -11, // EAGAIN
@@ -3690,7 +3948,10 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
         return match crate::ipc::timerfd::read(tfd_id) {
             Ok(val) => {
                 let bytes = val.to_le_bytes();
-                unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf_ptr, 8); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf_ptr, 8);
+                }
                 8
             }
             Err(e) => e,
@@ -3741,12 +4002,17 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
                     // Snapshot up to READ_BYTES (256) into a Vec we can feed
                     // to the ring-entry helper and to the inline log line.
                     let take = n.min(crate::syscall::ring::READ_BYTES);
-                    let mut snap = alloc::vec::Vec::with_capacity(take);
+                    // SMAP-bracketed snapshot — the buf_ptr derefs target
+                    // user memory.  Allocate the Vec upfront (outside the
+                    // guard) so the AC=1 region only spans the byte reads.
+                    let mut staging = [0u8; crate::syscall::ring::READ_BYTES];
                     unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
                         for i in 0..take {
-                            snap.push(*buf_ptr.add(i));
+                            staging[i] = *buf_ptr.add(i);
                         }
                     }
+                    let snap: alloc::vec::Vec<u8> = staging[..take].to_vec();
                     let idx = crate::subsys::linux::syscall_ring::current_entry();
                     crate::syscall::ring::set_read_bytes(pid, idx, &snap);
                     crate::syscall::ring::log_synthetic_read(
@@ -3804,19 +4070,25 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     {
         let pid = crate::proc::current_pid_lockless();
         if pid == 1 || crate::syscall::ring::is_tracked(pid) {
+            // SMAP-bracketed snapshot of the user buffer into a kernel
+            // Vec so the logging chatter below runs on kernel memory.
+            // The snapshot is capped at 512 bytes; everything we log
+            // (escape-printer, hex dump) reads from `snapshot` only.
+            let snap_take = count.min(512);
+            let snapshot: alloc::vec::Vec<u8> = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::slice::from_raw_parts(buf_ptr, snap_take).to_vec()
+            };
             // Skip ultra-short non-printable bursts (e.g. the 1-byte `\n`
             // ping-pongs some stdio buffers emit) unless clearly human-visible
             // output.  ASCII-printable / whitespace passes through.
-            let should_log = count >= 4 || {
-                let s = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
-                s.iter().all(|&b| b == b'\n' || b == b'\r' || b == b'\t' || (0x20..=0x7e).contains(&b))
-            };
+            let should_log = count >= 4 || snapshot.iter().all(|&b| {
+                b == b'\n' || b == b'\r' || b == b'\t' || (0x20..=0x7e).contains(&b)
+            });
             if should_log {
                 let truncated = count > 512;
-                let take = count.min(512);
-                let slice = unsafe { core::slice::from_raw_parts(buf_ptr, take) };
-                let mut buf = alloc::string::String::with_capacity(take + 16);
-                for &b in slice {
+                let mut buf = alloc::string::String::with_capacity(snap_take + 16);
+                for &b in &snapshot {
                     match b {
                         b'\n' => buf.push_str("\\n"),
                         b'\r' => buf.push_str("\\r"),
@@ -3835,16 +4107,13 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
             // Full-fd coverage: capture writes to fds OTHER than 0/1/2 so we
             // see any diagnostic chatter that was redirected to a log file,
             // syslog socket, etc.  Hex-encode the first 64 bytes — we don't
-            // know the encoding so don't assume UTF-8.  The ring buffer
-            // already captures the fd and length; this line exposes the
-            // bytes.  Silent on pipes/sockets would be fine too, but log
-            // them — in Firefox they're almost always user-authored.
+            // know the encoding so don't assume UTF-8.
             if fd > 2 {
                 let take = count.min(64);
-                let slice = unsafe { core::slice::from_raw_parts(buf_ptr, take) };
+                let hex_src = &snapshot[..snapshot.len().min(take)];
                 let mut hex = alloc::string::String::with_capacity(take * 2);
                 const HEX: &[u8; 16] = b"0123456789abcdef";
-                for &b in slice {
+                for &b in hex_src {
                     hex.push(HEX[(b >> 4) as usize] as char);
                     hex.push(HEX[(b & 0xF) as usize] as char);
                 }
@@ -3891,7 +4160,10 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     } else if crate::syscall::is_eventfd_fd(pid, fd as usize) {
         if count < 8 { return -22; } // EINVAL
         let efd_id = crate::syscall::get_eventfd_id(pid, fd as usize);
-        let val = unsafe { core::ptr::read_unaligned(buf_ptr as *const u64) };
+        let val = unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::read_unaligned(buf_ptr as *const u64)
+        };
         return match crate::ipc::eventfd::write(efd_id, u64::from_le(val)) {
             Ok(()) => {
                 // Per `man 2 eventfd`: a write that bumps the counter must
@@ -3935,7 +4207,7 @@ pub fn sys_open_linux(pathname: u64, flags: u64, _mode: u64) -> i64 {
     #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
     let path_snapshot: alloc::string::String = {
         let bytes = read_cstring_from_user(pathname);
-        alloc::string::String::from_utf8_lossy(bytes).into_owned()
+        alloc::string::String::from_utf8_lossy(&bytes).into_owned()
     };
     let ret = sys_open_linux_inner(pathname, flags, _mode);
     #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
@@ -3963,7 +4235,7 @@ fn sys_open_linux_inner(pathname: u64, flags: u64, _mode: u64) -> i64 {
     }
 
     let path_bytes = read_cstring_from_user(pathname);
-    let path = match core::str::from_utf8(path_bytes) {
+    let path = match core::str::from_utf8(&path_bytes) {
         Ok(s) => s,
         Err(_) => return -22,
     };
@@ -4108,7 +4380,7 @@ fn sys_stat_linux(pathname: u64, stat_buf: u64) -> i64 {
     // Pointer validation is done at the user/kernel boundary
     // (dispatch_body arms 4/6) — see sys_open_linux for the rationale.
     let path_bytes = read_cstring_from_user(pathname);
-    let path = match core::str::from_utf8(path_bytes) {
+    let path = match core::str::from_utf8(&path_bytes) {
         Ok(s) => s,
         Err(_) => return -22,
     };
@@ -4215,7 +4487,7 @@ fn sys_faccessat_linux(dirfd: u64, pathname: u64, mode: u64) -> i64 {
         }
     };
     let rel_bytes = read_cstring_from_user(pathname);
-    let rel = match core::str::from_utf8(rel_bytes) {
+    let rel = match core::str::from_utf8(&rel_bytes) {
         Ok(s) => s,
         Err(_) => return -22,
     };
@@ -4262,6 +4534,8 @@ fn sys_unlink_linux(pathname: u64) -> i64 {
 const LINUX_STAT_SIZE: usize = 144;
 
 fn fill_linux_stat(buf: *mut u8, st: &crate::vfs::FileStat) {
+    // SMAP bracket — `buf` is a user pointer in the syscall path.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf, LINUX_STAT_SIZE) };
     for b in out.iter_mut() {
         *b = 0;
@@ -4344,7 +4618,10 @@ pub fn sys_arch_prctl(code: u64, addr: u64) -> i64 {
                 return -14; // EFAULT
             }
             let fs = unsafe { crate::hal::rdmsr(0xC000_0100) };
-            unsafe { *(addr as *mut u64) = fs; }
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                *(addr as *mut u64) = fs;
+            }
             0
         }
         ARCH_SET_GS => {
@@ -4357,7 +4634,10 @@ pub fn sys_arch_prctl(code: u64, addr: u64) -> i64 {
                 return -14; // EFAULT
             }
             let gs = unsafe { crate::hal::rdmsr(0xC000_0101) };
-            unsafe { *(addr as *mut u64) = gs; }
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                *(addr as *mut u64) = gs;
+            }
             0
         }
         _ => -22 // EINVAL
@@ -4450,6 +4730,8 @@ pub fn sys_clock_gettime(clk_id: u64, tp: u64) -> i64 {
         secs
     };
 
+    // SMAP bracket — `tp` is a user-VA timespec pointer.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let buf = unsafe { core::slice::from_raw_parts_mut(tp as *mut u8, 16) };
     buf[0..8].copy_from_slice(&secs.to_le_bytes());
     buf[8..16].copy_from_slice(&nsecs.to_le_bytes());
@@ -4609,11 +4891,14 @@ pub fn sys_writev(fd: u64, iov_ptr: u64, iovcnt: u64) -> i64 {
     if !crate::syscall::validate_user_ptr(iov_ptr, (iovcnt as usize).saturating_mul(16)) {
         return -14; // EFAULT
     }
-    let iovecs = unsafe {
-        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize)
+    // SMAP-bracketed copy of the iovec array into kernel memory so the
+    // loop body below never re-derefs user storage.
+    let iovecs_owned: alloc::vec::Vec<[u64; 2]> = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize).to_vec()
     };
     let mut total = 0i64;
-    for iov in iovecs {
+    for iov in &iovecs_owned {
         let base = iov[0];
         let len = iov[1] as usize;
         if len == 0 { continue; }
@@ -4635,11 +4920,12 @@ fn sys_readv(fd: u64, iov_ptr: u64, iovcnt: u64) -> i64 {
     if !crate::syscall::validate_user_ptr(iov_ptr, (iovcnt as usize).saturating_mul(16)) {
         return -14; // EFAULT
     }
-    let iovecs = unsafe {
-        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize)
+    let iovecs_owned: alloc::vec::Vec<[u64; 2]> = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize).to_vec()
     };
     let mut total = 0i64;
-    for iov in iovecs {
+    for iov in &iovecs_owned {
         let base = iov[0];
         let len = iov[1] as usize;
         if len == 0 { continue; }
@@ -4671,9 +4957,13 @@ fn sys_fcntl(fd: u64, cmd: u64, arg: u64) -> i64 {
     match cmd {
         F_GETLK | F_SETLK | F_SETLKW => {
             if arg == 0 { return -22; } // EINVAL: null flock pointer
-            let l_type  = unsafe { *(arg as *const i16) };
-            let l_start = unsafe { *((arg + 8)  as *const i64) } as u64;
-            let l_len   = unsafe { *((arg + 16) as *const i64) } as u64;
+            // SMAP bracket the three user-pointer field reads.
+            let (l_type, l_start, l_len) = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                (*(arg as *const i16),
+                 *((arg + 8)  as *const i64) as u64,
+                 *((arg + 16) as *const i64) as u64)
+            };
 
             // Get fd's backing (mount_idx, inode).
             let (mount_idx, inode) = {
@@ -4694,13 +4984,17 @@ fn sys_fcntl(fd: u64, cmd: u64, arg: u64) -> i64 {
                 });
                 if let Some(lk) = conflict {
                     unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
                         *(arg as *mut i16)        = lk.lock_type;
                         *((arg + 8)  as *mut i64) = lk.start as i64;
                         *((arg + 16) as *mut i64) = lk.end as i64;
                         *((arg + 24) as *mut i32) = lk.pid as i32;
                     }
                 } else {
-                    unsafe { *(arg as *mut i16) = F_UNLCK; }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        *(arg as *mut i16) = F_UNLCK;
+                    }
                 }
                 return 0;
             }
@@ -4964,7 +5258,7 @@ fn sys_access(pathname: u64, mode: u64) -> i64 {
     // (dispatch_body arm 21) — see sys_open_linux for the rationale.
 
     let path_bytes = read_cstring_from_user(pathname);
-    let path = match core::str::from_utf8(path_bytes) {
+    let path = match core::str::from_utf8(&path_bytes) {
         Ok(s) => s,
         Err(_) => return -22, // EINVAL
     };
@@ -5060,6 +5354,8 @@ fn sys_gettimeofday(tv: u64, _tz: u64) -> i64 {
         (ticks / 100, (ticks % 100) * 10_000)
     };
     let secs = crate::proc::vdso::wall_secs_at_boot().saturating_add(mono_secs);
+    // SMAP bracket — `tv` is a user-VA timeval pointer.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let buf = unsafe { core::slice::from_raw_parts_mut(tv as *mut u8, 16) };
     buf[0..8].copy_from_slice(&secs.to_le_bytes());
     buf[8..16].copy_from_slice(&sub_usecs.to_le_bytes());
@@ -5101,6 +5397,9 @@ fn sys_getdents64(fd: u64, buf: u64, count: u64) -> i64 {
         }
     };
 
+    // SMAP bracket — `buf` is a user-VA pointer the dirent records are
+    // marshalled into.
+    let _smap_g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf as *mut u8, count as usize) };
     let mut pos = 0usize;
     let mut entry_idx = offset as usize;
@@ -5192,6 +5491,9 @@ fn getdents64_proc_fd(pid: u64, dir_fd: usize, buf: u64, count: u64, start_idx: 
         virtual_entries.push((name, ino, 10)); // DT_LNK
     }
 
+    // SMAP bracket — `buf` is a user-VA pointer the dirent records are
+    // marshalled into.
+    let _smap_g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf as *mut u8, count as usize) };
     let mut pos = 0usize;
     let mut entry_idx = start_idx as usize;
@@ -5249,7 +5551,7 @@ fn sys_openat(dirfd: u64, pathname: u64, flags: u64, mode: u64) -> i64 {
 
     // Real directory fd — resolve pathname relative to it.
     let path_bytes = read_cstring_from_user(pathname);
-    let rel_path = match core::str::from_utf8(path_bytes) {
+    let rel_path = match core::str::from_utf8(&path_bytes) {
         Ok(s) => s,
         Err(_) => return -22, // EINVAL
     };
@@ -5327,7 +5629,7 @@ fn sys_newfstatat(dirfd: u64, pathname: u64, statbuf: u64, flags: u64) -> i64 {
     if path_bytes.is_empty() {
         return sys_fstat_linux(dirfd as usize, statbuf as *mut u8);
     }
-    let path_str = match core::str::from_utf8(path_bytes) {
+    let path_str = match core::str::from_utf8(&path_bytes) {
         Ok(s) => s,
         Err(_) => return -22,
     };
@@ -5413,7 +5715,12 @@ fn sys_rt_sigaction_linux(sig: u64, act: u64, oldact: u64, _sigsetsize: u64) -> 
     let new_sa_mask: u64;
     let new_action: Option<SigAction>;
     if act != 0 {
-        let inp = unsafe { core::slice::from_raw_parts(act as *const u8, 32) };
+        // SMAP-bracketed copy of the 32-byte sigaction into kernel mem.
+        let mut inp = [0u8; 32];
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::copy_nonoverlapping(act as *const u8, inp.as_mut_ptr(), 32);
+        }
         let handler_addr = u64::from_le_bytes(inp[0..8].try_into().unwrap());
         let sa_flags    = u64::from_le_bytes(inp[8..16].try_into().unwrap());
         let sa_restorer = u64::from_le_bytes(inp[16..24].try_into().unwrap());
@@ -5478,11 +5785,15 @@ fn sys_rt_sigaction_linux(sig: u64, act: u64, oldact: u64, _sigsetsize: u64) -> 
     // round-trip — Mozilla's IPC layer compares the value it set against
     // the value it gets back to detect ABI mismatches.
     if oldact != 0 {
-        let out = unsafe { core::slice::from_raw_parts_mut(oldact as *mut u8, 32) };
+        let mut out = [0u8; 32];
         out[0..8].copy_from_slice(&prior_handler_addr.to_le_bytes());
         out[8..16].copy_from_slice(&prior_sa_flags.to_le_bytes());
         out[16..24].copy_from_slice(&prior_restorer_addr.to_le_bytes());
         out[24..32].copy_from_slice(&prior_sa_mask.to_le_bytes());
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::copy_nonoverlapping(out.as_ptr(), oldact as *mut u8, 32);
+        }
     }
 
     0
@@ -5523,9 +5834,12 @@ fn sys_rt_sigprocmask_linux(how: u64, set: u64, oldset: u64, _sigsetsize: u64) -
     // kernel lock is held.  Demand-paging that user page may take
     // `PROCESS_TABLE`; doing it under our own held lock would deadlock.
     let new_mask: Option<u64> = if set != 0 {
-        Some(u64::from_le_bytes(unsafe {
-            core::slice::from_raw_parts(set as *const u8, 8)
-        }.try_into().unwrap()))
+        let mut bytes = [0u8; 8];
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::copy_nonoverlapping(set as *const u8, bytes.as_mut_ptr(), 8);
+        }
+        Some(u64::from_le_bytes(bytes))
     } else {
         None
     };
@@ -5560,8 +5874,11 @@ fn sys_rt_sigprocmask_linux(how: u64, set: u64, oldset: u64, _sigsetsize: u64) -
     // Step 3: write the prior mask back to user memory AFTER releasing the
     // lock, again to keep demand-paging recursion-safe.
     if oldset != 0 {
-        let out = unsafe { core::slice::from_raw_parts_mut(oldset as *mut u8, 8) };
-        out[0..8].copy_from_slice(&prior_mask.to_le_bytes());
+        let bytes = prior_mask.to_le_bytes();
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), oldset as *mut u8, 8);
+        }
     }
 
     0
@@ -6097,6 +6414,7 @@ fn sys_pipe2_linux(fds_out: *mut u32, flags: u32) -> i64 {
     proc.file_descriptors[wi] = Some(write_fd);
 
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         core::ptr::write_unaligned(fds_out,          ri as u32);
         core::ptr::write_unaligned(fds_out.add(1),   wi as u32);
     }
@@ -6113,7 +6431,7 @@ fn sys_pipe2_linux(fds_out: *mut u32, flags: u32) -> i64 {
 fn sys_statfs_linux(path_ptr: u64, buf: *mut u8) -> i64 {
     if buf.is_null() { return -14; }
     let path_raw = read_cstring_from_user(path_ptr);
-    let path = core::str::from_utf8(path_raw).unwrap_or("");
+    let path = core::str::from_utf8(&path_raw).unwrap_or("");
 
     // Check the path exists (ignore error — statfs on /proc etc. always ok).
     let _ = crate::vfs::stat(path);
@@ -6134,6 +6452,8 @@ fn fill_statfs_buf(buf: *mut u8) {
     // Wipe first.
     #[cfg(feature = "firefox-test")]
     crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Preadv120, buf, 120);
+    // SMAP bracket — `buf` is a user-VA pointer.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     unsafe { core::ptr::write_bytes(buf, 0, 120); }
     // Use EXT2_SUPER_MAGIC (0xEF53) as f_type — widely recognised.
     let p = buf as *mut u64;
@@ -6560,7 +6880,10 @@ fn sys_epoll_ctl(epfd: usize, op: u64, fd: usize, event_ptr: u64) -> i64 {
 
     // Read the caller's epoll_event (only needed for ADD / MOD).
     let (events, data) = if event_ptr != 0 && op != EPOLL_CTL_DEL {
-        let ev = unsafe { core::ptr::read_unaligned(event_ptr as *const EpollEvent) };
+        let ev = unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::read_unaligned(event_ptr as *const EpollEvent)
+        };
         (ev.events, ev.data)
     } else {
         (0u32, 0u64)
@@ -6675,6 +6998,7 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     let count = fired.len();
     if count > 0 && events_ptr != 0 {
         unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
             core::ptr::copy_nonoverlapping(
                 fired.as_ptr(),
                 events_ptr as *mut EpollEvent,
@@ -6866,7 +7190,7 @@ fn sys_inotify_add_watch(fd_num: u64, path_ptr: u64, mask: u32) -> i64 {
     if !crate::syscall::is_inotify_fd(pid, fd_num as usize) { return -9; } // EBADF
     let id = crate::syscall::get_inotify_id(pid, fd_num as usize);
     let path_bytes = read_cstring_from_user(path_ptr);
-    let path = core::str::from_utf8(path_bytes).unwrap_or("");
+    let path = core::str::from_utf8(&path_bytes).unwrap_or("");
     let wd = crate::ipc::inotify::add_watch(id, path, mask);
     if wd < 0 { -1 } else { wd as i64 }
 }
@@ -7088,7 +7412,7 @@ fn sys_getitimer(which: u64, val_ptr: u64) -> i64 {
 fn resolve_at_path(dirfd: u64, rel_ptr: u64) -> Result<alloc::string::String, i64> {
     const AT_FDCWD: i64 = -100;
     let path_bytes = read_cstring_from_user(rel_ptr);
-    let rel_str = core::str::from_utf8(path_bytes).map_err(|_| -22i64)?;
+    let rel_str = core::str::from_utf8(&path_bytes).map_err(|_| -22i64)?;
     if rel_str.is_empty() {
         return Err(-2); // ENOENT
     }
@@ -7214,6 +7538,8 @@ fn sys_getdents(fd: u64, buf: u64, count: u64) -> i64 {
     if buf == 0 || !crate::syscall::validate_user_ptr(buf, count as usize) {
         return -14; // EFAULT
     }
+    // SMAP bracket — `buf` is a user-VA pointer.
+    let _smap_g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf as *mut u8, count as usize) };
     let mut pos = 0usize;
     let mut entry_idx = offset as usize;
@@ -7290,12 +7616,15 @@ fn sys_preadv(fd: u64, iov_ptr: u64, iovcnt: u64, offset: i64) -> i64 {
     let sk = crate::syscall::sys_lseek(fd as usize, offset, 0 /*SEEK_SET*/);
     if sk < 0 { return sk; }
     // SAFETY: iov_ptr range-validated above; iov_base/iov_len validated by
-    // the per-iov fd_read path (vfs handles short reads).
-    let iovecs = unsafe {
-        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize)
+    // the per-iov fd_read path (vfs handles short reads).  SMAP-bracketed
+    // copy into kernel Vec so the loop reads the descriptor table from
+    // kernel memory.
+    let iovecs_owned: alloc::vec::Vec<[u64; 2]> = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize).to_vec()
     };
     let mut total = 0i64;
-    for iov in iovecs {
+    for iov in &iovecs_owned {
         let base = iov[0];
         let len  = iov[1] as usize;
         if len == 0 { continue; }
@@ -7330,12 +7659,13 @@ fn sys_pwritev(fd: u64, iov_ptr: u64, iovcnt: u64, offset: i64) -> i64 {
     let sk = crate::syscall::sys_lseek(fd as usize, offset, 0 /*SEEK_SET*/);
     if sk < 0 { return sk; }
     // SAFETY: iov_ptr range-validated above; iov_base/iov_len reach fd_write
-    // via the vfs which handles short writes.
-    let iovecs = unsafe {
-        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize)
+    // via the vfs which handles short writes.  SMAP-bracketed copy.
+    let iovecs_owned: alloc::vec::Vec<[u64; 2]> = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iovcnt as usize).to_vec()
     };
     let mut total = 0i64;
-    for iov in iovecs {
+    for iov in &iovecs_owned {
         let base = iov[0];
         let len  = iov[1] as usize;
         if len == 0 { continue; }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -79,36 +79,64 @@ pub(crate) fn validate_user_ptr(ptr: u64, len: usize) -> bool {
     }
 }
 
-/// Validate and create a slice from a user pointer. Returns `None` on failure.
+/// Snapshot a user buffer into a kernel-resident `Vec<u8>` under one
+/// SMAP bracket.
 ///
-/// The returned slice borrows directly from user memory; SMAP enforcement
-/// will fault on any access made AFTER the caller's `UserGuard` scope
-/// (per Intel SDM Vol. 3A §4.6).  Callers that intend to perform reads
-/// against this slice must bracket those accesses themselves — typically
-/// by copying through `core::slice::copy_from_slice` or `iter().copied()`
-/// inside an explicit guard.  In practice almost every caller copies the
-/// slice into a kernel buffer right after this returns, so we bracket
-/// here so the SLICE materialisation itself is safe and the caller's
-/// downstream copies (which read the user page) inherit a kernel buffer.
+/// This is the **preferred** helper for any caller that intends to read
+/// every byte of a user buffer — it eliminates the footgun shape of
+/// returning a borrowed `&[u8]` whose backing memory is still a user
+/// page (which faults under SMAP, per Intel SDM Vol. 3A §4.6, once the
+/// caller's `UserGuard` scope ends).
+///
+/// On invalid pointer / overflow returns `None` (caller should surface
+/// EFAULT to the user).  On `len == 0` returns `Some(empty)`.
+///
+/// # Safety
+///
+/// Caller must ensure no concurrent kernel thread is writing to the
+/// same user page during the snapshot — the snapshot is non-atomic.
 #[inline]
-pub(crate) unsafe fn user_slice<'a>(ptr: u64, len: usize) -> Option<&'a [u8]> {
+pub(crate) unsafe fn user_slice_snapshot(ptr: u64, len: usize) -> Option<alloc::vec::Vec<u8>> {
+    if len == 0 { return Some(alloc::vec::Vec::new()); }
+    if !validate_user_ptr(ptr, len) { return None; }
+    let buf: alloc::vec::Vec<u8> = {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::slice::from_raw_parts(ptr as *const u8, len).to_vec()
+    };
+    Some(buf)
+}
+
+/// Validate and create a *borrowed* slice over user memory.
+///
+/// **Footgun warning**: the returned `&[u8]` borrows directly from a
+/// user page.  This function brackets the *materialisation* with
+/// STAC/CLAC, but the bracket drops on return — any caller that
+/// reads from the returned slice afterwards needs its **own**
+/// `UserGuard` scope wrapping those reads, or the access will fault
+/// under SMAP (Intel SDM Vol. 3A §4.6).  Prefer
+/// [`user_slice_snapshot`] when the caller will hold the data past
+/// a single tight bracket.
+///
+/// # Safety
+///
+/// In addition to the SMAP discipline above, the caller assumes
+/// responsibility for ensuring the underlying user memory remains
+/// mapped and unmodified for the slice's borrow lifetime (TOCTOU).
+#[inline]
+pub(crate) unsafe fn user_slice_unbracketed<'a>(ptr: u64, len: usize) -> Option<&'a [u8]> {
     if len == 0 { return Some(&[]); }
     if !validate_user_ptr(ptr, len) { return None; }
-    // Slice materialisation does not deref, but every realistic caller
-    // immediately reads from the slice; keep the guard live until the
-    // function returns so the &[u8] is hot under AC=1.  The caller still
-    // needs its own UserGuard for accesses that outlive this function.
     let _g = crate::arch::x86_64::smap::UserGuard::new();
     Some(core::slice::from_raw_parts(ptr as *const u8, len))
 }
 
-/// Validate and create a mutable slice from a user pointer.
-///
-/// See [`user_slice`] for the SMAP bracketing caveat — the caller MUST
-/// wrap any writes through the returned `&mut [u8]` in a `UserGuard`
-/// scope (or use one of the bracketed copy helpers).
+/// Mutable counterpart to [`user_slice_unbracketed`] — same footgun
+/// warning applies.  The caller MUST wrap any writes through the
+/// returned `&mut [u8]` in a `UserGuard` scope (or use a bracketed
+/// copy helper).  Prefer copy-out-then-copy-in patterns when the
+/// write set is bounded.
 #[inline]
-pub(crate) unsafe fn user_slice_mut<'a>(ptr: u64, len: usize) -> Option<&'a mut [u8]> {
+pub(crate) unsafe fn user_slice_mut_unbracketed<'a>(ptr: u64, len: usize) -> Option<&'a mut [u8]> {
     if len == 0 { return Some(&mut []); }
     if !validate_user_ptr(ptr, len) { return None; }
     let _g = crate::arch::x86_64::smap::UserGuard::new();

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -80,34 +80,63 @@ pub(crate) fn validate_user_ptr(ptr: u64, len: usize) -> bool {
 }
 
 /// Validate and create a slice from a user pointer. Returns `None` on failure.
+///
+/// The returned slice borrows directly from user memory; SMAP enforcement
+/// will fault on any access made AFTER the caller's `UserGuard` scope
+/// (per Intel SDM Vol. 3A §4.6).  Callers that intend to perform reads
+/// against this slice must bracket those accesses themselves — typically
+/// by copying through `core::slice::copy_from_slice` or `iter().copied()`
+/// inside an explicit guard.  In practice almost every caller copies the
+/// slice into a kernel buffer right after this returns, so we bracket
+/// here so the SLICE materialisation itself is safe and the caller's
+/// downstream copies (which read the user page) inherit a kernel buffer.
 #[inline]
 pub(crate) unsafe fn user_slice<'a>(ptr: u64, len: usize) -> Option<&'a [u8]> {
     if len == 0 { return Some(&[]); }
     if !validate_user_ptr(ptr, len) { return None; }
+    // Slice materialisation does not deref, but every realistic caller
+    // immediately reads from the slice; keep the guard live until the
+    // function returns so the &[u8] is hot under AC=1.  The caller still
+    // needs its own UserGuard for accesses that outlive this function.
+    let _g = crate::arch::x86_64::smap::UserGuard::new();
     Some(core::slice::from_raw_parts(ptr as *const u8, len))
 }
 
 /// Validate and create a mutable slice from a user pointer.
+///
+/// See [`user_slice`] for the SMAP bracketing caveat — the caller MUST
+/// wrap any writes through the returned `&mut [u8]` in a `UserGuard`
+/// scope (or use one of the bracketed copy helpers).
 #[inline]
 pub(crate) unsafe fn user_slice_mut<'a>(ptr: u64, len: usize) -> Option<&'a mut [u8]> {
     if len == 0 { return Some(&mut []); }
     if !validate_user_ptr(ptr, len) { return None; }
+    let _g = crate::arch::x86_64::smap::UserGuard::new();
     Some(core::slice::from_raw_parts_mut(ptr as *mut u8, len))
 }
 
 /// Read a u32 from a validated user address. Returns None on bad address.
+///
+/// STAC/CLAC bracketed (per Intel SDM Vol. 3A §4.6): when SMAP is
+/// enabled, the deref runs with EFLAGS.AC=1 and AC is cleared on
+/// return.  When SMAP is not enabled (older CPU / TCG without `+smap`)
+/// the bracket collapses to a single relaxed load + branch.
 #[inline]
 pub(crate) unsafe fn user_read_u32(addr: u64) -> Option<u32> {
     if !validate_user_ptr(addr, 4) { return None; }
     if addr % 4 != 0 { return None; } // alignment check
+    let _g = crate::arch::x86_64::smap::UserGuard::new();
     Some(core::ptr::read_volatile(addr as *const u32))
 }
 
 /// Read a u64 from a validated user address. Returns None on bad address.
+///
+/// SMAP-bracketed — see [`user_read_u32`].
 #[inline]
 pub(crate) unsafe fn user_read_u64(addr: u64) -> Option<u64> {
     if !validate_user_ptr(addr, 8) { return None; }
     if addr % 8 != 0 { return None; } // alignment check
+    let _g = crate::arch::x86_64::smap::UserGuard::new();
     Some(core::ptr::read_volatile(addr as *const u64))
 }
 
@@ -800,13 +829,22 @@ pub extern "C" fn syscall_int80_dispatch(
 ///
 /// Arguments: arg1 = path pointer, arg2 = path length.
 pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u64) -> i64 {
-    let path = unsafe {
-        let slice = core::slice::from_raw_parts(path_ptr as *const u8, path_len as usize);
+    // Copy the path into a kernel-resident String under a SMAP bracket so
+    // subsequent uses (logging, VFS lookup, shebang resolution) do not
+    // re-enter user space.  Anonymising the user borrow this way means we
+    // only need ONE UserGuard scope for the path read regardless of how
+    // far downstream the value travels.
+    let path_owned = {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        let slice = unsafe {
+            core::slice::from_raw_parts(path_ptr as *const u8, path_len as usize)
+        };
         match core::str::from_utf8(slice) {
-            Ok(s) => s,
+            Ok(s) => alloc::string::String::from(s),
             Err(_) => return -22, // EINVAL
         }
     };
+    let path = path_owned.as_str();
 
     crate::serial_println!("[SYSCALL] exec(\"{}\")", path);
 
@@ -1587,6 +1625,9 @@ pub(crate) fn sys_pty_master_ioctl(pty_n: u8, request: u64, arg_ptr: *mut u8) ->
     const TIOCGWINSZ: u64 = 0x5413;
     const TIOCSWINSZ: u64 = 0x5414;
 
+    // SMAP bracket — arg_ptr is a user-VA from the syscall arg.
+    // Bracketing once at the top covers all match arms.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     match request {
         TIOCGPTN => {
             if !arg_ptr.is_null() {
@@ -1655,6 +1696,8 @@ pub(crate) fn sys_fbdev_ioctl(request: u64, arg_ptr: *mut u8) -> i64 {
     let bpp:    u32 = 32;
     let line_length: u32 = pitch * (bpp / 8); // bytes per line
 
+    // SMAP bracket — arg_ptr is a user-VA for the syscall arg.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     match request {
         FBIOGET_VSCREENINFO => {
             // struct fb_var_screeninfo — 160 bytes
@@ -1737,6 +1780,8 @@ pub(crate) fn sys_input_ioctl(request: u64, arg_ptr: *mut u8) -> i64 {
     // We just check bits 0-23 (type + nr, ignore size).
     let req_lo = request & 0x0000_FFFF; // direction+type+nr stripped of size
 
+    // SMAP bracket — arg_ptr is a user-VA.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     match request {
         EVIOCGVERSION => {
             if !arg_ptr.is_null() {
@@ -1789,6 +1834,8 @@ pub(crate) fn sys_dsp_ioctl(request: u64, arg_ptr: *mut u8) -> i64 {
     // AFMT_S16_LE format tag
     const AFMT_S16_LE: i32 = 0x0000_0010;
 
+    // SMAP bracket — arg_ptr is a user-VA.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     match request {
         SNDCTL_DSP_SPEED => {
             // arg_ptr points to an int (sample rate); on success the driver
@@ -2366,7 +2413,10 @@ pub(crate) fn sys_getcwd(buf: *mut u8, size: usize) -> i64 {
         return -34; // ERANGE
     }
 
+    // SMAP-bracketed write to the user buffer.  The pointer was checked
+    // for null above; full range validation happens at the dispatch arm.
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         core::ptr::copy_nonoverlapping(cwd.as_ptr(), buf, cwd.len());
         *buf.add(cwd.len()) = 0; // null-terminate
     }
@@ -2375,13 +2425,17 @@ pub(crate) fn sys_getcwd(buf: *mut u8, size: usize) -> i64 {
 }
 
 pub(crate) fn sys_chdir(path_ptr: *const u8, path_len: usize) -> i64 {
-    let path = unsafe {
-        let slice = core::slice::from_raw_parts(path_ptr, path_len);
+    // Owned copy under SMAP bracket — same pattern as sys_exec, so the
+    // downstream stat/PROCESS_TABLE work runs against a kernel String.
+    let path_owned = {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        let slice = unsafe { core::slice::from_raw_parts(path_ptr, path_len) };
         match core::str::from_utf8(slice) {
-            Ok(s) => s,
+            Ok(s) => alloc::string::String::from(s),
             Err(_) => return -22,
         }
     };
+    let path = path_owned.as_str();
 
     // Verify the path exists and is a directory
     match crate::vfs::stat(path) {
@@ -2405,30 +2459,31 @@ pub(crate) fn sys_chdir(path_ptr: *const u8, path_len: usize) -> i64 {
 }
 
 pub(crate) fn sys_mkdir(path_ptr: *const u8, path_len: usize) -> i64 {
-    let path = unsafe {
-        let slice = core::slice::from_raw_parts(path_ptr, path_len);
+    // SMAP-bracketed copy — see sys_chdir for rationale.
+    let path_owned = {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        let slice = unsafe { core::slice::from_raw_parts(path_ptr, path_len) };
         match core::str::from_utf8(slice) {
-            Ok(s) => s,
+            Ok(s) => alloc::string::String::from(s),
             Err(_) => return -22,
         }
     };
-
-    match crate::vfs::mkdir(path) {
+    match crate::vfs::mkdir(path_owned.as_str()) {
         Ok(()) => 0,
         Err(e) => crate::subsys::linux::errno::vfs_err(e),
     }
 }
 
 pub(crate) fn sys_rmdir(path_ptr: *const u8, path_len: usize) -> i64 {
-    let path = unsafe {
-        let slice = core::slice::from_raw_parts(path_ptr, path_len);
+    let path_owned = {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        let slice = unsafe { core::slice::from_raw_parts(path_ptr, path_len) };
         match core::str::from_utf8(slice) {
-            Ok(s) => s,
+            Ok(s) => alloc::string::String::from(s),
             Err(_) => return -22,
         }
     };
-
-    match crate::vfs::remove(path) {
+    match crate::vfs::remove(path_owned.as_str()) {
         Ok(()) => 0,
         Err(e) => crate::subsys::linux::errno::vfs_err(e),
     }
@@ -2446,6 +2501,12 @@ pub(crate) fn sys_rmdir(path_ptr: *const u8, path_len: usize) -> i64 {
 const STAT_BUF_SIZE: usize = 64;
 
 pub(crate) fn fill_stat_buf(st: &crate::vfs::FileStat, buf: *mut u8) {
+    // SMAP bracket — the writes through `out` all hit user memory when
+    // `buf` is a user-VA (the common case from sys_stat / sys_fstat /
+    // sys_lstat).  Kernel-internal callers (test_runner) pass kernel
+    // buffers, for which SMAP is silent.  Bracketing here covers all
+    // sites that pass the buffer through fill_stat_buf.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf, STAT_BUF_SIZE) };
     // Zero everything first
     for b in out.iter_mut() {
@@ -2473,15 +2534,15 @@ pub(crate) fn fill_stat_buf(st: &crate::vfs::FileStat, buf: *mut u8) {
 }
 
 pub(crate) fn sys_stat(path_ptr: *const u8, path_len: usize, stat_buf: *mut u8) -> i64 {
-    let path = unsafe {
-        let slice = core::slice::from_raw_parts(path_ptr, path_len);
+    let path_owned = {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        let slice = unsafe { core::slice::from_raw_parts(path_ptr, path_len) };
         match core::str::from_utf8(slice) {
-            Ok(s) => s,
+            Ok(s) => alloc::string::String::from(s),
             Err(_) => return -22,
         }
     };
-
-    match crate::vfs::stat(path) {
+    match crate::vfs::stat(path_owned.as_str()) {
         Ok(st) => {
             fill_stat_buf(&st, stat_buf);
             0
@@ -2753,6 +2814,7 @@ pub(crate) fn sys_pipe(fds_out: *mut u64) -> i64 {
 
     // Write [read_fd, write_fd] to user buffer
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         *fds_out = ri as u64;
         *fds_out.add(1) = wi as u64;
     }
@@ -3100,6 +3162,8 @@ pub(crate) fn sys_uname(buf: *mut u8) -> i64 {
         b"x86_64",                      // machine
     ];
 
+    // SMAP bracket — `buf` is a user-VA for the syscall path.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf, TOTAL_LEN) };
     for b in out.iter_mut() {
         *b = 0;
@@ -3127,15 +3191,15 @@ pub(crate) fn sys_nanosleep(milliseconds: u64) -> i64 {
 }
 
 pub(crate) fn sys_unlink(path_ptr: *const u8, path_len: usize) -> i64 {
-    let path = unsafe {
-        let slice = core::slice::from_raw_parts(path_ptr, path_len);
+    let path_owned = {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        let slice = unsafe { core::slice::from_raw_parts(path_ptr, path_len) };
         match core::str::from_utf8(slice) {
-            Ok(s) => s,
+            Ok(s) => alloc::string::String::from(s),
             Err(_) => return -22,
         }
     };
-
-    match crate::vfs::remove(path) {
+    match crate::vfs::remove(path_owned.as_str()) {
         Ok(()) => 0,
         Err(e) => crate::subsys::linux::errno::vfs_err(e),
     }
@@ -3235,7 +3299,10 @@ pub(crate) fn sys_sigreturn() -> i64 {
 
     let (sig_num, saved_mask, saved_rsp, saved_r15, saved_r14, saved_r13,
          saved_r12, saved_rbx, saved_rbp, saved_r11, saved_rcx, saved_rax);
+    // SMAP bracket — frame_base has already been range-validated by
+    // validate_user_ptr above so the UserGuard is safe to lift AC.
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         sig_num   = (*frame_ptr).sig_num;
         saved_mask = (*frame_ptr).saved_mask;
         saved_rsp = (*frame_ptr).saved_rsp;
@@ -3348,6 +3415,12 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize, _flags: u32) -> i64 {
     #[cfg(feature = "firefox-test")]
     crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::Getrandom, buf, count);
 
+    // SMAP bracket — every iteration below writes through `out` which
+    // backs the user buffer.  Held for the full fill so RDRAND and the
+    // xorshift fallback both run with AC=1.  CPUID / RDRAND themselves
+    // do not touch memory, so the AC region is purely the user write
+    // surface.
+    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let out = unsafe { core::slice::from_raw_parts_mut(buf, count) };
 
     // Detect RDRAND support via CPUID leaf 1, ECX bit 30.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1594,6 +1594,16 @@ pub fn run() -> ! {
     total += 1;
     if test_security_user_ptr_validation_cwe823() { passed += 1; }
 
+    // ── Test 220b: SMAP CR4 + UserGuard coherence (H1-SMAP) ──────────────
+    // Verifies CR4.SMAP, CPUID, and smap::SMAP_ENABLED are mutually
+    // consistent and that UserGuard's STAC/CLAC bracket actually toggles
+    // EFLAGS.AC.  See `docs/SECURITY_AUDIT_2026-05-16.md` finding H1.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_security_smap_h1_state() { passed += 1; }
+    }
+
     // ── Test 221: cache::audit_invariant meta-test ───────────────────────
     // Verifies audit_invariant() reports zero orphan cache entries on an
     // idle kernel.  A failure here indicates either a false-positive in the
@@ -28424,6 +28434,123 @@ fn test_security_user_ptr_validation_cwe823() -> bool {
     }
 
     test_pass!("kernel-half pointers rejected with -EFAULT across writev/readv/preadv/pwritev/sendmsg/recvmsg/getrandom");
+    true
+}
+
+// ── Test 221: SMAP STAC/CLAC bracket regression ──────────────────────────────
+//
+// Closes finding H1-SMAP from `docs/SECURITY_AUDIT_2026-05-16.md`.  PR #250
+// landed CR4.SMEP and deferred SMAP.  The follow-up landed CR4.SMAP after
+// bracketing every legitimate user-pointer dereference with STAC/CLAC.
+//
+// This is a static-state regression guard: it verifies that the SMAP feature
+// has been correctly detected via CPUID and that CR4.SMAP / smap::SMAP_ENABLED
+// are coherent.  Per Intel SDM Vol. 3A §4.6, when SMAP is enabled the CPU
+// raises #PF on any supervisor access to a user-mapped page unless
+// EFLAGS.AC=1.  A kernel that runs userspace without faulting (which we
+// already exercise via the firefox-test boot in CI) is the dynamic proof
+// that bracketing is in place; this test is the cheap static sanity check.
+//
+// References:
+//   * Intel SDM Vol. 3A §4.6 (Supervisor Mode Access Prevention)
+//   * CPUID.(EAX=07H,ECX=00H):EBX[bit 20] = SMAP support
+//   * CWE-269 (Improper Privilege Management) — SMAP closes the
+//     unintentional-user-pointer-deref escalation primitive
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_security_smap_h1_state() -> bool {
+    test_header!("security: SMAP CR4.SMAP coherent with smap::SMAP_ENABLED (H1)");
+
+    // Probe CPUID for SMAP support (EBX bit 20 of leaf 7, sub-leaf 0).
+    let smap_supported = unsafe {
+        let ebx: u32;
+        core::arch::asm!(
+            "push rbx",
+            "cpuid",
+            "mov {ebx:e}, ebx",
+            "pop rbx",
+            ebx = out(reg) ebx,
+            inout("eax") 7u32 => _,
+            inout("ecx") 0u32 => _,
+            out("edx") _,
+        );
+        (ebx & (1 << 20)) != 0
+    };
+
+    let smap_enabled_flag = crate::arch::x86_64::smap::SMAP_ENABLED
+        .load(core::sync::atomic::Ordering::Relaxed);
+
+    let cr4: u64 = unsafe {
+        let v: u64;
+        core::arch::asm!("mov {}, cr4", out(reg) v, options(nomem, nostack));
+        v
+    };
+    let cr4_smap = (cr4 & (1u64 << 21)) != 0;
+
+    test_println!("  cpuid_smap={} cr4_smap={} flag={}",
+        smap_supported, cr4_smap, smap_enabled_flag);
+
+    if !smap_supported {
+        // Acceptable: an older CPU (or TCG without `+smap`) can't enable SMAP.
+        // The flag must agree (cleared) and CR4.SMAP must be 0.
+        if smap_enabled_flag || cr4_smap {
+            test_fail!("security_smap_h1_state",
+                "SMAP not in CPUID but flag={} cr4_smap={}",
+                smap_enabled_flag, cr4_smap);
+            return false;
+        }
+        test_pass!("SMAP not advertised by CPU — flag + CR4 correctly cleared");
+        return true;
+    }
+
+    // CPUID says supported → CR4.SMAP and SMAP_ENABLED must both be set.
+    if !cr4_smap {
+        test_fail!("security_smap_h1_state",
+            "CPUID advertises SMAP but CR4.SMAP=0");
+        return false;
+    }
+    if !smap_enabled_flag {
+        test_fail!("security_smap_h1_state",
+            "CR4.SMAP=1 but smap::SMAP_ENABLED=false (gating helpers will no-op)");
+        return false;
+    }
+
+    // Smoke test: verify STAC/CLAC can be issued safely on this CPU and that
+    // UserGuard's drop clears AC.  Reading EFLAGS via pushfq lets us check
+    // bit 18 before/after.
+    let ac_before = unsafe {
+        let f: u64;
+        core::arch::asm!("pushfq; pop {}", out(reg) f, options(nomem));
+        (f & (1u64 << 18)) != 0
+    };
+    let ac_in_guard;
+    let ac_after;
+    {
+        let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+        ac_in_guard = unsafe {
+            let f: u64;
+            core::arch::asm!("pushfq; pop {}", out(reg) f, options(nomem));
+            (f & (1u64 << 18)) != 0
+        };
+    }
+    ac_after = unsafe {
+        let f: u64;
+        core::arch::asm!("pushfq; pop {}", out(reg) f, options(nomem));
+        (f & (1u64 << 18)) != 0
+    };
+
+    test_println!("  AC before={} in-guard={} after={}", ac_before, ac_in_guard, ac_after);
+    if !ac_in_guard {
+        test_fail!("security_smap_h1_state",
+            "AC=0 inside UserGuard — STAC did not fire");
+        return false;
+    }
+    if ac_after {
+        test_fail!("security_smap_h1_state",
+            "AC=1 after UserGuard dropped — CLAC did not fire");
+        return false;
+    }
+
+    test_pass!("SMAP enabled coherently and STAC/CLAC bracket UserGuard correctly");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1604,6 +1604,19 @@ pub fn run() -> ! {
         if test_security_smap_h1_state() { passed += 1; }
     }
 
+    // ── Test 220c: SMAP UserGuard nested/early-drop regression ──────────
+    // Stronger negative-shape coverage than 220b: verifies the AC state
+    // machine across nested guards, mid-scope explicit `drop`, and an
+    // accessor that returns a borrowed slice (a known footgun shape —
+    // the borrow must NOT outlive AC=1 if there's no caller-side bracket).
+    // Regression guard against an unbracketed user-memory deref slipping
+    // back in.  Per Intel SDM Vol. 3A §4.6 + CWE-823.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_220c_smap_userguard_nesting() { passed += 1; }
+    }
+
     // ── Test 221: cache::audit_invariant meta-test ───────────────────────
     // Verifies audit_invariant() reports zero orphan cache entries on an
     // idle kernel.  A failure here indicates either a false-positive in the
@@ -28551,6 +28564,149 @@ fn test_security_smap_h1_state() -> bool {
     }
 
     test_pass!("SMAP enabled coherently and STAC/CLAC bracket UserGuard correctly");
+    true
+}
+
+// ── Test 220c: SMAP UserGuard nested/early-drop regression ──────────────────
+//
+// 220b verified the basic state machine.  220c is the stronger negative-shape
+// test: it exercises the situations where /review caught real bugs in PR #276
+// — borrowed user slices, early guard drops, nested guards.  Each scenario
+// reads AC after the bracket should have closed and fails if it's still
+// asserted (i.e. CLAC didn't fire).  Combined with the syscall-level fixes
+// in this PR, future regressions where someone forgets a bracket get caught
+// by either this state-machine test or the syscall arg-validation matrix
+// (Test 222).
+//
+// Threat model:
+//   * Attacker = sandboxed userspace process with code execution privilege
+//   * Capability: pass an attacker-controlled address into any syscall that
+//     dereferences a user pointer
+//   * Target: arbitrary kernel write via a corrupted/spoofed function
+//     pointer that the kernel deref's at AC=0 (CVE-2014-9322 class, CWE-269)
+//
+// References:
+//   * Intel SDM Vol. 3A §4.6 (SMAP enforcement)
+//   * CWE-823 (Use of Out-of-range Pointer Offset)
+//   * CWE-119 (Buffer Errors with Improper Bounds Checking)
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_220c_smap_userguard_nesting() -> bool {
+    test_header!("security: UserGuard nested/early-drop AC-state regression");
+
+    let smap_enabled = crate::arch::x86_64::smap::SMAP_ENABLED
+        .load(core::sync::atomic::Ordering::Relaxed);
+
+    // Helper to read EFLAGS.AC.
+    #[inline(always)]
+    fn ac_bit() -> bool {
+        let f: u64;
+        unsafe { core::arch::asm!("pushfq; pop {}", out(reg) f, options(nomem)); }
+        (f & (1u64 << 18)) != 0
+    }
+
+    if !smap_enabled {
+        // On non-SMAP CPUs the bracket is a no-op; AC always reads 0.
+        // The test only verifies the gating helpers don't crash.
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            let _ = ac_bit();
+        }
+        test_pass!("SMAP not advertised — UserGuard collapsed to no-op cleanly");
+        return true;
+    }
+
+    // ── Scenario A: nested guards.  Both must hold AC=1 throughout; the
+    // outer guard must keep AC=1 even after the inner one drops.
+    let (a_inner, a_after_inner_drop, a_after_outer_drop) = unsafe {
+        let _outer = crate::arch::x86_64::smap::UserGuard::new();
+        let mid: bool;
+        let after_inner: bool;
+        {
+            let _inner = crate::arch::x86_64::smap::UserGuard::new();
+            mid = ac_bit();
+        }
+        after_inner = ac_bit();
+        drop(_outer);
+        let after_outer = ac_bit();
+        (mid, after_inner, after_outer)
+    };
+
+    if !a_inner {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=0 inside nested guards — STAC missing on inner construct");
+        return false;
+    }
+    if !a_after_inner_drop {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=0 after inner guard drop while outer is live — outer guard's STAC was clobbered");
+        return false;
+    }
+    if a_after_outer_drop {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=1 after outer guard drop — CLAC did not fire");
+        return false;
+    }
+
+    // ── Scenario B: explicit early drop mid-scope.  This is the exact
+    // shape where /review caught the user_slice footgun — the slice
+    // borrow outlives the guard and any subsequent deref would fault.
+    // We don't deref (would panic the kernel without an extable), we
+    // just verify AC=0 after the explicit drop, before the scope ends.
+    let (b_before_drop, b_after_drop) = unsafe {
+        let g = crate::arch::x86_64::smap::UserGuard::new();
+        let before = ac_bit();
+        drop(g);
+        let after = ac_bit();
+        (before, after)
+    };
+
+    if !b_before_drop {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=0 before explicit drop — STAC missing");
+        return false;
+    }
+    if b_after_drop {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=1 after explicit drop — CLAC did not fire on Drop");
+        return false;
+    }
+
+    // ── Scenario C: function-boundary leak.  Confirm a helper that
+    // constructs a UserGuard and returns *without* the guard does NOT
+    // leak AC=1 to the caller.  user_slice_unbracketed / _mut have
+    // exactly this shape — they return a borrowed slice but the
+    // bracket has closed.
+    #[inline(never)]
+    fn make_guard_and_drop() {
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            // do nothing; guard drops on function return.
+        }
+    }
+    make_guard_and_drop();
+    let c_after_helper = ac_bit();
+    if c_after_helper {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=1 after helper function returned — guard leaked across call boundary");
+        return false;
+    }
+
+    // ── Scenario D: validate that user_slice_snapshot leaves AC=0 on
+    // return (the new safe helper from Improvement 6).  This catches
+    // regressions where someone changes the helper to return a borrow
+    // again without re-introducing the bracket.
+    //
+    // We pass len=0 + ptr=0 (always-valid empty case) so no real user
+    // memory is touched.
+    let _snap = unsafe { crate::syscall::user_slice_snapshot(0, 0) };
+    let d_after_snapshot = ac_bit();
+    if d_after_snapshot {
+        test_fail!("220c_smap_userguard_nesting",
+            "AC=1 after user_slice_snapshot returned — internal guard leaked");
+        return false;
+    }
+
+    test_pass!("UserGuard AC state machine is correct across nesting/early-drop/helper boundaries");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1660,6 +1660,17 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
 
 /// Read from a file descriptor.
 pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize) -> VfsResult<usize> {
+    // SMAP bracket — fd_read writes data into `buf` which is typically
+    // a user-VA from the syscall path.  The function does not call
+    // `schedule()` internally; it is a pure-kernel critical section
+    // wrapping FS / device / IPC reads.  Holding the guard across the
+    // whole function covers every leaf that writes to `buf` (including
+    // those inside FS callbacks) without per-site instrumentation.
+    //
+    // Internal kernel callers that pass a kernel-VA `buf` are unaffected
+    // because SMAP only fires on PTE.U=1 pages.  See Intel SDM Vol. 3A
+    // §4.6.1 (SMAP enforcement).
+    let _smap_g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let (mount_idx, inode, offset, flags, file_type, open_path) = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = procs.iter().find(|p| p.pid == pid).ok_or(VfsError::InvalidArg)?;
@@ -1677,7 +1688,10 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
             match crate::ipc::timerfd::read(inode) {
                 Ok(val) => {
                     let bytes = val.to_le_bytes();
-                    unsafe { core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, 8); }
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, 8);
+                    }
                     Ok(8)
                 }
                 Err(e) => Err(if e == -11 { VfsError::WouldBlock } else { VfsError::BadFd }),
@@ -1719,14 +1733,20 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
             if flags & 0x0200_0000 != 0 {
                 #[cfg(feature = "firefox-test")]
                 crate::mm::w215_diag::probe(crate::mm::w215_diag::Writer::DevZero, buf, count);
-                unsafe { core::ptr::write_bytes(buf, 0, count); }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_bytes(buf, 0, count);
+                }
                 return Ok(count);
             }
             // bit 24 = /dev/urandom | /dev/random  → fill with pseudo-random bytes
             if flags & 0x0100_0000 != 0 {
                 let t = crate::arch::x86_64::irq::get_ticks();
-                for i in 0..count {
-                    unsafe { *buf.add(i) = (t.wrapping_add(i as u64).wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407) & 0xFF) as u8; }
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    for i in 0..count {
+                        *buf.add(i) = (t.wrapping_add(i as u64).wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407) & 0xFF) as u8;
+                    }
                 }
                 return Ok(count);
             }
@@ -2004,6 +2024,11 @@ fn generate_proc_environ(pid: crate::proc::Pid) -> alloc::vec::Vec<u8> {
 
 /// Write to a file descriptor.
 pub fn fd_write(pid: crate::proc::Pid, fd_num: usize, buf: *const u8, count: usize) -> VfsResult<usize> {
+    // SMAP bracket — fd_write reads from `buf` which is typically a
+    // user-VA from the syscall path.  Same rationale as `fd_read`:
+    // pure-kernel critical section, no schedule points, all leaf
+    // reads against `buf` covered by a single guard.
+    let _smap_g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
     let (mount_idx, inode, offset, append, fd_flags, file_type, open_path) = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = procs.iter().find(|p| p.pid == pid).ok_or(VfsError::InvalidArg)?;


### PR DESCRIPTION
## Summary

Closes **H1-SMAP** from `docs/SECURITY_AUDIT_2026-05-16.md`.  PR #250 landed
CR4.SMEP and deliberately deferred CR4.SMAP because enabling it required
auditing every legitimate user-pointer dereference and bracketing it with
STAC/CLAC.  This PR completes that audit and lights SMAP up.

With CR4.SMAP set, the CPU raises #PF on any supervisor-mode access to a
user-mapped page (PTE.U=1) unless EFLAGS.AC=1.  Per Intel SDM Vol. 3A §4.6,
this converts the BadIRET-class unintentional-user-pointer-dereference
escalation primitive (CWE-269 / CVE-2014-9322) into a fail-stop fault.
Combined with SMEP from PR #250, both the *execution* and *data* legs of
ret2usr are now neutralised.

### Threat model

- **Attacker**: an unprivileged process able to coerce the kernel into
  dereferencing a pointer it controls (via a confused-deputy bug, a vtable
  corruption, or an unvalidated syscall arg).
- **Capability**: redirect a single kernel-mode load/store at a user-VA
  address the attacker has mapped with contents of its choosing.
- **Target**: arbitrary kernel write primitive (data corruption,
  privilege escalation).
- **Mitigation**: SMAP raises #PF on the unintentional access; the PF
  handler terminates the offending process before the write completes.

## Per-file changelog

### `kernel/src/arch/x86_64/smap.rs` (NEW)

- `stac()` / `clac()` raw asm primitives.  Memory clobber on both (we
  removed `nomem`) is **critical**: without it LLVM rewrites
  `let _g = UserGuard::new(); copy_nonoverlapping(p, buf, 32); use buf`
  into direct reads from `p` AFTER `_g` drops (literal observed failure
  mode during boot).
- `SMAP_ENABLED: AtomicBool` — one-way monotonic flag.
- `stac_if_smap()` / `clac_if_smap()` — branch-on-flag helpers (no #UD
  on non-SMAP CPUs).
- `UserGuard` RAII — `compiler_fence(SeqCst)` in both constructor and
  drop to prevent reordering across the bracket boundary.

### `kernel/src/arch/x86_64/mod.rs`

- `enable_cpu_security_features` now writes CR4.SMEP **and** CR4.SMAP
  under a single CR4 update when CPUID.(EAX=07H,ECX=00H):EBX[20]
  advertises SMAP.
- `SMAP_ENABLED` is published *after* CR4 is committed so the gating
  helpers cannot issue STAC before SMAP enforcement is live.

### `kernel/src/syscall/mod.rs`

- `user_slice` / `user_slice_mut` / `user_read_u32` / `user_read_u64`
  now hold a `UserGuard` across the deref/materialisation.
- Path-string syscalls (`sys_exec`, `sys_chdir`, `sys_mkdir`, `sys_rmdir`,
  `sys_stat`, `sys_unlink`) snapshot the user path into an owned
  `String` under a bracket so downstream uses run on kernel memory.
- `sys_getcwd`, `sys_uname`, `fill_stat_buf` bracket the user write.
- PTY/fbdev/input/DSP ioctl arms bracket the per-arm user struct
  accesses.
- `sys_getrandom` brackets the full RDRAND/xorshift fill.
- `rt_sigreturn` brackets the signal-frame field reads.
- `sys_pipe` brackets the fds_out writes.

### `kernel/src/subsys/linux/syscall.rs`

`read_cstring_from_user` now returns `alloc::vec::Vec<u8>`: staged
through a 4 KiB kernel stack buffer under one bracket, then copied out
(heap allocation cannot run with AC=1 — the allocator path takes locks).
35 callers updated to consume the owned `Vec` (`from_utf8(&bytes)`).

Per-arm bracketing for the entire socket/IPC surface: `connect`,
`bind`, `sendto`, `recvfrom`, `sendmsg`, `recvmsg` (including the
SCM_RIGHTS cmsg read/write paths and the per-iovec descriptor
snapshot), `getsockname`, `getpeername`, `socketpair`, `setsockopt`,
`getsockopt` (notably the SO_PEERCRED ucred writeback).

Per-arm bracketing for the time / wait / clock surface: `time(NULL)`,
`clock_gettime`, `gettimeofday`, `clock_getres`, `getrusage`, `sysinfo`,
`times`, `waitid` siginfo write.

Per-arm bracketing for the directory / fs metadata surface: `getdents`,
`getdents64`, `/proc/self/fd` getdents, `statx`, `readlink`,
`readlinkat`, `fcntl(F_GETLK, F_SETLK)`, `mincore`, `mremap` copy,
`pipe2`, `set_robust_list`, `get_robust_list`.

Per-arm bracketing for signal/process metadata: `rt_sigaction`,
`rt_sigprocmask`, `arch_prctl(GET_FS, GET_GS)`, `capget`, `capset`,
`setrlimit`, `prlimit64`, `prctl(PR_GET_NAME, PR_GET_CHILD_SUBREAPER)`,
`sched_getaffinity`, `getcpu`, `clone3(struct clone_args)`.

Per-arm bracketing for poll/select/epoll: `poll(pollfd[i])`,
`select(fd_set bits)`, `pselect6` timeval, `epoll_ctl(EpollEvent)`,
`epoll_wait(events[])`.

iovec syscalls (`sys_writev`, `sys_readv`, `sys_preadv`, `sys_pwritev`)
now snapshot the iovec descriptor array into a kernel
`Vec<[u64; 2]>` so iteration runs on kernel memory — defangs a TOCTOU
between validate and use as a side effect.

sys_write_linux firefox-test logging snapshots the user buffer into a
512-byte kernel `Vec` under one bracket before the escape-printer +
hex-dump loops.  sys_read_linux ring-buffer snapshot likewise.

### `kernel/src/ipc/pipe.rs`

`Pipe::read` / `Pipe::write` byte loops bracket the per-byte copy
(PIPE_TABLE lock held; no schedule points so AC=1 cannot leak).

### `kernel/src/net/unix.rs`

`UnixSocket::push` / `UnixSocket::pop` byte loops bracket the per-byte
copy (TABLE lock held; no schedule points).

### `kernel/src/vfs/mod.rs`

`fd_read` / `fd_write` open a function-scoped `UserGuard`.  Both are
pure-kernel critical sections with no `schedule()` points, so the
bracket safely covers every leaf that touches the user buf
(`/dev/zero`, `/dev/urandom`, timerfd, signalfd, inotify, FS reads,
PTY, virtio-serial).

### `kernel/src/drivers/tty.rs`

`Tty::read` / `Tty::write` snapshot the user slice into a 256-byte
kernel stack buffer in bounded chunks; the console-write byte loop
runs from kernel memory.

### `kernel/src/test_runner.rs`

New test **220b** `test_security_smap_h1_state` verifies:

- CPUID SMAP bit, CR4.SMAP, and `smap::SMAP_ENABLED` are mutually
  consistent.
- A `UserGuard` actually toggles EFLAGS.AC[18] on construction and
  clears it on drop (via `pushfq` introspection).

## CPUID detection logic

```rust
CPUID.(EAX=07H, ECX=00H):EBX[bit 20] = SMAP support
                            EBX[bit 7]  = SMEP support
```

Both bits are read in a single `cpuid` instruction.  CR4.SMAP is set
only if the CPUID bit is present; otherwise SMAP_ENABLED stays false
and every UserGuard collapses to a relaxed load + branch.

## Verification

Boot tests (KVM, post-fix):

| Build         | Result                                                |
|---------------|-------------------------------------------------------|
| default       | `[x86_64] SMAP enabled (CR4.SMAP=1, EFLAGS.AC gated by STAC/CLAC)` on BSP + AP; Ascension + Orbit reach Phase 11 cleanly; no #PF |
| firefox-test  | `sc=1024` reached, libpng16 load, content-process setup begins; no #PF, no SMAP-induced bugcheck |
| test-mode     | New test 220b passes; existing test 220 (CWE-823) still passes; build clean |

The W215-class plateau pattern in firefox-test is unchanged from the
post-#274 baseline — no regression introduced.

## Sites NOT bracketed (intentional)

- Kernel-only pointer access through `PHYS_OFF` (kernel direct map).
  These pages have PTE.U=0; SMAP is silent for them.  `write_u32_to_user`
  and `get_user_caller_rip` walk the user's page table to resolve the
  physical address, then deref through PHYS_OFF — no bracket needed.
- Tests that drive `dispatch_linux_kernel` with kernel-resident buffers
  bypass via the existing `KERNEL_DISPATCH_BYPASS` per-CPU counter.
  SMAP is silent on those accesses regardless because the buffers are
  kernel-VA.

## Test plan

- [x] `cargo check` clean for default, firefox-test, test-mode
- [x] Default boot reaches userspace Phase 11
- [x] firefox-test boot reaches Mozilla sc>=1000 without #PF
- [x] test-mode build new test 220b passes
- [x] No new SMAP-induced bugchecks under either trace
- [ ] Reviewer to confirm the read_cstring_from_user signature change
      doesn't break any caller outside the 35 sites already updated
- [ ] Reviewer to confirm UserGuard's `nomem`-less asm options are
      sufficient to suppress LLVM's load reordering

References: Intel SDM Vol. 3A §2.5, §4.6, §4.10.5; Intel SDM Vol. 2A
(STAC/CLAC); CWE-269 / CWE-119 / CWE-823; CVE-2014-9322 (BadIRET) class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)