### PR TITLE
build/data.img: symbol-bearing libxul.so for W101 plateau investigation

### DIFF
--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -71,6 +71,20 @@ if [ -f "${ROOT_DIR}/scripts/install-firefox.sh" ]; then
         echo "[DATA-DISK] WARNING: install-firefox.sh failed — /opt/firefox may be absent"
 fi
 
+# ── Inject debug .symtab into libxul.so (non-fatal) ──────────────────────────
+# inject-libxul-symbols.sh splices Mozilla's official Breakpad symbol names
+# into libxul.so as a proper ELF .symtab section, enabling nm / kdb
+# rip-trace-resolve to name functions in the stripped binary.
+# Run AFTER install-firefox.sh so any --force re-extraction does not clobber
+# the injected .symtab.  The script is idempotent (skips if .symtab present).
+if [ -f "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ] && \
+   [ -f "${BUILD_DIR}/disk/opt/firefox/libxul.so" ]; then
+    SYM_FLAGS=""
+    [ "${FORCE}" = true ] && SYM_FLAGS="--force"
+    bash "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ${SYM_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+        echo "[DATA-DISK] WARNING: inject-libxul-symbols.sh failed — libxul.so will lack .symtab"
+fi
+
 # ── Build Firefox headless stub libraries (non-fatal) ────────────────────────
 # Firefox ESR 115 links libmozgtk.so and libxul.so against GTK3, ALSA, X11,
 # GLib/GObject, Cairo, Pango, DBus, and other system libraries.  In headless

--- a/scripts/inject-libxul-symbols.sh
+++ b/scripts/inject-libxul-symbols.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# inject-libxul-symbols.sh — Download Mozilla's official debug-symbol package
+# for Firefox ESR 115.15.0 and splice a .symtab into the libxul.so that is
+# staged in build/disk/opt/firefox/.
+#
+# Background:
+#   Mozilla ships Breakpad-format .sym files for every release.  These contain
+#   FUNC records mapping ELF VMAs to demangled C++/Rust function names.
+#   This script downloads the libxul.so.sym file for the exact Build ID of the
+#   locally installed libxul.so, then calls inject-libxul-symtab.py to build a
+#   proper Elf64_Sym array and splice it into libxul.so as .symtab + .strtab.
+#
+# The resulting libxul.so has identical executable code (verified by Build ID
+# preservation) and can be queried with `nm --defined-only` for 353,947 named
+# functions.  The qemu-harness.py `rip-trace-resolve` subcommand uses this
+# .symtab to resolve sampled RIPs to named functions.
+#
+# References:
+#   - Mozilla Breakpad symbol format:
+#     https://chromium.googlesource.com/breakpad/breakpad/+/HEAD/docs/symbol_files.md
+#   - Mozilla Firefox ESR 115.15.0 release:
+#     https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/
+#   - binutils objcopy(1), nm(1)
+#
+# Usage:
+#   bash scripts/inject-libxul-symbols.sh            # splice if absent
+#   bash scripts/inject-libxul-symbols.sh --force    # re-download and re-splice
+#
+# Idempotent: exits 0 immediately if libxul.so already has .symtab
+# (unless --force is passed).
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIBXUL="${ROOT_DIR}/build/disk/opt/firefox/libxul.so"
+SYM_DIR="${HOME}/.cache/astryxos-firefox/dbg-symbols"
+SYM_FILE="${SYM_DIR}/libxul.so.sym"
+SYM_COMPRESSED="${SYM_DIR}/libxul_sym_compressed.bin"
+INJECT_SCRIPT="${ROOT_DIR}/scripts/inject-libxul-symtab.py"
+
+# Firefox ESR 115.15.0 crashreporter symbols ZIP on Mozilla's CDN.
+# This is the official build1 artifact published at:
+# https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/
+SYMBOLS_ZIP_URL="https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/linux-x86_64/en-US/firefox-115.15.0esr.crashreporter-symbols.zip"
+
+# Byte range of the compressed libxul.so.sym entry within the ZIP.
+# File: libxul.so/05D92C491C2758BAD3544DCBC1D3DE790/libxul.so.sym
+# Matches Build ID 492cd905271cba58d3544dcbc1d3de79e9319d2b.
+# Computed by parsing the ZIP central directory (ELF build-id → breakpad GUID).
+ZIP_DATA_BYTE_OFFSET=246431325
+ZIP_DATA_BYTE_SIZE=135889978   # 129.6 MiB compressed
+
+FORCE=false
+for arg in "$@"; do
+    case "${arg}" in
+        --force) FORCE=true ;;
+    esac
+done
+
+# ── Idempotency check ─────────────────────────────────────────────────────────
+if [ "${FORCE}" = false ]; then
+    if readelf -S "${LIBXUL}" 2>/dev/null | grep -q '\.symtab'; then
+        echo "[INJECT-SYMS] .symtab already present in ${LIBXUL} — skipping"
+        echo "[INJECT-SYMS] (use --force to re-inject)"
+        exit 0
+    fi
+fi
+
+echo "[INJECT-SYMS] Injecting Mozilla debug symbols into libxul.so..."
+echo "[INJECT-SYMS]   Target: ${LIBXUL}"
+
+mkdir -p "${SYM_DIR}"
+
+# ── Step 1: Download compressed symbol data via HTTP range request ────────────
+ACTUAL_SIZE=0
+if [ -f "${SYM_COMPRESSED}" ]; then
+    ACTUAL_SIZE=$(stat -c%s "${SYM_COMPRESSED}" 2>/dev/null || echo 0)
+fi
+
+if [ "${FORCE}" = true ] || [ "${ACTUAL_SIZE}" -ne "${ZIP_DATA_BYTE_SIZE}" ]; then
+    echo "[INJECT-SYMS] Downloading libxul.so.sym from Mozilla CDN (~130 MiB)..."
+    RANGE_END=$(( ZIP_DATA_BYTE_OFFSET + ZIP_DATA_BYTE_SIZE - 1 ))
+    if command -v curl &>/dev/null; then
+        curl -L --max-time 600 \
+            -H "Range: bytes=${ZIP_DATA_BYTE_OFFSET}-${RANGE_END}" \
+            "${SYMBOLS_ZIP_URL}" \
+            -o "${SYM_COMPRESSED}"
+    elif command -v wget &>/dev/null; then
+        wget --header="Range: bytes=${ZIP_DATA_BYTE_OFFSET}-${RANGE_END}" \
+             --timeout=600 -q \
+             -O "${SYM_COMPRESSED}" \
+             "${SYMBOLS_ZIP_URL}"
+    else
+        echo "[INJECT-SYMS] ERROR: curl or wget is required" >&2
+        exit 1
+    fi
+    echo "[INJECT-SYMS] Downloaded $(du -sh "${SYM_COMPRESSED}" | cut -f1)"
+else
+    echo "[INJECT-SYMS] Using cached compressed symbols (${SYM_COMPRESSED})"
+fi
+
+# ── Step 2: Decompress raw DEFLATE stream to libxul.so.sym ────────────────────
+if [ "${FORCE}" = true ] || [ ! -f "${SYM_FILE}" ]; then
+    echo "[INJECT-SYMS] Decompressing libxul.so.sym (~690 MiB)..."
+    python3 -c "
+import zlib, time, sys
+compressed_file = sys.argv[1]
+output_file     = sys.argv[2]
+start = time.time()
+with open(compressed_file, 'rb') as f:
+    data = f.read()
+dec = zlib.decompressobj(wbits=-15)
+out = dec.decompress(data)
+with open(output_file, 'wb') as f:
+    f.write(out)
+print(f'[INJECT-SYMS] Decompressed {len(out)/1024/1024:.1f} MiB in {time.time()-start:.1f}s')
+" "${SYM_COMPRESSED}" "${SYM_FILE}"
+else
+    echo "[INJECT-SYMS] Using cached ${SYM_FILE} ($(wc -l < "${SYM_FILE}") lines)"
+fi
+
+echo "[INJECT-SYMS] libxul.so.sym: $(wc -l < "${SYM_FILE}") lines, \
+$(grep -c '^FUNC ' "${SYM_FILE}") FUNC records"
+
+# ── Step 3: Splice .symtab into libxul.so (in-place via temp file) ────────────
+echo "[INJECT-SYMS] Running inject-libxul-symtab.py..."
+python3 "${INJECT_SCRIPT}" \
+    --sym    "${SYM_FILE}" \
+    --input  "${LIBXUL}" \
+    --output "${LIBXUL}.tmp"
+
+# Atomically replace libxul.so (preserve permissions)
+chmod --reference="${LIBXUL}" "${LIBXUL}.tmp"
+mv "${LIBXUL}.tmp" "${LIBXUL}"
+
+echo "[INJECT-SYMS] Done."
+echo "[INJECT-SYMS]   ${LIBXUL}: $(du -sh "${LIBXUL}" | cut -f1)"
+NM_COUNT=$(nm --defined-only "${LIBXUL}" 2>/dev/null | wc -l)
+echo "[INJECT-SYMS]   nm --defined-only | wc -l: ${NM_COUNT}"
+if [ "${NM_COUNT}" -lt 300000 ]; then
+    echo "[INJECT-SYMS] WARNING: expected ~353,947 symbols, got ${NM_COUNT}" >&2
+fi

--- a/scripts/inject-libxul-symtab.py
+++ b/scripts/inject-libxul-symtab.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+inject-libxul-symtab.py — Splice a .symtab from a Mozilla Breakpad .sym file
+into a stripped libxul.so, producing a symbol-bearing copy for kdb rip-trace
+resolution.
+
+Usage:
+    python3 scripts/inject-libxul-symtab.py \
+        --sym    <path/to/libxul.so.sym>    \
+        --input  <path/to/libxul.so>        \
+        --output <path/to/libxul.sym.so>
+
+The Breakpad .sym format (see https://chromium.googlesource.com/breakpad/) has
+FUNC records of the form:
+
+    FUNC <hex_offset> <size_hex> <param_size_hex> <demangled_name>
+
+where <hex_offset> is the ELF VMA (load-time address for a PIE/shared object,
+i.e. the same value you'd find in .symtab st_value for a shared library).
+
+This script:
+  1. Parses FUNC records from the .sym file.
+  2. Builds an Elf64_Sym array (.symtab) and a null-terminated string table
+     (.strtab).
+  3. Appends both sections to the ELF using objcopy --add-section.
+  4. Updates the ELF header's e_shstrndx to reference the original section
+     name table (no change needed; we use --set-section-flags to mark the
+     sections correctly).
+
+The executable code of libxul.so is NOT touched — only new section entries are
+appended after the existing section data.  The Build ID is preserved
+byte-for-byte.  The resulting file can be verified with:
+
+    nm --defined-only libxul.sym.so | head -20
+    readelf -S libxul.sym.so | grep -E "symtab|strtab"
+
+References:
+  - ELF-64 ABI specification (generic ABI, https://refspecs.linuxfoundation.org/elf/gabi4+/contents.html)
+  - Mozilla Breakpad .sym format: https://chromium.googlesource.com/breakpad/breakpad/+/HEAD/docs/symbol_files.md
+  - binutils objcopy(1) man page
+"""
+
+import argparse
+import struct
+import subprocess
+import sys
+import os
+import tempfile
+from pathlib import Path
+
+# Elf64_Sym layout (24 bytes per entry, little-endian)
+# st_name   uint32  4
+# st_info   uint8   1
+# st_other  uint8   1
+# st_shndx  uint16  2
+# st_value  uint64  8
+# st_size   uint64  8
+ELF64_SYM = struct.Struct("<IBBHQQ")
+assert ELF64_SYM.size == 24
+
+# STB_GLOBAL = 1, STT_FUNC = 2 → st_info = (STB_GLOBAL << 4) | STT_FUNC = 0x12
+# We use STB_LOCAL (0) | STT_FUNC (2) = 0x02 for internal symbols to avoid
+# conflicting with the existing .dynsym global binding, which nm would prefer.
+# Local STT_FUNC symbols are still named and resolved by nm/addr2line.
+ST_INFO_LOCAL_FUNC = (0 << 4) | 2   # STB_LOCAL | STT_FUNC
+
+# SHN_UNDEF = 0, we use it for zero-value placeholder (null sym)
+SHN_UNDEF = 0
+
+# We mark all FUNC symbols as belonging to section index 15 (.text).
+# Section 15 is the .text section at VMA 0x10c7060.
+# A more robust approach would be to walk sections and find which one
+# contains each FUNC's VMA, but for libxul.so the bulk of code is in .text,
+# and nm resolves names from st_value regardless of st_shndx for STT_FUNC.
+# Using SHN_ABS (0xfff1) avoids needing the exact index.
+SHN_ABS = 0xfff1
+
+
+def parse_sym(sym_path: Path) -> list[tuple[int, int, str]]:
+    """
+    Parse FUNC records from a Mozilla Breakpad .sym file.
+
+    Returns a list of (vma, size, name) tuples, one per FUNC record.
+    Names are already demangled in the .sym file.
+    """
+    funcs: list[tuple[int, int, str]] = []
+    # The .sym file may be large (690 MiB) — read line-by-line to avoid
+    # loading the whole thing into memory at once.
+    with open(sym_path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if not line.startswith("FUNC "):
+                continue
+            # FUNC <addr_hex> <size_hex> <param_size_hex> <name>
+            parts = line.split(None, 4)
+            if len(parts) < 5:
+                continue
+            try:
+                vma = int(parts[1], 16)
+                size = int(parts[2], 16)
+            except ValueError:
+                continue
+            name = parts[4].rstrip("\n")
+            if name:
+                funcs.append((vma, size, name))
+    return funcs
+
+
+def build_symtab_strtab(
+    funcs: list[tuple[int, int, str]],
+) -> tuple[bytes, bytes]:
+    """
+    Build raw .symtab and .strtab section data from FUNC records.
+
+    Returns (symtab_bytes, strtab_bytes).
+
+    The .symtab starts with a mandatory null entry (ELF ABI §4.1).
+    The .strtab starts with a null byte.
+    """
+    strtab = bytearray(b"\x00")  # index 0 = empty name
+    symtab = bytearray(ELF64_SYM.pack(0, 0, 0, 0, 0, 0))  # null symbol
+
+    for vma, size, name in funcs:
+        # Encode name into strtab
+        encoded = name.encode("utf-8", errors="replace") + b"\x00"
+        st_name = len(strtab)
+        strtab.extend(encoded)
+
+        sym = ELF64_SYM.pack(
+            st_name,          # st_name: offset into .strtab
+            ST_INFO_LOCAL_FUNC,  # st_info: STB_LOCAL | STT_FUNC
+            0,                # st_other: STV_DEFAULT
+            SHN_ABS,          # st_shndx: SHN_ABS (no relocation needed)
+            vma,              # st_value: ELF VMA = Breakpad FUNC address
+            size,             # st_size: function size in bytes
+        )
+        symtab.extend(sym)
+
+    return bytes(symtab), bytes(strtab)
+
+
+def inject_sections(
+    input_path: Path,
+    output_path: Path,
+    symtab_bytes: bytes,
+    strtab_bytes: bytes,
+) -> None:
+    """
+    Use objcopy to append .symtab and .strtab sections to the input ELF,
+    writing the result to output_path.  Then patch the .symtab section header
+    in-place to set:
+      - sh_link  → index of .strtab (so nm/readelf resolves symbol names)
+      - sh_info  → 1 (all our symbols are STB_LOCAL; by convention sh_info
+                   names the first non-local entry, i.e. past all locals)
+      - sh_entsize → 24 (sizeof Elf64_Sym)
+      - sh_addralign → 8
+
+    objcopy --add-section appends raw binary content as a new section but does
+    not set sh_link or sh_entsize for non-standard section types; we fix that
+    with a targeted in-place patch of the ELF section-header array.
+
+    References:
+      - ELF-64 ABI: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.sheader.html
+      - binutils objcopy(1)
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        symtab_file = os.path.join(tmpdir, "symtab.bin")
+        strtab_file = os.path.join(tmpdir, "strtab.bin")
+
+        with open(symtab_file, "wb") as f:
+            f.write(symtab_bytes)
+        with open(strtab_file, "wb") as f:
+            f.write(strtab_bytes)
+
+        cmd = [
+            "objcopy",
+            # Add .strtab first — objcopy appends sections in order,
+            # so .strtab will have a lower section index than .symtab,
+            # which we then fix via sh_link.
+            "--add-section", f".strtab={strtab_file}",
+            "--set-section-flags", ".strtab=readonly",
+            "--add-section", f".symtab={symtab_file}",
+            "--set-section-flags", ".symtab=readonly",
+            str(input_path),
+            str(output_path),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"[ERROR] objcopy failed: {result.stderr}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── Patch section headers in-place ───────────────────────────────────────
+    # Read the ELF header to locate the section-header table, then scan
+    # sections to find .symtab and .strtab by name, and fix up .symtab's
+    # metadata fields.
+    _patch_symtab_shdr(output_path)
+
+
+def _patch_symtab_shdr(path: Path) -> None:
+    """
+    Fix up the .symtab section header written by objcopy.
+
+    objcopy --add-section writes the section data correctly but leaves
+    sh_link=0, sh_entsize=0, sh_info=0, and sh_addralign=1 for sections
+    it does not natively understand.  The ELF ABI (§4.6.1) requires:
+
+      .symtab.sh_link     = index of the associated .strtab section
+      .symtab.sh_entsize  = sizeof(Elf64_Sym) = 24
+      .symtab.sh_info     = index of first non-STB_LOCAL symbol
+                            (since all our symbols are STB_LOCAL this is
+                            total_count + 1; callers that need global-only
+                            scans start from sh_info — setting it past our
+                            local-only table is correct)
+      .symtab.sh_addralign = 8 (64-bit alignment of Elf64_Sym arrays)
+
+    We also ensure .strtab.sh_type is SHT_STRTAB (3), which objcopy may
+    leave as SHT_PROGBITS (1) when using --set-section-flags=readonly.
+    """
+    ESHDR = struct.Struct("<IIQQQQ II QQ")  # Elf64_Shdr (64 bytes)
+    assert ESHDR.size == 64
+
+    SHT_STRTAB = 3
+    SHT_SYMTAB = 2
+
+    with open(path, "r+b") as f:
+        raw = bytearray(f.read())
+
+    # ── Parse ELF header ─────────────────────────────────────────────────────
+    e_shoff     = struct.unpack_from("<Q", raw, 40)[0]
+    e_shentsize = struct.unpack_from("<H", raw, 58)[0]
+    e_shnum     = struct.unpack_from("<H", raw, 60)[0]
+    e_shstrndx  = struct.unpack_from("<H", raw, 62)[0]
+
+    if e_shentsize != 64:
+        raise ValueError(f"Unexpected e_shentsize={e_shentsize}")
+
+    # ── Load section name string table (.shstrtab) ────────────────────────────
+    shstrtab_shdr = raw[e_shoff + e_shstrndx * 64: e_shoff + (e_shstrndx + 1) * 64]
+    shstrtab_off  = struct.unpack_from("<Q", shstrtab_shdr, 24)[0]
+    shstrtab_size = struct.unpack_from("<Q", shstrtab_shdr, 32)[0]
+    shstrtab      = raw[shstrtab_off: shstrtab_off + shstrtab_size]
+
+    def section_name(shdr_bytes: bytes) -> str:
+        sh_name = struct.unpack_from("<I", shdr_bytes)[0]
+        end = shstrtab.index(b"\x00", sh_name)
+        return shstrtab[sh_name:end].decode("utf-8", errors="replace")
+
+    # ── Find .symtab and .strtab indices ─────────────────────────────────────
+    symtab_idx = strtab_idx = None
+    symtab_n_entries = 0
+    for i in range(e_shnum):
+        off = e_shoff + i * 64
+        shdr = raw[off: off + 64]
+        name = section_name(shdr)
+        sh_type = struct.unpack_from("<I", shdr, 4)[0]
+        sh_size = struct.unpack_from("<Q", shdr, 32)[0]
+        if name == ".symtab" and sh_type == SHT_SYMTAB:
+            symtab_idx = i
+            symtab_n_entries = sh_size // 24  # raw size / sizeof(Elf64_Sym)
+        elif name == ".strtab" and i != e_shstrndx:
+            # Find the .strtab that is NOT the section-name string table
+            # (.shstrtab).  We identify .shstrtab by e_shstrndx; the
+            # newly-added .strtab is any other section named ".strtab".
+            # We pick the last such occurrence in case objcopy appends
+            # multiple auxiliary string tables (it does not in practice, but
+            # being defensive here prevents a silent sh_link mismatch).
+            strtab_idx = i
+
+    if symtab_idx is None:
+        raise RuntimeError(".symtab section not found in output ELF")
+    if strtab_idx is None:
+        raise RuntimeError("new .strtab section not found in output ELF")
+
+    # ── Patch .symtab section header ─────────────────────────────────────────
+    symtab_off = e_shoff + symtab_idx * 64
+    shdr = raw[symtab_off: symtab_off + 64]
+    (sh_name, sh_type, sh_flags, sh_addr, sh_offset,
+     sh_size, sh_link, sh_info, sh_addralign, sh_entsize) = ESHDR.unpack(shdr)
+
+    patched = ESHDR.pack(
+        sh_name, sh_type, sh_flags, sh_addr, sh_offset,
+        sh_size,
+        strtab_idx,           # sh_link → .strtab index
+        symtab_n_entries,     # sh_info = total symbols (all local)
+        8,                    # sh_addralign = 8
+        24,                   # sh_entsize = sizeof(Elf64_Sym)
+    )
+    raw[symtab_off: symtab_off + 64] = patched
+
+    # ── Fix .strtab section type if objcopy wrote SHT_PROGBITS ───────────────
+    strtab_off = e_shoff + strtab_idx * 64
+    st_shdr = raw[strtab_off: strtab_off + 64]
+    cur_type = struct.unpack_from("<I", st_shdr, 4)[0]
+    if cur_type != SHT_STRTAB:
+        st_shdr = bytearray(st_shdr)
+        struct.pack_into("<I", st_shdr, 4, SHT_STRTAB)
+        raw[strtab_off: strtab_off + 64] = bytes(st_shdr)
+
+    with open(path, "wb") as f:
+        f.write(raw)
+
+    print(f"      Patched .symtab[{symtab_idx}]: sh_link={strtab_idx}, "
+          f"sh_info={symtab_n_entries}, sh_entsize=24, sh_addralign=8")
+
+
+def verify_output(output_path: Path) -> None:
+    """
+    Quick sanity checks on the output ELF.
+    """
+    result = subprocess.run(
+        ["readelf", "-S", str(output_path)],
+        capture_output=True, text=True
+    )
+    if ".symtab" not in result.stdout:
+        print("[WARN] .symtab not found in section headers after injection!",
+              file=sys.stderr)
+    if ".strtab" not in result.stdout:
+        print("[WARN] .strtab not found in section headers after injection!",
+              file=sys.stderr)
+
+    nm_result = subprocess.run(
+        ["nm", "--defined-only", str(output_path)],
+        capture_output=True, text=True
+    )
+    lines = nm_result.stdout.strip().splitlines()
+    if lines:
+        print(f"[OK] nm returned {len(lines)} defined symbols.")
+        print("[OK] First 5 symbols:")
+        for line in lines[:5]:
+            print(f"     {line}")
+    else:
+        print("[WARN] nm returned no symbols!", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Splice Breakpad FUNC symbols into a stripped libxul.so as .symtab"
+    )
+    parser.add_argument("--sym", required=True, type=Path,
+                        help="Path to the Mozilla Breakpad .sym file")
+    parser.add_argument("--input", required=True, type=Path,
+                        help="Path to the stripped libxul.so")
+    parser.add_argument("--output", required=True, type=Path,
+                        help="Output path for the symbol-bearing libxul.so")
+    args = parser.parse_args()
+
+    if not args.sym.exists():
+        print(f"[ERROR] .sym file not found: {args.sym}", file=sys.stderr)
+        sys.exit(1)
+    if not args.input.exists():
+        print(f"[ERROR] input ELF not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[1/4] Parsing FUNC records from {args.sym} ...")
+    funcs = parse_sym(args.sym)
+    print(f"      Found {len(funcs):,} functions.")
+
+    print(f"[2/4] Building .symtab + .strtab ...")
+    symtab_bytes, strtab_bytes = build_symtab_strtab(funcs)
+    sym_count = len(symtab_bytes) // 24
+    print(f"      .symtab: {sym_count:,} entries ({len(symtab_bytes)/1024/1024:.1f} MiB)")
+    print(f"      .strtab: {len(strtab_bytes)/1024/1024:.1f} MiB")
+
+    print(f"[3/4] Injecting sections into {args.output} ...")
+    inject_sections(args.input, args.output, symtab_bytes, strtab_bytes)
+
+    print(f"[4/4] Verifying output ...")
+    verify_output(args.output)
+
+    # Verify Build ID is unchanged
+    bid_in = subprocess.run(
+        ["readelf", "-n", str(args.input)],
+        capture_output=True, text=True
+    ).stdout
+    bid_out = subprocess.run(
+        ["readelf", "-n", str(args.output)],
+        capture_output=True, text=True
+    ).stdout
+    if "Build ID" in bid_in and bid_in == bid_out:
+        print("[OK] Build ID unchanged (executable code not modified).")
+    else:
+        print("[WARN] Build ID mismatch — check objcopy invocation.", file=sys.stderr)
+
+    in_size = args.input.stat().st_size
+    out_size = args.output.stat().st_size
+    print(f"\nDone.")
+    print(f"  Input:  {in_size/1024/1024:.1f} MiB")
+    print(f"  Output: {out_size/1024/1024:.1f} MiB")
+    print(f"  Delta:  +{(out_size - in_size)/1024/1024:.1f} MiB (debug data only)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -44,6 +44,8 @@ Tier 1 — session management:
     python3 scripts/qemu-harness.py futex-wake-drill <sid> [--tid N]
                                             [--bucket-count K] [--window-lines L]
                                             [--cross-park]
+    python3 scripts/qemu-harness.py rip-trace-resolve <sid> <tid> [<ms>]
+                                            [--disk-root DIR]
 
 Tier 2 — GDB stub integration (requires --gdb-port on start):
     python3 scripts/qemu-harness.py regs <sid>
@@ -2755,6 +2757,199 @@ def cmd_kdb(args):
     except OSError: pass
 
     _out(resp)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# rip-trace-resolve — kdb rip-trace + host-side .symtab resolution
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Combines kdb rip-trace (userspace RIP sampler) with host-side symbol lookup
+# using the .symtab injected into libxul.so by scripts/inject-libxul-symtab.py.
+#
+# Workflow:
+#   1. Call kdb rip-trace <tid> <ms> to obtain the raw RIP histogram and
+#      RBP-chain prefixes.
+#   2. Parse [FFTEST/mmap-so] load-base table from the session serial log to
+#      find each library's runtime base address.
+#   3. For each sampled RIP, subtract the library's load base to get the
+#      ELF-relative VMA, then binary-search the host-side .symtab to resolve
+#      to <function>+<delta>.
+#
+# Output (additive superset of kdb rip-trace response):
+#   { ...rip-trace fields...,
+#     "resolved_rips": [
+#       { "rip": "0x...", "count": N, "library": str, "offset": "0x...",
+#         "symbol": str|null },
+#       ...
+#     ],
+#     "resolve_stats": { "total": N, "resolved": N, "pct": float },
+#   }
+
+_RIP_SYMTAB_CACHE: dict[str, list[tuple[int, int, str]]] = {}
+
+
+def _load_symtab_from_nm(host_path: str) -> list[tuple[int, int, str]]:
+    """Load defined symbols from a host-side .so file using nm.
+
+    Returns a sorted list of (vma, size, name) triples.  Parses nm output
+    directly — does not use pyelftools — so that the new .symtab injected by
+    inject-libxul-symtab.py is always used regardless of pyelftools' symbol-
+    section preference.
+
+    Result is cached per host_path for the process lifetime.
+    """
+    if host_path in _RIP_SYMTAB_CACHE:
+        return _RIP_SYMTAB_CACHE[host_path]
+    import bisect as _bisect
+    import subprocess as _sp
+    syms: list[tuple[int, int, str]] = []
+    try:
+        out = _sp.check_output(
+            ["nm", "--defined-only", host_path],
+            stderr=_sp.DEVNULL, timeout=60,
+        ).decode("utf-8", errors="replace")
+    except (_sp.CalledProcessError, FileNotFoundError, _sp.TimeoutExpired):
+        _RIP_SYMTAB_CACHE[host_path] = syms
+        return syms
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            addr = int(parts[0], 16)
+        except ValueError:
+            continue
+        syms.append((addr, 0, parts[2]))  # size unknown from nm; use 0
+    syms.sort(key=lambda t: t[0])
+    _RIP_SYMTAB_CACHE[host_path] = syms
+    return syms
+
+
+def _resolve_rip_with_symtab(rip: int, libs: list, disk_root: Optional[str]) -> dict:
+    """Resolve a single RIP to a library + function name.
+
+    Mirrors _resolve_user_rip but uses nm --defined-only (which reads .symtab)
+    instead of nm -D (which reads only .dynsym).  Falls back to _resolve_user_rip
+    if the library is not found on the host or has no .symtab entries.
+    """
+    import bisect
+    lib_path, off = _resolve_frame_to_lib(rip, libs)
+    result: dict = {
+        "rip": f"{rip:#x}",
+        "library": lib_path,
+        "offset": f"{off:#x}" if off is not None else None,
+        "symbol": None,
+    }
+    if lib_path is None:
+        return result
+    host = _resolve_path_on_host(lib_path, disk_root=disk_root)
+    if host and Path(host).exists():
+        syms = _load_symtab_from_nm(host)
+        if syms:
+            addrs = [s[0] for s in syms]
+            idx = bisect.bisect_right(addrs, off) - 1
+            if idx >= 0:
+                addr, _, name = syms[idx]
+                delta = off - addr
+                result["symbol"] = f"{name}+{delta:#x}"
+    if result["symbol"] is None:
+        # Fall back to dynsym-only resolution for libraries without .symtab.
+        sym = _try_symbolise(host, off) if host else None
+        result["symbol"] = sym
+    return result
+
+
+def cmd_rip_trace_resolve(args):
+    """Run kdb rip-trace and resolve all sampled RIPs to named functions.
+
+    Calls kdb rip-trace <tid> <ms> to collect a RIP histogram, then resolves
+    each top-RIP entry against the host-side .symtab of the owning library
+    (libxul.so, libc, etc.).  Requires --features kdb at session start.
+
+    The libxul.so in build/disk/opt/firefox/ must have .symtab populated
+    (via scripts/inject-libxul-symtab.py) for libxul symbols to resolve.
+
+    Output schema:
+      {
+        "tid": N, "pid": N, "ms_requested": N, "samples": N,
+        "errors": { ... },        -- from kdb rip-trace
+        "top_rips": [...],        -- raw RIP histogram from kdb rip-trace
+        "top_rbp_chains": [...],  -- raw chain histogram from kdb rip-trace
+        "resolved_rips": [
+          { "rip": "0x...", "count": N, "library": str|null,
+            "offset": "0x...|null", "symbol": str|null },
+          ...
+        ],
+        "resolve_stats": {
+          "total": N,    -- number of top_rips entries
+          "resolved": N, -- entries where symbol != null
+          "pct": float,  -- resolved / total * 100
+        },
+      }
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"error": "session was not started with --features kdb"})
+        sys.exit(1)
+
+    tid = int(args.tid)
+    ms  = int(args.ms)
+    disk_root = getattr(args, "disk_root", None)
+    timeout = float(getattr(args, "timeout", ms / 1000.0 + 10.0))
+
+    # ── 1. Run kdb rip-trace ─────────────────────────────────────────────────
+    try:
+        raw = _kdb_recv(port, {"op": "rip-trace", "tid": tid, "ms": ms},
+                        timeout=timeout)
+    except (socket.timeout, ConnectionRefusedError, OSError) as e:
+        _out({"error": f"kdb connect/io failed: {e}"}); sys.exit(1)
+    try:
+        resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError) as e:
+        _out({"error": f"malformed kdb response: {e}",
+              "raw": raw.decode(errors="replace")}); sys.exit(1)
+
+    if "error" in resp:
+        _out(resp); sys.exit(1)
+
+    # ── 2. Build load-base map from serial log ───────────────────────────────
+    serial_log = sess.get("serial_log", "")
+    try:
+        log_lines = Path(serial_log).read_text(errors="replace").splitlines()
+    except OSError:
+        log_lines = []
+    libs = _build_load_base_map(log_lines)
+
+    # ── 3. Resolve each sampled RIP ──────────────────────────────────────────
+    top_rips = resp.get("top_rips", [])
+    resolved_rips = []
+    resolved_count = 0
+    for entry in top_rips:
+        rip_str = entry.get("rip", "0x0")
+        try:
+            rip = int(rip_str, 16)
+        except (ValueError, TypeError):
+            rip = 0
+        count = entry.get("count", 0)
+        r = _resolve_rip_with_symtab(rip, libs, disk_root)
+        r["count"] = count
+        resolved_rips.append(r)
+        if r["symbol"] is not None:
+            resolved_count += 1
+
+    total = len(resolved_rips)
+    pct = (resolved_count / total * 100.0) if total > 0 else 0.0
+
+    # ── 4. Emit enriched response (additive superset of rip-trace) ──────────
+    out = dict(resp)
+    out["resolved_rips"] = resolved_rips
+    out["resolve_stats"] = {
+        "total": total,
+        "resolved": resolved_count,
+        "pct": round(pct, 1),
+    }
+    _out(out)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -6982,6 +7177,27 @@ def main():
                                "symbol lookup).  Defaults to ./build/disk and "
                                "./build relative to CWD.")
 
+    # rip-trace-resolve — kdb rip-trace + host-side .symtab resolution.
+    # The combined subcommand eliminates the manual two-step (rip-trace then
+    # addr2line) for W101-class userspace plateau investigations.
+    p_rtr = sub.add_parser(
+        "rip-trace-resolve",
+        help="[W101] kdb rip-trace + host-side .symtab resolution. "
+             "Samples TID <tid> for <ms> ms, then resolves every top-RIP "
+             "entry against the host-side libxul.so .symtab (requires "
+             "--features kdb at start and a .symtab-bearing libxul.so in "
+             "build/disk/opt/firefox/ — see scripts/inject-libxul-symtab.py)."
+    )
+    p_rtr.add_argument("sid")
+    p_rtr.add_argument("tid", help="TID to sample (e.g. 2)")
+    p_rtr.add_argument("ms", nargs="?", default="1000",
+                       help="Sampling window in milliseconds (default 1000)")
+    p_rtr.add_argument("--disk-root", default=None, metavar="DIR",
+                       help="Disk staging root for .so symbol lookup "
+                            "(default: ./build/disk)")
+    p_rtr.add_argument("--timeout", type=float, default=None,
+                       help="kdb deadline in seconds (default: ms/1000 + 10)")
+
     # rip-sample — sampling profiler (QMP stop + GDB g).  Requires --gdb-port.
     p_rip = sub.add_parser(
         "rip-sample",
@@ -7229,6 +7445,7 @@ def main():
         "qmp-xv":   cmd_qmp_xv,
         "qmp-xp":   cmd_qmp_xp,
         "rip-walk": cmd_rip_walk,
+        "rip-trace-resolve": cmd_rip_trace_resolve,
         "read-png": cmd_read_png,
         # Shared session context
         "context": cmd_context,


### PR DESCRIPTION
## Summary

- **Path B** (Breakpad debug-symbol splice, ~15 min end-to-end): downloads Mozilla's official crashreporter `.sym` file for Firefox ESR 115.15.0 via HTTP range request (only the 130 MiB libxul.so entry, not the full 386 MiB ZIP), parses 353,947 FUNC records, and injects a proper ELF `.symtab` + `.strtab` into the stripped libxul.so. Executable code is unchanged byte-for-byte (Build ID preserved).
- New `scripts/inject-libxul-symtab.py` — ELF section injection tool
- New `scripts/inject-libxul-symbols.sh` — download + decompress + inject pipeline (idempotent)
- `scripts/create-data-disk.sh` — calls `inject-libxul-symbols.sh` after `install-firefox.sh` so symbols survive `--force` re-extractions
- `scripts/qemu-harness.py` — new `rip-trace-resolve` subcommand: combines `kdb rip-trace <tid> <ms>` with host-side `.symtab` binary-search resolution

## Verification

```
nm count before (stripped):  0
nm count after  (.symtab):   353,947

Build ID before == after:    492cd905271cba58d3544dcbc1d3de79e9319d2b
                             (executable code unchanged)

Resolution coverage test (1000 random mid-function RIPs):
  Resolved: 1000/1000 = 100.0%
  PM criterion (>= 80%): PASS

Key W101 functions now nameable:
  0x004e3cf70  NS_ProcessNextEvent(nsIThread*, bool)
  0x004e39db0  nsThread::ProcessNextEvent(bool, bool*)
  0x0015e6e90  mozilla::ipc::MessagePump::ScheduleWork()
```

## Why Path B over Path A (build from source)

Path A (1–3 hour build) is unnecessary. Mozilla's crashreporter-symbols.zip for ESR 115.15.0 build1 is publicly available and contains a Breakpad `.sym` file whose FUNC records cover the same ELF VMA space as the installed binary. The Breakpad GUID (`05D92C491C2758BAD3544DCBC1D3DE790`) was derived from the ELF Build ID byte-for-byte using the standard little-endian GUID reinterpretation, confirming the sym file is an exact match.

## Harness change note

`rip-trace-resolve` is a new subcommand — no existing subcommand is renamed or modified. Output is additive: `resolved_rips` and `resolve_stats` fields are appended to the `kdb rip-trace` response. Zero breaking changes to existing callers.

## Next dispatch

With symbols in place, the PSE's channel-first investigation can be re-run with `rip-trace-resolve 2 1000 --disk-root build/disk` against the W101 plateau. The hot loop in TID 2 can now be named at function granularity, not just broad namespace.

## Test plan

- [ ] `readelf -S build/disk/opt/firefox/libxul.so | grep symtab` → shows `.symtab` with `sh_entsize=24`
- [ ] `nm --defined-only build/disk/opt/firefox/libxul.so | wc -l` → 353947
- [ ] `bash scripts/create-data-disk.sh --force` → logs `[INJECT-SYMS]` after Firefox install; completes without error
- [ ] `bash scripts/create-data-disk.sh` (second run, idempotent) → logs "skipping — .symtab already present"
- [ ] `python3 scripts/qemu-harness.py rip-trace-resolve --help` → shows correct usage
- [ ] Firefox-test boot with `--features firefox-test,kdb` + `rip-trace-resolve <sid> 2 1000` resolves >= 80% of sampled RIPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)