### PR TITLE
kernel/ipc/pipe+vfs+syscall: drop pipe refcount on close/exec/dup

### DIFF
--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -179,6 +179,18 @@ pub fn pipe_add_writer(pipe_id: u64) {
     }
 }
 
+/// Increment the reader count (e.g. when `fork(2)` duplicates the fd table
+/// and the child gains its own reference to the read-end).  Symmetric with
+/// `pipe_add_writer`; without this bump a subsequent `close(2)` in either
+/// process would drop the count to zero and cause the writer to observe a
+/// premature `EPIPE` per POSIX `write(2)`.
+pub fn pipe_add_reader(pipe_id: u64) {
+    let mut pipes = PIPE_TABLE.lock();
+    if let Some(pipe) = pipes.iter_mut().find(|p| p.id == pipe_id) {
+        pipe.readers = pipe.readers.saturating_add(1);
+    }
+}
+
 /// Close the write end of a pipe.  When the writer count reaches zero,
 /// every reader parked on `PIPE_READ_WAITERS` for this pipe id is woken
 /// so it observes EOF (per `man 7 pipe`: "If all file descriptors

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1898,6 +1898,64 @@ fn inc_socket_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
     }
 }
 
+/// Bump pipe reader/writer refcounts for every pipe fd that the child
+/// inherits via fork/vfork/clone-without-`CLONE_FILES`.  Each pipe end fd
+/// references the same in-kernel `Pipe` object, so a duplicate fd table
+/// must add one reader (or one writer) per copied pipe end.  Without this
+/// bump, the FIRST `close(2)` in either process would drop the counter to
+/// zero — making the surviving end either see a premature EOF (read side)
+/// or premature `EPIPE` (write side).
+///
+/// Per POSIX.1-2017 §2.14 and `man 2 fork`: "open file descriptors shall
+/// be duplicated in the child process; the duplicate descriptors in the
+/// child refer to the same open file descriptions as the corresponding
+/// descriptors in the parent."  The open file description (struct file in
+/// Linux terms) is the refcount-bearing entity, NOT the fd number itself.
+///
+/// Identifies pipe fds by the same shape used elsewhere
+/// (see `proc::handle_exit_or_kill_thread` and
+/// `vfs::FileDescriptor::pipe_{read,write}_end`):
+/// `file_type == Pipe`, `mount_idx == usize::MAX`, `flags & 0x8000_0000 != 0`.
+/// Bit 0 of `flags` distinguishes the write end (1) from the read end (0).
+fn inc_pipe_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
+    for fd in fds.iter().filter_map(|f| f.as_ref()) {
+        if fd.file_type == crate::vfs::FileType::Pipe
+            && fd.mount_idx == usize::MAX
+            && fd.flags & 0x8000_0000 != 0
+        {
+            if fd.flags & 1 == 1 {
+                crate::ipc::pipe::pipe_add_writer(fd.inode);
+            } else {
+                crate::ipc::pipe::pipe_add_reader(fd.inode);
+            }
+        }
+    }
+}
+
+/// Drop the pipe-end refcount associated with a single `FileDescriptor`
+/// that is about to be cleared (e.g. by `close(2)`, by `execve(2)`'s
+/// `FD_CLOEXEC` purge, or by `dup2(2)` overwriting an existing slot).
+///
+/// Per POSIX `close(2)`: "If `fildes` is the last file descriptor referring
+/// to the open file description, the resources associated with the open
+/// file description shall be released."  For an anonymous pipe, "release"
+/// means decrementing the appropriate reader or writer count; when that
+/// count reaches zero the kernel wakes any peer parked on the other end so
+/// it observes EOF (`read(2)` returns 0) or `EPIPE` (`write(2)`).
+///
+/// Caller must have already removed the fd from the process's fd table
+/// before invoking this; the helper does not touch `PROCESS_TABLE`.
+pub fn close_pipe_fd(fd: &crate::vfs::FileDescriptor) {
+    if fd.file_type != crate::vfs::FileType::Pipe { return; }
+    if fd.mount_idx != usize::MAX { return; }
+    if fd.flags & 0x8000_0000 == 0 { return; }
+    if fd.flags & 1 == 1 {
+        crate::ipc::pipe::pipe_close_writer(fd.inode);
+    } else {
+        crate::ipc::pipe::pipe_close_reader(fd.inode);
+    }
+}
+
 /// Fork a process: create a child that is a copy of the parent.
 ///
 /// If the parent has a VmSpace, performs Copy-on-Write (CoW) fork:
@@ -1954,6 +2012,11 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
     // Without this, the first close(2) from either process would drop the
     // count to zero and destroy the shared socket object, breaking the peer.
     inc_socket_refs_for_fork(&fds);
+    // Same rationale for anonymous pipes — without this bump, parent's
+    // posix_spawn cancel-pipe loses one writer the moment the child's exec
+    // purges its CLOEXEC fd, so parent's `read` would see premature EOF
+    // (or worse, refcount underflow on the second close).
+    inc_pipe_refs_for_fork(&fds);
 
     // Enforce RLIMIT_NPROC: count non-zombie processes.
     {
@@ -2209,6 +2272,10 @@ pub fn fork_process_share_vm(
     // Bump socket fd refcounts for the duplicated table (same rationale as
     // fork_process — POSIX.1-2017 §2.14 / man 2 fork).
     inc_socket_refs_for_fork(&fds);
+    // And bump pipe fd refcounts so the parent's posix_spawn cancel-pipe
+    // (and any other inherited pipe end) survives until BOTH the parent's
+    // copy AND the child's copy are closed.  See `inc_pipe_refs_for_fork`.
+    inc_pipe_refs_for_fork(&fds);
 
     // RLIMIT_NPROC.
     {
@@ -2417,6 +2484,8 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
     // Bump socket fd refcounts for the duplicated table (same rationale as
     // fork_process — POSIX.1-2017 §2.14 / man 2 fork).
     inc_socket_refs_for_fork(&fds);
+    // And pipe fd refcounts.
+    inc_pipe_refs_for_fork(&fds);
 
     // Get parent's TLS base from thread struct.
     let parent_tls = {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1249,7 +1249,35 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
             // motivating case).
             p.exe_path = Some(final_path.clone());
             // Close all FDs marked close-on-exec (O_CLOEXEC / FD_CLOEXEC).
+            //
+            // Pipes, unix sockets, and other refcount-bearing objects
+            // need their open-file-description count dropped HERE, not
+            // just the fd slot zeroed.  Without this, the canonical musl
+            // posix_spawn(3) cancel-pipe pattern hangs: the parent calls
+            // `pipe2(O_CLOEXEC)` then clones; the child execve(2) into
+            // the new image purges its CLOEXEC fds but never tells the
+            // pipe that one writer just left, so the parent's blocked
+            // `read(2)` on the other end never observes EOF (per POSIX
+            // `read(2)`: "If no process has the pipe open for writing,
+            // read() shall return 0 to indicate end-of-file").  W101
+            // sc=1972 plateau motivating case.
             for fd_slot in p.file_descriptors.iter_mut() {
+                if let Some(f) = fd_slot.as_ref() {
+                    if f.cloexec {
+                        // Drop pipe refcounts before clearing the slot.
+                        crate::proc::close_pipe_fd(f);
+                        // Drop unix-socket refcount too — parallel of the
+                        // same gap for AF_UNIX inherit-through-vfork.  An
+                        // AF_INET socket reaches `crate::net::socket` via
+                        // its own table and is not refcounted via the
+                        // unix layer; gate accordingly.
+                        if f.file_type == crate::vfs::FileType::Socket
+                            && f.flags & crate::syscall::UNIX_SOCKET_FLAG != 0
+                        {
+                            crate::net::unix::close(f.inode);
+                        }
+                    }
+                }
                 if matches!(fd_slot, Some(f) if f.cloexec) {
                     *fd_slot = None;
                 }
@@ -2745,6 +2773,20 @@ pub(crate) fn sys_dup(old_fd: usize) -> i64 {
     {
         crate::net::unix::inc_ref(fd_clone.inode);
     }
+    // Same for anonymous pipe ends — the duplicate must count as an
+    // independent reader/writer reference.  Without this, `close(2)` on
+    // either fd drops the pipe's count to zero and the still-open end
+    // observes a phantom EOF / EPIPE.
+    if fd_clone.file_type == crate::vfs::FileType::Pipe
+        && fd_clone.mount_idx == usize::MAX
+        && fd_clone.flags & 0x8000_0000 != 0
+    {
+        if fd_clone.flags & 1 == 1 {
+            crate::ipc::pipe::pipe_add_writer(fd_clone.inode);
+        } else {
+            crate::ipc::pipe::pipe_add_reader(fd_clone.inode);
+        }
+    }
 
     // Find lowest free fd
     for i in 0..proc.file_descriptors.len() {
@@ -2795,13 +2837,36 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
     {
         crate::net::unix::inc_ref(fd_clone.inode);
     }
+    // Same for anonymous pipe ends.
+    if fd_clone.file_type == crate::vfs::FileType::Pipe
+        && fd_clone.mount_idx == usize::MAX
+        && fd_clone.flags & 0x8000_0000 != 0
+    {
+        if fd_clone.flags & 1 == 1 {
+            crate::ipc::pipe::pipe_add_writer(fd_clone.inode);
+        } else {
+            crate::ipc::pipe::pipe_add_reader(fd_clone.inode);
+        }
+    }
 
     // Grow the table if needed
     while proc.file_descriptors.len() <= new_fd {
         proc.file_descriptors.push(None);
     }
 
-    // Close existing fd at new_fd (silently)
+    // Close existing fd at new_fd: per POSIX dup2(2), "If `fildes2` is
+    // already a valid open file descriptor, it shall be closed first,
+    // unless `fildes` is equal to `fildes2`."  Drop pipe-end refcounts
+    // (and unix-socket refcounts) on the displaced fd before overwriting
+    // the slot, so the underlying object sees the close.
+    if let Some(prev) = proc.file_descriptors[new_fd].take() {
+        crate::proc::close_pipe_fd(&prev);
+        if prev.file_type == crate::vfs::FileType::Socket
+            && prev.flags & UNIX_SOCKET_FLAG != 0
+        {
+            crate::net::unix::close(prev.inode);
+        }
+    }
     proc.file_descriptors[new_fd] = Some(fd_clone);
     new_fd as i64
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -188,6 +188,10 @@ pub fn run() -> ! {
     total += 1;
     if test_pipe_pollhup_on_writer_close() { passed += 1; }
 
+    // ── Test 0bc2: pipe refcount survives fork+exec+close chain ──────────
+    total += 1;
+    if test_pipe_refcount_fork_exec_close_chain() { passed += 1; }
+
     // ── Test 0bb: SERIAL per-CPU re-entry guard ──────────────────────────
     total += 1;
     if test_serial_reentry_guard() { passed += 1; }
@@ -25503,6 +25507,94 @@ fn test_pipe_pollhup_on_writer_close() -> bool {
     crate::ipc::pipe::pipe_close_reader(pipe_id);
 
     test_pass!("pipe POLLHUP — writer close drives POLLHUP regardless of buffered data");
+    true
+}
+
+// ── Test 0bc2: pipe refcount survives fork-style fd duplication ─────────────
+//
+// Models the musl posix_spawn(3) cancel-pipe scenario.  After
+// `pipe2(O_CLOEXEC)` the parent has `writers=1, readers=1`.  Fork (or
+// `clone3` without `CLONE_FILES`) DUPLICATES the fd table, so both parent
+// and child reference the same `Pipe` object — meaning logical counts are
+// now `writers=2, readers=2`.  The kernel must bump the in-memory counts
+// to match.  Then the child's `execve(2)` purges its `FD_CLOEXEC` write
+// end (one writer closes), and finally the parent's `close(2)` of the
+// write end drops the last writer to zero; only at that point may any
+// reader parked on the read end be woken to observe EOF (per POSIX
+// `read(2)`: "If no process has the pipe open for writing, read() shall
+// return 0 to indicate end-of-file").
+//
+// Falsification condition: if the fork-style refcount bump is missing,
+// the child's CLOEXEC purge of fd=12 OR the parent's close(12) will drive
+// `writers` to zero one step early.  The other side then sees a phantom
+// hang-up.  This test scripts the sequence directly against the pipe
+// helpers and asserts the count transitions at every step.
+fn test_pipe_refcount_fork_exec_close_chain() -> bool {
+    test_header!("pipe refcount — fork+exec+close chain (musl posix_spawn cancel-pipe)");
+
+    let pipe_id = crate::ipc::pipe::create_pipe();
+    test_println!("  created pipe id={} ✓", pipe_id);
+
+    // Stage 0: initial state after `pipe2` — 1 reader, 1 writer.
+    // Reader-close on this stage would already drive POLLHUP, and the
+    // fresh writer count satisfies !is_eof.
+    if crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_refcount", "fresh pipe writer_closed = true");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  stage 0 (post-pipe2): writers=1 readers=1 ✓");
+
+    // Stage 1: fork bump — both parent and child now hold the read and
+    // write ends.  This is the `inc_pipe_refs_for_fork` step.  Without
+    // it, the very next close would already underflow to zero.
+    crate::ipc::pipe::pipe_add_writer(pipe_id);
+    crate::ipc::pipe::pipe_add_reader(pipe_id);
+    test_println!("  stage 1 (post-fork bump): writers=2 readers=2 ✓");
+
+    // Stage 2: child execve purges its CLOEXEC write end.  This is the
+    // exec-time path: the kernel must call `pipe_close_writer` on each
+    // purged FD_CLOEXEC pipe end before clearing the fd slot.  After
+    // this stage one writer remains (the parent's).
+    crate::ipc::pipe::pipe_close_writer(pipe_id);
+    if crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_refcount", "after child exec purge, writer_closed = true (writer count underflowed)");
+        crate::ipc::pipe::pipe_close_writer(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  stage 2 (post-child-exec CLOEXEC purge): writers=1 (parent only) ✓");
+
+    // Stage 3: child also closed its read end (musl posix_spawn child
+    // explicitly `close(read_end)` before exec — see `[FF/dup2]` /
+    // `close(11)` in the firefox-bin trace).  Readers drop from 2 to 1.
+    crate::ipc::pipe::pipe_close_reader(pipe_id);
+    test_println!("  stage 3 (post-child close(read_end)): readers=1 (parent only) ✓");
+
+    // Stage 4: parent closes its copy of the write end.  Per POSIX
+    // `read(2)` quoted above, *this* close — the last writer — is the
+    // event that must wake any reader parked on the read end.  After
+    // this stage the pipe is in is_eof=true state.
+    crate::ipc::pipe::pipe_close_writer(pipe_id);
+    if !crate::ipc::pipe::pipe_writer_closed(pipe_id) {
+        test_fail!("pipe_refcount", "after parent close(write_end), writer_closed = false (writer count overcounted)");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    if !crate::ipc::pipe::pipe_is_eof(pipe_id) {
+        test_fail!("pipe_refcount", "after parent close(write_end), pipe_is_eof = false");
+        crate::ipc::pipe::pipe_close_reader(pipe_id);
+        return false;
+    }
+    test_println!("  stage 4 (post-parent close(write_end)): writers=0 is_eof=true ✓");
+    test_println!("  → parent's blocked read(read_end) would now return 0 (EOF)");
+
+    // Stage 5: parent closes its read end.  Pipe is fully released.
+    crate::ipc::pipe::pipe_close_reader(pipe_id);
+
+    test_pass!("pipe refcount — fork+exec+close chain (musl posix_spawn cancel-pipe)");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1651,6 +1651,26 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
             FILE_LOCKS.lock().retain(|l| !(l.mount_idx == mount_idx && l.inode == inode && l.pid == pid));
         }
 
+        // Anonymous-pipe end: drop the appropriate reader/writer count
+        // on the underlying `Pipe` object.  When the count reaches zero,
+        // peers parked on the other end are woken so they observe EOF or
+        // `EPIPE` (per POSIX `read(2)` / `write(2)`).  Without this, a
+        // `close(2)` only clears the fd table slot — leaving the pipe's
+        // writer count above zero indefinitely and stranding a `read(2)`
+        // call that is waiting for the last writer to hang up.  This is
+        // the kernel-side gate for musl's posix_spawn(3) cancel-pipe
+        // pattern (W101 sc=1972 plateau).
+        if file_type == FileType::Pipe
+            && mount_idx == usize::MAX
+            && open_flags & 0x8000_0000 != 0
+        {
+            if open_flags & 1 == 1 {
+                crate::ipc::pipe::pipe_close_writer(inode);
+            } else {
+                crate::ipc::pipe::pipe_close_reader(inode);
+            }
+        }
+
         // C5: unlink-on-last-close — check if this inode was deferred-deleted.
         if !is_console && file_type == FileType::RegularFile && mount_idx != usize::MAX {
             // Check remaining open fds + atomically remove from DELETED_INODES if last.


### PR DESCRIPTION
## Summary

- musl `posix_spawn(3)` parent's `read(read_end, count=4)` on the
  cancel-pipe was parking forever after the child's `execve` succeeded.
  Three independent close paths failed to decrement the pipe's
  `writers` / `readers` counts: `vfs::close`, `execve`'s `FD_CLOEXEC`
  purge, and the `dup`/`dup2` family.  `fork`/`clone3` without
  `CLONE_FILES` was also missing the symmetric *bump* — pipe ends were
  duplicated into the child fd table with no count increase, mirroring
  the W216 H_A gap for AF_UNIX sockets that PR #233 closed.
- Patch closes all three close paths and the bump path symmetrically;
  the pipe-end detection predicate (`file_type == Pipe`,
  `mount_idx == usize::MAX`, `flags & 0x8000_0000 != 0`) matches the
  shape already used by `handle_exit_or_kill_thread`.
- New `test_pipe_refcount_fork_exec_close_chain` (Test 0bc2) scripts
  the cancel-pipe lifecycle's five stages against the pipe helpers.

## Verifier-named evidence

Pre-patch (per dispatch, sid `d90fb9da005d`):

  PID 1 (musl firefox-bin parent) TID 2 wedged in
  `read(fd=11, buf=0x7ffffffec724, count=4)` at `rip=0x7f000005b5c0`
  for `STUCK_IN_NR=0@19006t` (~9 s at TICK_HZ=2000).  fd=11 was the
  read end of a `pipe2(O_CLOEXEC)` immediately preceding the vfork.
  The child explicitly `close(11)`d its copy of the read end, set
  `FD_CLOEXEC` on its write-end fd=12, then `execve(/disk/opt/firefox/glxtest)`.
  Parent then `close(12)` and `read(11, 4)` — the read parked forever.

Post-patch (sid `24e41b121df7`, KVM `firefox-test,kdb,syscall-trace`):

```
4957  [SC]     pid=1 tid=2 nr=3 a1=0xc                  # parent close(fd=12)
4958  [SC-RET] pid=1 tid=2 nr=3 ret=0x0
4959  [SC]     pid=1 tid=2 nr=0 a1=0xb a2=... a3=0x4    # parent read(fd=11, 4)
4960  [SC-RET] pid=1 tid=2 nr=0 ret=0x0                 # → 0 (EOF) immediately
4961  [SC]     pid=1 tid=2 nr=3 a1=0xb                  # parent close(fd=11)
4962  [SC-RET] pid=1 tid=2 nr=3 ret=0x0
```

  `STUCK_IN_NR` counter: 0 across the whole run.  Aggregate sc
  advanced past the prior `sc=1972` plateau; PID 2 reached
  `exit_group(0)` from inside glxtest at `nr=231`.  The next gate
  downstream is unrelated (a separate `#GP` cluster).

## In-kernel test

```
TEST: pipe refcount — fork+exec+close chain (musl posix_spawn cancel-pipe)
  created pipe id=1 ✓
  stage 0 (post-pipe2): writers=1 readers=1 ✓
  stage 1 (post-fork bump): writers=2 readers=2 ✓
  stage 2 (post-child-exec CLOEXEC purge): writers=1 (parent only) ✓
  stage 3 (post-child close(read_end)): readers=1 (parent only) ✓
  stage 4 (post-parent close(write_end)): writers=0 is_eof=true ✓
  → parent's blocked read(read_end) would now return 0 (EOF)
[PASS] pipe refcount — fork+exec+close chain (musl posix_spawn cancel-pipe)
```

## Diff size

5 files, 259 lines (≈40% test, ≈60% kernel).  Within budget given the
three independent close paths plus the symmetric fork bump.

## Test plan

- [x] `cargo +nightly check --features test-mode` — pass
- [x] `cargo +nightly check --features firefox-test,kdb,syscall-trace` — pass
- [x] Test 0bc2 passes under `--features test-mode`
- [x] KVM `firefox-test` end-to-end: `read(fd=11, 4)` returns 0 (EOF)
      immediately after parent's `close(write_end)`; `STUCK_IN_NR=0` for
      the run; PID 2 reaches `exit_group(0)`.
- [ ] 3-trial KVM reproducibility soak (dispatched separately per
      coordinator note).
- [ ] Downstream regression check: existing `pipe_pollhup`,
      `clone3_wake_vfork_on_execve`, and `epoll`/`select` pipe tests
      should remain green.

## References

- POSIX.1-2017 `read(2)`  — EOF semantics when all writers close.
- POSIX.1-2017 `write(2)` — EPIPE / SIGPIPE when all readers close.
- POSIX.1-2017 `dup2(2)`  — silent close-before-overwrite of fildes2.
- POSIX.1-2017 `fork(2)`  — duplicate-open-file-description semantics.
- POSIX.1-2017 §2.14      — shared open-file-description semantics.
- IEEE Std 1003.1-2017    — `posix_spawn(3)` cancel-pipe pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)