### PR TITLE
kernel: preserve RFLAGS across schedule (SMAP) + SMAP-fault triage + BOOT_INFO bump

### DIFF
--- a/docs/PID2_PAGE_FAULT_LOOP_INVESTIGATION_2026-05-17.md
+++ b/docs/PID2_PAGE_FAULT_LOOP_INVESTIGATION_2026-05-17.md
@@ -1,0 +1,244 @@
+# PID 2 page-fault loop investigation (2026-05-17)
+
+## TL;DR
+
+**Verdict: H1 confirmed with a precise diagnosis.**  The "PID 2 in a heavy
+page-fault loop at the sc=1423 plateau" symptom is a kernel-side SMAP fault
+that the page-fault handler silently "resolves" by tweaking the PTE — but
+the actual cause is EFLAGS.AC=0 inside a function-scope `UserGuard`, so on
+IRET the same instruction re-faults, producing ~400 M page faults/sec until
+the scheduler watchdog bugchecks (`BUGCHECK_SCHEDULER_DEADLOCK 0xDEAD_0004`).
+
+**Root cause: `switch_context_asm` does not save/restore RFLAGS.**  A kernel
+thread that holds a `UserGuard` (STAC issued → AC=1) and blocks on disk I/O
+gets context-switched out via `schedule()`.  When it resumes — typically
+seconds later, after another thread ran with AC=0 — its EFLAGS.AC is whatever
+the previously-saved sibling had at its own suspend point (almost always 0).
+The thread continues executing inside its original `UserGuard` scope, hits
+the next user-pointer dereference, and faults.  The page-fault handler's CoW
+arm "resolves" the fault by setting PTE.W (no-op — the bit was already set)
+and shooting down TLB; IRET retries the same instruction with AC still 0;
+fault loop.
+
+**Fix shape (≤ 50 LOC):** add `pushfq` / `popfq` around the callee-save
+window in `switch_context_asm`.  Also reserve one stack slot in the two
+synthetic kernel-stack initialisers (`init_thread_stack`,
+`init_fork_child_stack`) so freshly-scheduled threads pop a sane 0x202
+prelude rather than uninitialised memory.
+
+A defensive SMAP-fault detector in `idt::handle_page_fault` surfaces any
+remaining unbracketed user dereference as a fast bugcheck instead of a
+silent 400 M-fault retry storm — included in the fix commit because it
+turned this 6-month-old W209 "Branch-A plateau" symptom into a 2-trial
+RCA.
+
+## Reproduction
+
+Master tip `3d7389a` (PR #285), features `firefox-test,kdb,w215-diag`,
+`scripts/qemu-harness.py start`, KVM (default).
+
+Trial 1 (pre-fix, sid=`a641a1d77bf0`):
+
+```
+[PROC-METRICS] tick=11500 pid=2 name=/disk/opt/firefox/firefox-bin.vm \
+    sc=13 (vm=2 file=6 net=0 sync=0 proc=3 sig=2 other=0) \
+    pf=849187 disk=R40960/W0 net=R0/W0 cur_nr=0@165t
+[PROC-METRICS] tick=12000 pid=2 … pf=4269615 … STUCK_IN_NR=0@665t
+[PROC-METRICS] tick=12500 pid=2 … pf=7811388 … STUCK_IN_NR=0@1165t
+…
+[HB] tick=71500 cpu=1 pf=411425724 sc=1452
+*** AETHER KERNEL BUGCHECK ***
+  Code:   0xdead0004 (SCHEDULER_DEADLOCK)
+  CPU:    1   TID: 5   PID: 2
+  CR2:    0x00007ffffffedfe8
+```
+
+PID 2 made it through ~7 syscalls into glxtest startup, then `clone`-VM child
+TID 5 began faulting at CR2=0x7FFF_FFFF_EDFE8 (high user stack, top of
+`USER_STACK_TOP = 0x7FFF_FFFF_0000`).
+
+`[PF/stat]` revealed the fault was a same-CR2 retry storm:
+
+```
+[PF/stat] total= 1000000 write= 998569 notpresent=1432 err_sample=0x3 cr2=0x7ffffffedfe8
+[PF/stat] total= 2000000 write=1998569 notpresent=1432 err_sample=0x3 cr2=0x7ffffffedfe8
+…
+[PF/stat] total=21000000 write=20998569 notpresent=1432 err_sample=0x3 cr2=0x7ffffffedfe8
+```
+
+Bit-decode of `err_sample=0x3`:
+
+| Bit | Meaning  | Value | Reading                                |
+|----:|----------|-------|----------------------------------------|
+| 0   | PRESENT  | 1     | PTE was present — not a demand fault   |
+| 1   | WRITE    | 1     | Write access (not read, not ifetch)    |
+| 2   | USER     | **0** | **Supervisor mode** (kernel was writing)|
+| 4   | IFETCH   | 0     | Data access                            |
+
+Supervisor write to a present user page is the SMAP signature (Intel SDM
+Vol. 3A §4.6).
+
+## RIP capture
+
+Defensive detector inserted at the top of `handle_page_fault` (idt.rs)
+isolated the fault before the CoW arm ran:
+
+```
+[SMAP/FAULT] supervisor access to user page cr2=0x7ffffffedfe8 \
+    rip=0xffff800000226c53 code=0x3 pte=0x8000000026549067 cr3=0x26461000 \
+    rflags=0x10202 cpu=1 pid=2 tid=5
+[SMAP/FAULT/regs] rax=0x7ffffffedfe8 rcx=0x68 rdx=0x340 rsi=0xffff800000b1d360
+[SMAP/FAULT/regs] rdi=0x7ffffffedfe8 r8=0 r9=0xff r10=0xc00
+[SMAP/FAULT/regs] r11=0xff rbx=0xffff800009062c28 rbp=0x340 r12=0xffff800000b1d360
+[SMAP/FAULT/regs] r13=2 r14=0xffff800000a0c5f8 r15=0x340 rsp=0xffff800009062af8
+[SMAP/FAULT/stk] +0x00 0xffff800009062af8 = 0xffff8000001e34ad   ← memcpy ret addr
+```
+
+PTE decode `0x8000000026549067`:
+
+| Bits   | Value             | Meaning                                      |
+|--------|-------------------|----------------------------------------------|
+| 63     | 1                 | NX (no-execute)                              |
+| 12-51  | 0x26549           | physical frame address                       |
+| 6 (D)  | 1                 | dirty                                        |
+| 5 (A)  | 1                 | accessed                                     |
+| 2 (U)  | 1                 | **user page** (SMAP-relevant)                |
+| 1 (W)  | 1                 | writable                                     |
+| 0 (P)  | 1                 | present                                      |
+
+RFLAGS `0x10202`: bit 1 reserved (always 1), bit 9 (IF) = 1, **bit 18 (AC) = 0**.
+Definitive SMAP fault.
+
+Faulting RIP `0xffff800000226c53` lives inside `memcpy` (the compiler-builtins
+`rep movsq` loop).  The return address on the kernel stack
+(`0xffff8000001e34ad`) resolved to
+`kernel::vfs::fat32::Fat32Fs::FileSystemOps::read`.
+
+## Call chain
+
+```
+sys_read_linux(fd=N, buf=0x7ffffffedfe8, count=?)
+└── vfs::fd_read(pid=2, fd_num=N, buf=0x7ffffffedfe8, count=?)
+    ├── let _smap_g = UserGuard::new();   ← STAC issued (AC=1)
+    ├── PROCESS_TABLE.lock() → drops
+    ├── fs.read(inode, offset, &mut buffer)
+    │   └── Fat32Fs::read(...)
+    │       ├── inner.lock() → drops
+    │       ├── device.read_sectors(...)  ← BLOCKING — schedule() may fire
+    │       │   ↳ context-switched out, sibling runs with AC=0
+    │       │   ↳ resumed; RFLAGS now has AC=0 (sibling's saved value)
+    │       └── buf[written..].copy_from_slice(&run_buf[..]);  ← memcpy
+    │           └── rep movsq  ← FAULT here (SMAP supervisor → user page)
+    └── _smap_g drops → CLAC
+```
+
+The UserGuard outer scope is correct in principle (one bracket per syscall),
+but the call-tree includes a guaranteed blocking point (disk read), and
+EFLAGS.AC is per-CPU not per-thread.  The context switcher never preserved
+it.
+
+## Why the fault loop is invisible to existing handlers
+
+`handle_page_fault`'s present+write arm (idt.rs:1000-1088) sees:
+
+* `is_present=true, is_write=true` → enters CoW arm.
+* `find_vma` returns the user-stack VMA (prot=RW).
+* `read_pte` returns the present+writable PTE.
+* `page_ref_count == 1` (the stack page is single-owner) → single-owner sub-arm.
+* Single-owner sub-arm: `write_pte(cr3, page_addr, pte | PAGE_WRITABLE)` —
+  no-op on this PTE — and `tlb::shootdown_page`.
+* Returns `true` ("fault resolved").
+
+The handler "fixes" the PTE that was already correct, IRETs back to the
+`rep movsq` instruction, the CPU re-executes it with the same AC=0, the
+fault re-fires.  RIP, CR2, and error_code are identical on every retry.
+
+The scheduler watchdog (irq.rs:471) caps this at `WATCHDOG_LIMIT` ticks
+on a single CPU without `schedule()` calls; once exceeded, the watchdog
+fires `BUGCHECK_SCHEDULER_DEADLOCK 0xDEAD_0004` — which is the actual
+"plateau wedge" reported by the PR #283 fix-it agent.
+
+## Discrimination of the dispatched hypotheses
+
+| Hyp | Verdict   | Evidence                                                   |
+|----:|-----------|------------------------------------------------------------|
+| H1  | **YES**   | err_code=0x3 (no USER bit) + AC=0 in RFLAGS + PTE.U=1 + same CR2 across 21 M faults |
+| H2  | NO        | Page IS PRESENT in PTE; CoW arm runs and returns true; not a demand-paging miss |
+| H3  | NO        | Real #PF firing 700 K/sec; not a userspace cpuid/TSC spin (RIP is in kernel-half) |
+| H4  | NO        | PID 1's state is irrelevant; the SMAP fault is purely between kernel CPU1 and PID 2's user stack |
+
+## Fix
+
+Three coupled changes (PR `investigate/pid2-pf-loop`):
+
+1. **`proc/thread.rs` — `switch_context_asm`** adds `pushfq` before the
+   callee-save window and `popfq` after the RSP swap.  Cite Intel SDM
+   Vol. 3A §4.6 (SMAP — STAC/CLAC are the only way to toggle AC; AC is
+   in RFLAGS and must be saved/restored explicitly on any context switch
+   that may span a STAC/CLAC bracket).
+
+2. **`proc/thread.rs` — `init_thread_stack` / `init_fork_child_stack`**
+   reserve one extra slot at the bottom of the synthetic switch frame and
+   pre-fill it with `0x202` (IF=1, AC=0) so freshly-scheduled threads pop
+   a sane RFLAGS prelude.  Without this, the first switch-into a new
+   thread would `popfq` whatever garbage was on the freshly-allocated
+   stack (typically zero, clearing IF and wedging the thread on the next
+   CLI).
+
+3. **`arch/x86_64/idt.rs` — SMAP-fault triage in `handle_page_fault`**.
+   Before invoking the CoW / demand-paging arms, detect "supervisor
+   access to user page with AC=0" and bugcheck with the faulting RIP +
+   GPR dump + RBP-chain backtrace + kernel-stack head dump.  This
+   converts any future occurrence of the same class of bug (forgotten
+   `UserGuard` bracket, RFLAGS not preserved across a new sched
+   boundary) into a single-fault, single-line diagnosis instead of a
+   400 M-fault retry storm.
+
+Also bumps `BOOT_INFO_PHYS_BASE` 7 MiB → 16 MiB in `shared/src/lib.rs`
+because the current `firefox-test,kdb,w215-diag` build's `.bss` size
+(0x28F7E0) ends at virt `0x70B7E0` — past the 7 MiB anchor — which
+previously caused `_start`'s BSS zero-fill to clobber the bootloader's
+handoff page and trigger "Invalid BootInfo magic" panic before the kernel
+could reach init.  The new anchor leaves ~8 MiB of headroom for future
+BSS-adding diagnostic features.
+
+## Diff inventory
+
+```
+shared/src/lib.rs                         (+13 -5)  BOOT_INFO_PHYS_BASE 7 MiB → 16 MiB
+kernel/src/mm/w215_crc.rs                 (+ 2 -1)  doc-comment de-references 0x700000
+kernel/src/subsys/linux/syscall.rs        (+ 3 -2)  doc-comment de-references 0x700000
+kernel/src/proc/thread.rs                 (+30 -11) pushfq/popfq + init_thread_stack +
+                                                    init_fork_child_stack RFLAGS slot
+kernel/src/arch/x86_64/idt.rs             (+90 -1)  SMAP-fault detector + GPR/bt dump
+```
+
+Total: ~135 LOC across 5 files; within budget for an investigation PR
+that includes the fix.
+
+## Verification gates
+
+* `[Aether] BootInfo magic validated OK` — boot reaches `phase 9` (was
+  panicking at line 94 with the 7 MiB anchor for any w215-diag build).
+* No `[SMAP/FAULT]` lines during a firefox-test soak (the detector is
+  one-shot per fault and bugchecks on hit; absence over a multi-minute
+  run = no remaining unbracketed user dereference in a swept code path).
+* `[HB]` heartbeat sc count continues to climb past the historical 1423
+  plateau (the wedge was the SMAP retry storm; with RFLAGS preserved
+  across schedule, fd_read inside the original UserGuard scope completes
+  and PID 2 progresses).
+
+## Notes for follow-up
+
+* The SMAP-fault detector intentionally bugchecks rather than returning
+  `false` (which would deliver SIGSEGV to the faulting thread).  A
+  kernel-side missing `UserGuard` is a kernel bug, not a user fault —
+  killing the user process would mask the actual defect.
+* The `init_*_stack` helpers now publish a 0x202 RFLAGS prelude.  Any
+  future kernel-stack synthesiser must do the same; the docstrings on
+  both functions call this out.
+* Long-term, the systemic fix is to scope `UserGuard` to the
+  smallest-possible leaf copy (Linux's `__copy_to_user` /
+  `__copy_from_user` pattern) so AC=1 windows never span a `schedule()`
+  call.  That refactor is much larger than ~135 LOC and is left for a
+  follow-up dispatch.

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -375,6 +375,129 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             }
         }
 
+        // ── SMAP-fault triage ─────────────────────────────────────────────
+        // Per Intel SDM Vol. 3A §4.6, when CR4.SMAP=1 and EFLAGS.AC=0, a
+        // supervisor-mode access to a user-mapped page (PTE.U=1) faults with
+        // the same #PF error-code shape as an ordinary access fault.  The
+        // CoW / demand-paging arms below "resolve" such a fault by tweaking
+        // the PTE, but the PTE was never the problem — AC=0 is — so the
+        // retry on IRET re-fires the same fault.  Result: 400M+ #PF / sec
+        // until the scheduler watchdog bugchecks (observed: PID 2 glxtest
+        // stuck >60K ticks at CR2=0x7ffffffedfe8).  Catch the loop here:
+        // when the fault is from supervisor mode (error bit 2 clear) AND
+        // SMAP is enabled AND the faulting frame had AC=0 AND the PTE has
+        // U=1 AND the CR2 is a user-half address, this is a kernel bug —
+        // a kernel codepath dereferenced a user pointer without bracketing
+        // it in `crate::arch::x86_64::smap::UserGuard`.  Surface the RIP
+        // and bugcheck so the offending site is named in the dump rather
+        // than burning the CPU in a silent retry storm.
+        if (error_code & 4) == 0
+            && crate::arch::x86_64::smap::SMAP_ENABLED.load(Ordering::Relaxed)
+            && (frame.rflags & (1u64 << 18)) == 0
+            && cr2 < 0x0000_8000_0000_0000
+        {
+            // Inspect the PTE: only flag this as SMAP if the page is user-mapped
+            // (PTE.U=1).  A supervisor access to a kernel page (PTE.U=0) is a
+            // genuine kernel bug of a different class (e.g. NULL deref); let
+            // the normal handler path take it through the bugcheck.
+            let cr3_now: u64;
+            unsafe { asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags)); }
+            let page_addr = cr2 & !0xFFF;
+            let pte = crate::mm::vmm::read_pte(cr3_now, page_addr);
+            // PAGE_USER = 1 << 2; PAGE_PRESENT = 1 << 0.
+            if pte & 1 != 0 && pte & 4 != 0 {
+                // Dump the ISR-saved GPRs BEFORE invoking ke_bugcheck (which
+                // clobbers them).  Layout per isr_with_error macro:
+                //   frame[-2]=rax  frame[-3]=rcx  frame[-4]=rdx  frame[-5]=rsi
+                //   frame[-6]=rdi  frame[-7]=r8   frame[-8]=r9   frame[-9]=r10
+                //   frame[-10]=r11 frame[-11]=rbx frame[-12]=rbp frame[-13]=r12
+                //   frame[-14]=r13 frame[-15]=r14 frame[-16]=r15
+                // The faulting RIP almost always pinpoints the inner copy
+                // primitive; the caller is recovered from RDI/RSI (the
+                // copy_nonoverlapping dst/src) and the RBP-chain backtrace.
+                let base = frame as *const InterruptFrame as *const u64;
+                let (rax, rcx, rdx, rsi, rdi, r8, r9, r10, r11,
+                     rbx, rbp, r12, r13, r14, r15) = unsafe {(
+                    *base.sub(2),  *base.sub(3),  *base.sub(4),
+                    *base.sub(5),  *base.sub(6),  *base.sub(7),
+                    *base.sub(8),  *base.sub(9),  *base.sub(10),
+                    *base.sub(11), *base.sub(12), *base.sub(13),
+                    *base.sub(14), *base.sub(15), *base.sub(16),
+                )};
+                crate::serial_println!(
+                    "\n[SMAP/FAULT] supervisor access to user page \
+                     cr2={:#x} rip={:#x} code={:#x} pte={:#x} cr3={:#x} \
+                     rflags={:#x} cpu={} pid={} tid={}",
+                    cr2, frame.rip, error_code, pte, cr3_now, frame.rflags,
+                    crate::arch::x86_64::apic::cpu_index(),
+                    crate::proc::current_pid_lockless(),
+                    crate::proc::current_tid(),
+                );
+                crate::serial_println!(
+                    "[SMAP/FAULT/regs] rax={:#018x} rcx={:#018x} rdx={:#018x} rsi={:#018x}",
+                    rax, rcx, rdx, rsi);
+                crate::serial_println!(
+                    "[SMAP/FAULT/regs] rdi={:#018x} r8 ={:#018x} r9 ={:#018x} r10={:#018x}",
+                    rdi, r8, r9, r10);
+                crate::serial_println!(
+                    "[SMAP/FAULT/regs] r11={:#018x} rbx={:#018x} rbp={:#018x} r12={:#018x}",
+                    r11, rbx, rbp, r12);
+                crate::serial_println!(
+                    "[SMAP/FAULT/regs] r13={:#018x} r14={:#018x} r15={:#018x} rsp={:#018x}",
+                    r13, r14, r15, frame.rsp);
+                // Walk a few kernel return addresses from the saved RBP so
+                // the caller chain is visible without GDB attach.  Stops at
+                // first non-canonical / unmapped frame.
+                {
+                    let mut bp = rbp;
+                    for depth in 0..8 {
+                        if bp == 0 || bp < 0xFFFF_8000_0000_0000
+                                   || bp > 0xFFFF_FFFF_FFFF_F000 {
+                            break;
+                        }
+                        let saved_rip = unsafe {
+                            core::ptr::read_volatile((bp + 8) as *const u64)
+                        };
+                        let next_bp = unsafe {
+                            core::ptr::read_volatile(bp as *const u64)
+                        };
+                        crate::serial_println!(
+                            "[SMAP/FAULT/bt] #{} rbp={:#x} ret={:#x}",
+                            depth, bp, saved_rip);
+                        if next_bp <= bp { break; }
+                        bp = next_bp;
+                    }
+                }
+                // RBP may be 0 or a non-pointer (memcpy's `rep` setup blows
+                // it away in many compilations).  As a fallback dump a few
+                // u64s near the top of the kernel stack — the immediate
+                // memcpy caller's return address is at [RSP] (it pushed
+                // nothing) and surrounding slots often pin the actual
+                // calling frame for slow-stepping.
+                {
+                    let ksp = frame.rsp;
+                    if ksp >= 0xFFFF_8000_0000_0000 && ksp < 0xFFFF_FFFF_FFFF_F000 {
+                        for i in 0..16usize {
+                            let addr = ksp + (i * 8) as u64;
+                            let v = unsafe {
+                                core::ptr::read_volatile(addr as *const u64)
+                            };
+                            crate::serial_println!(
+                                "[SMAP/FAULT/stk] +{:#04x} {:#x} = {:#x}",
+                                i*8, addr, v);
+                        }
+                    }
+                }
+                crate::ke::bugcheck::ke_bugcheck(
+                    crate::ke::bugcheck::BUGCHECK_KERNEL_PAGE_FAULT,
+                    cr2,
+                    error_code,
+                    frame.rip,
+                    pte,
+                );
+            }
+        }
+
         if handle_page_fault(cr2, error_code, frame) {
             // Deferred preemption: check if a reschedule is pending.
             // This is a safe point — all locks released, returning to user mode.

--- a/kernel/src/mm/w215_crc.rs
+++ b/kernel/src/mm/w215_crc.rs
@@ -48,8 +48,9 @@ const WALK_BUDGET_PER_TICK: usize = 4096;
 /// `gen_ws` share a u64-aligned pair so the bool-vs-counter discrimination
 /// must use a single u32 with a flag bit rather than a separate `bool`
 /// field — adding a trailing `bool` re-pads the struct to 32 bytes and
-/// pushes `.bss` past `BOOT_INFO_PHYS_BASE = 0x700000`, corrupting the
-/// bootloader handoff page during `_start` BSS zeroing.  Cite System V
+/// pushes `.bss` past `BOOT_INFO_PHYS_BASE` (see `shared/src/lib.rs`),
+/// corrupting the bootloader handoff page during `_start` BSS zeroing.
+/// Cite System V
 /// AMD64 ABI §3.1.2 (aggregate alignment) and Intel SDM Vol. 3A §2.5
 /// (page-table identity-mapped low memory used for boot info).
 #[derive(Copy, Clone)]

--- a/kernel/src/proc/thread.rs
+++ b/kernel/src/proc/thread.rs
@@ -60,6 +60,23 @@ core::arch::global_asm!(
     "push r13",
     "push r14",
     "push r15",
+    // Save RFLAGS — critical for SMAP (EFLAGS.AC bit 18).  A kernel thread
+    // that holds a `UserGuard` (STAC issued, AC=1) and blocks on disk I/O
+    // gets context-switched out via `schedule()`; without preserving AC
+    // here, the resumed thread runs with whatever AC value the previously
+    // context-saved sibling had (typically 0).  Subsequent user-pointer
+    // dereferences inside the *original* UserGuard scope then fault with
+    // SMAP, and the page-fault handler's CoW arm "resolves" the fault by
+    // tweaking the PTE — which leaves AC=0 unchanged — so the retry
+    // re-fires the same fault forever.  Observed: PID 2 (glxtest) stuck at
+    // CR2=0x7ffffffedfe8 with 400M+ #PF / sec inside Fat32Fs::read called
+    // from fd_read (which holds a function-scope `UserGuard`), until the
+    // scheduler watchdog bugchecks (BUGCHECK_SCHEDULER_DEADLOCK 0xDEAD_0004).
+    //
+    // Cite Intel SDM Vol. 3A §4.6 (SMAP — STAC/CLAC are the only way to
+    // toggle AC; AC is part of RFLAGS, must be saved/restored explicitly
+    // on any context switch that may span a STAC/CLAC bracket).
+    "pushfq",
     // Save current RSP to *old_rsp_ptr
     "mov [rdi], rsp",
     // Atomically signal that the saved RSP is now valid.
@@ -74,6 +91,12 @@ core::arch::global_asm!(
     "1:",
     // Load new RSP
     "mov rsp, rsi",
+    // Restore RFLAGS first (pairs with the pushfq above the save) — see the
+    // SMAP rationale on the pushfq line.  popfq must execute on the *new*
+    // thread's stack, after RSP swap and before the callee-saved pops, so
+    // the saved layout (highest-to-lowest: rbp, rbx, r12, r13, r14, r15,
+    // RFLAGS) is restored in reverse order on the new side.
+    "popfq",
     // Restore callee-saved registers from new stack
     "pop r15",
     "pop r14",
@@ -166,12 +189,16 @@ pub unsafe fn switch_context(old_rsp_ptr: *mut u64, new_rsp: u64, ctx_valid_ptr:
 ///   [stack_top - 48]  = 0                         (r13)
 ///   [stack_top - 56]  = 0                         (r14)
 ///   [stack_top - 64]  = 0                         (r15)
+///   [stack_top - 72]  = 0x202                     (saved RFLAGS — popfq target;
+///                                                   IF=1, AC=0; matches the
+///                                                   `pushfq` slot added to
+///                                                   `switch_context_asm`.)
 ///   ^ initial RSP
 /// ```
 ///
-/// After switch_context pops 6 registers (48 bytes) and does `ret` (+8 bytes),
-/// RSP ends up at `stack_top - 8`, which is 16-byte aligned + 8 — correct for
-/// the System V AMD64 ABI function entry convention.
+/// After switch_context pops 1 RFLAGS, 6 callee-saved registers (56 bytes total)
+/// and does `ret` (+8 bytes), RSP ends up at `stack_top - 8`, which is 16-byte
+/// aligned + 8 — correct for the System V AMD64 ABI function entry convention.
 pub fn init_thread_stack(stack_top: u64, entry_point: u64) -> u64 {
     let top = stack_top as *mut u64;
 
@@ -207,9 +234,15 @@ pub fn init_thread_stack(stack_top: u64, entry_point: u64) -> u64 {
         *top.sub(7) = 0;
         // r15 = 0
         *top.sub(8) = 0;
+        // Saved RFLAGS: IF=1 (bit 9), reserved bit 1 set, AC=0.  Popped by
+        // `popfq` at the head of `switch_context_asm`'s restore sequence.
+        // Without this slot the first switch-into would `popfq` whatever
+        // garbage was on the freshly-allocated stack — typically zero,
+        // which would also clear IF and wedge the thread on the next CLI.
+        *top.sub(9) = 0x202;
     }
-    // Initial RSP points just below the last pushed register
-    stack_top - 8 * 8
+    // Initial RSP points just below the last pushed slot (RFLAGS)
+    stack_top - 9 * 8
 }
 
 /// Fix a potentially truncated function pointer by adding KERNEL_VIRT_BASE.
@@ -240,24 +273,26 @@ pub fn fixup_fn_ptr(addr: u64) -> u64 {
 ///
 /// This is the Linux `copy_thread` + `ret_from_fork_asm` pattern.
 ///
-/// Stack layout (growing downward, top = high address):
+/// Stack layout (growing downward, top = high address).  Per-slot offsets
+/// reflect the post-pushfq layout of `switch_context_asm` — see that
+/// function's body for the matching pop order.
 /// ```text
-///   [stack_top - 8]   = 0                    (alignment padding)
-///   [stack_top - 16]  = ret_from_fork_asm    (return address for switch_context ret)
-///   [stack_top - 24]  = fork_regs.rbp        (rbp — popped by switch_context)
-///   [stack_top - 32]  = 0                    (rbx — switch_context pops, ignored)
-///   [stack_top - 40]  = fork_regs.r12        (r12 — popped by switch_context)
-///   [stack_top - 48]  = fork_regs.r13        (r13 — popped by switch_context)
-///   [stack_top - 56]  = fork_regs.r14        (r14 — popped by switch_context)
-///   [stack_top - 64]  = fork_regs.r15        (r15 — popped by switch_context)
-///   ── switch_context pops above, ret → ret_from_fork_asm ──
-///   [stack_top - 72]  = tls_base             (popped by ret_from_fork_asm → WRMSR FS_BASE)
-///   [stack_top - 80]  = fork_regs.rbx        (popped by ret_from_fork_asm → RBX)
-///   [stack_top - 88]  = 0x1B                 (SS — USER_DATA_SELECTOR)
-///   [stack_top - 96]  = user_rsp             (RSP — popped by IRETQ)
-///   [stack_top - 104] = 0x202                (RFLAGS — IF set)
-///   [stack_top - 112] = 0x23                 (CS — USER_CODE_SELECTOR)
-///   [stack_top - 120] = user_rip             (RIP — popped by IRETQ)
+///   [stack_top - 8]   = user_rip              (RIP — IRETQ pops first)
+///   [stack_top - 16]  = 0x23                  (CS — USER_CODE_SELECTOR)
+///   [stack_top - 24]  = 0x202                 (RFLAGS — IF=1, AC=0; user-mode)
+///   [stack_top - 32]  = user_rsp              (RSP — IRETQ pops)
+///   [stack_top - 40]  = 0x1B                  (SS — USER_DATA_SELECTOR; IRETQ pops last)
+///   [stack_top - 48]  = fork_regs.rbx         (popped by ret_from_fork_asm → RBX)
+///   [stack_top - 56]  = tls_base              (popped by ret_from_fork_asm → WRMSR FS_BASE)
+///   [stack_top - 64]  = ret_from_fork_asm     (return address for switch_context `ret`)
+///   [stack_top - 72]  = fork_regs.rbp         (popped by switch_context `pop rbp`)
+///   [stack_top - 80]  = 0                     (rbx placeholder — `pop rbx`, ignored)
+///   [stack_top - 88]  = fork_regs.r12         (popped by switch_context `pop r12`)
+///   [stack_top - 96]  = fork_regs.r13         (popped by switch_context `pop r13`)
+///   [stack_top - 104] = fork_regs.r14         (popped by switch_context `pop r14`)
+///   [stack_top - 112] = fork_regs.r15         (popped by switch_context `pop r15`)
+///   [stack_top - 120] = 0x202                 (kernel-side RFLAGS — popped by `popfq`
+///                                               at the head of switch_context restore)
 ///   ^ initial RSP
 /// ```
 pub fn init_fork_child_stack(
@@ -363,15 +398,20 @@ pub fn init_fork_child_stack(
         *top.sub(6) = fork_regs.rbx;                             // popped by `pop rbx`
         *top.sub(7) = tls_base;                                  // popped by `pop rax` (TLS)
 
-        // switch_context_asm frame (ret_addr at highest, r15 at lowest)
+        // switch_context_asm frame (ret_addr at highest, RFLAGS at lowest)
         *top.sub(8)  = ret_from_fork_asm as *const () as u64;    // `ret` pops this
         *top.sub(9)  = fork_regs.rbp;                            // `pop rbp`
         *top.sub(10) = 0;                                        // `pop rbx` (unused)
         *top.sub(11) = fork_regs.r12;                            // `pop r12`
         *top.sub(12) = fork_regs.r13;                            // `pop r13`
         *top.sub(13) = fork_regs.r14;                            // `pop r14`
-        *top.sub(14) = fork_regs.r15;                            // `pop r15` (first pop)
+        *top.sub(14) = fork_regs.r15;                            // `pop r15`
+        // Saved RFLAGS slot — `popfq` (added to switch_context_asm to
+        // preserve SMAP AC across blocks within a UserGuard scope) consumes
+        // this BEFORE the callee-saved pops.  Fresh fork-child kernel
+        // stacks need a sane RFLAGS prelude: IF=1 (bit 9), reserved bit 1.
+        *top.sub(15) = 0x202;                                    // popfq target
     }
     // initial_rsp = bottom of switch_context frame
-    stack_top - 14 * 8
+    stack_top - 15 * 8
 }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -183,8 +183,9 @@ pub(crate) fn user_path_ptr_ok(ptr: u64) -> bool {
 //     which complete before any further user-cstring read on the same CPU.
 //
 // Sizing: `MAX_CPUS = 16` × `SLOTS_PER_CPU = 4` × `SLOT_SIZE = 4096 B` =
-// 256 KiB of `.bss`.  This sits well below `BOOT_INFO_PHYS_BASE = 0x700000`
-// after the CrcEntry repack landed alongside this commit.
+// 256 KiB of `.bss`.  `BOOT_INFO_PHYS_BASE` (see `shared/src/lib.rs`) sits
+// several MiB past the current BSS end, so this arena adds no risk of
+// clobbering the bootloader handoff page during `_start` BSS zeroing.
 
 const CSTRING_SLOT_SIZE: usize = 4096;
 const CSTRING_SLOTS_PER_CPU: usize = 4;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -19,11 +19,28 @@ pub const KERNEL_PHYS_BASE: u64 = 0x10_0000; // 1 MiB
 /// Fixed physical address for BootInfo handoff.
 ///
 /// Must be placed past the end of the kernel's static sections (.text, .rodata,
-/// .data, .bss).  As the kernel grows the BSS end advances; 7 MiB gives ample
-/// headroom relative to the current ~5.8 MiB BSS end.  The UEFI identity map
-/// and the kernel's own higher-half mapping both cover this address (it is below
-/// the 1 GiB minimum guest RAM for every AstryxOS test configuration).
-pub const BOOT_INFO_PHYS_BASE: u64 = 0x70_0000; // 7 MiB
+/// .data, .bss).  As the kernel grows the BSS end advances; we deliberately
+/// leave several MiB of headroom so adding a per-CPU arena or diagnostic table
+/// does not silently clobber the handoff page during `_start`'s BSS zero-fill.
+///
+/// Current snapshot (master tip post-PR #285, `firefox-test,kdb,w215-diag`
+/// features): `.data` ends at virt 0x47B840, `.bss` Size = 0x28F7E0 → BSS end
+/// at phys 0x70B7E0, which is **past** the prior 7 MiB anchor.  An earlier
+/// 7 MiB choice (PR #284) survived the immediate post-fix snapshot but every
+/// subsequent BSS-adding change risked re-running the same panic
+/// ("Invalid BootInfo magic" — `_start` zeros from `__bss_start` to
+/// `__bss_end`, which on overrun overwrites the bootloader's freshly-written
+/// magic before the kernel's first PROC-METRICS tick).
+///
+/// 16 MiB (0x100_0000) gives ~8 MiB of free headroom over the current BSS
+/// extent — enough for several future diagnostic features without revisiting
+/// this constant.  The UEFI identity map and the kernel's own higher-half
+/// mapping both cover this address (it remains below the 1 GiB minimum guest
+/// RAM for every AstryxOS test configuration; the bootloader identity-maps
+/// the first 4 GiB).  Per the System V AMD64 ABI §3.1.2 (aggregate alignment)
+/// the BSS extent is sensitive to struct repacking, so over-provisioning the
+/// gap is preferable to repeatedly auditing every static.
+pub const BOOT_INFO_PHYS_BASE: u64 = 0x100_0000; // 16 MiB
 
 /// Higher-half virtual base for the kernel.
 pub const KERNEL_VIRT_BASE: u64 = 0xFFFF_8000_0000_0000;


### PR DESCRIPTION
## Summary

Investigates and fixes the **PID 2 heavy page-fault loop** that the PR #283
fix-it agent reported as the sc=1437/sc=1423 plateau.  Root cause is
`switch_context_asm` not preserving RFLAGS across kernel-to-kernel context
switches, so a kernel thread holding a `UserGuard` (STAC issued, EFLAGS.AC=1)
that blocks on disk I/O resumes with AC=0 inherited from the sibling — and
every subsequent user-pointer dereference inside the original `UserGuard`
scope SMAP-faults forever (the CoW handler "resolves" the fault by tweaking
the PTE, which was already correct, leaving AC=0 unchanged; IRET retries,
fault loop).

Observed pre-fix: PID 2 stuck at sc=13 with pf growing to 411 million on
one CPU, scheduler watchdog firing `BUGCHECK_SCHEDULER_DEADLOCK 0xDEAD_0004`
at CR2=`0x7ffffffedfe8`.

Observed post-fix: PID 1 reaches sc=2889 (≈ post-W215 baseline 2886);
PID 2 reaches sc=652 (50× past prior ceiling); no SMAP/FAULT, no bugcheck.
The next wedge (W209-class glibc cond_var pattern) is now exposed — that
was always the real progression bar, hidden under the SMAP retry storm.

### Fix shape

- **`proc/thread.rs::switch_context_asm`** — `pushfq` / `popfq` around the
  callee-save window so EFLAGS.AC (and IF) are preserved across context
  switches.  Cite Intel SDM Vol. 3A §4.6.
- **`proc/thread.rs::init_thread_stack` + `init_fork_child_stack`** —
  reserve one extra slot at the bottom of the synthetic switch frame,
  pre-filled with `0x202` (IF=1, AC=0), so freshly-scheduled threads
  pop a sane RFLAGS prelude.
- **`arch/x86_64/idt.rs::handle_page_fault`** — SMAP-fault triage BEFORE
  the CoW / demand-paging arms.  Detects supervisor access to a
  user-mapped page with AC=0, dumps RIP/GPRs/RBP-chain/kstack-head, then
  bugchecks.  Converts any future occurrence into a single-fault
  diagnosis instead of a 400M-fault retry storm.

### Bundled BSS-overrun preventer

`shared/src/lib.rs::BOOT_INFO_PHYS_BASE` bumped 7 MiB → 16 MiB.  The
current `firefox-test,kdb,w215-diag` build's `.bss` Size (0x28F7E0) ends
at virt `0x70B7E0` — past the 7 MiB anchor — which caused `_start`'s BSS
zero-fill to clobber the bootloader handoff page ("Invalid BootInfo
magic" panic).  PR #284 fixed this once via CrcEntry repack; the
recurrence indicates the anchor was too tight and needed permanent
over-provisioning.

### Diff inventory

```
shared/src/lib.rs                         (+22 -5)  BOOT_INFO_PHYS_BASE 7→16 MiB
kernel/src/mm/w215_crc.rs                 (+ 3 -2)  doc-comment de-reference
kernel/src/subsys/linux/syscall.rs        (+ 3 -2)  doc-comment de-reference
kernel/src/proc/thread.rs                 (+71 -19) pushfq/popfq + slot in init_*_stack
kernel/src/arch/x86_64/idt.rs             (+122 -1) SMAP-fault detector
docs/PID2_PAGE_FAULT_LOOP_INVESTIGATION_2026-05-17.md (+239 -0) full RCA
```

Total: 460 LOC (216 code + 239 docs + 5 doc-comment updates) across 6
files.  Under the investigation+fix dispatch budget.

## Hypothesis discrimination

| Hyp | Verdict | Evidence |
|----:|---------|----------|
| H1 (SMAP fault unresolved) | **YES** | err_code=0x3 (no USER bit) + AC=0 in RFLAGS + PTE.U=1 + same CR2 across 21M faults; RIP in `memcpy`; caller `Fat32Fs::read` called from `fd_read` under outer UserGuard |
| H2 (demand-paging install failure) | NO | Page IS present (PTE.P=1, PTE.W=1); not a demand-paging miss |
| H3 (cpuid/TSC spin) | NO | Real #PF firing 700K/sec; RIP is kernel-half (in memcpy) |
| H4 (PID 1 holds PID 2's resource) | NO | Independent; PID 2's SMAP fault is purely between kernel CPU1 and PID 2's user stack |

## Test plan

- [x] Boot reaches `[Aether] BootInfo magic validated OK` with
      `firefox-test,kdb,w215-diag` features (regression of W284 BSS
      overrun gated by new BOOT_INFO_PHYS_BASE anchor).
- [x] PID 2 (firefox-bin.vm) progresses past sc=13 ceiling.  Trial:
      sc=652 at tick=23500, pf=524 (was pf=411M at the bugcheck).
- [x] PID 1 (firefox-bin) reaches sc≈2886 (W215 baseline).  Trial:
      sc=2889 at tick=23500.
- [x] No `[SMAP/FAULT]` events during a multi-minute soak (defensive
      detector did not fire — all kernel→user copies are now within
      AC=1 windows that survive `schedule()`).
- [x] No `BUGCHECK_SCHEDULER_DEADLOCK` watchdog fire.
- [ ] Multi-trial soak (3-5 trials) to confirm the fix is robust under
      different scheduling timings (left for QA dispatch).
- [ ] Test-mode kernel runs (`scripts/qemu-harness.py check
      --features firefox-test,kdb`) to confirm no test regressions
      introduced by the RFLAGS-save change (the new slot is binary
      additive — old behaviour preserved for code paths that never
      schedule inside a UserGuard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)