### PR TITLE
scripts/qemu-harness: wire futex-stats + futex-set-cluster-wake to CLI

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -6717,6 +6717,9 @@ def main():
         "arm-phys",
         "coverage-flush", "proc-metrics", "thread-park-audit",
         "futex-ghost-hist",
+        # FUTEX_WAKE cluster-wake compensation (firefox-test/test-mode only).
+        # See subsys/linux/futex_cluster.rs.
+        "futex-stats", "futex-set-cluster-wake",
     ])
     p_kdb.add_argument("args", nargs="*",
                         help="Op-specific positional args: "


### PR DESCRIPTION
## Summary

Follow-up to PR #287. The kernel exposes two new kdb ops via `kernel/src/kdb.rs` — `futex-stats` and `futex-set-cluster-wake` — but the `scripts/qemu-harness.py` CLI choices list was never extended, so calling them via the harness front-end failed with `argparse: invalid choice`.

Both ops already have their request-builder branches in `_build_kdb_request`; this PR just adds the missing choices-list entries so the front-end matches the back-end.

## Diff

3 lines, single file:

\`\`\`python
         "coverage-flush", "proc-metrics", "thread-park-audit",
         "futex-ghost-hist",
+        # FUTEX_WAKE cluster-wake compensation (firefox-test/test-mode only).
+        # See subsys/linux/futex_cluster.rs.
+        "futex-stats", "futex-set-cluster-wake",
     ])
\`\`\`

## References

- POSIX pthread_cond_signal(3p) §2.9.5
- glibc Bugzilla 25847 (<https://sourceware.org/bugzilla/show_bug.cgi?id=25847>)

🤖 Generated with [Claude Code](https://claude.com/claude-code)