### PR TITLE
kernel/arch/x86_64/irq: clear EFLAGS.AC at hardware IRQ entry (SMAP gate; CWE-693)

### DIFF
--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -224,11 +224,31 @@ pub fn get_ticks() -> u64 {
 /// Generate a naked ISR stub that saves caller-saved registers, calls
 /// `$handler`, then restores and `iretq`s.  All four hardware IRQ stubs
 /// are identical in structure; this macro removes the duplication.
+///
+/// ## SMAP entry guard
+///
+/// Hardware IRQs fire asynchronously on ring-3 contexts and per Intel SDM
+/// Vol. 3A §6.4 the CPU pushes the interrupted RFLAGS unchanged onto the
+/// kernel stack — leaving the live EFLAGS.AC at whatever the user held.
+/// EFLAGS.AC is not a privileged bit, so a ring-3 attacker can set AC=1
+/// and rely on an asynchronous IRQ to enter the kernel with SMAP silently
+/// lifted (CWE-269 / CWE-693).  Today the hardware-IRQ paths below only
+/// touch the kernel direct-physical map, but the post-#302 invariant —
+/// "AC=0 at every ring-3 → ring-0 boundary unless inside a nested
+/// `UserGuard`" — must hold for every entry to keep the property
+/// composable.  Per Intel SDM Vol. 2A (CLAC) the instruction raises #UD
+/// if CR4.SMAP=0, so the emit is gated on the runtime `SMAP_ENABLED`
+/// flag set by `arch::x86_64::enable_cpu_security_features`.
 macro_rules! irq_stub {
     ($name:ident, $handler:ident) => {
         #[unsafe(naked)]
         pub extern "C" fn $name() {
             core::arch::naked_asm!(
+                // ── SMAP entry guard — see macro-level doc comment ──
+                "cmp byte ptr [rip + {smap_enabled}], 0",
+                "je 90f",
+                "clac",
+                "90:",
                 "push rax", "push rcx", "push rdx",
                 "push rsi", "push rdi",
                 "push r8",  "push r9",  "push r10", "push r11",
@@ -238,6 +258,7 @@ macro_rules! irq_stub {
                 "pop rdx",  "pop rcx",  "pop rax",
                 "iretq",
                 handler = sym $handler,
+                smap_enabled = sym crate::arch::x86_64::smap::SMAP_ENABLED,
             );
         }
     };
@@ -267,6 +288,24 @@ macro_rules! irq_stub {
 #[unsafe(naked)]
 pub extern "C" fn irq_timer_handler() {
     core::arch::naked_asm!(
+        // ── SMAP entry guard ────────────────────────────────────────────
+        // Asynchronous LAPIC timer IRQ may land on a ring-3 context that
+        // set EFLAGS.AC=1 in userspace (the AC bit is not privileged —
+        // CWE-269 / CWE-693).  Per Intel SDM Vol. 3A §6.4 the CPU
+        // preserves the interrupted RFLAGS into the IRETQ frame and
+        // leaves the live AC bit alone, so a kernel-side user-pointer
+        // deref taken in the ISR would run with SMAP silently lifted.
+        // The timer ISR itself does not deref user pointers today, but
+        // the post-#302 invariant — "AC=0 at every ring-3 → ring-0
+        // boundary unless inside a nested `UserGuard`" — must hold here
+        // for the property to compose with any future user-mode helper
+        // the timer path calls (e.g. activity-metrics probes).  CLAC
+        // raises #UD if CR4.SMAP=0 (Intel SDM Vol. 2A), so the emit is
+        // gated on the runtime `SMAP_ENABLED` flag.
+        "cmp byte ptr [rip + {smap_enabled}], 0",
+        "je 90f",
+        "clac",
+        "90:",
         // Save ALL registers (caller + callee saved)
         "push rax", "push rcx", "push rdx",
         "push rsi", "push rdi",
@@ -301,6 +340,7 @@ pub extern "C" fn irq_timer_handler() {
         timer_tick = sym timer_tick,
         sample_tick = sym sample_tick_trampoline,
         check_resched = sym crate::sched::check_reschedule,
+        smap_enabled = sym crate::arch::x86_64::smap::SMAP_ENABLED,
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #302 (`c9a6d68`): extends the SMAP `CLAC` entry prologue from the
IDT exception macros and the two syscall entry paths to the hardware-IRQ entry
stubs that PR #302 missed.

Coverage delta after this change:

| Entry point | CLAC prologue source |
|---|---|
| IDT exception entries (vectors 0-19) — `isr_no_error!` / `isr_with_error!` | PR #302 |
| `INT 0x80` legacy syscall stub (`isr_syscall_int80`) | PR #302 |
| `SYSCALL` fast path (FMASK) | PR #302 |
| Hardware-IRQ stubs (`irq_stub!`): keyboard, mouse, e1000, virtio-blk, virtio-serial, TLB-shootdown IPI, w215-diag DR-sync IPI | **this PR** |
| Timer IRQ entry (`irq_timer_handler`) | **this PR** |

Discovered during the security-engineer's PR #302 re-review (CWE-693 / CWE-269).

## Why this matters

Per Intel SDM Vol. 3A §6.4 the CPU pushes the interrupted RFLAGS unchanged
into the IRETQ frame and leaves the live `EFLAGS.AC` bit alone during
interrupt entry — there is no microarchitectural masking analogous to
SYSCALL's `FMASK`. `EFLAGS.AC` is also not a privileged bit
(Intel SDM Vol. 1 §3.4.3.1), so a ring-3 attacker may set `AC=1` and rely
on an asynchronous IRQ to enter ring-0 with SMAP silently lifted.
(CWE-693 Protection Mechanism Failure / CWE-269 Improper Privilege
Management.)

Today the hardware-IRQ paths only touch the kernel direct-physical map,
so the gap is latent. But the post-PR-#302 kernel-wide invariant is
"`EFLAGS.AC = 0` at every ring-3 → ring-0 boundary unless inside a nested
`UserGuard`" (Intel SDM Vol. 3A §4.6.1 SMAP semantics). The invariant
must hold for IRQ entries too or any future user-pointer deref reached
from an ISR — e.g. a per-process activity-metrics probe in the timer
ISR, or a deferred wake hook touching a user futex value — would
silently bypass SMAP.

## Shape

Byte-identical to the PR #302 prologue:

```asm
cmp byte ptr [rip + {smap_enabled}], 0
je 90f
clac
90:
```

It runs before any other instruction in the stub. `CLAC` raises `#UD` on
`CR4.SMAP=0` (Intel SDM Vol. 2A "CLAC — Clear AC Flag in EFLAGS Register"),
hence the runtime gate on the `SMAP_ENABLED` atomic, which is set
exactly once by `arch::x86_64::enable_cpu_security_features` after the
BSP/APs commit `CR4.SMAP` and is monotonically one-way.

## Test plan

- [x] Clean kernel build under `cargo +nightly` (via `qemu-harness.py`),
      `firefox-test,kdb,syscall-trace`, KVM with `-cpu host`.
- [x] Baseline soak on bare master (sid `413d7bac4630`): hits the
      pre-existing recvmsg SMAP `BUGCHECK` at `rip=0xffff800000128381`
      `cr2=0x7ffffffef4e0` at `tick≈26000` / `sc≈1914` — confirms the
      fault is upstream of this change and orthogonal to IRQ entry.
- [x] Post-rebase soak on `c9a6d68` (PR #302 merged) + this commit (sid
      `dc5cdf32c9f2`): advances cleanly to `tick=27500` / `sc=1905`,
      heartbeats firing on AP `cpu=1` every 500 ticks, **zero**
      `BUGCHECK` / `#UD` / `SMAP/FAULT` / `panic` markers.
- [x] No #UD raised on KVM host CPU during ~5 minutes of asynchronous
      LAPIC timer + PIC keyboard IRQ traffic, confirming the
      `SMAP_ENABLED` runtime gate correctly suppresses `CLAC` before
      bringup and emits it after.
- [x] Test 220c (A-E) continues to validate the underlying state
      machine — no new test required; this change widens the
      entry-point coverage of the existing invariant rather than
      changing the semantics.

## References

- Intel SDM Vol. 1 §3.4.3.1 (RFLAGS register, AC bit non-privileged)
- Intel SDM Vol. 2A "CLAC", "STAC"
- Intel SDM Vol. 3A §4.6.1 (SMAP semantics), §6.4 (interrupt and
  exception handling, RFLAGS preservation), §6.8.8 (IA-32e SYSCALL FMASK)
- CWE-693 (Protection Mechanism Failure), CWE-269 (Improper Privilege
  Management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)