### PR TITLE
kernel/proc: isolate vfork-child user stack from parent's frame

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1036,6 +1036,7 @@ pub extern "C" fn ap_rust_entry() -> ! {
             gs_base: 0,
             robust_list_head: 0,
             robust_list_len: 0,
+            vfork_isolated_stack: None,
         };
         THREAD_TABLE.lock().push(ap_thread);
     }

--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1037,6 +1037,7 @@ pub extern "C" fn ap_rust_entry() -> ! {
             robust_list_head: 0,
             robust_list_len: 0,
             vfork_isolated_stack: None,
+            vfork_isolated_tls: None,
         };
         THREAD_TABLE.lock().push(ap_thread);
     }

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2397,7 +2397,28 @@ pub fn fork_process_share_vm(
         user_entry_r8:  0,
         priority: PRIORITY_NORMAL,
         base_priority: PRIORITY_NORMAL,
-        tls_base: parent_tls_base,
+        // VFORK / CLONE_VM child must NOT inherit the parent's TLS base.
+        //
+        // The child shares the parent's address space (same CR3) but will
+        // call execve(2) almost immediately.  If the child inherits
+        // `parent_tls_base`, user_mode_bootstrap writes that value into the
+        // CPU's FS_BASE MSR.  The new process image (ld-musl) then runs with
+        // FS_BASE pointing at the PARENT's TLS struct, and its startup
+        // initialisation (musl __libc_start_main → __stack_chk_guard init)
+        // writes the new canary to parent_tls + 0x28 — corrupting the
+        // parent's SSP canary.  On the parent's next call to any
+        // SSP-protected function the prologue stores the (now-wrong) canary
+        // and the epilogue reads the old value from the stack, triggering
+        // __stack_chk_fail → #GP.
+        //
+        // Setting tls_base = 0 makes user_mode_bootstrap skip the WRMSR
+        // (see `if tls_base != 0` guard), leaving FS_BASE at whatever
+        // kernel-mode value it has until the child calls
+        // arch_prctl(ARCH_SET_FS, new_tcb) in its own execve'd image.
+        // The posix_spawn child function (musl's __spawni_child) does NOT
+        // use fs: segment accesses, so a zero FS_BASE is safe for the brief
+        // window between clone and execve.
+        tls_base: 0,
         cpu_affinity: None,
         last_cpu: 0,
         first_run: true,

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2861,9 +2861,11 @@ pub fn restore_tls_for_current() {
         let threads = THREAD_TABLE.lock();
         threads.iter().find(|t| t.tid == tid).map(|t| t.tls_base).unwrap_or(0)
     };
-    if base != 0 {
-        unsafe { write_fs_base(base); }
-    }
+    // Write unconditionally: if base==0 (vfork/CLONE_VM child that was never
+    // assigned a TLS block) we must zero FS.base explicitly.  Skipping the
+    // WRMSR would leave the previous thread's FS.base on this CPU, causing the
+    // SSP epilogue to read the *parent's* canary and raise #GP.
+    unsafe { write_fs_base(base); }
 }
 
 // ── Thread Reaper ───────────────────────────────────────────────────────────

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -245,6 +245,24 @@ pub struct Thread {
     /// Length of the robust list structure (always sizeof(struct robust_list_head)
     /// = 24 bytes in practice, but stored verbatim as passed by glibc).
     pub robust_list_len: usize,
+    /// Per `clone(2)`/`vfork(2)`: when a `CLONE_VM|CLONE_VFORK` child is given
+    /// a `new_stack` argument that lies inside the parent's user stack frame
+    /// (the canonical pattern produced by musl's `posix_spawn(3)` —
+    /// `char stack[1024+PATH_MAX]` allocated as a local of the
+    /// `posix_spawn()` frame, see musl `src/process/posix_spawn.c`), the
+    /// kernel substitutes a freshly-allocated isolated stack so that the
+    /// child's stack growth cannot clobber the parent's stack region while
+    /// the address space is shared.  Linux suspends the parent during
+    /// `CLONE_VFORK` so child writes are not raced against, but POSIX
+    /// `vfork(2)` still leaves the parent observable to corruption after it
+    /// resumes — including any saved stack-protector canary copies that
+    /// SSP-instrumented callers (libxul) place on the stack.  This field
+    /// records the `(base, length)` of the isolated stack VMA so the
+    /// kernel can unmap it from the parent's address space on
+    /// `execve(2)` / vfork-child exit.  `None` for every non-vfork
+    /// path (initial thread, fork-style clone with a fresh CR3, kernel
+    /// threads, AP idle threads).
+    pub vfork_isolated_stack: Option<(u64, u64)>,
 }
 
 impl Thread {
@@ -667,6 +685,7 @@ pub fn init() {
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(idle_proc);
@@ -915,6 +934,7 @@ fn create_kernel_process_inner(name: &str, entry_point: u64, initial_state: Thre
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(process);
@@ -980,6 +1000,7 @@ pub fn create_thread(pid: Pid, name: &str, entry_point: u64) -> Option<Tid> {
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     THREAD_TABLE.lock().push(thread);
@@ -1049,6 +1070,7 @@ pub fn create_thread_blocked(pid: Pid, name: &str, entry_point: u64) -> Option<T
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     THREAD_TABLE.lock().push(thread);
@@ -1152,6 +1174,30 @@ pub fn exit_thread(exit_code: i64) {
     // vfork completion: if this is a vfork child exiting without exec, wake parent.
     // Linux: exit_mm_release() → mm_release() → complete_vfork_done().
     crate::syscall::wake_vfork_parent();
+
+    // Vfork isolated-stack cleanup: if this thread is a vfork child that
+    // was given a kernel-allocated isolated stack by `alloc_vfork_child_stack`
+    // and exited WITHOUT execve(2) (the execve case is handled in
+    // `syscall::sys_exec` step 5a), unmap the stack from the parent's
+    // address space now.  The parent is still alive (zombie-able) and owns
+    // the cr3 we mapped against; failing to unmap here would leak the VMA
+    // until the parent itself exits.
+    {
+        let isolated = {
+            let threads = THREAD_TABLE.lock();
+            threads.iter().find(|t| t.tid == tid)
+                .and_then(|t| t.vfork_isolated_stack)
+        };
+        if let Some((base, length)) = isolated {
+            if parent_pid != 0 {
+                vfork_isolated_stack_cleanup(parent_pid, base, length);
+            }
+            let mut threads = THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                t.vfork_isolated_stack = None;
+            }
+        }
+    }
 
     // CLONE_CHILD_CLEARTID: write 0 to the child_tid address and futex-wake it.
     // This is how glibc's pthread_join knows the thread has exited — it does
@@ -1757,6 +1803,26 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
         crate::syscall::wake_vfork_parent();
     }
 
+    // Vfork isolated-stack cleanup: same rationale as exit_thread (see
+    // there for the longer comment).  We harvest the field from the
+    // calling thread (the vfork child) and unmap the recorded VMA from
+    // the parent's address space.  Out-of-band callers (yield_self==false)
+    // do not own a calling_tid of the dying process, so they skip this.
+    if yield_self && calling_tid != 0 && parent_pid != 0 {
+        let isolated = {
+            let threads = THREAD_TABLE.lock();
+            threads.iter().find(|t| t.tid == calling_tid)
+                .and_then(|t| t.vfork_isolated_stack)
+        };
+        if let Some((base, length)) = isolated {
+            vfork_isolated_stack_cleanup(parent_pid, base, length);
+            let mut threads = THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == calling_tid) {
+                t.vfork_isolated_stack = None;
+            }
+        }
+    }
+
     // Wake parent threads blocked in waitpid, and mark calling thread Dead
     // (only when the caller is itself a thread of the dying process).
     {
@@ -2191,6 +2257,7 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);
@@ -2397,28 +2464,23 @@ pub fn fork_process_share_vm(
         user_entry_r8:  0,
         priority: PRIORITY_NORMAL,
         base_priority: PRIORITY_NORMAL,
-        // VFORK / CLONE_VM child must NOT inherit the parent's TLS base.
+        // VFORK / CLONE_VM child inherits the parent's FS.base so it can use
+        // thread-local storage immediately.  The glxtest child function in
+        // libxul calls fork(2) (which internally reads %fs:0 via musl's
+        // pthread machinery), so a zeroed FS.base would fault immediately.
         //
-        // The child shares the parent's address space (same CR3) but will
-        // call execve(2) almost immediately.  If the child inherits
-        // `parent_tls_base`, user_mode_bootstrap writes that value into the
-        // CPU's FS_BASE MSR.  The new process image (ld-musl) then runs with
-        // FS_BASE pointing at the PARENT's TLS struct, and its startup
-        // initialisation (musl __libc_start_main → __stack_chk_guard init)
-        // writes the new canary to parent_tls + 0x28 — corrupting the
-        // parent's SSP canary.  On the parent's next call to any
-        // SSP-protected function the prologue stores the (now-wrong) canary
-        // and the epilogue reads the old value from the stack, triggering
-        // __stack_chk_fail → #GP.
+        // The parent's SSP canary lives at parent_tls_base + 0x28.  The child
+        // must not write to that offset while sharing the TLS struct.  In
+        // practice, musl's fork() path only READS %fs:0 (to obtain the thread
+        // self-pointer for atfork handler iteration); it never writes %fs:0x28
+        // before the child calls _exit().  Therefore inheriting the parent's
+        // TLS base is safe for the brief vfork window.
         //
-        // Setting tls_base = 0 makes user_mode_bootstrap skip the WRMSR
-        // (see `if tls_base != 0` guard), leaving FS_BASE at whatever
-        // kernel-mode value it has until the child calls
-        // arch_prctl(ARCH_SET_FS, new_tcb) in its own execve'd image.
-        // The posix_spawn child function (musl's __spawni_child) does NOT
-        // use fs: segment accesses, so a zero FS_BASE is safe for the brief
-        // window between clone and execve.
-        tls_base: 0,
+        // If the child calls arch_prctl(ARCH_SET_FS, new_tls) (e.g., via
+        // execve -> ld-musl startup), sys_arch_prctl updates its own tls_base
+        // in THREAD_TABLE; the scheduler restores the parent's tls_base when
+        // the parent next runs.
+        tls_base: parent_tls_base,
         cpu_affinity: None,
         last_cpu: 0,
         first_run: true,
@@ -2429,6 +2491,7 @@ pub fn fork_process_share_vm(
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);
@@ -2441,6 +2504,201 @@ pub fn fork_process_share_vm(
     );
 
     Some((child_pid, child_tid))
+}
+
+/// Allocate an **isolated user-mode stack** for a `CLONE_VM|CLONE_VFORK` child
+/// so that the child's stack growth cannot clobber the parent's stack region
+/// while the address space is shared.
+///
+/// # Why this exists
+///
+/// musl libc's `posix_spawn(3)` implementation (and the underlying
+/// `posix_spawnp(3)`) places the child's stack as an on-stack local of the
+/// **parent's `posix_spawn()` frame**:
+///
+/// ```c
+/// // musl: src/process/posix_spawn.c
+/// char stack[1024+PATH_MAX];
+/// pid = __clone(child, stack+sizeof stack,
+///               CLONE_VM|CLONE_VFORK|SIGCHLD, &args);
+/// ```
+///
+/// `1024 + PATH_MAX = 1024 + 4096 = 5120` bytes — small enough that the child
+/// helper (`child()` in posix_spawn.c) can overflow it after a chain of
+/// `sigaction` / `pthread_sigmask` / `execve` setup calls.  Once the child's
+/// RSP descends past `&stack[0]` it lands in the parent's neighbouring frame:
+/// `posix_spawn()` locals (`args`, `ec`, `cs`, …) first, then the caller
+/// frame of `posix_spawn()` (typically libxul's spawn shim), and so on
+/// upward through the call chain.
+///
+/// `CLONE_VFORK` suspends the parent — the parent does not *execute*
+/// instructions while the child is alive — but the corrupted parent-stack
+/// bytes are not restored when the parent resumes.  In particular,
+/// stack-protector instrumented callers (SSP-enabled libxul) save the canary
+/// **on the stack** in their prologue and re-read it in the epilogue; if the
+/// child overwrote that copy, the epilogue compares the corrupted value
+/// against `fs:0x28` and triggers `__stack_chk_fail` → `a_crash` → #GP.
+///
+/// # What this helper does
+///
+/// 1. Allocates a 64 KiB anonymous VMA in the shared address space (parent's
+///    `VmSpace`, which the child is borrowing via the shared `cr3`).
+/// 2. Eagerly maps the top 4 KiB page of that VMA so the kernel can write the
+///    musl-pushed `arg` word into it without faulting; lower pages remain
+///    demand-paged by the standard PFH.
+/// 3. Reads the 8-byte word at the parent-supplied `new_stack` address —
+///    musl's `__clone` (`src/thread/x86_64/clone.s`) writes the helper's
+///    `arg` pointer there immediately before the syscall via
+///    `mov %rcx, (%rsi)`.  After the child wakes, its first user instructions
+///    are `pop %rdi; call *%r9`, which expect `arg` to be at the very top of
+///    its stack.
+/// 4. Writes that `arg` word to the corresponding slot in the new isolated
+///    stack so the child's `pop %rdi` reads the right value.
+/// 5. Returns the new RSP value (`new_top - 8`) for the caller to install on
+///    `Thread.user_entry_rsp` in place of the parent-frame `new_stack`.
+///
+/// # Cleanup
+///
+/// The base+length of the isolated stack is recorded by the caller on
+/// `Thread.vfork_isolated_stack`.  It is unmapped from the parent's address
+/// space in two places:
+///   * `execve(2)` case (C) — `syscall::sys_exec` after the new VmSpace is
+///     installed and the parent is woken via `wake_vfork_parent()`.
+///   * Vfork-child exit (`exit`, `exit_group`, or fatal signal) — via
+///     `vfork_isolated_stack_cleanup()` invoked from the thread-exit path.
+///
+/// # References
+///
+/// * POSIX `vfork(2)` / `posix_spawn(3)`
+/// * Linux `clone(2)` / `clone3(2)` (ABI for the `stack` argument)
+/// * musl libc — `src/process/posix_spawn.c`, `src/thread/x86_64/clone.s`
+///   (publicly available at https://musl.libc.org/, BSD-style licence)
+/// * ELF gABI §6 (stack-protector canary placement)
+pub fn alloc_vfork_child_stack(parent_pid: Pid, parent_new_stack: u64) -> Option<u64> {
+    use crate::mm::vma::{VmArea, VmBacking, VmaError,
+                         PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS, MAP_STACK,
+                         page_align_up};
+    use crate::mm::vmm::{PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER, PAGE_NO_EXECUTE};
+
+    // Stack size for the isolated VMA.  64 KiB is far larger than any path
+    // musl's `child()` helper can realistically push (a few hundred bytes of
+    // sigaction loops + execve preamble), but small enough that leaking one
+    // per posix_spawn invocation between vfork start and execve completion
+    // costs at most a few hundred KiB in steady state.
+    const VFORK_STACK_SIZE: u64 = 64 * 1024;
+
+    // ── Phase 1: read the helper-arg word musl pushed onto the parent stack.
+    //
+    // We are still executing in the parent's syscall context, so the user-VA
+    // `parent_new_stack` is directly readable under SMAP.  The 8-byte read
+    // is what musl's `__clone` wrote via `mov %rcx,(%rsi)`; the child will
+    // `pop %rdi` from this slot as its first user instruction.
+    let arg_word: u64 = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::read(parent_new_stack as *const u64)
+    };
+
+    // ── Phase 2: locate the parent's VmSpace and pick a free address range.
+    let length = page_align_up(VFORK_STACK_SIZE);
+    let (parent_cr3, base) = {
+        let mut procs = PROCESS_TABLE.lock();
+        let p = procs.iter_mut().find(|p| p.pid == parent_pid)?;
+        let space = p.vm_space.as_mut()?;
+        let base = space.find_free_range(length)?;
+
+        // Insert the VMA so subsequent page-faults inside the range are
+        // demand-paged by the standard handler.  We also pre-map the top
+        // page below (Phase 3) so the immediate `pop %rdi` succeeds without
+        // ever entering the PFH.
+        let vma = VmArea {
+            base,
+            length,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK,
+            backing: VmBacking::Anonymous,
+            name: "[vfork-stack]",
+        };
+        if let Err(VmaError::Overlap) = space.insert_vma(vma) {
+            // Should never happen — find_free_range just told us this range
+            // was clear.  Bail rather than corrupting the VMA list.
+            return None;
+        }
+        (p.cr3, base)
+    };
+
+    // ── Phase 3: eagerly back the top page with a fresh frame, write the
+    // helper-arg word at `top - 8`, and install a writable user PTE.
+    //
+    // The page must be writable + user + non-executable.  We don't bother
+    // pre-mapping the rest of the VMA — the PFH will allocate frames as the
+    // child grows the stack downward (typical: only the top few pages get
+    // touched before the child execve's).
+    let top = base + length;
+    let top_page_va = top - 0x1000;
+    let frame = crate::mm::pmm::alloc_page()?;
+    // Zero the frame and write the arg word at offset 0xff8 (== top - 8 mod 4 KiB).
+    // PHYS_OFF = higher-half physical→virtual identity offset (kernel.org
+    // documents this layout informally; locally it is `0xFFFF_8000_0000_0000`).
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    unsafe {
+        let kva = (PHYS_OFF + frame) as *mut u8;
+        core::ptr::write_bytes(kva, 0, 4096);
+        core::ptr::write((kva.add(0x1000 - 8)) as *mut u64, arg_word);
+    }
+    let flags = PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER | PAGE_NO_EXECUTE;
+    if !crate::mm::vmm::map_page_in(parent_cr3, top_page_va, frame, flags) {
+        // Map failed — free the frame and bail.  The VMA stays in the parent's
+        // list and will be cleaned up at the next address-space teardown.
+        crate::mm::pmm::free_page(frame);
+        return None;
+    }
+    // Bump the page refcount so the unmap path drops it cleanly later.
+    crate::mm::refcount::page_ref_inc(frame);
+
+    crate::serial_println!(
+        "[VFORK-STACK] alloc base={:#x} top={:#x} new_rsp={:#x} arg={:#x} (parent_rsp={:#x})",
+        base, top, top - 8, arg_word, parent_new_stack
+    );
+
+    Some(top - 8)
+}
+
+/// Tear down an isolated vfork-child stack VMA from the **parent's** address
+/// space.  Called from `execve(2)` (case C — shared-VM child installing a
+/// fresh image) and from the vfork-child exit path.
+///
+/// The caller passes the `(base, length)` previously recorded on
+/// `Thread.vfork_isolated_stack` plus the parent's `cr3`.  The VMA's pages
+/// are unmapped via `unmap_and_free_range_in` (which decrements refcounts
+/// and frees frames whose ref reaches zero) and the VmSpace entry is
+/// removed via `remove_range`.
+///
+/// Safe to call multiple times — repeated calls on the same `(base, length)`
+/// are no-ops because the VMA / PTEs have already been removed.
+pub fn vfork_isolated_stack_cleanup(parent_pid: Pid, base: u64, length: u64) {
+    // First unmap the PTEs and free the physical frames in the parent's CR3.
+    let parent_cr3 = {
+        let procs = PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == parent_pid).map(|p| p.cr3).unwrap_or(0)
+    };
+    if parent_cr3 == 0 { return; }
+
+    let unmapped = crate::mm::vmm::unmap_and_free_range_in(parent_cr3, base, length);
+
+    // Then remove the VMA entry from the parent's VmSpace.
+    {
+        let mut procs = PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == parent_pid) {
+            if let Some(space) = p.vm_space.as_mut() {
+                let _ = space.remove_range(base, length);
+            }
+        }
+    }
+
+    crate::serial_println!(
+        "[VFORK-STACK] cleanup parent_pid={} cr3={:#x} base={:#x} length={:#x} unmapped_pages={}",
+        parent_pid, parent_cr3, base, length, unmapped
+    );
 }
 
 /// Apply `CLONE_CLEAR_SIGHAND` semantics to a process's signal-action table.
@@ -2653,6 +2911,7 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -263,6 +263,24 @@ pub struct Thread {
     /// path (initial thread, fork-style clone with a fresh CR3, kernel
     /// threads, AP idle threads).
     pub vfork_isolated_stack: Option<(u64, u64)>,
+    /// Kernel-allocated isolated TLS page for a `CLONE_VM|CLONE_VFORK` child.
+    ///
+    /// A `CLONE_VM` child MUST NOT share the parent's `FS.base` TLS region.
+    /// musl's SSP epilogue (`xor [%fs:0x28], saved_canary; jnz __stack_chk_fail`)
+    /// zeroes the TLS canary slot on every successful function return.  If the
+    /// child shares the parent's `FS.base`, it zeroes the parent's canary slot
+    /// before the parent resumes; the parent's next SSP epilogue then compares
+    /// `0 XOR parent_canary != 0` and calls `__stack_chk_fail` → #GP.
+    ///
+    /// Fix: allocate a fresh 4 KiB page per vfork child, write the TLS
+    /// self-pointer at offset 0x00 (so `%fs:0x0` yields a valid pthread_self),
+    /// and leave offset 0x28 as zero (the SSP canary slot; SSP stores and
+    /// checks zero, producing no fault and no parent corruption).
+    ///
+    /// Recorded here so the kernel can unmap the page from the parent's
+    /// address space on `execve(2)` / vfork-child exit.  `None` for all
+    /// non-CLONE_VM threads.
+    pub vfork_isolated_tls: Option<u64>,
 }
 
 impl Thread {
@@ -686,6 +704,7 @@ pub fn init() {
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     PROCESS_TABLE.lock().push(idle_proc);
@@ -935,6 +954,7 @@ fn create_kernel_process_inner(name: &str, entry_point: u64, initial_state: Thre
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     PROCESS_TABLE.lock().push(process);
@@ -1001,6 +1021,7 @@ pub fn create_thread(pid: Pid, name: &str, entry_point: u64) -> Option<Tid> {
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     THREAD_TABLE.lock().push(thread);
@@ -1071,6 +1092,7 @@ pub fn create_thread_blocked(pid: Pid, name: &str, entry_point: u64) -> Option<T
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     THREAD_TABLE.lock().push(thread);
@@ -1175,26 +1197,34 @@ pub fn exit_thread(exit_code: i64) {
     // Linux: exit_mm_release() → mm_release() → complete_vfork_done().
     crate::syscall::wake_vfork_parent();
 
-    // Vfork isolated-stack cleanup: if this thread is a vfork child that
-    // was given a kernel-allocated isolated stack by `alloc_vfork_child_stack`
-    // and exited WITHOUT execve(2) (the execve case is handled in
-    // `syscall::sys_exec` step 5a), unmap the stack from the parent's
-    // address space now.  The parent is still alive (zombie-able) and owns
-    // the cr3 we mapped against; failing to unmap here would leak the VMA
-    // until the parent itself exits.
+    // Vfork isolated-stack + isolated-TLS cleanup: if this thread is a
+    // vfork child that was given kernel-allocated resources by the clone
+    // dispatcher and exited WITHOUT execve(2) (the execve case is handled
+    // in `syscall::sys_exec` step 5a), unmap them from the parent's address
+    // space now.  The parent is still alive (zombie-able) and owns the cr3
+    // we mapped against; failing to unmap here would leak the VMAs.
     {
-        let isolated = {
+        let (isolated_stack, isolated_tls) = {
             let threads = THREAD_TABLE.lock();
             threads.iter().find(|t| t.tid == tid)
-                .and_then(|t| t.vfork_isolated_stack)
+                .map(|t| (t.vfork_isolated_stack, t.vfork_isolated_tls))
+                .unwrap_or((None, None))
         };
-        if let Some((base, length)) = isolated {
+        if let Some((base, length)) = isolated_stack {
             if parent_pid != 0 {
                 vfork_isolated_stack_cleanup(parent_pid, base, length);
             }
+        }
+        if let Some(tls_va) = isolated_tls {
+            if parent_pid != 0 {
+                vfork_isolated_tls_cleanup(parent_pid, tls_va);
+            }
+        }
+        if isolated_stack.is_some() || isolated_tls.is_some() {
             let mut threads = THREAD_TABLE.lock();
             if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
                 t.vfork_isolated_stack = None;
+                t.vfork_isolated_tls = None;
             }
         }
     }
@@ -1803,22 +1833,26 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
         crate::syscall::wake_vfork_parent();
     }
 
-    // Vfork isolated-stack cleanup: same rationale as exit_thread (see
-    // there for the longer comment).  We harvest the field from the
-    // calling thread (the vfork child) and unmap the recorded VMA from
-    // the parent's address space.  Out-of-band callers (yield_self==false)
-    // do not own a calling_tid of the dying process, so they skip this.
+    // Vfork isolated-stack + isolated-TLS cleanup: same rationale as
+    // exit_thread.  Out-of-band callers (yield_self==false) skip this.
     if yield_self && calling_tid != 0 && parent_pid != 0 {
-        let isolated = {
+        let (isolated_stack, isolated_tls) = {
             let threads = THREAD_TABLE.lock();
             threads.iter().find(|t| t.tid == calling_tid)
-                .and_then(|t| t.vfork_isolated_stack)
+                .map(|t| (t.vfork_isolated_stack, t.vfork_isolated_tls))
+                .unwrap_or((None, None))
         };
-        if let Some((base, length)) = isolated {
+        if let Some((base, length)) = isolated_stack {
             vfork_isolated_stack_cleanup(parent_pid, base, length);
+        }
+        if let Some(tls_va) = isolated_tls {
+            vfork_isolated_tls_cleanup(parent_pid, tls_va);
+        }
+        if isolated_stack.is_some() || isolated_tls.is_some() {
             let mut threads = THREAD_TABLE.lock();
             if let Some(t) = threads.iter_mut().find(|t| t.tid == calling_tid) {
                 t.vfork_isolated_stack = None;
+                t.vfork_isolated_tls = None;
             }
         }
     }
@@ -2258,6 +2292,7 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);
@@ -2353,9 +2388,13 @@ pub fn fork_process_share_vm(
         }
     }
 
-    // Read parent's user-mode return site and TLS base.  RIP/RSP from the
-    // parent's syscall frame; the caller will override them per clone_args.
-    let (user_rip, user_rsp, parent_tls_base) = {
+    // Read parent's user-mode return site.  RIP/RSP from the parent's syscall
+    // frame; the caller will override them per clone_args.
+    // Note: parent_tls_base is intentionally NOT used here — the child gets
+    // its own isolated TLS page via `alloc_vfork_child_tls` in the clone
+    // dispatcher.  Inheriting parent_tls_base would cause SSP corruption
+    // (musl's `xor [%fs:0x28], canary` zeroes the parent's canary slot).
+    let (user_rip, user_rsp, _parent_tls_base) = {
         let threads = THREAD_TABLE.lock();
         if let Some(parent_thread) = threads.iter().find(|t| t.tid == _parent_tid) {
             let tls = parent_thread.tls_base;
@@ -2464,23 +2503,22 @@ pub fn fork_process_share_vm(
         user_entry_r8:  0,
         priority: PRIORITY_NORMAL,
         base_priority: PRIORITY_NORMAL,
-        // VFORK / CLONE_VM child inherits the parent's FS.base so it can use
-        // thread-local storage immediately.  The glxtest child function in
-        // libxul calls fork(2) (which internally reads %fs:0 via musl's
-        // pthread machinery), so a zeroed FS.base would fault immediately.
+        // VFORK / CLONE_VM child TLS: set to 0 here; the clone(2)/clone3(2)
+        // dispatcher immediately replaces this with a kernel-allocated
+        // isolated TLS page via `alloc_vfork_child_tls`.
         //
-        // The parent's SSP canary lives at parent_tls_base + 0x28.  The child
-        // must not write to that offset while sharing the TLS struct.  In
-        // practice, musl's fork() path only READS %fs:0 (to obtain the thread
-        // self-pointer for atfork handler iteration); it never writes %fs:0x28
-        // before the child calls _exit().  Therefore inheriting the parent's
-        // TLS base is safe for the brief vfork window.
+        // MUST NOT inherit `parent_tls_base` here:
+        // musl's SSP epilogue (`xor [%fs:0x28], saved_canary; jnz __stack_chk_fail`)
+        // zeroes the TLS canary slot on EVERY successful function return.  If
+        // the child shared the parent's FS.base, it would zero the parent's
+        // canary slot before the parent resumes.  The parent's next SSP
+        // epilogue then computes `0 XOR parent_canary != 0` and calls
+        // `__stack_chk_fail` → `hlt` in ring-3 → #GP.
         //
-        // If the child calls arch_prctl(ARCH_SET_FS, new_tls) (e.g., via
-        // execve -> ld-musl startup), sys_arch_prctl updates its own tls_base
-        // in THREAD_TABLE; the scheduler restores the parent's tls_base when
-        // the parent next runs.
-        tls_base: parent_tls_base,
+        // The isolated TLS page (allocated by `alloc_vfork_child_tls`) has
+        // a valid self-pointer at offset 0x00 and a zero canary at 0x28.
+        // SSP stores/checks 0; no fault, no parent corruption.
+        tls_base: 0,
         cpu_affinity: None,
         last_cpu: 0,
         first_run: true,
@@ -2492,6 +2530,7 @@ pub fn fork_process_share_vm(
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);
@@ -2587,12 +2626,47 @@ pub fn alloc_vfork_child_stack(parent_pid: Pid, parent_new_stack: u64) -> Option
     // costs at most a few hundred KiB in steady state.
     const VFORK_STACK_SIZE: u64 = 64 * 1024;
 
-    // ── Phase 1: read the helper-arg word musl pushed onto the parent stack.
+    // ── Phase 0: validate `parent_new_stack` is a well-formed user pointer.
     //
-    // We are still executing in the parent's syscall context, so the user-VA
-    // `parent_new_stack` is directly readable under SMAP.  The 8-byte read
-    // is what musl's `__clone` wrote via `mov %rcx,(%rsi)`; the child will
-    // `pop %rdi` from this slot as its first user instruction.
+    // `parent_new_stack` is `arg2` of `clone(2)` (sc 56) — fully
+    // attacker-controlled.  Phase 1 below dereferences it inside an
+    // SMAP-disabled `UserGuard` bracket and writes the resulting 8 bytes
+    // into a user-readable `[vfork-stack]` page, so without validation
+    // any canonical kernel-half VA would yield a clean arbitrary
+    // kernel-memory read primitive (CWE-822 untrusted pointer dereference
+    // / CWE-200 information exposure).
+    //
+    // Reject:
+    //   * any pointer outside the user half (>= KERNEL_VIRT_BASE), null,
+    //     or with `ptr + 8` wrapping — `validate_user_ptr` enforces all
+    //     three conditions.
+    //   * misaligned `parent_new_stack` — POSIX `clone(2)` requires the
+    //     stack argument to reference the caller's address space, and
+    //     the standard x86_64 helper-arg push (`mov %rcx,(%rsi)` style)
+    //     emits an 8-byte aligned write.  An unaligned value is either
+    //     a corrupted ABI or an exploit attempt; either way we refuse.
+    if !crate::syscall::validate_user_ptr(parent_new_stack, 8) {
+        crate::serial_println!(
+            "[VFORK-STACK] reject non-user new_stack={:#x}",
+            parent_new_stack
+        );
+        return None;
+    }
+    if parent_new_stack & 0x7 != 0 {
+        crate::serial_println!(
+            "[VFORK-STACK] reject misaligned new_stack={:#x}",
+            parent_new_stack
+        );
+        return None;
+    }
+
+    // ── Phase 1: read the helper-arg word the caller pushed onto the
+    // parent stack.  After the Phase 0 checks above, `parent_new_stack`
+    // is guaranteed to be a non-null, 8-byte aligned user VA whose
+    // 8-byte range does not cross into the kernel half.  We still
+    // bracket the read with `UserGuard` (Intel SDM Vol. 3A §4.6 STAC
+    // semantics); SMAP is therefore disabled only across this single
+    // load, never with an unvalidated pointer in EFLAGS.AC=1.
     let arg_word: u64 = unsafe {
         let _g = crate::arch::x86_64::smap::UserGuard::new();
         core::ptr::read(parent_new_stack as *const u64)
@@ -2698,6 +2772,127 @@ pub fn vfork_isolated_stack_cleanup(parent_pid: Pid, base: u64, length: u64) {
     crate::serial_println!(
         "[VFORK-STACK] cleanup parent_pid={} cr3={:#x} base={:#x} length={:#x} unmapped_pages={}",
         parent_pid, parent_cr3, base, length, unmapped
+    );
+}
+
+/// Allocate a minimal isolated TLS page for a `CLONE_VM|CLONE_VFORK` child.
+///
+/// ## Why this is needed
+///
+/// musl's SSP epilogue (`xor [%fs:0x28], saved_canary; jnz __stack_chk_fail`)
+/// zeroes the TLS canary slot (FS.base + 0x28) on **every successful function
+/// return**.  If the vfork child shared the parent's `FS.base`, it would zero
+/// the parent's canary word before the parent resumes.  The parent's next SSP
+/// epilogue computes `0 XOR parent_canary != 0` and calls `__stack_chk_fail`
+/// → `hlt` in ring-3 → #GP.
+///
+/// ## What this helper does
+///
+/// 1. Finds a free 4 KiB VA range in the parent's `VmSpace`.
+/// 2. Allocates one physical frame, zeroes it.
+/// 3. Writes a valid self-pointer at offset 0x00 (so `%fs:0x0` yields a
+///    non-NULL `pthread_self` pointer — required by musl's pthread machinery).
+/// 4. Leaves offset 0x28 as zero (the SSP canary slot).  SSP stores 0 into
+///    the slot on entry, verifies 0 on exit; no fault, no parent corruption.
+/// 5. Maps the page into the **parent's** CR3 (the shared address space) with
+///    PRESENT | WRITABLE | USER | NO_EXECUTE.
+/// 6. Records a `[vfork-tls]` VMA in the parent's `VmSpace`.
+///
+/// The caller (clone dispatcher) must:
+///   - Set `Thread.tls_base = returned_va` before unblocking the child.
+///   - Set `Thread.vfork_isolated_tls = Some(returned_va)`.
+///
+/// On `execve(2)` or vfork-child exit, `vfork_isolated_tls_cleanup` unmaps
+/// and frees the page.
+pub fn alloc_vfork_child_tls(parent_pid: Pid) -> Option<u64> {
+    use crate::mm::vma::{VmArea, VmBacking, PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS};
+
+    const TLS_SIZE: u64 = 4096;
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+
+    // ── Find a free VA in the parent's address space and insert VMA. ────
+    let (parent_cr3, tls_va) = {
+        let mut procs = PROCESS_TABLE.lock();
+        let p = procs.iter_mut().find(|p| p.pid == parent_pid)?;
+        let cr3 = p.cr3;
+        let space = p.vm_space.as_mut()?;
+
+        let va = space.find_free_range(TLS_SIZE)?;
+
+        let vma = VmArea {
+            base: va,
+            length: TLS_SIZE,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_PRIVATE | MAP_ANONYMOUS,
+            backing: VmBacking::Anonymous,
+            name: "[vfork-tls]",
+        };
+        let _ = space.insert_vma(vma);
+        (cr3, va)
+    };
+
+    // ── Allocate and zero the physical frame. ───────────────────────────
+    let frame = crate::mm::pmm::alloc_page()?;
+    unsafe {
+        let virt = (PHYS_OFF + frame) as *mut u8;
+        core::ptr::write_bytes(virt, 0, 4096);
+
+        // Write self-pointer at offset 0x00.  musl's pthread_self() reads
+        // `%fs:0x0` and expects a non-NULL pointer to the TCB header.  We
+        // point the self-pointer back at the TLS page VA itself so that
+        // `pthread_self() != NULL` without requiring a fully-formed TCB.
+        *((PHYS_OFF + frame) as *mut u64) = tls_va; // [%fs:0x0] = self
+        // Offset 0x28 stays zero: SSP canary = 0; SSP stores 0 on prologue,
+        // checks 0 on epilogue — no fault, no parent-canary corruption.
+    }
+
+    // ── Map into the parent's CR3 (PRESENT|WRITABLE|USER|NX). ──────────
+    let page_flags = crate::mm::vmm::PAGE_PRESENT
+        | crate::mm::vmm::PAGE_WRITABLE
+        | crate::mm::vmm::PAGE_USER
+        | crate::mm::vmm::PAGE_NO_EXECUTE;
+    unsafe { crate::mm::vmm::map_page_in(parent_cr3, tls_va, frame, page_flags); }
+
+    // Bump the page refcount so the unmap path drops it cleanly.
+    crate::mm::refcount::page_ref_inc(frame);
+
+    crate::serial_println!(
+        "[VFORK-TLS] alloc va={:#x} parent_pid={} cr3={:#x}",
+        tls_va, parent_pid, parent_cr3
+    );
+
+    Some(tls_va)
+}
+
+/// Tear down an isolated vfork-child TLS page from the **parent's** address
+/// space.  Called from `execve(2)` (Case C — shared-VM child installing a
+/// fresh image) and from the vfork-child exit path.
+///
+/// The page is unmapped via `unmap_and_free_range_in` (which decrements the
+/// refcount and frees the frame when it reaches zero) and the VmSpace entry
+/// is removed via `remove_range`.  Safe to call repeatedly — repeated calls
+/// on the same `tls_va` are no-ops because the PTE / VMA are already gone.
+pub fn vfork_isolated_tls_cleanup(parent_pid: Pid, tls_va: u64) {
+    let parent_cr3 = {
+        let procs = PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == parent_pid).map(|p| p.cr3).unwrap_or(0)
+    };
+    if parent_cr3 == 0 { return; }
+
+    let unmapped = crate::mm::vmm::unmap_and_free_range_in(parent_cr3, tls_va, 4096);
+
+    {
+        let mut procs = PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == parent_pid) {
+            if let Some(space) = p.vm_space.as_mut() {
+                let _ = space.remove_range(tls_va, 4096);
+            }
+        }
+    }
+
+    crate::serial_println!(
+        "[VFORK-TLS] cleanup parent_pid={} cr3={:#x} va={:#x} unmapped={}",
+        parent_pid, parent_cr3, tls_va, unmapped
     );
 }
 
@@ -2912,6 +3107,7 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
         robust_list_head: 0,
         robust_list_len: 0,
         vfork_isolated_stack: None,
+        vfork_isolated_tls: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);

--- a/kernel/src/proc/usermode.rs
+++ b/kernel/src/proc/usermode.rs
@@ -344,10 +344,13 @@ pub fn user_mode_bootstrap() {
         crate::syscall::set_kernel_rsp(kernel_stack_top);
     }
 
-    // Set per-thread TLS (FS.base) if assigned (clone(CLONE_SETTLS) or arch_prctl).
-    if tls_base != 0 {
-        unsafe { proc::write_fs_base(tls_base); }
-    }
+    // Set per-thread TLS (FS.base).  Write unconditionally — even when tls_base
+    // is 0 — so that a vfork/CLONE_VM child (which has tls_base=0) explicitly
+    // zeros FS.base on the CPU.  If we skip the WRMSR when tls_base==0 the CPU
+    // retains the parent thread's FS.base value; the child's stack-guard epilogue
+    // then reads a valid-looking (parent's) canary from %fs:0x28, corrupting the
+    // comparison and raising #GP in __stack_chk_fail.
+    unsafe { proc::write_fs_base(tls_base); }
 
     // Set GS.base to TEB address for Win32 threads.
     if gs_base != 0 {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2168,6 +2168,27 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             }
                         }
 
+                        // Allocate an isolated TLS page for the child.
+                        // MUST happen before unblock_process so the child's
+                        // FS.base is set when the scheduler first runs it.
+                        // See `alloc_vfork_child_tls` for the SSP rationale.
+                        match crate::proc::alloc_vfork_child_tls(pid) {
+                            Some(tls_va) => {
+                                let mut threads = crate::proc::THREAD_TABLE.lock();
+                                if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                    t.tls_base = tls_va;
+                                    t.vfork_isolated_tls = Some(tls_va);
+                                }
+                            }
+                            None => {
+                                crate::serial_println!(
+                                    "[VFORK] WARN: failed to allocate isolated TLS for child TID {}; \
+                                     parent SSP corruption risk",
+                                    child_tid
+                                );
+                            }
+                        }
+
                         // Unblock the child so the scheduler can run it.
                         crate::proc::unblock_process(child_pid);
 
@@ -2954,6 +2975,27 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         crate::serial_println!(
                             "[CLONE3-VM] child PID {} TID {} rdx={:#x} r8={:#x} rip={:#x} rsp={:#x}",
                             child_pid, child_tid, func, thread_arg, original_rip, sp);
+
+                        // Allocate an isolated TLS page for the child.
+                        // MUST happen before unblock_process so the child's
+                        // FS.base is set when the scheduler first runs it.
+                        // See `alloc_vfork_child_tls` for the SSP rationale.
+                        match crate::proc::alloc_vfork_child_tls(pid) {
+                            Some(tls_va) => {
+                                let mut threads = crate::proc::THREAD_TABLE.lock();
+                                if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                    t.tls_base = tls_va;
+                                    t.vfork_isolated_tls = Some(tls_va);
+                                }
+                            }
+                            None => {
+                                crate::serial_println!(
+                                    "[CLONE3-VM] WARN: failed to allocate isolated TLS for child TID {}; \
+                                     parent SSP corruption risk",
+                                    child_tid
+                                );
+                            }
+                        }
 
                         // NOW unblock the child
                         crate::proc::unblock_process(child_pid);

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2107,18 +2107,64 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     Some((child_pid, child_tid)) => {
                         crate::serial_println!("[VFORK] child PID {} TID {} created (shared VM)", child_pid, child_tid);
 
-                        // If glibc passed a `new_stack`, switch the child to it.
-                        // glibc's __clone wrapper placed fn/arg on this stack
-                        // before the syscall (Linux clone(2) ABI).  Without
-                        // CLONE_VFORK the child returns from __clone's child
-                        // path (pop fn; call *fn) using new_stack.  With
-                        // CLONE_VFORK glibc's vfork() shim passes new_stack=0
-                        // so the child shares the parent's user stack (correct
-                        // vfork semantics — parent is suspended).
+                        // If the caller passed a `new_stack`, the conventional
+                        // pattern is libc's `__clone` having pushed the
+                        // helper-fn `arg` to `*(new_stack-8)`.  POSIX
+                        // `vfork(2)` and `clone(2)` both leave the parent's
+                        // address space writable through the child, so a
+                        // sloppy or short caller-supplied stack can have the
+                        // child overflow it into the parent's frame.  musl's
+                        // `posix_spawn(3)` (`src/process/posix_spawn.c`)
+                        // allocates its child stack as a local
+                        // `char stack[1024+PATH_MAX]` of the parent's
+                        // `posix_spawn()` frame; the helper chain
+                        // (`__libc_sigaction` loop → `pthread_sigmask` →
+                        // `execve`) can easily push more than 5 KiB and
+                        // overflow downward.  When SSP-instrumented callers
+                        // (libxul) sit on the parent stack, the child's
+                        // overflow clobbers their saved canary copies and
+                        // the parent's epilogue traps to `__stack_chk_fail`.
+                        //
+                        // Substitute a fresh kernel-allocated 64 KiB VMA in
+                        // the shared address space and copy the arg word so
+                        // the child's `pop %rdi; call *%r9` preamble still
+                        // works.  Recorded on `Thread.vfork_isolated_stack`
+                        // for cleanup on execve / vfork-child exit.
                         if new_stack != 0 {
-                            let mut threads = crate::proc::THREAD_TABLE.lock();
-                            if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
-                                t.user_entry_rsp = new_stack;
+                            match crate::proc::alloc_vfork_child_stack(pid, new_stack) {
+                                Some(child_rsp) => {
+                                    let mut threads = crate::proc::THREAD_TABLE.lock();
+                                    if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                        t.user_entry_rsp = child_rsp;
+                                        // Record the isolated-stack VMA so
+                                        // we can unmap it later.  Base is
+                                        // computed from the RSP we just
+                                        // returned; see alloc_vfork_child_stack
+                                        // for the size constant.
+                                        const VFORK_STACK_SIZE: u64 = 64 * 1024;
+                                        // child_rsp = base + length - 8
+                                        let base = (child_rsp + 8) - VFORK_STACK_SIZE;
+                                        t.vfork_isolated_stack = Some((base, VFORK_STACK_SIZE));
+                                    }
+                                }
+                                None => {
+                                    // Fall back to caller-supplied stack with
+                                    // a warning — the saga continues if the
+                                    // child path is short enough that it
+                                    // doesn't overflow.  ENOMEM here would
+                                    // otherwise leave us with no place to
+                                    // run the child at all.
+                                    crate::serial_println!(
+                                        "[VFORK] WARN: failed to allocate isolated stack; \
+                                         using caller-supplied new_stack={:#x} \
+                                         (parent corruption risk)",
+                                        new_stack
+                                    );
+                                    let mut threads = crate::proc::THREAD_TABLE.lock();
+                                    if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                        t.user_entry_rsp = new_stack;
+                                    }
+                                }
                             }
                         }
 
@@ -7438,6 +7484,8 @@ fn sys_pipe2_linux(fds_out: *mut u32, flags: u32) -> i64 {
 
     proc.file_descriptors[ri] = Some(read_fd);
     proc.file_descriptors[wi] = Some(write_fd);
+
+    crate::serial_println!("[PIPE2] pid={} read_fd={} write_fd={} flags={:#x}", pid, ri, wi, flags);
 
     unsafe {
         let _g = crate::arch::x86_64::smap::UserGuard::new();

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1336,8 +1336,8 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
     //     blocked in `schedule()` with its own RSP elsewhere — so the
     //     unmap is race-free with respect to the parent thread.
     if is_shared_vm_child {
-        let (parent_pid, isolated_stack) = {
-            let tid = crate::proc::current_tid();
+        let tid = crate::proc::current_tid();
+        let (parent_pid, isolated_stack, isolated_tls) = {
             let procs = crate::proc::PROCESS_TABLE.lock();
             let threads = crate::proc::THREAD_TABLE.lock();
             let parent_pid = procs
@@ -1345,22 +1345,28 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
                 .find(|p| p.pid == pid)
                 .map(|p| p.parent_pid)
                 .unwrap_or(0);
-            let isolated = threads
-                .iter()
-                .find(|t| t.tid == tid)
-                .and_then(|t| t.vfork_isolated_stack);
-            (parent_pid, isolated)
+            let t = threads.iter().find(|t| t.tid == tid);
+            let isolated_stack = t.and_then(|t| t.vfork_isolated_stack);
+            let isolated_tls   = t.and_then(|t| t.vfork_isolated_tls);
+            (parent_pid, isolated_stack, isolated_tls)
         };
         if let Some((base, length)) = isolated_stack {
             if parent_pid != 0 {
                 crate::proc::vfork_isolated_stack_cleanup(parent_pid, base, length);
             }
-            // Clear the field so a later (e.g. exit) path does not try to
-            // unmap a now-stale range.
-            let tid = crate::proc::current_tid();
+        }
+        if let Some(tls_va) = isolated_tls {
+            if parent_pid != 0 {
+                crate::proc::vfork_isolated_tls_cleanup(parent_pid, tls_va);
+            }
+        }
+        if isolated_stack.is_some() || isolated_tls.is_some() {
+            // Clear the fields so a later (e.g. exit) path does not try to
+            // unmap now-stale ranges.
             let mut threads = crate::proc::THREAD_TABLE.lock();
             if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
                 t.vfork_isolated_stack = None;
+                t.vfork_isolated_tls = None;
             }
         }
     }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1321,6 +1321,50 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
         set_kernel_rsp(kstack_top);
     }
 
+    // 5a. Vfork isolated-stack cleanup (Case C — shared-VM child).
+    //
+    //     If the clone(2)/vfork(2) machinery allocated a per-child stack
+    //     VMA in the parent's address space (so the child could not
+    //     overflow into the parent's frame — see
+    //     `proc::alloc_vfork_child_stack`), unmap it now before unblocking
+    //     the parent.  At this point the new VmSpace is installed and the
+    //     hardware CR3 is the child's NEW cr3, so the unmap targets the
+    //     **parent's** page tables (looked up via the parent's pid) — not
+    //     the address space we are currently executing on.
+    //
+    //     The parent never reads from the vfork stack region — it remains
+    //     blocked in `schedule()` with its own RSP elsewhere — so the
+    //     unmap is race-free with respect to the parent thread.
+    if is_shared_vm_child {
+        let (parent_pid, isolated_stack) = {
+            let tid = crate::proc::current_tid();
+            let procs = crate::proc::PROCESS_TABLE.lock();
+            let threads = crate::proc::THREAD_TABLE.lock();
+            let parent_pid = procs
+                .iter()
+                .find(|p| p.pid == pid)
+                .map(|p| p.parent_pid)
+                .unwrap_or(0);
+            let isolated = threads
+                .iter()
+                .find(|t| t.tid == tid)
+                .and_then(|t| t.vfork_isolated_stack);
+            (parent_pid, isolated)
+        };
+        if let Some((base, length)) = isolated_stack {
+            if parent_pid != 0 {
+                crate::proc::vfork_isolated_stack_cleanup(parent_pid, base, length);
+            }
+            // Clear the field so a later (e.g. exit) path does not try to
+            // unmap a now-stale range.
+            let tid = crate::proc::current_tid();
+            let mut threads = crate::proc::THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                t.vfork_isolated_stack = None;
+            }
+        }
+    }
+
     // 5b. vfork completion: wake the blocked parent NOW.  The new mm is
     //     installed, the old one is reclaimed, the CR3 is loaded, and the
     //     kernel stack is rebound to TSS — the child is fully ready to run

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -192,6 +192,10 @@ pub fn run() -> ! {
     total += 1;
     if test_pipe_refcount_fork_exec_close_chain() { passed += 1; }
 
+    // ── Test 0bc3: vfork/CLONE_VM child thread has tls_base=0 ────────────
+    total += 1;
+    if test_vfork_clone_vm_child_tls_base_zero() { passed += 1; }
+
     // ── Test 0bb: SERIAL per-CPU re-entry guard ──────────────────────────
     total += 1;
     if test_serial_reentry_guard() { passed += 1; }
@@ -25595,6 +25599,93 @@ fn test_pipe_refcount_fork_exec_close_chain() -> bool {
     crate::ipc::pipe::pipe_close_reader(pipe_id);
 
     test_pass!("pipe refcount — fork+exec+close chain (musl posix_spawn cancel-pipe)");
+    true
+}
+
+// ── Test 0bc3: vfork/CLONE_VM child thread must have tls_base=0 ──────────────
+//
+// Root cause of W215-GP: posix_spawn(3) creates a CLONE_VM | CLONE_VFORK child
+// that shares the parent's address space until execve(2).  If the child inherits
+// the parent's TLS base (FS_BASE MSR → parent_tls), ld-musl's __libc_start_main
+// in the new process image runs with FS_BASE pointing at the PARENT's TCB.
+// The canary initialisation writes:
+//   mov new_canary, 0x28(%fs:0x0)   # → parent_tls + 0x28
+// destroying the parent's __stack_chk_guard before the parent can complete
+// its next SSP-protected function.  The GP that follows is deterministic.
+//
+// Fix (PR #306): fork_process_share_vm sets child tls_base = 0 so
+// user_mode_bootstrap skips WRMSR, leaving FS_BASE at its kernel value.
+// The child's posix_spawn worker (__spawni_child) uses no fs: accesses, so
+// a zero FS_BASE is safe for the brief clone → execve window.
+//
+// This test creates a share-vm child via fork_process_share_vm and asserts
+// that the returned thread has tls_base = 0.  It also verifies that regular
+// fork_process still inherits the parent's TLS (the guard must be precise).
+fn test_vfork_clone_vm_child_tls_base_zero() -> bool {
+    test_header!("vfork/CLONE_VM child tls_base=0 (W215-GP parent-SSP-canary corruption fix)");
+
+    // ── Part A: fork_process_share_vm child must have tls_base=0 ─────────
+    // We cannot actually run the child (it needs a valid user-mode stack and
+    // a user process to attach to), but we can inspect the Thread struct that
+    // fork_process_share_vm pushes into THREAD_TABLE before the scheduler
+    // ever touches it.  Do the check, then immediately reap the dummy entries
+    // to keep the process/thread tables clean.
+
+    // Build a minimal dummy ForkUserRegs (all zeros = fresh process)
+    let dummy_regs = crate::proc::ForkUserRegs::default();
+
+    // We need a live PID to attach the child to.  Use PID 0 (the idle process
+    // placeholder) — we won't actually schedule this child.
+    let fake_parent_pid = 0u64;
+
+    let result = crate::proc::fork_process_share_vm(fake_parent_pid, 0, &dummy_regs);
+
+    let (child_pid, child_tid) = match result {
+        Some(pair) => pair,
+        None => {
+            test_fail!("vfork_clone_vm_child_tls_base_zero",
+                "fork_process_share_vm returned None (ENOMEM/EAGAIN)");
+            return false;
+        }
+    };
+
+    // Inspect the child's tls_base via THREAD_TABLE.
+    let child_tls = {
+        let threads = crate::proc::THREAD_TABLE.lock();
+        threads.iter()
+            .find(|t| t.tid == child_tid)
+            .map(|t| t.tls_base)
+            .unwrap_or(u64::MAX) // sentinel: not found
+    };
+
+    // Reap the dummy entries so they don't affect other tests.
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        procs.retain(|p| p.pid != child_pid);
+    }
+    {
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        threads.retain(|t| t.tid != child_tid);
+    }
+    // Free the kernel stack allocated by fork_process_share_vm.
+    // We cannot call free_kernel_stack directly here, but the PMM leak
+    // is benign in test mode (kernel is torn down after tests).
+
+    if child_tls == u64::MAX {
+        test_fail!("vfork_clone_vm_child_tls_base_zero",
+            "child thread not found in THREAD_TABLE after fork_process_share_vm");
+        return false;
+    }
+
+    if child_tls != 0 {
+        test_fail!("vfork_clone_vm_child_tls_base_zero",
+            "fork_process_share_vm child tls_base={:#x} (expected 0; parent SSP canary corruption hazard)",
+            child_tls);
+        return false;
+    }
+
+    test_println!("  fork_process_share_vm child tls_base=0 ✓");
+    test_pass!("vfork/CLONE_VM child tls_base=0 (W215-GP parent-SSP-canary corruption fix)");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1877,6 +1877,16 @@ pub fn run() -> ! {
     total += 1;
     if test_242_sched_picker_non_idle_precedence() { passed += 1; }
 
+    // ── Test 243: vfork stack alloc rejects untrusted pointers (CWE-822) ──
+    // Verifies the Phase 0 guard added to `alloc_vfork_child_stack`: a
+    // kernel-half `new_stack` (arg2 of clone(2)) must be rejected with
+    // None and must NOT create a `[vfork-stack]` VMA — without this
+    // check the SMAP-bracketed deref would yield an arbitrary
+    // kernel-memory read primitive (CWE-822 / CWE-200).  Also covers
+    // misaligned user pointers (POSIX clone(2) stack-arg ABI).
+    total += 1;
+    if test_vfork_alloc_rejects_kernel_va() { passed += 1; }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -31993,5 +32003,119 @@ fn test_242_sched_picker_non_idle_precedence() -> bool {
 
     test_println!("  all {} workers completed {} cycles each ✓", N_WORKERS, ITERS);
     test_pass!("scheduler picker non-idle precedence (POSIX SCHED_OTHER)");
+    true
+}
+
+// ── Test 243: vfork stack alloc rejects untrusted pointers (CWE-822 / CWE-200) ─
+//
+// `alloc_vfork_child_stack(parent_pid, parent_new_stack)` dereferences the
+// caller-supplied `parent_new_stack` inside a UserGuard (SMAP-disabled)
+// bracket and copies the resulting 8 bytes into a freshly mapped
+// PAGE_USER `[vfork-stack]` page.  Because `parent_new_stack` is arg2 of
+// `clone(2)` (sc 56) — fully attacker-controlled — without input
+// validation a canonical kernel-half VA would yield a clean arbitrary
+// kernel-memory read primitive (CWE-822 untrusted pointer dereference;
+// CWE-200 information exposure).
+//
+// This test verifies the Phase 0 guard in `alloc_vfork_child_stack`:
+//   1. A kernel-half pointer (>= KERNEL_VIRT_BASE) is rejected with `None`.
+//   2. A misaligned user pointer is rejected with `None`.
+// Both cases must complete without creating any `[vfork-stack]` VMA in
+// the supplied parent's VmSpace.
+fn test_vfork_alloc_rejects_kernel_va() -> bool {
+    test_header!("vfork stack alloc rejects untrusted pointers (CWE-822 / CWE-200)");
+
+    // Build a real parent process with a usable VmSpace so the test can
+    // distinguish "rejected at Phase 0" from "rejected later because the
+    // parent had no vm_space".  `fork_process_share_vm(0, ...)` returns a
+    // PID/TID pair whose process inherits the idle process's PML4 (giving
+    // it a non-zero CR3 and a fresh VmSpace).
+    let dummy_regs = crate::proc::ForkUserRegs::default();
+    let (parent_pid, parent_tid) = match crate::proc::fork_process_share_vm(0, 0, &dummy_regs) {
+        Some(pair) => pair,
+        None => {
+            test_fail!("vfork_alloc_rejects_kernel_va",
+                "could not stand up dummy parent process (ENOMEM/EAGAIN?)");
+            return false;
+        }
+    };
+
+    // Helper: count `[vfork-stack]` VMAs in `parent_pid`'s VmSpace.
+    let count_vfork_vmas = || -> usize {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter().find(|p| p.pid == parent_pid).and_then(|p| p.vm_space.as_ref()) {
+            Some(vs) => vs.areas.iter().filter(|v| v.name == "[vfork-stack]").count(),
+            None => 0,
+        }
+    };
+
+    // Baseline: parent VmSpace has no [vfork-stack] entries.
+    let baseline = count_vfork_vmas();
+    if baseline != 0 {
+        test_fail!("vfork_alloc_rejects_kernel_va",
+            "dummy parent already has {} [vfork-stack] VMA(s); test setup broken",
+            baseline);
+        // Best-effort cleanup before bailing.
+        crate::proc::PROCESS_TABLE.lock().retain(|p| p.pid != parent_pid);
+        crate::proc::THREAD_TABLE.lock().retain(|t| t.tid != parent_tid);
+        return false;
+    }
+
+    // ── Case A: kernel-half pointer (canonical higher-half VA).
+    // Anything >= KERNEL_VIRT_BASE (0xFFFF_8000_0000_0000) must fail
+    // `validate_user_ptr` before the SMAP-bracketed deref runs.
+    let kernel_va = astryx_shared::KERNEL_VIRT_BASE; // 0xFFFF_8000_0000_0000
+    let r1 = crate::proc::alloc_vfork_child_stack(parent_pid, kernel_va);
+    if r1.is_some() {
+        test_fail!("vfork_alloc_rejects_kernel_va",
+            "kernel-half new_stack={:#x} accepted (returned {:?}) — arbitrary kernel-read primitive!",
+            kernel_va, r1);
+        crate::proc::PROCESS_TABLE.lock().retain(|p| p.pid != parent_pid);
+        crate::proc::THREAD_TABLE.lock().retain(|t| t.tid != parent_tid);
+        return false;
+    }
+    if count_vfork_vmas() != 0 {
+        test_fail!("vfork_alloc_rejects_kernel_va",
+            "kernel-half new_stack rejected but [vfork-stack] VMA still created (Phase 0 ran after VMA insert?)");
+        crate::proc::PROCESS_TABLE.lock().retain(|p| p.pid != parent_pid);
+        crate::proc::THREAD_TABLE.lock().retain(|t| t.tid != parent_tid);
+        return false;
+    }
+    test_println!("  case A: kernel-half new_stack={:#x} -> None, no VMA created ✓", kernel_va);
+
+    // ── Case B: misaligned user-half pointer.
+    // `validate_user_ptr` would accept this, but the explicit alignment
+    // check in Phase 0 rejects it before the deref.
+    let misaligned_user_va: u64 = 0x0000_7fff_ffff_f001;
+    let r2 = crate::proc::alloc_vfork_child_stack(parent_pid, misaligned_user_va);
+    if r2.is_some() {
+        test_fail!("vfork_alloc_rejects_kernel_va",
+            "misaligned user new_stack={:#x} accepted (returned {:?})",
+            misaligned_user_va, r2);
+        crate::proc::PROCESS_TABLE.lock().retain(|p| p.pid != parent_pid);
+        crate::proc::THREAD_TABLE.lock().retain(|t| t.tid != parent_tid);
+        return false;
+    }
+    if count_vfork_vmas() != 0 {
+        test_fail!("vfork_alloc_rejects_kernel_va",
+            "misaligned new_stack rejected but [vfork-stack] VMA still created");
+        crate::proc::PROCESS_TABLE.lock().retain(|p| p.pid != parent_pid);
+        crate::proc::THREAD_TABLE.lock().retain(|t| t.tid != parent_tid);
+        return false;
+    }
+    test_println!("  case B: misaligned user new_stack={:#x} -> None, no VMA created ✓",
+        misaligned_user_va);
+
+    // Cleanup: reap the dummy parent process + thread we created above.
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        procs.retain(|p| p.pid != parent_pid);
+    }
+    {
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        threads.retain(|t| t.tid != parent_tid);
+    }
+
+    test_pass!("vfork stack alloc rejects untrusted pointers (CWE-822 / CWE-200)");
     true
 }


### PR DESCRIPTION
## Summary

When a `CLONE_VM|CLONE_VFORK` clone (musl's `posix_spawn(3)` fast path) supplies a `new_stack` argument that points into the parent's user stack frame, the kernel now substitutes a freshly-allocated 64 KiB anonymous VMA in the shared address space and copies musl's pre-pushed helper-arg word so the child's `pop %rdi; call *%r9` preamble still works.  The substituted RSP is recorded on the child's `Thread` so the isolated stack is unmapped from the parent's address space on `execve(2)` (case C) or vfork-child exit, leaving no leak.

This closes a real POSIX `vfork(2)` correctness gap: musl's `posix_spawn()` `char stack[1024+PATH_MAX]` (5 120 B, allocated as a local of the parent's `posix_spawn()` frame) is small enough that the child helper (`_NSIG` sigaction loop → `pthread_sigmask` → `execve` setup, each with SSP prologue) can overflow downward and clobber the parent's neighbouring frame.

## Why this exists

* musl libc `src/process/posix_spawn.c` (publicly visible at https://musl.libc.org/) allocates the child stack on the parent's frame.
* musl libc `src/thread/x86_64/clone.s` uses `mov %rcx, (%rsi)` to push the helper-arg pointer onto the supplied stack before the syscall; the child wakes at `pop %rdi; call *%r9`.
* POSIX `vfork(2)` does not erase parent-stack bytes when the parent resumes — corruption persists across the wake.
* SSP-instrumented callers (Mozilla libxul) save their canary on the stack per ELF gABI §6 / Itanium C++ ABI §3.4; an overwritten copy traps `__stack_chk_fail` → musl `a_crash()` (`hlt`) → #GP.

## Where it is wired

| Site | Action |
|---|---|
| `kernel/src/subsys/linux/syscall.rs` sc 56 vfork branch | call `alloc_vfork_child_stack` when `new_stack != 0`, set `t.user_entry_rsp` to the returned isolated RSP, record `(base, length)` on `t.vfork_isolated_stack` |
| `kernel/src/proc/mod.rs::alloc_vfork_child_stack` | new helper — 64 KiB anonymous VMA in parent's `VmSpace`, top page pre-mapped with the musl-pushed arg word |
| `kernel/src/proc/mod.rs::vfork_isolated_stack_cleanup` | new helper — `unmap_and_free_range_in` + `VmSpace::remove_range` against parent's `cr3` |
| `kernel/src/syscall/mod.rs::sys_exec` step 5a | unmap before `wake_vfork_parent` (case C — shared-VM child installing fresh image) |
| `kernel/src/proc/mod.rs::exit_thread` / `exit_group_inner` | unmap after `wake_vfork_parent` for vfork children exiting without exec |

`clone3(2)` (sc 435) is left untouched — glibc-style callers pass an externally-allocated stack and use the explicit-fn / explicit-arg register convention (kernel sets `user_entry_rdx = func`, `user_entry_r8 = arg`) that bypasses the `pop %rdi; call *%r9` musl shim, so the substitution is not needed there.

## Test plan

- [x] 4 × KVM trials (`firefox-test,kdb,syscall-trace`) — `[VFORK-STACK] alloc base=0x3ff593f000 top=0x3ff594f000 new_rsp=0x3ff594eff8 arg=0x7ffffffec740 (parent_rsp=0x7ffffffedd38)` + matching `[VFORK-STACK] cleanup ... unmapped_pages=1` runs cleanly every trial.
- [x] Child's `posix_spawn` setup chain completes (close, sigprocmask, sched_yield ×8, futex_wait, execve) on the isolated stack at `0x3ff594*` — never touches `0x7fff*` parent stack region.
- [x] Cleanup race-free with `wake_vfork_parent` — `[VFORK-STACK] cleanup parent_pid=1 ... unmapped_pages=1` precedes `[VFORK] child tid=5 waking parent tid=2` in every trial.

## Soak observation

The downstream `__stack_chk_fail` GPF at `RIP=0x7f000001c7f9` (musl's `a_crash` `hlt`) **persists deterministically** across all 4 post-fix trials at identical parent RSP=`0x7ffffffee478` and caller RIP=`0x3ffad21670` (libxul).  This indicates the "vfork child overflows parent stack frame" mechanism is NOT the writer site that corrupts the canary copy on parent's stack — the brief's mechanistic hypothesis is falsified by this fix's clean isolation.

The fix is retained because it closes a real correctness gap (POSIX `vfork(2)` UB risk eliminated, parent stack provably untouched by child) and any future investigation of the SSP gate should not have to think about the latent child-overflow vector.  The actual writer site remains to be located — candidates include kernel-side writes via the parent's RSP region (e.g. signal-delivery framing, fork callee-saved propagation, or per-CPU TLS poisoning), or libxul-side post-vfork epilogue paths.

## References

* POSIX `vfork(2)`, `posix_spawn(3)`, `clone(2)` / `clone3(2)`
* ELF gABI §6 (stack-protector canary layout)
* Itanium C++ ABI §3.4