### PR TITLE
scripts/install-firefox-musl: add zlib + runtime deps for musl FF

### DIFF
--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -402,6 +402,28 @@ EOF
         mcopy -o -i "${DATA_IMG}" "${LIBC_MUSL}" "::lib/libc.musl-x86_64.so.1"
         echo "[DATA-DISK] Copied libc.musl-x86_64.so.1 to /lib/"
     fi
+    # musl Firefox: Alpine places several base shared libs in /lib/ rather
+    # than /usr/lib/ (libz.so.1, libcrypto.so.3, libssl.so.3, libblkid.so.1,
+    # libmount.so.1).  install-firefox-musl.sh stages the whole /lib/ tree
+    # into ${BUILD_DIR}/disk/lib/; copy every *.so* here so libxul's
+    # DT_NEEDED libz.so.1 etc. resolve at runtime.  See PR #298 trial for
+    # the missing-libz.so.1 ld-musl exit_group signature.
+    if [ "${FIREFOX_VARIANT}" = "musl" ]; then
+        lib_count=0
+        for f in "${BUILD_DIR}/disk/lib/"*.so*; do
+            [ -f "${f}" ] || continue
+            base="$(basename "${f}")"
+            # Skip the three already-copied above (ld-musl, libc.so, libc.musl).
+            case "${base}" in
+                ld-musl-x86_64.so.1|libc.so|libc.musl-x86_64.so.1) continue ;;
+            esac
+            mcopy -o -i "${DATA_IMG}" "${f}" "::lib/${base}" 2>/dev/null || true
+            lib_count=$((lib_count + 1))
+        done
+        if [ "${lib_count}" -gt 0 ]; then
+            echo "[DATA-DISK] Copied ${lib_count} musl base libs to /lib/ (Alpine /lib/ tree)"
+        fi
+    fi
 
     # ── Dynamic linker + glibc (needed by Firefox and other glibc binaries) ──
     if [ -d "${BUILD_DIR}/disk/lib64" ]; then

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -75,12 +75,16 @@ for arg in "$@"; do
 done
 
 # ── Idempotency check ─────────────────────────────────────────────────────────
-# We consider the install up-to-date if firefox-bin exists AND its PT_INTERP
-# is /lib/ld-musl-x86_64.so.1 (which proves it is the musl variant, not the
-# leftover glibc Firefox).
+# We consider the install up-to-date if firefox-bin exists, is musl-linked
+# (PT_INTERP = /lib/ld-musl-x86_64.so.1), AND the base shared libraries
+# we now stage from ${ROOTFS}/lib/ are all present in ${DISK_LIB}.  The
+# libz.so.1 sentinel covers older partial installs where /lib/ was not
+# staged (pre-PR build/musl-zlib-install) — those need a restage so
+# libxul's DT_NEEDED libz.so.1 resolves at runtime.
 if [ "${FORCE}" = false ] && [ -f "${FIREFOX_BIN}" ] && \
-   file "${FIREFOX_BIN}" 2>/dev/null | grep -q 'ld-musl'; then
-    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked — skipping (use --force to reinstall)"
+   file "${FIREFOX_BIN}" 2>/dev/null | grep -q 'ld-musl' && \
+   [ -e "${DISK_LIB}/libz.so.1" ]; then
+    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base libs staged — skipping (use --force to reinstall)"
     exit 0
 fi
 
@@ -163,12 +167,48 @@ echo "[FF-MUSL]   rootfs size: $(du -sh "${ROOTFS}" | cut -f1)"
 
 echo "[FF-MUSL] Staging musl Firefox into ${DISK_DIR}"
 
-# (a) musl interpreter + libc
+# (a) musl interpreter + libc + Alpine "base" shared libraries
+#
+# Alpine places several runtime libraries in /lib/ rather than /usr/lib/:
+# the musl interpreter (ld-musl-x86_64.so.1) and libc symlink, plus a
+# small but load-bearing set of "base" libs that firefox-esr's deps
+# transitively pull in:
+#
+#   libz.so.1            (zlib       — used by libpng, libxml2, fontconfig,
+#                                       libxul itself for compressed assets)
+#   libcrypto.so.3       (openssl    — NSS depends on it; libxul uses it
+#                                       for TLS / signature verification)
+#   libssl.so.3          (openssl    — same as above)
+#   libblkid.so.1        (util-linux — pulled by glib's GIO mount monitor)
+#   libmount.so.1        (util-linux — same as above)
+#
+# Missing libz.so.1 specifically caused musl-FF to abort at sc≈548 during
+# the library-load chain (libxul → libpng16 → libz lookup → ld-musl
+# exit_group(255) on the unresolved DT_NEEDED) — see PR #298 trial.  We
+# stage the entire /lib/ tree, dereferencing symlinks (FAT32 has none),
+# to mirror the /usr/lib/ approach in step (c) — Alpine version bumps
+# that move libs between /lib/ and /usr/lib/ then "just work" without
+# further script changes.
 mkdir -p "${DISK_LIB}"
-cp -f "${ROOTFS}/lib/ld-musl-x86_64.so.1" "${DISK_LIB}/ld-musl-x86_64.so.1"
-# libc.musl-x86_64.so.1 is a symlink to ld-musl in Alpine; FAT32 has no
-# symlinks, so we copy the resolved file under the link name.
-cp -fL "${ROOTFS}/lib/libc.musl-x86_64.so.1" "${DISK_LIB}/libc.musl-x86_64.so.1"
+for f in "${ROOTFS}"/lib/*; do
+    [ -e "${f}" ] || continue
+    name="$(basename "${f}")"
+    # Skip apk's bookkeeping (/lib/apk/db/...); not useful at runtime.
+    [ "${name}" = "apk" ] && continue
+    if [ -L "${f}" ]; then
+        # Symlink: dereference to a real file under the link name so the
+        # dynamic linker finds e.g. libz.so.1 as a real ELF, not a
+        # dangling link (FAT32 has no symlinks).
+        cp -fL "${f}" "${DISK_LIB}/${name}"
+    elif [ -f "${f}" ]; then
+        cp -f  "${f}" "${DISK_LIB}/${name}"
+    elif [ -d "${f}" ]; then
+        # Recurse for subdirs (none expected today, but defensive against
+        # Alpine layout changes).
+        cp -aL "${f}" "${DISK_LIB}/" 2>/dev/null || \
+            cp -a  "${f}" "${DISK_LIB}/"
+    fi
+done
 
 # (b) Firefox tree.  Clear any prior contents so we cannot end up with a
 # glibc/musl hybrid in /disk/opt/firefox/.
@@ -239,11 +279,28 @@ if [ ! -f "${DISK_LIB}/ld-musl-x86_64.so.1" ]; then
     echo "[FF-MUSL] ERROR: ${DISK_LIB}/ld-musl-x86_64.so.1 missing"
     exit 1
 fi
+# Verify the base shared libs landed.  libz in particular is mandatory —
+# libxul DT_NEEDEDs it (via libpng16 / libxml2), and ld-musl will
+# exit_group on missing libz at first dlopen.  See PR #298 trial.
+MISSING_BASE_LIBS=""
+for lib in libz.so.1 libcrypto.so.3 libssl.so.3; do
+    if [ ! -e "${DISK_LIB}/${lib}" ]; then
+        MISSING_BASE_LIBS="${MISSING_BASE_LIBS} ${lib}"
+    fi
+done
+if [ -n "${MISSING_BASE_LIBS}" ]; then
+    echo "[FF-MUSL] ERROR: required base libs missing from ${DISK_LIB}:${MISSING_BASE_LIBS}"
+    echo "[FF-MUSL]        Alpine may have moved them out of /lib/ in this release"
+    echo "[FF-MUSL]        — check ${ROOTFS}/usr/lib/ and extend stage step (a)."
+    exit 1
+fi
 
 echo "[FF-MUSL] Staged:"
 echo "[FF-MUSL]   firefox-bin: $(stat -c%s "${FIREFOX_BIN}") bytes, musl PT_INTERP"
 echo "[FF-MUSL]   libxul.so:   $(stat -c%s "${DISK_OPT}/libxul.so") bytes"
 echo "[FF-MUSL]   ld-musl:     $(stat -c%s "${DISK_LIB}/ld-musl-x86_64.so.1") bytes"
+echo "[FF-MUSL]   libz.so.1:   $(stat -c%s "${DISK_LIB}/libz.so.1") bytes"
+echo "[FF-MUSL]   /lib:         $(du -sh "${DISK_LIB}" | cut -f1)"
 echo "[FF-MUSL]   /opt/firefox: $(du -sh "${DISK_OPT}" | cut -f1)"
 echo "[FF-MUSL]   /usr/lib:     $(du -sh "${DISK_USR_LIB}" | cut -f1)"
 echo "[FF-MUSL] Done."


### PR DESCRIPTION
## Summary

PR #298 fixed three kernel-ABI gaps for the Alpine musl Firefox track. The post-fix trial reached **sc=548** in the library-load chain (libstdc++ → libgcc_s → libXinerama → libpcre2-8 → libffi) and then hit:

```
ld-musl: cannot find libz.so.1
exit_group(255)
```

Root cause: `install-firefox-musl.sh` step (a) only copied two specific files out of `${ROOTFS}/lib/` (the musl interpreter and libc symlink), ignoring the other shared libraries Alpine places there. Five base libs were silently dropped:

| Library | Owner | Why it matters |
|---|---|---|
| `libz.so.1` | `zlib` | libxul DT_NEEDED via libpng16 / libxml2 |
| `libcrypto.so.3` | `openssl` | NSS dep; libxul TLS / sig verification |
| `libssl.so.3` | `openssl` | NSS dep |
| `libblkid.so.1` | `util-linux` | glib GIO mount monitor |
| `libmount.so.1` | `util-linux` | glib GIO mount monitor |

`libz.so.1` specifically caused the visible failure: libxul DT_NEEDEDs it (via libpng16 / libxml2) so ld-musl bails at the very first dlopen of the libxul transitive graph.

## What changed

**`scripts/install-firefox-musl.sh`** — step (a) now loops over `${ROOTFS}/lib/*`, copying every regular file and dereferencing symlinks under the link name (FAT32 has no symlinks). apk's `/lib/apk/db/` bookkeeping subdir is skipped. This mirrors the `/usr/lib/` approach in step (c) — Alpine version bumps that reshuffle libs between `/lib/` and `/usr/lib/` then "just work" without further script changes.

Three safeguards added:
- Idempotency check now also requires `${DISK_LIB}/libz.so.1` to be present, so pre-fix partial installs trigger a restage on the next plain invocation (no `--force` needed).
- Step 4 sanity-check verifies `libz.so.1`, `libcrypto.so.3`, and `libssl.so.3` all landed; clear diagnostic + exit 1 if Alpine has moved any of them.
- Final staging summary prints `libz.so.1` size and total `/lib/` footprint so regressions are visible in the script log.

**`scripts/create-data-disk.sh`** — under `--firefox-variant=musl`, it now copies every `*.so*` from `${BUILD_DIR}/disk/lib/` onto the FAT32 image. The previous code only copied three specific files by name (ld-musl, libc.so, libc.musl), so the libs staged by `install-firefox-musl.sh` would not have reached the kernel at boot even with the staging fix alone.

## Note on diff size

89 LOC across 2 files (~1.8× the single-file 50 LOC soft target). The two-file scope is **required**: without the `create-data-disk.sh` extension, the staging changes alone do nothing at runtime — the new libs in `${BUILD_DIR}/disk/lib/` would never be copied onto the FAT32 image. Splitting would leave a half-fix.

## Test plan

- [x] Cold run from existing apk cache: stages `libz.so.1` + 7.4 MiB total `/lib/` (verified locally)
- [x] Plain re-run (no `--force`): skip branch hit on the new libz sentinel
- [x] `--force` re-run: re-stages cleanly
- [x] Restage-on-missing: manually deleting `libz.so.1` triggers a full re-stage on the next plain invocation
- [x] `file build/disk/lib/libz.so.1` reports a real ELF (not a dangling symlink)
- [ ] Full end-to-end via `qemu-harness.py start --features firefox-test` (caller verifies)
- [ ] Confirm the sc=548 plateau moves past the libz.so.1 ld-musl exit

## Public refs

- https://wiki.alpinelinux.org/wiki/Apk
- https://pkgs.alpinelinux.org/package/v3.20/main/x86_64/zlib

🤖 Generated with [Claude Code](https://claude.com/claude-code)