### PR TITLE
kernel/sched: idle-is-last-resort invariant + BSP polling yield (POSIX SCHED_OTHER hardening)

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -570,6 +570,20 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                     break;
                 }
 
+                // Yield CPU 0 so the scheduler can run Ready peers (Mozilla
+                // workers etc.) here instead of sitting idle.  W101 saga-
+                // closer: without this yield, the BSP polling loop runs
+                // forever in Ring 0; the timer ISR's check_reschedule()
+                // path only fires from Ring 3 (see arch/x86_64/irq.rs), so
+                // Ring-0 idle never enters schedule() on its own and Ready
+                // peers (cpu_affinity=None) are starved on CPU 0.  Together
+                // with the sched picker invariant (sched/mod.rs) this lets
+                // worker threads actually run on CPU 0 and unblock the
+                // condition-variable hand-offs that drive Mozilla's event
+                // loop.  Per POSIX SCHED_OTHER (1003.1-2017 §2.8) and
+                // sched(7), a CPU must never be idle while a runnable peer
+                // exists.
+                crate::sched::yield_cpu();
                 unsafe { core::arch::asm!("hlt"); }
             }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -571,8 +571,8 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 }
 
                 // Yield CPU 0 so the scheduler can run Ready peers (Mozilla
-                // workers etc.) here instead of sitting idle.  W101 saga-
-                // closer: without this yield, the BSP polling loop runs
+                // workers etc.) here instead of sitting idle.  Without
+                // this yield, the BSP polling loop runs
                 // forever in Ring 0; the timer ISR's check_reschedule()
                 // path only fires from Ring 3 (see arch/x86_64/irq.rs), so
                 // Ring-0 idle never enters schedule() on its own and Ready

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -426,7 +426,7 @@ pub fn schedule() {
         //   - last_cpu match (cache-warm): +1
         //   - no match: +0
         //
-        // INVARIANT (W101 saga-closer): a CPU MUST NEVER pick an idle thread
+        // INVARIANT (POSIX SCHED_OTHER hardening): a CPU MUST NEVER pick an idle thread
         // while a non-idle Ready peer exists.  POSIX SCHED_OTHER and sched(7)
         // both require that the per-CPU idle thread is the "schedule of last
         // resort" — it runs ONLY when no runnable user/kernel work is

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -425,8 +425,24 @@ pub fn schedule() {
         //   - affinity match (pinned to this cpu): +2
         //   - last_cpu match (cache-warm): +1
         //   - no match: +0
+        //
+        // INVARIANT (W101 saga-closer): a CPU MUST NEVER pick an idle thread
+        // while a non-idle Ready peer exists.  POSIX SCHED_OTHER and sched(7)
+        // both require that the per-CPU idle thread is the "schedule of last
+        // resort" — it runs ONLY when no runnable user/kernel work is
+        // available on this CPU.  The picker enforces this by doing TWO
+        // passes: pass 1 considers only NON-IDLE Ready peers; pass 2 (run
+        // only when pass 1 finds nothing) considers idle peers.  Without the
+        // two-pass split, a per-CPU idle thread with `cpu_affinity=Some(cpu)`
+        // (+2 affinity bonus) could in principle tie or beat a worker that
+        // has never run on this CPU (+0) at sufficiently low worker priority,
+        // even though SCHED_OTHER says workers must always win.  The two-pass
+        // structure also reads as a clear invariant in the source, making
+        // future picker edits less likely to regress.
         let mut best_idx: Option<usize> = None;
         let mut best_score: u16 = 0;
+        let mut idle_best_idx: Option<usize> = None;
+        let mut idle_best_score: u16 = 0;
 
         for i in 1..len {
             let idx = (current_idx + i) % len;
@@ -454,11 +470,45 @@ pub fn schedule() {
                 score += 1; // Ran here last — cache-warm preference.
             }
 
-            if score > best_score || best_idx.is_none() {
+            // AP idle threads (TID >= 0x1000 + apic_id, see
+            // arch/x86_64/apic.rs) are constructed at PRIORITY_IDLE with
+            // a per-CPU affinity pin and exist purely to give the AP a
+            // Ready thread to context-switch through when no other work
+            // is available.  Route them to the idle pool so non-idle
+            // peers always win pass 1.
+            //
+            // NB: the BSP idle thread (TID 0) is intentionally NOT in
+            // the idle pool.  TID 0 doubles as the BSP main thread that
+            // drives the kernel's polling loops (net::poll, x11::poll,
+            // gui::compositor::compose, the firefox-test heartbeat,
+            // etc.) — work that must keep advancing under load.
+            // Classifying TID 0 as idle would starve those polls when
+            // user threads saturate CPU 0, hanging the network stack and
+            // the framebuffer compositor.  Treat TID 0 as an ordinary
+            // PRIORITY_IDLE peer that loses to higher-priority workers
+            // on score alone but never falls into the schedule-of-last-
+            // resort bucket.
+            let is_idle_thread = t.tid >= 0x1000;
+            if is_idle_thread {
+                if score > idle_best_score || idle_best_idx.is_none() {
+                    idle_best_idx = Some(idx);
+                    idle_best_score = score;
+                }
+            } else if score > best_score || best_idx.is_none() {
                 best_idx = Some(idx);
                 best_score = score;
             }
         }
+
+        // Pass 2 fallback: if no non-idle Ready peer is available on this
+        // CPU, fall through to the idle thread.  This preserves the
+        // existing "no work → HLT" behaviour for genuinely idle systems
+        // while honouring the invariant above when work IS available.
+        if best_idx.is_none() {
+            best_idx = idle_best_idx;
+            best_score = idle_best_score;
+        }
+        let _ = best_score; // suppress "unused" if later edits drop the read
 
         match best_idx {
             Some(idx) => {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1859,7 +1859,7 @@ pub fn run() -> ! {
         if test_241_kdb_rip_trace_shape() { passed += 1; }
     }
 
-    // ── Test 242: scheduler picker non-idle precedence (W101 saga-closer) ──
+    // ── Test 242: scheduler picker non-idle precedence (POSIX SCHED_OTHER) ──
     // Verifies the picker invariant added in this PR: a CPU must never
     // pick an idle thread while a non-idle Ready peer exists on that CPU.
     // The test spawns N PRIORITY_NORMAL workers that sleep+yield in a loop,
@@ -31584,9 +31584,9 @@ fn test_241_kdb_rip_trace_shape() -> bool {
     true
 }
 
-// ── Test 242: scheduler picker non-idle precedence (W101 saga-closer) ──────
+// ── Test 242: scheduler picker non-idle precedence (POSIX SCHED_OTHER) ──────
 //
-// Regression test for the W101 scheduler-starvation saga.  The pre-fix
+// Regression test for the idle-thread-as-last-resort invariant.  The pre-fix
 // picker iterated all Ready peers in one pass and chose the highest-
 // scoring candidate.  On a 2-CPU system the BSP idle thread (TID 0,
 // PRIORITY_IDLE, cpu_affinity=Some(0)) and the AP idle thread
@@ -31617,7 +31617,7 @@ fn test_241_kdb_rip_trace_shape() -> bool {
 fn test_242_sched_picker_non_idle_precedence() -> bool {
     use core::sync::atomic::{AtomicU32, Ordering};
 
-    test_header!("scheduler picker non-idle precedence (W101 saga-closer)");
+    test_header!("scheduler picker non-idle precedence (POSIX SCHED_OTHER)");
 
     // Shared counter: each worker increments it once after completing its loops.
     static DONE_COUNT: AtomicU32 = AtomicU32::new(0);
@@ -31748,6 +31748,6 @@ fn test_242_sched_picker_non_idle_precedence() -> bool {
     }
 
     test_println!("  all {} workers completed {} cycles each ✓", N_WORKERS, ITERS);
-    test_pass!("scheduler picker non-idle precedence (W101 saga-closer)");
+    test_pass!("scheduler picker non-idle precedence (POSIX SCHED_OTHER)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1859,6 +1859,16 @@ pub fn run() -> ! {
         if test_241_kdb_rip_trace_shape() { passed += 1; }
     }
 
+    // ── Test 242: scheduler picker non-idle precedence (W101 saga-closer) ──
+    // Verifies the picker invariant added in this PR: a CPU must never
+    // pick an idle thread while a non-idle Ready peer exists on that CPU.
+    // The test spawns N PRIORITY_NORMAL workers that sleep+yield in a loop,
+    // then verifies every worker reaches its iteration target within a
+    // bounded tick budget — proving that the BSP idle (TID 0) and AP idle
+    // threads (TID >= 0x1000) do not starve them on either CPU.
+    total += 1;
+    if test_242_sched_picker_non_idle_precedence() { passed += 1; }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -31571,5 +31581,173 @@ fn test_241_kdb_rip_trace_shape() -> bool {
     }
 
     test_pass!("kdb rip-trace shape — bogus tid + dispatch errors validated");
+    true
+}
+
+// ── Test 242: scheduler picker non-idle precedence (W101 saga-closer) ──────
+//
+// Regression test for the W101 scheduler-starvation saga.  The pre-fix
+// picker iterated all Ready peers in one pass and chose the highest-
+// scoring candidate.  On a 2-CPU system the BSP idle thread (TID 0,
+// PRIORITY_IDLE, cpu_affinity=Some(0)) and the AP idle thread
+// (TID 0x1001, PRIORITY_IDLE, cpu_affinity=Some(1)) were each pinned to
+// their own CPU and could win on score against PRIORITY_NORMAL workers
+// with `cpu_affinity=None`.  Even when the score math made workers the
+// winner, the absence of an explicit "non-idle precedence" invariant
+// left the picker fragile to future priority/affinity tuning.
+//
+// The fix in `kernel/src/sched/mod.rs` splits the picker into two passes:
+// pass 1 considers only non-idle Ready peers; pass 2 falls through to the
+// idle pool only when pass 1 finds nothing.  This matches POSIX
+// SCHED_OTHER (1003.1-2017 §2.8) and sched(7) "idle is schedule of last
+// resort".
+//
+// The test spawns N PRIORITY_NORMAL kernel workers that each run a fixed
+// number of yield+sleep cycles, then verifies every worker completes
+// within a bounded tick budget.  Without the picker invariant, a worker
+// with `cpu_affinity=None` that has never run on a given CPU has score
+// `priority*4 = 32` against an idle thread pinned to that CPU with
+// score `0 + 2 = 2` — workers win cleanly today, but the test pins the
+// invariant explicitly so a future scoring change (e.g. raising
+// PRIORITY_IDLE, or increasing the affinity bonus) cannot silently
+// regress to starvation.
+//
+// Cite: POSIX 1003.1-2017 §2.8 (Process Scheduling), sched(7) on idle-
+// thread semantics, Intel SDM Vol. 3A §8 (SMP scheduling boundaries).
+fn test_242_sched_picker_non_idle_precedence() -> bool {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    test_header!("scheduler picker non-idle precedence (W101 saga-closer)");
+
+    // Shared counter: each worker increments it once after completing its loops.
+    static DONE_COUNT: AtomicU32 = AtomicU32::new(0);
+    // Per-worker run count.  After completion each worker writes the
+    // number of cycles it actually executed into RUN_COUNTS[index].
+    // A worker that never gets picked stays at 0 → caught as starvation.
+    const N_WORKERS: usize = 6;
+    static RUN_COUNTS: [AtomicU32; N_WORKERS] = [
+        AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0),
+        AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0),
+    ];
+    // Each worker gets a small per-instance counter via this atomic index.
+    static NEXT_WORKER_IDX: AtomicU32 = AtomicU32::new(0);
+    // Iterations each worker must complete before exiting.  Kept small so
+    // a slow TCG host finishes within the harness watchdog window.
+    const ITERS: u32 = 12;
+
+    DONE_COUNT.store(0, Ordering::SeqCst);
+    NEXT_WORKER_IDX.store(0, Ordering::SeqCst);
+    for slot in RUN_COUNTS.iter() {
+        slot.store(0, Ordering::SeqCst);
+    }
+
+    fn worker_entry() {
+        // Sibling threads inherit IF=0 from the scheduler's CLI before
+        // switch_context.  Re-enable interrupts so the timer ISR fires
+        // and the worker can be preempted normally.
+        crate::hal::enable_interrupts();
+
+        let idx = NEXT_WORKER_IDX.fetch_add(1, Ordering::SeqCst) as usize;
+        let slot = if idx < N_WORKERS {
+            Some(&RUN_COUNTS[idx])
+        } else {
+            None
+        };
+
+        for _ in 0..ITERS {
+            // sleep_ticks(1) parks us until the next timer tick.  The
+            // wake puts us in Ready state; the picker must then choose
+            // us over any pinned idle thread.
+            crate::proc::sleep_ticks(1);
+            if let Some(s) = slot {
+                s.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        DONE_COUNT.fetch_add(1, Ordering::SeqCst);
+        crate::proc::exit_thread(0);
+    }
+
+    let was_active = crate::sched::is_active();
+    if !was_active {
+        crate::sched::enable();
+    }
+
+    // Spawn N_WORKERS kernel processes.  Each runs at PRIORITY_HIGH by
+    // default (create_kernel_process sets PRIORITY_HIGH so kdb-style pump
+    // threads stay scheduled).  Drop them to PRIORITY_NORMAL via
+    // set_thread_priority so they resemble Mozilla worker threads.
+    let mut tids = [0u64; N_WORKERS];
+    for i in 0..N_WORKERS {
+        let pid = crate::proc::create_kernel_process(
+            "sched_starve_worker",
+            worker_entry as u64,
+        );
+        // Resolve TID for this PID (single-thread process).
+        let tid = {
+            let pt = crate::proc::PROCESS_TABLE.lock();
+            pt.iter().find(|p| p.pid == pid)
+                .and_then(|p| p.threads.first().copied())
+                .unwrap_or(0)
+        };
+        tids[i] = tid;
+        // Demote to NORMAL so a regression in priority weighting could
+        // realistically lose to PRIORITY_IDLE pinned threads.
+        let _ = crate::proc::set_thread_priority(tid, crate::proc::PRIORITY_NORMAL);
+        test_println!("  spawned worker {} pid={} tid={} ✓", i, pid, tid);
+    }
+
+    // Wait for all workers to finish.  Budget: 4000 spin iterations with
+    // an explicit yield_cpu() each iteration so the scheduler runs on
+    // this CPU too.  Each iteration also does ~500 spin_loop hints +
+    // an explicit STI window so a slow TCG run still progresses.
+    let mut all_done = false;
+    for i in 0..4000u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..500u32 { core::hint::spin_loop(); }
+        if DONE_COUNT.load(Ordering::SeqCst) >= N_WORKERS as u32 {
+            all_done = true;
+            break;
+        }
+        if i != 0 && i % 256 == 0 {
+            test_println!("  sched_picker: still waiting (done={}/{}, iter {})",
+                DONE_COUNT.load(Ordering::SeqCst), N_WORKERS, i);
+        }
+    }
+
+    if !was_active {
+        crate::sched::disable();
+    }
+
+    // Verdict 1: total completion.
+    let done = DONE_COUNT.load(Ordering::SeqCst);
+    if !all_done || done < N_WORKERS as u32 {
+        // Diagnostic: dump per-worker run counts to spot starvation.
+        for i in 0..N_WORKERS {
+            test_println!("  worker[{}] tid={} ran {} cycles (target {})",
+                i, tids[i], RUN_COUNTS[i].load(Ordering::SeqCst), ITERS);
+        }
+        test_fail!("test242",
+            "only {}/{} workers completed (sched picker may be starving non-idle peers)",
+            done, N_WORKERS);
+        return false;
+    }
+
+    // Verdict 2: per-worker fairness.  Every worker must have hit the
+    // iteration target.  A worker stuck at 0 cycles would prove the
+    // picker never picked it — the precise pre-fix saga signature.
+    for i in 0..N_WORKERS {
+        let cycles = RUN_COUNTS[i].load(Ordering::SeqCst);
+        if cycles < ITERS {
+            test_fail!("test242",
+                "worker[{}] tid={} only ran {} cycles (target {}) — \
+                 picker starvation regression",
+                i, tids[i], cycles, ITERS);
+            return false;
+        }
+    }
+
+    test_println!("  all {} workers completed {} cycles each ✓", N_WORKERS, ITERS);
+    test_pass!("scheduler picker non-idle precedence (W101 saga-closer)");
     true
 }


### PR DESCRIPTION
## Summary

Codifies POSIX SCHED_OTHER's "idle is schedule of last resort" invariant
in the AstryxOS picker plus the BSP polling loop, so a CPU never sits
idle while a runnable peer exists.  Lands as **three** changes:

1. **`kernel/src/sched/mod.rs`** — two-pass picker.  Pass 1 considers only
   non-idle Ready peers; pass 2 falls through to the idle pool only when
   pass 1 finds nothing.  AP idle threads (`tid >= 0x1000`) are the only
   inhabitants of the idle pool — the BSP idle thread (TID 0) is
   intentionally treated as an ordinary peer because it doubles as the
   BSP main thread driving `net::poll`, `x11::poll`, the framebuffer
   compositor, and the firefox-test harness loop.  Classifying TID 0 as
   idle would starve those polls under load.

2. **`kernel/src/main.rs`** — the firefox-test BSP polling loop now calls
   `sched::yield_cpu()` before its `hlt` each iteration.  The timer
   ISR's `check_reschedule` path only fires from Ring 3 (see
   `arch/x86_64/irq.rs:286-292`), so a Ring-0 polling loop never enters
   `schedule()` on its own.  Without the explicit yield, the BSP holds
   CPU 0 forever; Ready user peers with `cpu_affinity=None` are starved
   on that CPU and only schedule on the AP.

3. **`kernel/src/test_runner.rs`** — new Test 242 spawns N
   PRIORITY_NORMAL kernel workers that exercise the sleep/wake →
   Ready → picker → Running → exit_thread path.  Verifies (a) all
   workers complete and (b) per-worker iteration counts hit the target
   — a worker stuck at zero is the precise starvation signature the
   picker invariant prevents.

## Option A vs B choice

The hypothesis input was that picker scoring `priority*4 + bonus` could
let the BSP idle (PRIORITY_IDLE=0, `cpu_affinity=Some(0)`) tie or beat
PRIORITY_NORMAL workers on CPU 0 (idle = `0*4 + 2 = 2` vs worker =
`8*4 + 0 = 32`; workers in fact dominate cleanly today).  Even though
the score math is OK at current constants, the codebase lacked an
explicit invariant — a future tweak to `PRIORITY_IDLE`, the affinity
bonus, or the idle thread priority could silently regress to
starvation.  **Option A** (exclude idle from the candidate set unless
no non-idle peer exists) is the cleanest way to make the invariant
load-bearing in the source.  Option B (drop the affinity bonus on
`priority == PRIORITY_IDLE`) only fixes the score path; Option A also
prevents future regressions where idle's priority is bumped.

## Picker invariant (new)

> **A CPU MUST NEVER pick an idle thread while a non-idle Ready peer
> exists on that CPU.**

Enforced via the two-pass split in `schedule()`'s picker.

## Regression test

`test_242_sched_picker_non_idle_precedence` spawns 6 PRIORITY_NORMAL
kernel workers that each `sleep_ticks(1)` for ITERS cycles before
exiting.  Each worker writes its actual cycle count to a per-worker
atomic so a starvation regression (where one worker never gets picked)
is caught with a precise diagnostic ("worker[i] tid=X only ran 0
cycles of 12").

## 5-trial KVM firefox-test soak

| Trial | sc(PID 1) | libpng16 | contentproc exit | final-ui | PNG | Plateau |
|---|---|---|---|---|---|---|
| T1 | 2887 | Y | Y | N | N | Steady |
| T2 | 2909 | Y | Y | N | N | Steady |
| T3 | 2913 | Y | Y | N | N | Steady |
| T4 | 2881 | Y | Y | N | N | Steady |
| T5 | 2885 | Y | Y | N | N | Steady |
| Master baseline (control) | 2885 | Y | Y | N | N | Steady |

## Verdict on the W101 demo gate

**The picker fix does not move the demo plateau.**  PID 1 still stalls
at sc ≈ 2885-2913 across 5 trials, essentially identical to the
master-baseline N=1 control (sc=2885).  The invariant and the BSP
yield are both real correctness fixes (POSIX SCHED_OTHER, sched(7)),
but the wedge is downstream of the picker — most likely Mozilla
algorithmic (the cond_var at uaddr 0x7effff4c8c90 has dozens of
workers wake-and-re-park every time TID 2 broadcasts, with only one
actually advancing) rather than a kernel-side scheduling bug.  The
saga's "scheduler-starves-workers" framing in the PSE handoff does not
survive this verification.

The picker invariant should still land — it pins POSIX behaviour the
codebase did not previously enforce in the source, and Test 242 will
catch any future regression — but it should not be billed as the
W101 saga-closer.  The actual next blocker (whatever flips PID 1
forward past sc≈2900) is the next dispatch.

## Test plan

- [x] `scripts/qemu-harness.py check --features firefox-test,kdb` — clean build
- [x] 5-trial KVM firefox-test soak — no regression vs master (within noise)
- [ ] Full kernel test suite — blocked by pre-existing Test 44b (W215 page-aliasing reproducer) systemic bugcheck; Test 242 is queued after Test 241 and would be reached on a clean test-mode boot

## Cite

- POSIX 1003.1-2017 §2.8 (Process Scheduling)
- sched(7) — idle-thread / SCHED_IDLE semantics
- Intel SDM Vol. 3A §8 (SMP preemption boundaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)