### PR TITLE
kernel/test_runner: fix Test 49 + Test 57 mprotect/mremap hangs (SMAP user-VA without STAC)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -9458,7 +9458,14 @@ fn test_mprotect_syscall() -> bool {
     test_println!("  mmap anon page @ {:#x} ✓", addr);
 
     // 2. Write a sentinel value to the page.
+    //
+    // The mmap'd address is a user-VA (PTE.U=1).  With CR4.SMAP set, any
+    // supervisor-mode access to a user-mapped page without EFLAGS.AC=1
+    // raises #PF (Intel SDM Vol. 3A §4.6).  UserGuard issues STAC on
+    // construction and CLAC on drop, bracketing this intentional
+    // kernel→user dereference so SMAP enforcement is temporarily lifted.
     unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
         *(addr as *mut u64) = 0xDEAD_BEEF_CAFE_BABE;
     }
     test_println!("  Wrote sentinel to page ✓");
@@ -9485,7 +9492,11 @@ fn test_mprotect_syscall() -> bool {
         test_fail!("mprotect", "mprotect(PROT_RW restore) failed: {}", r);
         return false;
     }
-    let val = unsafe { *(addr as *const u64) };
+    // Verify sentinel through UserGuard (user-VA; same SMAP rationale as above).
+    let val = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        *(addr as *const u64)
+    };
     if val != 0xDEAD_BEEF_CAFE_BABE {
         test_fail!("mprotect", "sentinel corrupted: {:#x}", val);
         return false;
@@ -10259,12 +10270,20 @@ fn test_phase1_linux_syscalls() -> bool {
         // mmap(0, 4096, PROT_RW, MAP_ANON, -1, 0)
         let addr = dispatch(9, 0, 4096, 3, 0x22, u64::MAX, 0);
         if addr > 0 {
-            // Write a canary byte
-            unsafe { *(addr as *mut u8) = 0xAB; }
+            // Write a canary byte.  UserGuard required: addr is a user-VA
+            // (PTE.U=1) and CR4.SMAP is set — supervisor-mode access without
+            // EFLAGS.AC raises #PF.  Per Intel SDM Vol. 3A §4.6.
+            unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                *(addr as *mut u8) = 0xAB;
+            }
             // mremap: grow to 8192 (MREMAP_MAYMOVE=1)
             let new_addr = dispatch(25, addr as u64, 4096, 8192, 1 /*MAYMOVE*/, 0, 0);
             // The canary must still be readable at the (possibly moved) base.
-            let canary = unsafe { *(new_addr as *const u8) };
+            let canary = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                *(new_addr as *const u8)
+            };
             if new_addr > 0 && canary == 0xAB {
                 test_println!("  mremap(grow 4096→8192) = {:#x} ✓", new_addr);
                 // Clean up
@@ -18723,8 +18742,12 @@ fn test_mremap_shrink() -> bool {
     }
     test_println!("  mmap 4 pages @ {:#x} ✓", addr);
 
-    // Write a sentinel into the first page
-    unsafe { core::ptr::write(addr as *mut u64, 0xCAFE_BABE_1234_5678u64); }
+    // Write a sentinel into the first page.  UserGuard: user-VA, CR4.SMAP
+    // active — per Intel SDM Vol. 3A §4.6.
+    unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::write(addr as *mut u64, 0xCAFE_BABE_1234_5678u64);
+    }
 
     // mremap(addr, 0x4000, 0x2000, 0) — shrink to 2 pages, no MAYMOVE
     let r = crate::syscall::dispatch_linux_kernel(
@@ -18743,8 +18766,11 @@ fn test_mremap_shrink() -> bool {
         return false;
     }
 
-    // Sentinel in first page must still be readable
-    let sentinel = unsafe { core::ptr::read(addr as *const u64) };
+    // Sentinel in first page must still be readable.  UserGuard: user-VA.
+    let sentinel = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::read(addr as *const u64)
+    };
     if sentinel != 0xCAFE_BABE_1234_5678u64 {
         test_fail!("mremap_shrink", "sentinel corrupted: {:#x}", sentinel);
         return false;


### PR DESCRIPTION
## Summary

- PR #276 enabled CR4.SMAP; supervisor-mode accesses to PTE.U=1 pages without EFLAGS.AC=1 now raise #PF (Intel SDM Vol. 3A §4.6).
- Six direct kernel→user-VA dereferences in `test_runner.rs` lacked STAC/CLAC bracketing, producing an infinite #PF loop — the page fault handler resolves demand-paging but cannot set AC, so the CPU retries and SMAP fires again indefinitely.
- This caused Test 49 (`test_mprotect_syscall`) to hang at its first mmap sentinel write, blocking all tests downstream (52, 222, 230b).

**Fix:** wrap each dereference in `{ let _g = crate::arch::x86_64::smap::UserGuard::new(); ... }`. UserGuard issues STAC on construction and CLAC on drop.

**Affected sites (6 total):**
| Function | Site |
|---|---|
| `test_mprotect_syscall` | sentinel write (`addr as *mut u64`) |
| `test_mprotect_syscall` | sentinel read after mprotect restore (`addr as *const u64`) |
| `test_phase1_linux_syscalls` | mremap grow canary write (`addr as *mut u8`) |
| `test_phase1_linux_syscalls` | mremap grow canary read (`new_addr as *const u8`) |
| `test_mremap_shrink` | sentinel write (`addr as *mut u64`) |
| `test_mremap_shrink` | sentinel read (`addr as *const u64`) |

## Test plan

- [x] Build clean (0 errors, 38 warnings — same as pre-patch baseline)
- [x] Test 49 (`mprotect`): `[PASS] mprotect page-table protection changes` — no longer hangs
- [x] Test 52 (`futex REQUEUE + WAIT_BITSET`): `[PASS]` — unblocked downstream
- [x] Test 57 (`Phase 1 Linux syscalls`): `[PASS]` — mremap grow/shrink pass
- [ ] Tests 222/230b: blocked by a **separate** pre-existing hang at Test 58 (`test_phase1_linux_syscalls_batch2`) — `sc` and `pf` counters both flat (not a SMAP loop). Out of scope for this fix; should be investigated in a follow-up.

**Diff size:** 34 ins / 8 del across 5 hunks in 1 file — well within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)