### PR TITLE
kernel/proc/elf+usermode+syscall: musl libc ABI compatibility (W101 Option 3)

### DIFF
--- a/kernel/src/proc/elf.rs
+++ b/kernel/src/proc/elf.rs
@@ -796,18 +796,56 @@ pub fn load_elf_with_args(data: &[u8], cr3: u64, argv: &[&str], envp: &[&str]) -
     }
 
     // ── Apply DT_RELR packed relative relocations (PIE + ASLR) ─────────
+    //
     // For ET_DYN with ASLR, all stored absolute pointers in .got/.data need
-    // to be adjusted by pie_bias.  The DT_RELR table encodes which slots to
-    // patch.  ET_EXEC binaries (pie_bias==0) need no patching.
-    if pie_bias != 0 {
+    // the load bias added.  The DT_RELR table encodes which slots to patch.
+    //
+    // CRITICAL ABI INVARIANT — only patch a STATIC PIE binary (no PT_INTERP):
+    //
+    //   Real Linux NEVER applies DT_RELR (or any relocations) to a
+    //   dynamically-linked ET_DYN binary.  The dynamic linker
+    //   (ld-linux-x86-64.so.2 / ld-musl-x86_64.so.1) applies DT_RELR itself
+    //   as part of `_dl_relocate_object` / `do_relr_relocs`, after running
+    //   its own bootstrap.  See:
+    //     * musl ldso/dynlink.c — `do_relr_relocs` (called from `reloc_all`)
+    //     * glibc elf/dl-reloc.c — `elf_dynamic_do_Rel*` path
+    //   ELF gABI says DT_REL* tables describe relocations to be performed
+    //   by the dynamic linker, not the kernel.
+    //
+    //   If the kernel also applies DT_RELR, each covered slot ends up with
+    //   `bias + bias + link_time_value` instead of `bias + link_time_value`
+    //   — the value's high bits land in the non-canonical / unmapped range
+    //   and the first indirect call through any such slot (init_array
+    //   entry, vtable, function-pointer table in .data.rel.ro) faults.
+    //
+    //   Static PIE binaries (ET_DYN with NO PT_INTERP) embed their own
+    //   `_dlstart` in `crt1.o` that self-applies relocations.  For those,
+    //   the kernel is the only relocator — we still need to apply DT_RELR.
+    //
+    //   ET_EXEC (pie_bias==0) and static PIE without DT_RELR are no-ops via
+    //   the guard inside `apply_relr_relocations`.
+    let is_static_pie = interp_path.is_none();
+    if pie_bias != 0 && is_static_pie {
         let (relr_off, relr_sz, _has_gnu_hash) =
             parse_dynamic_for_relr(data, header, 0 /* link-time bias = 0 for ET_DYN */);
         if relr_sz > 0 {
             crate::serial_println!(
-                "[ELF] DT_RELR: applying {} bytes at file offset {:#x} with bias={:#x}",
+                "[ELF] DT_RELR: applying {} bytes at file offset {:#x} with bias={:#x} (static PIE)",
                 relr_sz, relr_off, pie_bias
             );
             apply_relr_relocations(data, relr_off, relr_sz, pie_bias, &mapped_pages);
+        }
+    } else if pie_bias != 0 && interp_path.is_some() {
+        // Dynamic PIE: log that we are deliberately skipping kernel-side
+        // DT_RELR so post-mortem diagnostics can distinguish "skipped" from
+        // "no DT_RELR present".
+        let (_relr_off, relr_sz, _) =
+            parse_dynamic_for_relr(data, header, 0);
+        if relr_sz > 0 {
+            crate::serial_println!(
+                "[ELF] DT_RELR: deferring {} bytes to dynamic linker (PT_INTERP present)",
+                relr_sz
+            );
         }
     }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -119,6 +119,32 @@ pub struct ForkUserRegs {
     pub r13: u64,
     pub r14: u64,
     pub r15: u64,
+    /// Parent's R9 at the syscall site.
+    ///
+    /// musl libc's `__clone` (clone2 ABI, x86-64) stashes the thread entry
+    /// function pointer in R9 across the `syscall` instruction:
+    ///
+    /// ```text
+    ///   mov    %rdi,%r11        // r11 = func (caller's rdi)
+    ///   mov    %rdx,%rdi        // ...
+    ///   mov    %r11,%r9         // r9  = func (preserved across syscall)
+    ///   syscall                  // → kernel
+    ///   test   %eax,%eax
+    ///   jnz    1f
+    ///   xor    %ebp,%ebp
+    ///   pop    %rdi              // arg from new stack
+    ///   call   *%r9              // ← must hold parent's R9 (= func)
+    /// ```
+    ///
+    /// Per POSIX clone(2) and the Linux kernel x86-64 syscall ABI, all
+    /// caller-saved registers except RAX/RCX/R11 must survive a syscall
+    /// in both the parent and child paths.  Linux's `start_thread` for a
+    /// clone child returns from the syscall via IRETQ with the parent's
+    /// register snapshot intact (RAX zeroed for the child).  When the
+    /// kernel zeros R9 in the child, musl's `call *%r9` jumps to NULL.
+    ///
+    /// See: <https://git.musl-libc.org/cgit/musl/tree/src/thread/x86_64/clone.s>
+    pub r9: u64,
 }
 
 pub struct Thread {

--- a/kernel/src/proc/usermode.rs
+++ b/kernel/src/proc/usermode.rs
@@ -39,6 +39,16 @@ pub fn create_user_thread(
         procs.iter().find(|p| p.pid == pid)?.cr3
     };
 
+    // Capture the parent's caller-saved register snapshot from the syscall
+    // entry frame.  The child of clone(CLONE_THREAD) must observe the same
+    // R9 (and callee-saves) the parent had at the syscall instruction so
+    // that musl's `__clone` epilogue can dispatch through R9 to the entry
+    // function.  For brand-new processes (which never hit this function)
+    // this would still be valid — they all observe whatever was on the
+    // syscall stack.  See `crate::syscall::read_fork_user_regs` and the
+    // doc on `ForkUserRegs::r9`.
+    let parent_regs = crate::syscall::read_fork_user_regs();
+
     // Populate the run-time fields and mark the thread Ready in one lock region.
     {
         let mut threads = THREAD_TABLE.lock();
@@ -49,13 +59,14 @@ pub fn create_user_thread(
             t.user_entry_r8  = entry_r8;
             t.tls_base       = tls;
             t.context.cr3    = cr3;
+            t.fork_user_regs = parent_regs;
             t.state          = proc::ThreadState::Ready; // safe to schedule now
         }
     }
 
     crate::serial_println!(
-        "[USER] Created clone thread TID {} in PID {}: RIP={:#x} RSP={:#x} TLS={:#x} RDX={:#x} R8={:#x}",
-        tid, pid, user_rip, user_rsp, tls, entry_rdx, entry_r8
+        "[USER] Created clone thread TID {} in PID {}: RIP={:#x} RSP={:#x} TLS={:#x} RDX={:#x} R8={:#x} R9={:#x}",
+        tid, pid, user_rip, user_rsp, tls, entry_rdx, entry_r8, parent_regs.r9
     );
     Some(tid)
 }
@@ -409,6 +420,7 @@ pub unsafe extern "C" fn jump_to_user_mode(
         //
         // ForkUserRegs layout (#[repr(C)] — see proc/mod.rs):
         //   +0  = rbp, +8  = rbx, +16 = r12, +24 = r13, +32 = r14, +40 = r15
+        //   +48 = r9 (parent's R9 at syscall site — musl __clone func pointer)
         //
         // Build IRETQ frame.
         "push 0x1B",        // SS = USER_DATA_SELECTOR
@@ -429,13 +441,18 @@ pub unsafe extern "C" fn jump_to_user_mode(
         "mov r13, [r9 + 24]",    // ForkUserRegs.r13
         "mov r14, [r9 + 32]",    // ForkUserRegs.r14
         "mov r15, [r9 + 40]",    // ForkUserRegs.r15
+        // R9 must be loaded LAST because it is also our pointer to ForkUserRegs.
+        // For brand-new processes the saved value is zero, preserving the old
+        // info-leak protection.  For clone(CLONE_THREAD) children this carries
+        // the parent's R9 = musl `__clone` entry-function pointer.
+        // See ForkUserRegs::r9 doc comment.
+        "mov r9, [r9 + 48]",     // ForkUserRegs.r9
         // Zero the remaining caller-saved regs that might still hold kernel data.
-        // RDX and R8 already hold the values the child expects to see.
+        // RDX, R8, and R9 already hold the values the child expects to see.
         "xor eax, eax",
         "xor esi, esi",
         "xor edi, edi",
         "xor ecx, ecx",
-        "xor r9d, r9d",
         "xor r10d, r10d",
         "xor r11d, r11d",
         "iretq",

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -6800,7 +6800,26 @@ pub fn sys_futex_linux(
         Relative(u64),        // duration in nanoseconds
         AlreadyExpired,       // absolute deadline in the past
     }
-    let timeout_ns = if timeout_ptr == 0 {
+    // Per futex(2): the `timeout` argument is only consulted for operations
+    // that actually park the caller (WAIT, WAIT_BITSET, LOCK_PI, WAIT_REQUEUE_PI).
+    // For wake-class ops (WAKE, WAKE_OP, WAKE_BITSET, REQUEUE, CMP_REQUEUE,
+    // UNLOCK_PI, TRYLOCK_PI) the 4th syscall argument is reused as a count
+    // or comparison value and MUST NOT be dereferenced as a pointer — musl's
+    // pthread_cond_signal passes a non-zero non-pointer in this slot, so a
+    // blanket dereference here faults on a small integer (e.g. 0x8).
+    //
+    // Mainline Linux uses the same gate: `kernel/futex/syscalls.c` only
+    // calls `get_timespec64()` from the WAIT/LOCK_PI/WAIT_REQUEUE_PI paths,
+    // never from the WAKE paths.  See futex(2) "TIMEOUTS".
+    const FUTEX_OPS_WITH_TIMEOUT: [u64; 5] = [
+        0,  // FUTEX_WAIT
+        9,  // FUTEX_WAIT_BITSET
+        6,  // FUTEX_LOCK_PI
+        8,  // FUTEX_WAIT_REQUEUE_PI
+        11, // FUTEX_LOCK_PI2
+    ];
+    let timeout_consumed_by_op = FUTEX_OPS_WITH_TIMEOUT.contains(&op);
+    let timeout_ns = if timeout_ptr == 0 || !timeout_consumed_by_op {
         TimeoutNs::Indefinite
     } else {
         // Read the full timespec (tv_sec, tv_nsec) under ONE SMAP

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -721,6 +721,10 @@ pub(crate) fn read_fork_user_regs() -> crate::proc::ForkUserRegs {
             r13: *p.add(8),
             r14: *p.add(7),
             r15: *p.add(6),
+            // R9 lives at frame slot 4 per the layout comment above.
+            // Captured so clone(CLONE_THREAD) children can preserve the
+            // entry-function pointer that musl's `__clone` stashes there.
+            r9:  *p.add(4),
         }
     }
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -28151,6 +28151,7 @@ fn test_fork_callee_saved_propagation() -> bool {
         r13: 0x4444_4444_4444_4444,
         r14: 0x5555_5555_5555_5555,
         r15: 0x6666_6666_6666_6666,
+        r9:  0x7777_7777_7777_7777,
     };
 
     // ── Path 1: CoW fork (sys_fork / clone-without-CLONE_VM) ──────────────
@@ -28233,17 +28234,22 @@ fn test_fork_callee_saved_propagation() -> bool {
     // `jump_to_user_mode` indexes this struct by raw byte offsets in its
     // naked-asm trampoline (proc/usermode.rs).  Catch field-reorder
     // regressions here rather than at the IRETQ landing site.
-    assert_eq!(core::mem::size_of::<crate::proc::ForkUserRegs>(), 48,
-        "ForkUserRegs must be 6 × u64 with no padding");
+    if core::mem::size_of::<crate::proc::ForkUserRegs>() != 56 {
+        test_fail!("w113",
+            "ForkUserRegs size {} ≠ 56 (expected 7 × u64 with no padding)",
+            core::mem::size_of::<crate::proc::ForkUserRegs>());
+        return false;
+    }
     let probe = crate::proc::ForkUserRegs {
-        rbp: 1, rbx: 2, r12: 3, r13: 4, r14: 5, r15: 6,
+        rbp: 1, rbx: 2, r12: 3, r13: 4, r14: 5, r15: 6, r9: 7,
     };
     unsafe {
         let p = &probe as *const _ as *const u64;
         if *p.add(0) != 1 || *p.add(1) != 2 || *p.add(2) != 3
             || *p.add(3) != 4 || *p.add(4) != 5 || *p.add(5) != 6
+            || *p.add(6) != 7
         {
-            test_fail!("w113", "ForkUserRegs field order ≠ rbp/rbx/r12/r13/r14/r15");
+            test_fail!("w113", "ForkUserRegs field order ≠ rbp/rbx/r12/r13/r14/r15/r9");
             return false;
         }
     }


### PR DESCRIPTION
## Summary

Three closely-coupled kernel ABI gaps the **musl-linked** Firefox build surfaces. The glibc Firefox path masks all three; PR #296 swapped to Alpine musl Firefox specifically to surface these.

After this PR, the Alpine musl Firefox boot goes from **SIGSEGV at sc=32** inside firefox-bin's `__libc_start_init` to **sc≥548 with full thread spawn** and dynamic library load progressing through libstdc++ → libgcc_s → libXinerama → libpcre2-8 → libffi. The remaining exit is a clean `exit_group(255)` from ld-musl when `libz.so.1` is not present in the data image (orthogonal data-disk content gap, not a kernel bug).

## Three fixes

### 1. ELF loader: defer DT_RELR to the dynamic linker for binaries with PT_INTERP

When the kernel applies DT_RELR to a dynamically-linked ET_DYN main binary, every covered slot ends up with the load bias added **once by the kernel** and **a second time by ld.so** during its own reloc pass. Per the ELF gABI, DT_REL/DT_RELA/DT_RELR describe relocations the dynamic linker performs — the kernel never touches them on a binary that has PT_INTERP.

Static PIE binaries (ET_DYN without PT_INTERP) still need kernel-side DT_RELR because they embed their own `_dlstart` but have no separate ld.so. Gated accordingly.

Glibc Firefox ESR 115 has no DT_RELR — only DT_RELA with RELACOUNT — so the bug was invisible on that path. Alpine's musl-linked Firefox uses DT_RELR (96-byte table, 314 relocated locations).

Pre-fix evidence: faulting RIP `0xeb9fe26ce0` decomposes as `2 * 0x75cff01000 + 0x24ce0` where `0x75cff01000` is the PIE bias and `0x24ce0` is the file-resident pre-link value of `firefox-bin.init_array[1]`.

The existing comment in `load_elf_dyn` already documented the exact same double-bias pattern for the interpreter — we just hadn't applied the same rule to the main binary.

### 2. clone(CLONE_THREAD): preserve parent R9 for musl `__clone`

musl libc's x86-64 `__clone` asm stashes the thread entry function pointer in **R9** across the `syscall` instruction:

```asm
    mov %r11, %r9        ; r9 = func
    syscall
    test %eax, %eax      ; child path
    jnz 1f
    pop %rdi             ; arg from new stack
    call *%r9            ; <-- must be parent's R9
```

Per Linux x86-64 syscall ABI and POSIX `clone(2)`, all caller-saved registers except RAX/RCX/R11 survive a syscall in the child. Our `jump_to_user_mode` was zeroing R9 in the new thread, so musl's `call *%r9` jumped to NULL.

glibc's clone3 passes `func`/`arg` in RDX/R8 (already preserved), so the glibc path didn't notice.

- `ForkUserRegs` gains an `r9` field
- `read_fork_user_regs` reads it from frame slot 4 of the syscall entry frame
- `jump_to_user_mode` loads it from the struct (replacing the unconditional `xor r9d, r9d`)
- `create_user_thread` now captures the parent's frame via `read_fork_user_regs` so the child observes its R9 verbatim

For fresh processes the captured struct is the post-exec zero state, so the existing kernel-data-leak protection is preserved.

Reference: <https://git.musl-libc.org/cgit/musl/tree/src/thread/x86_64/clone.s>

### 3. futex(): only dereference `timeout` for ops that actually use it

musl's `pthread_cond_signal` issues:

```c
futex(uaddr, FUTEX_WAKE | FUTEX_PRIVATE, 1, 0x8, ...);
```

where the 4th arg (`a4` / r10) is reused as a count or comparison value — **not** a timespec pointer. Our `sys_futex_linux` was reading `*timeout_ptr` unconditionally whenever it was non-zero, so the user-passed `0x8` triggered a kernel-mode #PF (CR2=0x8) inside the SMAP-bracketed `user_read_timespec`.

Per `futex(2)` "TIMEOUTS", the timespec is consumed **only** by:

- FUTEX_WAIT (0)
- FUTEX_WAIT_BITSET (9)
- FUTEX_LOCK_PI (6)
- FUTEX_WAIT_REQUEUE_PI (8)
- FUTEX_LOCK_PI2 (11)

Wake-class ops (WAKE, WAKE_OP, WAKE_BITSET, REQUEUE, CMP_REQUEUE, UNLOCK_PI, TRYLOCK_PI) ignore the 4th argument. Mainline Linux gates the same way in `kernel/futex/syscalls.c`.

## Test plan

- **Test 113** (ForkUserRegs layout invariant) updated for the new 7-field layout — exercises the field-byte-offset map `jump_to_user_mode` reads through.
- **KVM smoke** with `ASTRYXOS_FIREFOX_VARIANT=musl bash scripts/create-data-disk.sh --force`:

| Stage | Outcome |
|---|---|
| Pre-fix | `exit_group(-11)` at sc=32, RIP=`0xeb9fe26ce0` (non-canonical; double-biased init_array slot) |
| After fix #1 (RELR) | `exit_group(-11)` at sc=46, `KERNEL_PAGE_FAULT` inside `sys_futex_linux` from R9-zeroed `call *%r9` |
| After fix #2 (R9) | `KERNEL_PAGE_FAULT CR2=0x8` in `user_read_timespec` on a FUTEX_WAKE with `a4=0x8` |
| **After fix #3 (futex)** | `exit_group(255)` at **sc=548**; full library load chain succeeds; exit triggered by missing `libz.so.1` in disk image |

## Diff size

136 LOC across 6 files (well within budget).

## Citations

- musl public source: <https://git.musl-libc.org/cgit/musl/>
- ELF gABI relocation semantics
- RELR encoding: <https://sourceware.org/glibc/wiki/RelativeRelocations>
- `futex(2)` man page (TIMEOUTS section)
- `clone(2)` man page
- POSIX clone semantics

No mention of internal-corpus paths. All `feedback_no_upstream_binary_edits` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)