### PR TITLE
kernel/vfs: add /opt → /disk/opt boot symlink (musl FF DT_NEEDED chain)

### DIFF
--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -368,6 +368,7 @@ pub fn init() {
     let _ = symlink("/lib",   "/disk/lib");
     let _ = symlink("/lib64", "/disk/lib64");
     let _ = symlink("/usr",   "/disk/usr");
+    let _ = symlink("/opt",   "/disk/opt");
 
     // Create /dev/null and /dev/console.
     let _ = create_file("/dev/null");


### PR DESCRIPTION
## Summary

1-line completion of the existing boot-symlinks pattern at `kernel/src/vfs/mod.rs:368-370`. Currently the kernel remaps `/lib`, `/lib64`, `/usr` → `/disk/*` at boot so glibc/musl ld.so can resolve canonical Linux paths against the data-disk mount. This PR adds `/opt → /disk/opt`, completing the table for Mozilla artefacts that live under `/opt/firefox/`.

## Why

Post-PR-#298+#299 verification soak (KVM, master `4cf9154`, single-trial N=1):
- sc reached **871** (vs sc=548 pre-#299, vs sc=2902 glibc) — +323 syscalls of forward progress.
- exit cause: `exit_group(255)` from ld-musl with stderr:
  ```
  XPCOMGlueLoad error for file /disk/opt/firefox/libxul.so:
  Error loading shared library libmozsandbox.so:
  No such file or directory (needed by /disk/opt/firefox/libxul.so)
  ```

The verifier traced the gate: `libxul.so` itself loaded fine (the test runner exec'd it with the `/disk/` prefix and the kernel's vfs followed that). But libxul's transitive `DT_NEEDED` lookups (`libmozsandbox.so`, etc.) go through musl ldso's `LD_LIBRARY_PATH` search using the **canonical** path `/opt/firefox/...` — no `/disk/` prefix. The kernel had no `/opt` symlink to remap it, so the lookup hit ENOENT despite the file being staged at `/disk/opt/firefox/libmozsandbox.so` (166 KiB, confirmed via `mdir` on `build/data.img`).

This is the same architectural pattern as `/lib`, `/lib64`, `/usr` — just completing the table.

## Diff

```diff
     let _ = symlink("/lib",   "/disk/lib");
     let _ = symlink("/lib64", "/disk/lib64");
     let _ = symlink("/usr",   "/disk/usr");
+    let _ = symlink("/opt",   "/disk/opt");
```

1 file, 1 insertion.

## References

- POSIX dlopen(3) — DT_RUNPATH / LD_LIBRARY_PATH precedence
- musl ldso documentation for search-order semantics

## Test plan

- [x] Verifier (qa-engineer) confirmed pre-fix sc=871 exit on libmozsandbox.so ENOENT
- [ ] Post-merge soak to confirm sc advances past 871 cleanly (will be done via the next firefox-test trial after merge)

## Risk

- No glibc-path regression: existing /lib/lib64/usr symlinks unchanged; only adds a new symlink that didn't exist.
- Native AstryxOS userland: doesn't use `/opt` for its own programs, so no clash.