### PR TITLE
scripts/qemu-harness: handle --timeout None safely in rip-trace-resolve

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2896,7 +2896,8 @@ def cmd_rip_trace_resolve(args):
     tid = int(args.tid)
     ms  = int(args.ms)
     disk_root = getattr(args, "disk_root", None)
-    timeout = float(getattr(args, "timeout", ms / 1000.0 + 10.0))
+    timeout_val = getattr(args, "timeout", None)
+    timeout = float(timeout_val) if timeout_val is not None else (ms / 1000.0 + 10.0)
 
     # ── 1. Run kdb rip-trace ─────────────────────────────────────────────────
     try:


### PR DESCRIPTION
## Summary

Tiny hygiene fix surfaced during the W101 PSE saga: `rip-trace-resolve` was calling `float(args.timeout)` with `timeout=None` (argparse stores `None` when `--timeout` is absent because the parser default is `None`), which raised `TypeError`.

The original code used `getattr(args, "timeout", default)` — but argparse always *creates* the attribute (and sets it to `None`), so `getattr`'s default never applied.

## Fix

Explicit None-check so the per-call default `(ms/1000 + 10s)` is used whether the attribute is missing OR `None`:

```python
timeout_val = getattr(args, "timeout", None)
timeout = float(timeout_val) if timeout_val is not None else (ms / 1000.0 + 10.0)
```

2 insertions, 1 deletion in `scripts/qemu-harness.py::cmd_rip_trace_resolve`. No behaviour change for callers that pass `--timeout <N>`.

(Note: sibling `cmd_rip_trace_sym` already uses the safer `or default` pattern.)

## Test plan

- [x] Reproduced TypeError on `rip-trace-resolve <sid> 2 1000` without `--timeout`
- [x] Confirmed fix: same invocation now uses the default 11s window