### PR TITLE
build/musl-runpath: stage Mozilla tree at DT_RUNPATH (/usr/lib/firefox-esr)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -877,12 +877,18 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         "MOZ_ACCELERATED=0",
         "LIBGL_ALWAYS_SOFTWARE=1",
         // The path list covers both Firefox variants:
-        //   glibc: /lib/x86_64-linux-gnu (multiarch glibc tree)
-        //   musl : /usr/lib (Alpine's flat support-lib tree, plus /opt/firefox
-        //          for libxul.so + Mozilla's own .so files)
+        //   glibc: /lib/x86_64-linux-gnu (multiarch glibc tree), /opt/firefox
+        //          for libxul.so + Mozilla's own .so files (in-tree convention)
+        //   musl : /usr/lib (Alpine's flat support-lib tree) + /usr/lib/firefox-esr
+        //          (Alpine canonical Mozilla tree — DT_RUNPATH target baked
+        //          into every Mozilla DSO per readelf -d; see ELF gABI §5.4
+        //          "Shared Object Dependencies" and ld-musl(8) search order)
         // /disk/lib/firefox is a legacy build-firefox.sh path retained for
         // any caller using the in-tree built variant.
-        "LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib:/opt/firefox:/disk/lib/firefox",
+        // LD_LIBRARY_PATH precedes DT_RUNPATH in the search order, so listing
+        // /usr/lib/firefox-esr here is a belt-and-braces guard for any
+        // dlopen("libfoo.so") call that lacks RUNPATH propagation.
+        "LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib:/usr/lib/firefox-esr:/opt/firefox:/disk/lib/firefox",
         // libfontconfig-interposer.so — defensive FcPatternGetString *out
         // wrapper.  Real libfontconfig (PR #179) leaves *out untouched on
         // FcResultNoMatch per spec; Mozilla's gfxFcPlatformFontList caller

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -493,7 +493,32 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 Err(e) => serial_println!("[FFTEST] WARNING: could not write /tmp/hello.html: {:?}", e),
             }
 
-            serial_println!("[FFTEST] Launching /disk/opt/firefox/firefox-bin ...");
+            // The Mozilla launcher (firefox-bin) reads its dependentlibs.list,
+            // application.ini, omni.ja, defaults/, browser/, etc. via
+            // readlink("/proc/self/exe") + dirname, then opens those files
+            // relative to that resolved directory.  We therefore launch from
+            // wherever the FULL Mozilla tree is staged.
+            //
+            //   musl variant:  /disk/usr/lib/firefox-esr/firefox-bin
+            //                  (Alpine's package layout; DT_RUNPATH target;
+            //                   contains dependentlibs.list, application.ini,
+            //                   omni.ja, every Mozilla .so file)
+            //   glibc variant: /disk/opt/firefox/firefox-bin
+            //                  (in-tree convention; install-firefox.sh stages
+            //                   the tarball there directly)
+            //
+            // Prefer the musl path when present so readlink-relative file
+            // opens (notably dependentlibs.list — ENOENT here aborts the
+            // process at sc≈73) land in the right tree.  Both fall through
+            // to firefox-test's --headless --screenshot pipeline.
+            const CMDLINE_MUSL:  &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            const CMDLINE_GLIBC: &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            let cmdline = if crate::vfs::read_file("/disk/usr/lib/firefox-esr/firefox-bin").is_ok() {
+                CMDLINE_MUSL
+            } else {
+                CMDLINE_GLIBC
+            };
+            serial_println!("[FFTEST] Launching {} ...", cmdline.split(' ').next().unwrap_or(""));
             // Headless mode: pass `--headless` so libxul takes the IsHeadless()
             // path and does not call XOpenDisplay() / gdk_display_open().  With
             // a stub libX11.so XOpenDisplay returns NULL and Firefox prints
@@ -510,9 +535,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // the headless demo bar for issue #88.  /tmp/hello.html is now
             // written to the ramdisk above (W150) so the handler will not
             // hit ENOENT when it resolves file:///tmp/hello.html.
-            gui::terminal::launch_process(
-                "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html",
-            );
+            gui::terminal::launch_process(cmdline);
 
             // Run for up to 30000 ticks (~300 s), polling output and network.
             // We detect Firefox exit via EXEC_RUNNING going false (set by poll_output).

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -443,19 +443,25 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // later mmap()s these files, demand-paging hits the cache
             // (instant) instead of reading from disk (5+ minutes on WSL2/KVM).
             serial_println!("[FFTEST] Pre-populating page cache from disk (slow ATA PIO)...");
-            // We list both glibc and musl interpreter / libc paths.  Whichever
-            // variant is staged on the data disk resolves; the other returns
-            // 0 pages benignly (prepopulate_file → resolve_path Err → 0).
-            // /opt/firefox/firefox-bin and /opt/firefox/libxul.so are shared
-            // — install-firefox-musl.sh renames Alpine's firefox-esr binary
-            // to firefox-bin so this list works for both variants.
+            // We list both glibc and musl interpreter / libc paths plus both
+            // possible libxul.so locations.  Whichever variant is staged on
+            // the data disk resolves; the other returns 0 pages benignly
+            // (prepopulate_file → resolve_path Err → 0).
+            //
+            // libxul.so location by variant:
+            //   - glibc: /opt/firefox/libxul.so (kernel-internal staging path)
+            //   - musl : /usr/lib/firefox-esr/libxul.so (the DT_RUNPATH baked
+            //            into firefox-bin per readelf -d; ELF gABI §5.4)
+            // /opt/firefox/firefox-bin is mirrored for both variants so the
+            // kernel launch path stays stable.
             for path in &[
-                "/disk/lib64/ld-linux-x86-64.so.2",     // glibc — 236 KB
-                "/disk/lib/ld-musl-x86_64.so.1",        // musl  — 650 KB
-                "/disk/opt/firefox/firefox-bin",         // 671 KB — ~3s
-                "/disk/lib/x86_64-linux-gnu/libc.so.6",  // glibc — 2.0 MB
-                "/disk/lib/libc.musl-x86_64.so.1",       // musl  — symlink to ld-musl
-                "/disk/opt/firefox/libxul.so",           // 157 MB — ~10 min (but worth it)
+                "/disk/lib64/ld-linux-x86-64.so.2",         // glibc — 236 KB
+                "/disk/lib/ld-musl-x86_64.so.1",            // musl  — 650 KB
+                "/disk/opt/firefox/firefox-bin",            // 671 KB — ~3s
+                "/disk/lib/x86_64-linux-gnu/libc.so.6",     // glibc — 2.0 MB
+                "/disk/lib/libc.musl-x86_64.so.1",          // musl  — symlink to ld-musl
+                "/disk/opt/firefox/libxul.so",              // 157 MB — glibc variant
+                "/disk/usr/lib/firefox-esr/libxul.so",      // 130 MB — musl variant (DT_RUNPATH)
             ] {
                 let t0 = arch::x86_64::irq::get_ticks();
                 let pages = mm::cache::prepopulate_file(path);

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -475,6 +475,30 @@ EOF
             fi
         done
         echo "[DATA-DISK] Copied ${local_count} musl support libs to /usr/lib/ (Alpine deps)"
+
+        # The canonical Mozilla tree must land at /usr/lib/firefox-esr/ on the
+        # FAT32 image — that is the DT_RUNPATH baked into firefox-bin,
+        # libxul.so, libmozsandbox.so, etc. (readelf -d shows
+        # RUNPATH=[/usr/lib/firefox-esr]).  Per the ELF gABI (System V ABI
+        # §5.4) and ld-musl(8), DT_RUNPATH is the third entry in the dynamic
+        # linker search order; without the tree at this path, libxul's
+        # transitive dlopen calls (e.g. libmozsandbox.so) fail with ENOENT
+        # and ld-musl exit_group()s at startup.
+        MUSL_FF_ESR="${BUILD_DIR}/disk/usr/lib/firefox-esr"
+        if [ -d "${MUSL_FF_ESR}" ]; then
+            echo "[DATA-DISK] Copying /usr/lib/firefox-esr (~206 MiB) to data image — this takes a moment..."
+            mmd -i "${DATA_IMG}" "::usr/lib/firefox-esr" 2>/dev/null || true
+            # mcopy -s walks the full tree (omni.ja, browser/, defaults/,
+            # fonts/, gmp-clearkey/, every .so file).  Tolerate failures for
+            # any deep symlink chains (none expected — install-firefox-musl.sh
+            # dereferences with cp -L during staging).
+            mcopy -s -o -i "${DATA_IMG}" "${MUSL_FF_ESR}/." \
+                "::usr/lib/firefox-esr/" 2>&1 | \
+                grep -v "^$" | grep -iv "^skipping" | head -20 || true
+            echo "[DATA-DISK] Copied /usr/lib/firefox-esr/ to data image (DT_RUNPATH target)"
+        else
+            echo "[DATA-DISK] WARNING: ${MUSL_FF_ESR} missing — musl FF DT_RUNPATH lookup will fail"
+        fi
     fi
     HOST_FONTS="${BUILD_DIR}/disk/usr/share/fonts"
     if [ -d "${HOST_FONTS}/truetype/dejavu" ]; then

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -19,13 +19,25 @@
 #      ~/.cache/astryxos-firefox-musl/rootfs/ and `apk add firefox-esr`
 #      (pulls 122 transitive deps + the musl libc itself).
 #   3. Stage the rootfs into build/disk/ under the layout the kernel
-#      pre-cache + ELF loader expect:
+#      pre-cache + ELF loader + dynamic-linker DT_RUNPATH expect:
 #        - /disk/lib/ld-musl-x86_64.so.1     (interpreter, /lib/ in PT_INTERP)
-#        - /disk/lib/libc.musl-x86_64.so.1   (musl libc, symlink to ld-musl)
-#        - /disk/opt/firefox/firefox-bin     (the ELF; kernel pre-cache target)
-#        - /disk/opt/firefox/libxul.so       (kernel pre-cache target)
-#        - /disk/opt/firefox/...              (all other Mozilla artefacts)
-#        - /disk/usr/lib/                    (all Alpine support libs)
+#        - /disk/lib/libc.musl-x86_64.so.1   (musl libc, sibling of ld-musl)
+#        - /disk/usr/lib/firefox-esr/...     (canonical Mozilla tree, matches
+#                                              DT_RUNPATH baked into every
+#                                              Mozilla DSO — readelf -d shows
+#                                              RUNPATH=[/usr/lib/firefox-esr])
+#        - /disk/opt/firefox/firefox-bin     (launcher mirror — small, kept
+#                                              so the kernel launch and
+#                                              pre-cache paths remain stable)
+#        - /disk/usr/lib/                    (Alpine support libs flat:
+#                                              libnss, libnspr, libsqlite,
+#                                              ICU, GTK3, fontconfig, ...)
+#
+#      Per ELF gABI (System V ABI §5.4 "Shared Object Dependencies") and
+#      ld-musl(8), the dynamic linker searches in order: LD_LIBRARY_PATH,
+#      DT_RUNPATH, system defaults.  Placing Mozilla artefacts anywhere
+#      other than DT_RUNPATH means transitive dlopen calls (libxul →
+#      libmozsandbox.so etc.) fail with ENOENT and ld-musl exit_group()s.
 #
 # Idempotent — exits 0 if build/disk/opt/firefox/firefox-bin already exists
 # and looks musl-linked.  Pass --force to rebuild.
@@ -48,6 +60,14 @@ DISK_DIR="${BUILD_DIR}/disk"
 DISK_OPT="${DISK_DIR}/opt/firefox"
 DISK_LIB="${DISK_DIR}/lib"
 DISK_USR_LIB="${DISK_DIR}/usr/lib"
+# Mozilla artefacts ship with DT_RUNPATH=/usr/lib/firefox-esr baked into the
+# ELF .dynamic section.  Per the ELF gABI (System V ABI §5.4 "Dynamic Linking
+# — Shared Object Dependencies"), DT_RUNPATH is consulted when resolving
+# DT_NEEDED entries.  FAT32 has no symlinks, so the canonical Mozilla tree
+# (libxul.so, libmozsandbox.so, liblgpllibs.so, … and the browser/, defaults/,
+# fonts/, gmp-clearkey/ subdirs) MUST be staged at this absolute path on disk
+# for the dynamic linker to find them.
+DISK_FF_ESR="${DISK_DIR}/usr/lib/firefox-esr"
 FIREFOX_BIN="${DISK_OPT}/firefox-bin"
 
 CACHE_DIR="${HOME}/.cache/astryxos-firefox-musl"
@@ -76,15 +96,16 @@ done
 
 # ── Idempotency check ─────────────────────────────────────────────────────────
 # We consider the install up-to-date if firefox-bin exists, is musl-linked
-# (PT_INTERP = /lib/ld-musl-x86_64.so.1), AND the base shared libraries
-# we now stage from ${ROOTFS}/lib/ are all present in ${DISK_LIB}.  The
-# libz.so.1 sentinel covers older partial installs where /lib/ was not
-# staged (pre-PR build/musl-zlib-install) — those need a restage so
-# libxul's DT_NEEDED libz.so.1 resolves at runtime.
+# (PT_INTERP = /lib/ld-musl-x86_64.so.1), the base shared libraries we stage
+# from ${ROOTFS}/lib/ are present in ${DISK_LIB}, AND the canonical Mozilla
+# tree is present at ${DISK_FF_ESR} (DT_RUNPATH).  The libxul.so sentinel under
+# /usr/lib/firefox-esr covers older partial installs that staged Mozilla under
+# /opt/firefox/ only — those need a restage so DT_RUNPATH lookups succeed.
 if [ "${FORCE}" = false ] && [ -f "${FIREFOX_BIN}" ] && \
    file "${FIREFOX_BIN}" 2>/dev/null | grep -q 'ld-musl' && \
-   [ -e "${DISK_LIB}/libz.so.1" ]; then
-    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base libs staged — skipping (use --force to reinstall)"
+   [ -e "${DISK_LIB}/libz.so.1" ] && \
+   [ -e "${DISK_FF_ESR}/libxul.so" ]; then
+    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base + runpath staged — skipping (use --force to reinstall)"
     exit 0
 fi
 
@@ -210,42 +231,62 @@ for f in "${ROOTFS}"/lib/*; do
     fi
 done
 
-# (b) Firefox tree.  Clear any prior contents so we cannot end up with a
-# glibc/musl hybrid in /disk/opt/firefox/.
-rm -rf "${DISK_OPT}"
+# (b) Wipe prior /opt/firefox/ and /usr/lib/firefox-esr/ staging so we cannot
+# end up with a hybrid (e.g. glibc firefox-bin + musl libxul.so).  Step (c)
+# below will repopulate /usr/lib/firefox-esr/ from the rootfs.
+#
+# DT_RUNPATH context: every Mozilla ELF (firefox-bin, libxul.so,
+# libmozsandbox.so, ...) carries DT_RUNPATH=/usr/lib/firefox-esr per
+# readelf -d.  Per the ELF gABI (System V ABI §5.4 "Shared Object
+# Dependencies") and ld-musl(8), DT_RUNPATH is consulted after
+# LD_LIBRARY_PATH for DT_NEEDED resolution.  Placing the Mozilla tree
+# anywhere else means libxul's dlopen for its sibling .so files fails with
+# ENOENT and ld-musl exit_group()s.  The canonical tree must live at
+# /disk/usr/lib/firefox-esr/ (mapped to guest /usr/lib/firefox-esr by the
+# kernel's /usr → /disk/usr VFS symlink).
+#
+# We keep a minimal /opt/firefox/ duplicate consisting of firefox-bin alone
+# (~795 KiB) so the kernel's launch path (kernel/src/main.rs:508) and
+# pre-cache loader (kernel/src/main.rs:455) remain stable.  The launched
+# ELF's DT_RUNPATH is absolute, not relative to its on-disk location.
+rm -rf "${DISK_OPT}" "${DISK_FF_ESR}"
 mkdir -p "${DISK_OPT}"
-
-# Copy everything Alpine staged at /usr/lib/firefox-esr/ into /opt/firefox/.
-# This preserves Mozilla's expected internal layout (omni.ja, browser/,
-# defaults/, fonts/, etc.).
-cp -aL "${ROOTFS}/usr/lib/firefox-esr/." "${DISK_OPT}/" 2>/dev/null || \
-    cp -a  "${ROOTFS}/usr/lib/firefox-esr/." "${DISK_OPT}/"
-
-# Rename Alpine's "firefox-esr" → "firefox-bin" so the kernel pre-cache
-# path /disk/opt/firefox/firefox-bin works without kernel changes.  Also
-# create a "firefox" alias for any caller using the unsuffixed name.
-if [ -f "${DISK_OPT}/firefox-esr" ]; then
-    cp -f "${DISK_OPT}/firefox-esr" "${DISK_OPT}/firefox-bin"
-    cp -f "${DISK_OPT}/firefox-esr" "${DISK_OPT}/firefox"
-fi
-# firefox-esr-bin is an Alpine internal symlink to /usr/bin/firefox-esr (a
-# shell wrapper); strip it — we're using the resolved ELF directly.
-rm -f "${DISK_OPT}/firefox-esr-bin"
 
 # (c) Support libraries from Alpine's /usr/lib/.  Strip Alpine-specific
 # build helpers (apk db, pkgconfig data, header dirs) and keep only the
 # .so* files plus the directory structure.
 mkdir -p "${DISK_USR_LIB}"
-# Copy every regular file (cp -L derefs symlinks → real bytes under link name,
-# matching the FAT32-friendly approach used elsewhere in create-data-disk.sh).
-# We deliberately copy the whole /usr/lib tree (~120 MiB) so transitive deps
-# (icu, libnss/nspr/nssutil/smime/sqlite, ffi, ssl3, etc.) are all available.
+# We deliberately copy the whole /usr/lib tree (~325 MiB including the
+# /usr/lib/firefox-esr/ subdir = ~206 MiB) so transitive deps (icu, libnss /
+# nspr / nssutil / smime / sqlite, ffi, ssl3, GTK, libavcodec, ...) are all
+# available AND the canonical Mozilla tree lands at the DT_RUNPATH path.
+# `cp -aL` preserves hard-link relationships within the tree — Alpine ships
+# several library SONAMEs as hard links to the fully-versioned file
+# (libgtk-3.so.0 ↔ libgtk-3.so.0.2411.32, etc.).  Breaking those by
+# walking the tree file-by-file would inflate /usr/lib from ~120 MiB
+# (non-firefox-esr portion) to ~225 MiB.
 cp -aL "${ROOTFS}/usr/lib/." "${DISK_USR_LIB}/" 2>/dev/null || true
-# Drop the firefox-esr subdir from /usr/lib/ — we already staged it at
-# /opt/firefox/ above; keeping two copies would waste ~205 MiB.
-rm -rf "${DISK_USR_LIB}/firefox-esr"
 # Drop apk's bookkeeping; not useful at runtime.
-rm -rf "${DISK_USR_LIB}/apk" "${DISK_USR_LIB}/.." 2>/dev/null || true
+rm -rf "${DISK_USR_LIB}/apk" 2>/dev/null || true
+
+# Within ${DISK_FF_ESR}: rename Alpine's "firefox-esr" → "firefox-bin" so
+# callers that follow the launcher's readlink("/proc/self/exe") + "-bin"
+# convention resolve there.  Keep the original "firefox-esr" name as an
+# alias for any caller using Alpine's name.  firefox-esr-bin is an Alpine
+# internal symlink to /usr/bin/firefox-esr (a shell wrapper); strip it —
+# we are using the resolved ELF directly.
+if [ -f "${DISK_FF_ESR}/firefox-esr" ]; then
+    cp -f "${DISK_FF_ESR}/firefox-esr" "${DISK_FF_ESR}/firefox-bin"
+    cp -f "${DISK_FF_ESR}/firefox-esr" "${DISK_FF_ESR}/firefox"
+fi
+rm -f "${DISK_FF_ESR}/firefox-esr-bin"
+
+# Mirror firefox-bin into /disk/opt/firefox/ (kernel launch + pre-cache path
+# stability).  Do NOT mirror the .so files — DT_RUNPATH is /usr/lib/firefox-esr,
+# so a duplicate libxul at /opt/firefox/ would never be loaded and would waste
+# ~160 MiB of FAT32 capacity.
+cp -f "${DISK_FF_ESR}/firefox-bin" "${DISK_OPT}/firefox-bin"
+cp -f "${DISK_FF_ESR}/firefox-bin" "${DISK_OPT}/firefox"
 
 # (d) Etc — fontconfig / nss / dbus config that musl Firefox reads at runtime.
 mkdir -p "${DISK_DIR}/etc"
@@ -279,6 +320,19 @@ if [ ! -f "${DISK_LIB}/ld-musl-x86_64.so.1" ]; then
     echo "[FF-MUSL] ERROR: ${DISK_LIB}/ld-musl-x86_64.so.1 missing"
     exit 1
 fi
+# Verify the canonical Mozilla tree landed at DT_RUNPATH.  libxul.so under
+# /usr/lib/firefox-esr/ is the single most load-bearing file — every Mozilla
+# DSO dlopen indirects through DT_RUNPATH to that directory.  See readelf -d
+# output: firefox-bin, libxul.so, libmozsandbox.so all have
+# DT_RUNPATH=/usr/lib/firefox-esr per ELF gABI §5.4.
+if [ ! -f "${DISK_FF_ESR}/libxul.so" ]; then
+    echo "[FF-MUSL] ERROR: ${DISK_FF_ESR}/libxul.so missing — DT_RUNPATH lookup will fail"
+    exit 1
+fi
+if [ ! -f "${DISK_FF_ESR}/libmozsandbox.so" ]; then
+    echo "[FF-MUSL] ERROR: ${DISK_FF_ESR}/libmozsandbox.so missing — first DT_NEEDED of libxul will fail"
+    exit 1
+fi
 # Verify the base shared libs landed.  libz in particular is mandatory —
 # libxul DT_NEEDEDs it (via libpng16 / libxml2), and ld-musl will
 # exit_group on missing libz at first dlopen.  See PR #298 trial.
@@ -296,11 +350,14 @@ if [ -n "${MISSING_BASE_LIBS}" ]; then
 fi
 
 echo "[FF-MUSL] Staged:"
-echo "[FF-MUSL]   firefox-bin: $(stat -c%s "${FIREFOX_BIN}") bytes, musl PT_INTERP"
-echo "[FF-MUSL]   libxul.so:   $(stat -c%s "${DISK_OPT}/libxul.so") bytes"
-echo "[FF-MUSL]   ld-musl:     $(stat -c%s "${DISK_LIB}/ld-musl-x86_64.so.1") bytes"
-echo "[FF-MUSL]   libz.so.1:   $(stat -c%s "${DISK_LIB}/libz.so.1") bytes"
-echo "[FF-MUSL]   /lib:         $(du -sh "${DISK_LIB}" | cut -f1)"
-echo "[FF-MUSL]   /opt/firefox: $(du -sh "${DISK_OPT}" | cut -f1)"
-echo "[FF-MUSL]   /usr/lib:     $(du -sh "${DISK_USR_LIB}" | cut -f1)"
+echo "[FF-MUSL]   firefox-bin (launcher):  $(stat -c%s "${FIREFOX_BIN}") bytes, musl PT_INTERP"
+echo "[FF-MUSL]   firefox-bin (runpath):   $(stat -c%s "${DISK_FF_ESR}/firefox-bin") bytes"
+echo "[FF-MUSL]   libxul.so (runpath):     $(stat -c%s "${DISK_FF_ESR}/libxul.so") bytes"
+echo "[FF-MUSL]   libmozsandbox (runpath): $(stat -c%s "${DISK_FF_ESR}/libmozsandbox.so") bytes"
+echo "[FF-MUSL]   ld-musl:                 $(stat -c%s "${DISK_LIB}/ld-musl-x86_64.so.1") bytes"
+echo "[FF-MUSL]   libz.so.1:               $(stat -c%s "${DISK_LIB}/libz.so.1") bytes"
+echo "[FF-MUSL]   /lib:                    $(du -sh "${DISK_LIB}" | cut -f1)"
+echo "[FF-MUSL]   /opt/firefox (launcher): $(du -sh "${DISK_OPT}" | cut -f1)"
+echo "[FF-MUSL]   /usr/lib/firefox-esr:    $(du -sh "${DISK_FF_ESR}" | cut -f1)"
+echo "[FF-MUSL]   /usr/lib (total):        $(du -sh "${DISK_USR_LIB}" | cut -f1)"
 echo "[FF-MUSL] Done."


### PR DESCRIPTION
## Summary

- Alpine's prebuilt Firefox ESR has `DT_RUNPATH=/usr/lib/firefox-esr` baked into every Mozilla DSO (`readelf -d firefox-bin`, `libxul.so`, `libmozsandbox.so`, ...). Per the ELF gABI (System V ABI §5.4 \"Shared Object Dependencies\") and ld-musl(8), `DT_RUNPATH` is consulted after `LD_LIBRARY_PATH` to resolve `DT_NEEDED` for a DSO. Prior staging placed every Mozilla artefact at `/disk/opt/firefox/` only, which `DT_RUNPATH` never looks at — libxul's transitive dlopen of `libmozsandbox.so` therefore failed with ENOENT, and ld-musl `exit_group(255)`'d at sc≈871 with `XPCOMGlueLoad error … libmozsandbox.so: No such file or directory`.
- This PR re-stages the canonical Mozilla tree at `/disk/usr/lib/firefox-esr/` (mapped to guest `/usr/lib/firefox-esr` via the existing `/usr → /disk/usr` VFS symlink). The kernel now launches musl Firefox directly from `/disk/usr/lib/firefox-esr/firefox-bin` so that the launcher's `readlink(\"/proc/self/exe\") + dirname` resolution lands in the tree containing `dependentlibs.list`, `application.ini`, `omni.ja`, and the full set of Mozilla `.so` files. A minimal mirror of `firefox-bin` alone (~795 KiB) remains at `/disk/opt/firefox/` for backwards-compatibility with the glibc variant launch path.
- Additive kernel changes: pre-cache list grows by one entry (`/disk/usr/lib/firefox-esr/libxul.so` — returns 0 pages benignly for the glibc variant), and `LD_LIBRARY_PATH` gains `/usr/lib/firefox-esr` as a belt-and-braces guard for direct `dlopen(\"libfoo.so\")` calls lacking RUNPATH propagation. Launch path tries the musl location first; falls back to `/disk/opt/firefox/firefox-bin` for the glibc variant.

## Files changed

| File | Change |
|---|---|
| `scripts/install-firefox-musl.sh` | `cp -aL` of rootfs `/usr/lib/.` now populates `/disk/usr/lib/firefox-esr/` (preserving hard-link relationships so /usr/lib stays ~325 MiB instead of inflating to ~430 MiB); step (b) wipes the targets first; firefox-bin rename + /opt/firefox/ mirror handled inline. Sanity checks now assert `libxul.so` and `libmozsandbox.so` exist under DT_RUNPATH. |
| `scripts/create-data-disk.sh` | Musl branch `mcopy -s` the `/usr/lib/firefox-esr/` tree into `::usr/lib/firefox-esr/` on the FAT32 image (FAT32 has no symlinks; the tree is staged as real-bytes copies). |
| `kernel/src/main.rs` | Pre-cache list adds `/disk/usr/lib/firefox-esr/libxul.so` alongside the legacy `/disk/opt/firefox/libxul.so` glibc path; launch path tries the musl variant location first. |
| `kernel/src/gui/terminal.rs` | `LD_LIBRARY_PATH` gains `/usr/lib/firefox-esr` (precedes DT_RUNPATH in search order per ELF gABI §5.4). |

## Smoke test (qemu-harness.py, KVM, --features firefox-test)

| Metric | Pre-fix (master 4cf9154) | Post-fix (this branch) |
|---|---|---|
| Final exit reason | `exit_group(255)` libmozsandbox ENOENT | Downstream `[SMAP/FAULT]` (kernel-side, separate H1-SMAP class) |
| sc at exit | 871 | 1227 (pid=1) + 487 (pid=2 content process) |
| `[CACHE] prepopulate /disk/usr/lib/firefox-esr/libxul.so` | n/a | 31856 pages (124 MiB) cached |
| `[FFTEST/mmap-so] pid=2 base=0x3fffee4000 ... fd=10 path=...` | n/a | content process forked and mapping libs |
| DT_RUNPATH resolution `/usr/lib/firefox-esr/libxul.so` | fail (ENOENT) | success |
| libmozsandbox.so DT_NEEDED resolution | fail (ld-musl exit_group) | success |

The libxul → libmozsandbox load chain that was the entire prior-PR blocker now resolves cleanly. The follow-on `SMAP/FAULT` belongs to the parallel H1-SMAP track (kernel supervisor-access-to-user-page during a content-process syscall path, unrelated to RUNPATH).

## Test plan

- [x] `bash scripts/install-firefox-musl.sh --force` succeeds and reports `libxul.so (runpath)` + `libmozsandbox (runpath)` byte counts
- [x] `mdir -i build/data.img ::usr/lib/firefox-esr` lists `libxul.so`, `libmozsandbox.so`, `liblgpllibs.so` etc. after `ASTRYXOS_FIREFOX_VARIANT=musl scripts/create-data-disk.sh --force --firefox-variant=musl`
- [x] `python3 scripts/qemu-harness.py start --features 'firefox-test'` reaches sc=1227 (pid=1) past the prior `sc=871` baseline; content process pid=2 spawned and progressing at sc=487

## References

- ELF gABI / System V ABI Update §5.4 \"Shared Object Dependencies\": https://refspecs.linuxfoundation.org/elf/gabi4+/ch5.dynamic.html
- ld-musl(8) — musl libc.org documentation on the dynamic linker search order
- Alpine Linux package layout for firefox-esr: https://pkgs.alpinelinux.org/package/v3.20/community/x86_64/firefox-esr
- Mozilla launcher / dependentlibs.list convention: https://firefox-source-docs.mozilla.org/build/buildsystem/components.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)