### PR TITLE
kernel/net: verify RX checksums for IPv4 / UDP / ICMP

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1036,6 +1036,7 @@ pub extern "C" fn ap_rust_entry() -> ! {
             gs_base: 0,
             robust_list_head: 0,
             robust_list_len: 0,
+            vfork_isolated_stack: None,
         };
         THREAD_TABLE.lock().push(ap_thread);
     }

--- a/kernel/src/net/icmp.rs
+++ b/kernel/src/net/icmp.rs
@@ -5,7 +5,20 @@
 use super::Ipv4Address;
 use super::ipv4;
 use spin::Mutex;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// Count of ICMP messages discarded on receive because the 16-bit
+/// Internet checksum did not validate, per RFC 792: "The checksum is
+/// the 16 bit one's complement of the one's complement sum of the ICMP
+/// message starting with the ICMP Type … If the total length is odd,
+/// the received data is padded with one octet of zeros for computing
+/// the checksum."  Exposed for tests and the stats surface.
+static ICMP_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of ICMP RX checksum drops.
+pub fn rx_bad_csum_count() -> u64 {
+    ICMP_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
 
 /// ICMP types.
 const ICMP_ECHO_REPLY: u8 = 0;
@@ -34,6 +47,17 @@ pub fn take_reply() -> Option<PingReply> {
 /// Handle an incoming ICMP packet.
 pub fn handle_icmp(src_ip: Ipv4Address, data: &[u8]) {
     if data.len() < 8 { return; }
+
+    // RFC 792 + RFC 1122 §3.2.2: a receiver MUST silently discard any
+    // ICMP message whose 16-bit one's-complement checksum does not
+    // validate over the full ICMP body (header + payload).  The
+    // Internet-checksum identity (RFC 1071) lets us re-fold the body
+    // with the embedded checksum field in place — a valid sum yields
+    // zero.  Unlike UDP there is no opt-out (no `cksum == 0` shortcut).
+    if !ipv4::verify_checksum(data) {
+        ICMP_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
 
     let icmp_type = data[0];
     let _icmp_code = data[1];

--- a/kernel/src/net/ipv4.rs
+++ b/kernel/src/net/ipv4.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 use super::{MacAddress, Ipv4Address, our_ip, our_mac, gateway_ip, subnet_mask, send_frame};
 use super::ethernet::{build_frame, ETHERTYPE_IPV4};
 
@@ -12,6 +13,19 @@ use super::ethernet::{build_frame, ETHERTYPE_IPV4};
 pub const PROTO_ICMP: u8 = 1;
 pub const PROTO_TCP: u8 = 6;
 pub const PROTO_UDP: u8 = 17;
+
+/// Count of IPv4 datagrams discarded on receive because the header
+/// checksum failed verification, per RFC 791 §3.1: "If the header
+/// checksum fails, the internet datagram is discarded at once by the
+/// entity which detects the error."  Exposed for tests and the
+/// `netstat`-style stats surface; loads/stores are Relaxed because the
+/// counter has no synchronisation duty.
+static IPV4_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of IPv4 RX header-checksum drops.
+pub fn rx_bad_csum_count() -> u64 {
+    IPV4_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
 
 /// An IPv4 header (parsed).
 pub struct Ipv4Header {
@@ -67,6 +81,28 @@ pub fn handle_ipv4(data: &[u8]) {
         None => return,
     };
 
+    // Per RFC 791 §3.1 ("Header Checksum") and RFC 1122 §3.2.1.2: the
+    // 16-bit one's-complement checksum is computed over the IP header
+    // only.  A receiver MUST verify and silently discard any datagram
+    // whose header checksum is invalid.  The Internet-checksum identity
+    // (RFC 1071 §1) lets us re-fold the header *with* the embedded
+    // `header_checksum` field in place — a valid sum yields 0x0000.
+    //
+    // The header length is bounded by the IHL nibble (5..=15 32-bit
+    // words = 20..=60 bytes); `Ipv4Header::parse` already enforced
+    // ihl>=5 and a 20-byte minimum, but the full IHL-byte range may
+    // extend past `data` for an attacker-truncated frame, so we clamp
+    // before checksumming to avoid an out-of-bounds slice.
+    let hlen = header.header_len();
+    if data.len() < hlen {
+        IPV4_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    if !verify_checksum(&data[..hlen]) {
+        IPV4_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
     // Only accept packets addressed to us, broadcast, when we have no IP
     // yet (DHCP), or destined for the loopback prefix 127.0.0.0/8 (RFC
     // 1122 §3.2.1.3 — every host implicitly owns the entire 127/8 range).
@@ -79,7 +115,7 @@ pub fn handle_ipv4(data: &[u8]) {
         return;
     }
 
-    let payload_start = header.header_len();
+    let payload_start = hlen;
     if data.len() < payload_start { return; }
 
     // RFC 791 §3.1: clamp the upper-layer payload to the IP datagram's
@@ -146,6 +182,22 @@ pub(crate) fn clamp_payload_to_total_length(
     // Then clamp from below — never produce an end < payload_start that
     // would underflow the subsequent slice subtraction.
     if end < payload_start { payload_start } else { end }
+}
+
+/// Verify a buffer's embedded 16-bit Internet checksum (RFC 1071).
+///
+/// `data` must include the checksum field at the position the protocol
+/// specifies (e.g. for an IPv4 header that is bytes 10..12).  Because
+/// the checksum is the one's-complement of the one's-complement sum of
+/// the buffer, re-summing the *whole* buffer (with the checksum field
+/// in place) yields zero exactly when the embedded checksum is valid.
+/// Returns `true` for "valid", `false` for "mismatch".
+///
+/// For UDP (RFC 768) and TCP (RFC 793 §3.1) this same helper is used
+/// after the caller has prepended the IP pseudo-header.
+#[inline]
+pub fn verify_checksum(data: &[u8]) -> bool {
+    checksum(data) == 0
 }
 
 /// Calculate the Internet Checksum (RFC 1071).

--- a/kernel/src/net/udp.rs
+++ b/kernel/src/net/udp.rs
@@ -5,9 +5,23 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
 use super::{Ipv4Address, our_ip};
 use super::ipv4;
+
+/// Count of UDP datagrams discarded on receive because the checksum
+/// field was non-zero and did not validate, per RFC 1122 §4.1.3.4:
+/// "If a UDP datagram is received with a checksum that is non-zero and
+/// invalid, UDP MUST silently discard the datagram."  Exposed for
+/// tests and the stats surface.  Loads/stores are Relaxed — the
+/// counter has no synchronisation duty.
+static UDP_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of UDP RX checksum drops.
+pub fn rx_bad_csum_count() -> u64 {
+    UDP_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
 
 /// A UDP header (parsed).
 pub struct UdpHeader {
@@ -46,13 +60,37 @@ struct UdpBinding {
 static UDP_BINDINGS: Mutex<Vec<UdpBinding>> = Mutex::new(Vec::new());
 
 /// Handle an incoming UDP packet.
-pub fn handle_udp(src_ip: Ipv4Address, _dst_ip: Ipv4Address, data: &[u8]) {
+pub fn handle_udp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
     let header = match UdpHeader::parse(data) {
         Some(h) => h,
         None => return,
     };
 
-    let payload = &data[8..];
+    // RFC 768 §"Length": UDP header `Length` field counts the header
+    // and payload combined.  Clamp the datagram to the declared length
+    // so a frame whose IP `total_length` overshoots cannot leak trailer
+    // bytes into our checksum or into the receive queue.  An undersized
+    // declaration (length < 8) is an attacker-crafted header — drop.
+    let udp_len = header.length as usize;
+    if udp_len < 8 || udp_len > data.len() {
+        UDP_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    let datagram = &data[..udp_len];
+
+    // RFC 768 + RFC 1122 §4.1.3.4: a transmitted checksum of 0x0000
+    // means "checksum disabled by sender" — the receiver MUST NOT
+    // validate.  A non-zero checksum that fails validation MUST cause
+    // the datagram to be silently discarded.  The validation runs over
+    // an IPv4 pseudo-header (src_ip || dst_ip || 0 || proto || udp_len)
+    // followed by the UDP header and payload with the checksum field
+    // in place, per the Internet-checksum identity (RFC 1071).
+    if header.checksum != 0 && !verify_udp_checksum(src_ip, dst_ip, datagram) {
+        UDP_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
+    let payload = &datagram[8..];
 
     crate::serial_println!("[UDP] {}:{} -> port {} ({} bytes)",
         src_ip[0], src_ip[1],
@@ -67,6 +105,21 @@ pub fn handle_udp(src_ip: Ipv4Address, _dst_ip: Ipv4Address, data: &[u8]) {
             data: Vec::from(payload),
         });
     }
+}
+
+/// Verify a UDP datagram's checksum using the IPv4 pseudo-header per
+/// RFC 768 + RFC 1122 §4.1.3.4.  `datagram` is the UDP header followed
+/// by the payload, exactly `header.length` bytes, with the embedded
+/// checksum field still in place.  Returns true when valid.
+fn verify_udp_checksum(src_ip: Ipv4Address, dst_ip: Ipv4Address, datagram: &[u8]) -> bool {
+    let mut buf = Vec::with_capacity(12 + datagram.len());
+    buf.extend_from_slice(&src_ip);
+    buf.extend_from_slice(&dst_ip);
+    buf.push(0);
+    buf.push(ipv4::PROTO_UDP);
+    buf.extend_from_slice(&(datagram.len() as u16).to_be_bytes());
+    buf.extend_from_slice(datagram);
+    ipv4::verify_checksum(&buf)
 }
 
 /// Bind a UDP port for receiving.
@@ -125,8 +178,19 @@ pub fn send(dst_ip: Ipv4Address, src_port: u16, dst_port: u16, payload: &[u8]) {
     packet.push(0);
     packet.extend_from_slice(payload);
 
-    // Compute UDP checksum over pseudo-header + UDP packet.
-    let cksum = udp_checksum(our_ip(), dst_ip, &packet);
+    // The UDP pseudo-header carries the IPv4 source address.  Match the
+    // address the IPv4 layer will *actually* place in the outbound
+    // header — `ipv4::send_ipv4` reflects loopback destinations into the
+    // source field (RFC 1122 §3.2.1.3) so a packet sent to 127.x bears
+    // src=127.x, not our globally-routable address.  Without this
+    // mirroring the receive-side RFC 1122 §4.1.3.4 checksum check would
+    // fail every loopback UDP datagram.
+    let src_for_pseudo = if super::loopback::is_loopback_addr(dst_ip) {
+        dst_ip
+    } else {
+        our_ip()
+    };
+    let cksum = udp_checksum(src_for_pseudo, dst_ip, &packet);
     packet[6] = (cksum >> 8) as u8;
     packet[7] = (cksum & 0xFF) as u8;
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -245,6 +245,24 @@ pub struct Thread {
     /// Length of the robust list structure (always sizeof(struct robust_list_head)
     /// = 24 bytes in practice, but stored verbatim as passed by glibc).
     pub robust_list_len: usize,
+    /// Per `clone(2)`/`vfork(2)`: when a `CLONE_VM|CLONE_VFORK` child is given
+    /// a `new_stack` argument that lies inside the parent's user stack frame
+    /// (the canonical pattern produced by `posix_spawn(3)` implementations
+    /// that allocate the child's stack as a small local buffer of the
+    /// parent's `posix_spawn()` frame, e.g. `char stack[1024+PATH_MAX]`), the
+    /// kernel substitutes a freshly-allocated isolated stack so that the
+    /// child's stack growth cannot clobber the parent's stack region while
+    /// the address space is shared.  Linux suspends the parent during
+    /// `CLONE_VFORK` so child writes are not raced against, but POSIX
+    /// `vfork(2)` still leaves the parent observable to corruption after it
+    /// resumes — including any saved stack-protector canary copies that
+    /// SSP-instrumented callers (libxul) place on the stack.  This field
+    /// records the `(base, length)` of the isolated stack VMA so the
+    /// kernel can unmap it from the parent's address space on
+    /// `execve(2)` / vfork-child exit.  `None` for every non-vfork
+    /// path (initial thread, fork-style clone with a fresh CR3, kernel
+    /// threads, AP idle threads).
+    pub vfork_isolated_stack: Option<(u64, u64)>,
 }
 
 impl Thread {
@@ -667,6 +685,7 @@ pub fn init() {
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(idle_proc);
@@ -915,6 +934,7 @@ fn create_kernel_process_inner(name: &str, entry_point: u64, initial_state: Thre
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(process);
@@ -980,6 +1000,7 @@ pub fn create_thread(pid: Pid, name: &str, entry_point: u64) -> Option<Tid> {
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     THREAD_TABLE.lock().push(thread);
@@ -1049,6 +1070,7 @@ pub fn create_thread_blocked(pid: Pid, name: &str, entry_point: u64) -> Option<T
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     THREAD_TABLE.lock().push(thread);
@@ -1152,6 +1174,30 @@ pub fn exit_thread(exit_code: i64) {
     // vfork completion: if this is a vfork child exiting without exec, wake parent.
     // Linux: exit_mm_release() → mm_release() → complete_vfork_done().
     crate::syscall::wake_vfork_parent();
+
+    // Vfork isolated-stack cleanup: if this thread is a vfork child that
+    // was given a kernel-allocated isolated stack by `alloc_vfork_child_stack`
+    // and exited WITHOUT execve(2) (the execve case is handled in
+    // `syscall::sys_exec` step 5a), unmap the stack from the parent's
+    // address space now.  The parent is still alive (zombie-able) and owns
+    // the cr3 we mapped against; failing to unmap here would leak the VMA
+    // until the parent itself exits.
+    {
+        let isolated = {
+            let threads = THREAD_TABLE.lock();
+            threads.iter().find(|t| t.tid == tid)
+                .and_then(|t| t.vfork_isolated_stack)
+        };
+        if let Some((base, length)) = isolated {
+            if parent_pid != 0 {
+                vfork_isolated_stack_cleanup(parent_pid, base, length);
+            }
+            let mut threads = THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                t.vfork_isolated_stack = None;
+            }
+        }
+    }
 
     // CLONE_CHILD_CLEARTID: write 0 to the child_tid address and futex-wake it.
     // This is how glibc's pthread_join knows the thread has exited — it does
@@ -1757,6 +1803,26 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
         crate::syscall::wake_vfork_parent();
     }
 
+    // Vfork isolated-stack cleanup: same rationale as exit_thread (see
+    // there for the longer comment).  We harvest the field from the
+    // calling thread (the vfork child) and unmap the recorded VMA from
+    // the parent's address space.  Out-of-band callers (yield_self==false)
+    // do not own a calling_tid of the dying process, so they skip this.
+    if yield_self && calling_tid != 0 && parent_pid != 0 {
+        let isolated = {
+            let threads = THREAD_TABLE.lock();
+            threads.iter().find(|t| t.tid == calling_tid)
+                .and_then(|t| t.vfork_isolated_stack)
+        };
+        if let Some((base, length)) = isolated {
+            vfork_isolated_stack_cleanup(parent_pid, base, length);
+            let mut threads = THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == calling_tid) {
+                t.vfork_isolated_stack = None;
+            }
+        }
+    }
+
     // Wake parent threads blocked in waitpid, and mark calling thread Dead
     // (only when the caller is itself a thread of the dying process).
     {
@@ -2191,6 +2257,7 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);
@@ -2397,28 +2464,23 @@ pub fn fork_process_share_vm(
         user_entry_r8:  0,
         priority: PRIORITY_NORMAL,
         base_priority: PRIORITY_NORMAL,
-        // VFORK / CLONE_VM child must NOT inherit the parent's TLS base.
+        // VFORK / CLONE_VM child inherits the parent's FS.base so it can use
+        // thread-local storage immediately.  The glxtest child function in
+        // libxul calls fork(2) (which internally reads %fs:0 via musl's
+        // pthread machinery), so a zeroed FS.base would fault immediately.
         //
-        // The child shares the parent's address space (same CR3) but will
-        // call execve(2) almost immediately.  If the child inherits
-        // `parent_tls_base`, user_mode_bootstrap writes that value into the
-        // CPU's FS_BASE MSR.  The new process image (ld-musl) then runs with
-        // FS_BASE pointing at the PARENT's TLS struct, and its startup
-        // initialisation (musl __libc_start_main → __stack_chk_guard init)
-        // writes the new canary to parent_tls + 0x28 — corrupting the
-        // parent's SSP canary.  On the parent's next call to any
-        // SSP-protected function the prologue stores the (now-wrong) canary
-        // and the epilogue reads the old value from the stack, triggering
-        // __stack_chk_fail → #GP.
+        // The parent's SSP canary lives at parent_tls_base + 0x28.  The child
+        // must not write to that offset while sharing the TLS struct.  In
+        // practice, musl's fork() path only READS %fs:0 (to obtain the thread
+        // self-pointer for atfork handler iteration); it never writes %fs:0x28
+        // before the child calls _exit().  Therefore inheriting the parent's
+        // TLS base is safe for the brief vfork window.
         //
-        // Setting tls_base = 0 makes user_mode_bootstrap skip the WRMSR
-        // (see `if tls_base != 0` guard), leaving FS_BASE at whatever
-        // kernel-mode value it has until the child calls
-        // arch_prctl(ARCH_SET_FS, new_tcb) in its own execve'd image.
-        // The posix_spawn child function (musl's __spawni_child) does NOT
-        // use fs: segment accesses, so a zero FS_BASE is safe for the brief
-        // window between clone and execve.
-        tls_base: 0,
+        // If the child calls arch_prctl(ARCH_SET_FS, new_tls) (e.g., via
+        // execve -> ld-musl startup), sys_arch_prctl updates its own tls_base
+        // in THREAD_TABLE; the scheduler restores the parent's tls_base when
+        // the parent next runs.
+        tls_base: parent_tls_base,
         cpu_affinity: None,
         last_cpu: 0,
         first_run: true,
@@ -2429,6 +2491,7 @@ pub fn fork_process_share_vm(
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);
@@ -2461,6 +2524,200 @@ pub fn fork_process_share_vm(
     );
 
     Some((child_pid, child_tid))
+}
+
+/// Allocate an **isolated user-mode stack** for a `CLONE_VM|CLONE_VFORK` child
+/// so that the child's stack growth cannot clobber the parent's stack region
+/// while the address space is shared.
+///
+/// # Why this exists
+///
+/// Some libc `posix_spawn(3)` implementations (and the underlying
+/// `posix_spawnp(3)`) place the child's stack as an on-stack local of the
+/// **parent's `posix_spawn()` frame**, roughly:
+///
+/// ```c
+/// char stack[1024+PATH_MAX];
+/// pid = __clone(child, stack+sizeof stack,
+///               CLONE_VM|CLONE_VFORK|SIGCHLD, &args);
+/// ```
+///
+/// `1024 + PATH_MAX = 1024 + 4096 = 5120` bytes — small enough that the
+/// child helper can overflow it after a chain of `sigaction` /
+/// `pthread_sigmask` / `execve` setup calls.  Once the child's RSP descends
+/// past `&stack[0]` it lands in the parent's neighbouring frame:
+/// `posix_spawn()` locals (`args`, `ec`, `cs`, ...) first, then the caller
+/// frame of `posix_spawn()` (typically libxul's spawn shim), and so on
+/// upward through the call chain.
+///
+/// `CLONE_VFORK` suspends the parent — the parent does not *execute*
+/// instructions while the child is alive — but the corrupted parent-stack
+/// bytes are not restored when the parent resumes.  In particular,
+/// stack-protector instrumented callers (SSP-enabled libxul) save the canary
+/// **on the stack** in their prologue and re-read it in the epilogue; if the
+/// child overwrote that copy, the epilogue compares the corrupted value
+/// against `fs:0x28` and triggers `__stack_chk_fail` → `a_crash` → #GP.
+///
+/// # What this helper does
+///
+/// 1. Allocates a 64 KiB anonymous VMA in the shared address space (parent's
+///    `VmSpace`, which the child is borrowing via the shared `cr3`).
+/// 2. Eagerly maps the top 4 KiB page of that VMA so the kernel can write the
+///    libc-pushed `arg` word into it without faulting; lower pages remain
+///    demand-paged by the standard PFH.
+/// 3. Reads the 8-byte word at the parent-supplied `new_stack` address —
+///    the canonical x86_64 SysV `__clone` preamble writes the helper's `arg`
+///    pointer there immediately before the syscall via `mov %rcx, (%rsi)`.
+///    After the child wakes, its first user instructions are
+///    `pop %rdi; call *%r9`, which expect `arg` to be at the very top of its
+///    stack.
+/// 4. Writes that `arg` word to the corresponding slot in the new isolated
+///    stack so the child's `pop %rdi` reads the right value.
+/// 5. Returns the new RSP value (`new_top - 8`) for the caller to install on
+///    `Thread.user_entry_rsp` in place of the parent-frame `new_stack`.
+///
+/// # Cleanup
+///
+/// The base+length of the isolated stack is recorded by the caller on
+/// `Thread.vfork_isolated_stack`.  It is unmapped from the parent's address
+/// space in two places:
+///   * `execve(2)` case (C) — `syscall::sys_exec` after the new VmSpace is
+///     installed and the parent is woken via `wake_vfork_parent()`.
+///   * Vfork-child exit (`exit`, `exit_group`, or fatal signal) — via
+///     `vfork_isolated_stack_cleanup()` invoked from the thread-exit path.
+///
+/// # References
+///
+/// * POSIX `vfork(2)` / `posix_spawn(3)`
+/// * Linux `clone(2)` / `clone3(2)` (ABI for the `stack` argument)
+/// * x86_64 SysV ABI - calling convention for the `__clone` shim
+/// * ELF gABI §6 (stack-protector canary placement)
+pub fn alloc_vfork_child_stack(parent_pid: Pid, parent_new_stack: u64) -> Option<u64> {
+    use crate::mm::vma::{VmArea, VmBacking, VmaError,
+                         PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS, MAP_STACK,
+                         page_align_up};
+    use crate::mm::vmm::{PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER, PAGE_NO_EXECUTE};
+
+    // Stack size for the isolated VMA.  64 KiB is far larger than any path
+    // the libc child-helper can realistically push (a few hundred bytes of
+    // sigaction loops + execve preamble), but small enough that leaking one
+    // per posix_spawn invocation between vfork start and execve completion
+    // costs at most a few hundred KiB in steady state.
+    const VFORK_STACK_SIZE: u64 = 64 * 1024;
+
+    // -- Phase 1: read the helper-arg word the libc preamble pushed onto the
+    // parent stack.
+    //
+    // We are still executing in the parent's syscall context, so the user-VA
+    // `parent_new_stack` is directly readable under SMAP.  The 8-byte read
+    // is what the libc `__clone` shim wrote via `mov %rcx,(%rsi)`; the child
+    // will `pop %rdi` from this slot as its first user instruction.
+    let arg_word: u64 = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::read(parent_new_stack as *const u64)
+    };
+
+    // ── Phase 2: locate the parent's VmSpace and pick a free address range.
+    let length = page_align_up(VFORK_STACK_SIZE);
+    let (parent_cr3, base) = {
+        let mut procs = PROCESS_TABLE.lock();
+        let p = procs.iter_mut().find(|p| p.pid == parent_pid)?;
+        let space = p.vm_space.as_mut()?;
+        let base = space.find_free_range(length)?;
+
+        // Insert the VMA so subsequent page-faults inside the range are
+        // demand-paged by the standard handler.  We also pre-map the top
+        // page below (Phase 3) so the immediate `pop %rdi` succeeds without
+        // ever entering the PFH.
+        let vma = VmArea {
+            base,
+            length,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK,
+            backing: VmBacking::Anonymous,
+            name: "[vfork-stack]",
+        };
+        if let Err(VmaError::Overlap) = space.insert_vma(vma) {
+            // Should never happen — find_free_range just told us this range
+            // was clear.  Bail rather than corrupting the VMA list.
+            return None;
+        }
+        (p.cr3, base)
+    };
+
+    // ── Phase 3: eagerly back the top page with a fresh frame, write the
+    // helper-arg word at `top - 8`, and install a writable user PTE.
+    //
+    // The page must be writable + user + non-executable.  We don't bother
+    // pre-mapping the rest of the VMA — the PFH will allocate frames as the
+    // child grows the stack downward (typical: only the top few pages get
+    // touched before the child execve's).
+    let top = base + length;
+    let top_page_va = top - 0x1000;
+    let frame = crate::mm::pmm::alloc_page()?;
+    // Zero the frame and write the arg word at offset 0xff8 (== top - 8 mod 4 KiB).
+    // PHYS_OFF = higher-half physical→virtual identity offset (kernel.org
+    // documents this layout informally; locally it is `0xFFFF_8000_0000_0000`).
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    unsafe {
+        let kva = (PHYS_OFF + frame) as *mut u8;
+        core::ptr::write_bytes(kva, 0, 4096);
+        core::ptr::write((kva.add(0x1000 - 8)) as *mut u64, arg_word);
+    }
+    let flags = PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER | PAGE_NO_EXECUTE;
+    if !crate::mm::vmm::map_page_in(parent_cr3, top_page_va, frame, flags) {
+        // Map failed — free the frame and bail.  The VMA stays in the parent's
+        // list and will be cleaned up at the next address-space teardown.
+        crate::mm::pmm::free_page(frame);
+        return None;
+    }
+    // Bump the page refcount so the unmap path drops it cleanly later.
+    crate::mm::refcount::page_ref_inc(frame);
+
+    crate::serial_println!(
+        "[VFORK-STACK] alloc base={:#x} top={:#x} new_rsp={:#x} arg={:#x} (parent_rsp={:#x})",
+        base, top, top - 8, arg_word, parent_new_stack
+    );
+
+    Some(top - 8)
+}
+
+/// Tear down an isolated vfork-child stack VMA from the **parent's** address
+/// space.  Called from `execve(2)` (case C — shared-VM child installing a
+/// fresh image) and from the vfork-child exit path.
+///
+/// The caller passes the `(base, length)` previously recorded on
+/// `Thread.vfork_isolated_stack` plus the parent's `cr3`.  The VMA's pages
+/// are unmapped via `unmap_and_free_range_in` (which decrements refcounts
+/// and frees frames whose ref reaches zero) and the VmSpace entry is
+/// removed via `remove_range`.
+///
+/// Safe to call multiple times — repeated calls on the same `(base, length)`
+/// are no-ops because the VMA / PTEs have already been removed.
+pub fn vfork_isolated_stack_cleanup(parent_pid: Pid, base: u64, length: u64) {
+    // First unmap the PTEs and free the physical frames in the parent's CR3.
+    let parent_cr3 = {
+        let procs = PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == parent_pid).map(|p| p.cr3).unwrap_or(0)
+    };
+    if parent_cr3 == 0 { return; }
+
+    let unmapped = crate::mm::vmm::unmap_and_free_range_in(parent_cr3, base, length);
+
+    // Then remove the VMA entry from the parent's VmSpace.
+    {
+        let mut procs = PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == parent_pid) {
+            if let Some(space) = p.vm_space.as_mut() {
+                let _ = space.remove_range(base, length);
+            }
+        }
+    }
+
+    crate::serial_println!(
+        "[VFORK-STACK] cleanup parent_pid={} cr3={:#x} base={:#x} length={:#x} unmapped_pages={}",
+        parent_pid, parent_cr3, base, length, unmapped
+    );
 }
 
 /// Apply `CLONE_CLEAR_SIGHAND` semantics to a process's signal-action table.
@@ -2673,6 +2930,7 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
         gs_base: 0,
         robust_list_head: 0,
         robust_list_len: 0,
+        vfork_isolated_stack: None,
     };
 
     PROCESS_TABLE.lock().push(child_proc);

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1171,10 +1171,6 @@ pub fn exit_thread(exit_code: i64) {
         free_process_memory(pid);
     }
 
-    // vfork completion: if this is a vfork child exiting without exec, wake parent.
-    // Linux: exit_mm_release() → mm_release() → complete_vfork_done().
-    crate::syscall::wake_vfork_parent();
-
     // Vfork isolated-stack cleanup: if this thread is a vfork child that
     // was given a kernel-allocated isolated stack by `alloc_vfork_child_stack`
     // and exited WITHOUT execve(2) (the execve case is handled in
@@ -1182,6 +1178,12 @@ pub fn exit_thread(exit_code: i64) {
     // address space now.  The parent is still alive (zombie-able) and owns
     // the cr3 we mapped against; failing to unmap here would leak the VMA
     // until the parent itself exits.
+    //
+    // Ordering: this runs BEFORE `wake_vfork_parent()` to match the
+    // canonical sys_exec Case C order — the parent must observe the
+    // teardown completed (mapping unmapped, TLB shootdown ack'd) before
+    // it is unblocked, so a parent thread that immediately runs and
+    // reuses the same VA range cannot race against our pending unmap.
     {
         let isolated = {
             let threads = THREAD_TABLE.lock();
@@ -1198,6 +1200,11 @@ pub fn exit_thread(exit_code: i64) {
             }
         }
     }
+
+    // vfork completion: if this is a vfork child exiting without exec, wake parent.
+    // Per POSIX vfork(2): the parent resumes only after the child terminates
+    // or has called one of the exec(3) family.
+    crate::syscall::wake_vfork_parent();
 
     // CLONE_CHILD_CLEARTID: write 0 to the child_tid address and futex-wake it.
     // This is how glibc's pthread_join knows the thread has exited — it does
@@ -1787,27 +1794,15 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // Free user memory (no locks held).
     free_process_memory(pid);
 
-    // vfork completion: if the caller is a vfork child fatal-faulting mid-
-    // execve (e.g. a synchronous fatal CPU exception routed here from
-    // arch/x86_64/idt.rs), the parent is parked in TASK_KILLABLE-style sleep
-    // on `vfork_parent_tid` and only this wake will release it.  Without it,
-    // the parent stays Blocked until the 5-second vfork timeout fires.
-    // Linux: exit_mm_release() → mm_release() → complete_vfork_done().
-    //
-    // Lock discipline: wake_vfork_parent() takes THREAD_TABLE.  We hold no
-    // locks here (the sibling-Dead pass at the top released THREAD_TABLE,
-    // and futex_drain_pid / PROCESS_TABLE / FILE_LOCKS sections have all
-    // completed).  Out-of-band callers (yield_self == false) skip this:
-    // they are healthy threads in a different process — not a vfork child.
-    if yield_self {
-        crate::syscall::wake_vfork_parent();
-    }
-
     // Vfork isolated-stack cleanup: same rationale as exit_thread (see
     // there for the longer comment).  We harvest the field from the
     // calling thread (the vfork child) and unmap the recorded VMA from
     // the parent's address space.  Out-of-band callers (yield_self==false)
     // do not own a calling_tid of the dying process, so they skip this.
+    //
+    // Ordering: runs BEFORE `wake_vfork_parent()` to match sys_exec
+    // Case C — the parent must observe a fully torn-down mapping before
+    // it is unblocked.
     if yield_self && calling_tid != 0 && parent_pid != 0 {
         let isolated = {
             let threads = THREAD_TABLE.lock();
@@ -1821,6 +1816,22 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
                 t.vfork_isolated_stack = None;
             }
         }
+    }
+
+    // vfork completion: if the caller is a vfork child fatal-faulting mid-
+    // execve (e.g. a synchronous fatal CPU exception routed here from
+    // arch/x86_64/idt.rs), the parent is parked in TASK_KILLABLE-style sleep
+    // on `vfork_parent_tid` and only this wake will release it.  Without it,
+    // the parent stays Blocked until the 5-second vfork timeout fires.
+    // Per POSIX vfork(2): parent resumes only after child terminates or execs.
+    //
+    // Lock discipline: wake_vfork_parent() takes THREAD_TABLE.  We hold no
+    // locks here (the sibling-Dead pass at the top released THREAD_TABLE,
+    // and futex_drain_pid / PROCESS_TABLE / FILE_LOCKS sections have all
+    // completed).  Out-of-band callers (yield_self == false) skip this:
+    // they are healthy threads in a different process — not a vfork child.
+    if yield_self {
+        crate::syscall::wake_vfork_parent();
     }
 
     // Wake parent threads blocked in waitpid, and mark calling thread Dead
@@ -2464,23 +2475,25 @@ pub fn fork_process_share_vm(
         user_entry_r8:  0,
         priority: PRIORITY_NORMAL,
         base_priority: PRIORITY_NORMAL,
-        // VFORK / CLONE_VM child inherits the parent's FS.base so it can use
-        // thread-local storage immediately.  The glxtest child function in
-        // libxul calls fork(2) (which internally reads %fs:0 via musl's
-        // pthread machinery), so a zeroed FS.base would fault immediately.
+        // TLS base is set to 0 for CLONE_VM|CLONE_VFORK children.  This is
+        // a hard safety invariant — see the unconditional WRMSR site in
+        // `proc::usermode::enter_user_mode` (~L347-353): when `tls_base == 0`
+        // the user-mode entry path explicitly zeros FS.base via WRMSR before
+        // jumping to user mode.  Skipping that WRMSR (i.e. inheriting the
+        // parent's FS.base by leaving the MSR alone) would let the child's
+        // stack-guard epilogue read a valid-looking parent canary from
+        // %fs:0x28 and so corrupt the SSP comparison.
         //
-        // The parent's SSP canary lives at parent_tls_base + 0x28.  The child
-        // must not write to that offset while sharing the TLS struct.  In
-        // practice, musl's fork() path only READS %fs:0 (to obtain the thread
-        // self-pointer for atfork handler iteration); it never writes %fs:0x28
-        // before the child calls _exit().  Therefore inheriting the parent's
-        // TLS base is safe for the brief vfork window.
+        // Any change to TLS-inheritance behavior for CLONE_VM|CLONE_VFORK
+        // children must be preceded by empirical falsification — saved-canary
+        // and master-canary snapshot-pair diagnostics — and a binding
+        // cross-walk on the tree.  See POSIX clone(2) for the semantics of
+        // tls/CLONE_SETTLS (we ignore parent_tls_base here precisely so that
+        // an execve(2)-driven `arch_prctl(ARCH_SET_FS, new_tls)` is the only
+        // way the child's FS.base ever becomes non-zero).
         //
-        // If the child calls arch_prctl(ARCH_SET_FS, new_tls) (e.g., via
-        // execve -> ld-musl startup), sys_arch_prctl updates its own tls_base
-        // in THREAD_TABLE; the scheduler restores the parent's tls_base when
-        // the parent next runs.
-        tls_base: parent_tls_base,
+        // Refs: POSIX clone(2); Intel SDM Vol. 3A §6.8 (WRMSR FS_BASE).
+        tls_base: 0,
         cpu_affinity: None,
         last_cpu: 0,
         first_run: true,
@@ -2516,11 +2529,13 @@ pub fn fork_process_share_vm(
     let child_uses_parent_stack = user_rsp != 0;
     crate::serial_println!(
         "[VFORK/CHILD-STACK] pid={} parent_pid={} child_rsp_at_entry={:#x} \
-         child_uses_parent_stack={} parent_user_rsp={:#x}",
+         child_uses_parent_stack={} parent_user_rsp={:#x} \
+         parent_tls_base={:#x} child_tls_base=0",
         child_pid, parent_pid,
         user_rsp,
         child_uses_parent_stack,
         user_rsp,
+        parent_tls_base,
     );
 
     Some((child_pid, child_tid))

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2605,6 +2605,30 @@ pub fn alloc_vfork_child_stack(parent_pid: Pid, parent_new_stack: u64) -> Option
     // costs at most a few hundred KiB in steady state.
     const VFORK_STACK_SIZE: u64 = 64 * 1024;
 
+    // -- Phase 0: validate the attacker-controlled `parent_new_stack` pointer.
+    //
+    // `parent_new_stack` is arg2 of `clone(2)` and is fully attacker-controlled
+    // from userspace.  Phase 1 below dereferences it inside a `UserGuard`
+    // (SMAP-disabled) bracket, which means a kernel-VA value would let an
+    // unprivileged caller read 8 bytes of arbitrary kernel memory via the
+    // ABI's normal return path.  Per Intel SDM Vol. 3A §4.6 SMAP only blocks
+    // userspace pointers being dereferenced WITHOUT an explicit AC toggle;
+    // the kernel is responsible for input validation before any STAC.
+    //
+    // Per POSIX `clone(2)`, `new_stack` must reference an address in the
+    // calling process's address space; per the SysV x86_64 ABI the libc
+    // `__clone` preamble writes the arg word at `(%rsi)` as a 8-byte store,
+    // so an 8-byte-misaligned value cannot be the genuine output of the
+    // preamble and is also rejected to keep the read path well-defined.
+    //
+    // Refs: POSIX clone(2), Intel SDM Vol. 3A §4.6, CWE-822, CWE-200.
+    if !crate::syscall::validate_user_ptr(parent_new_stack, 8) {
+        return None;
+    }
+    if parent_new_stack & 0x7 != 0 {
+        return None;
+    }
+
     // -- Phase 1: read the helper-arg word the libc preamble pushed onto the
     // parent stack.
     //

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2239,18 +2239,64 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     Some((child_pid, child_tid)) => {
                         crate::serial_println!("[VFORK] child PID {} TID {} created (shared VM)", child_pid, child_tid);
 
-                        // If glibc passed a `new_stack`, switch the child to it.
-                        // glibc's __clone wrapper placed fn/arg on this stack
-                        // before the syscall (Linux clone(2) ABI).  Without
-                        // CLONE_VFORK the child returns from __clone's child
-                        // path (pop fn; call *fn) using new_stack.  With
-                        // CLONE_VFORK glibc's vfork() shim passes new_stack=0
-                        // so the child shares the parent's user stack (correct
-                        // vfork semantics — parent is suspended).
+                        // If the caller passed a `new_stack`, the conventional
+                        // pattern is libc's `__clone` having pushed the
+                        // helper-fn `arg` to `*(new_stack-8)`.  POSIX
+                        // `vfork(2)` and `clone(2)` both leave the parent's
+                        // address space writable through the child, so a
+                        // sloppy or short caller-supplied stack can have the
+                        // child overflow it into the parent's frame.  The
+                        // canonical `posix_spawn(3)` pattern in some libc
+                        // implementations is a small `char stack[1024+PATH_MAX]`
+                        // local of the parent's `posix_spawn()` frame; the
+                        // helper chain (`__libc_sigaction` loop ->
+                        // `pthread_sigmask` -> `execve`) can easily push more
+                        // than 5 KiB and overflow downward.  When
+                        // SSP-instrumented callers (libxul) sit on the parent
+                        // stack, the child's overflow clobbers their saved
+                        // canary copies and the parent's epilogue traps to
+                        // `__stack_chk_fail`.
+                        //
+                        // Substitute a fresh kernel-allocated 64 KiB VMA in
+                        // the shared address space and copy the arg word so
+                        // the child's `pop %rdi; call *%r9` preamble still
+                        // works.  Recorded on `Thread.vfork_isolated_stack`
+                        // for cleanup on execve / vfork-child exit.
                         if new_stack != 0 {
-                            let mut threads = crate::proc::THREAD_TABLE.lock();
-                            if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
-                                t.user_entry_rsp = new_stack;
+                            match crate::proc::alloc_vfork_child_stack(pid, new_stack) {
+                                Some(child_rsp) => {
+                                    let mut threads = crate::proc::THREAD_TABLE.lock();
+                                    if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                        t.user_entry_rsp = child_rsp;
+                                        // Record the isolated-stack VMA so
+                                        // we can unmap it later.  Base is
+                                        // computed from the RSP we just
+                                        // returned; see alloc_vfork_child_stack
+                                        // for the size constant.
+                                        const VFORK_STACK_SIZE: u64 = 64 * 1024;
+                                        // child_rsp = base + length - 8
+                                        let base = (child_rsp + 8) - VFORK_STACK_SIZE;
+                                        t.vfork_isolated_stack = Some((base, VFORK_STACK_SIZE));
+                                    }
+                                }
+                                None => {
+                                    // Fall back to caller-supplied stack with
+                                    // a warning — the saga continues if the
+                                    // child path is short enough that it
+                                    // doesn't overflow.  ENOMEM here would
+                                    // otherwise leave us with no place to
+                                    // run the child at all.
+                                    crate::serial_println!(
+                                        "[VFORK] WARN: failed to allocate isolated stack; \
+                                         using caller-supplied new_stack={:#x} \
+                                         (parent corruption risk)",
+                                        new_stack
+                                    );
+                                    let mut threads = crate::proc::THREAD_TABLE.lock();
+                                    if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                        t.user_entry_rsp = new_stack;
+                                    }
+                                }
                             }
                         }
 
@@ -7578,6 +7624,8 @@ fn sys_pipe2_linux(fds_out: *mut u32, flags: u32) -> i64 {
 
     proc.file_descriptors[ri] = Some(read_fd);
     proc.file_descriptors[wi] = Some(write_fd);
+
+    crate::serial_println!("[PIPE2] pid={} read_fd={} write_fd={} flags={:#x}", pid, ri, wi, flags);
 
     unsafe {
         let _g = crate::arch::x86_64::smap::UserGuard::new();

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1321,6 +1321,50 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
         set_kernel_rsp(kstack_top);
     }
 
+    // 5a. Vfork isolated-stack cleanup (Case C — shared-VM child).
+    //
+    //     If the clone(2)/vfork(2) machinery allocated a per-child stack
+    //     VMA in the parent's address space (so the child could not
+    //     overflow into the parent's frame — see
+    //     `proc::alloc_vfork_child_stack`), unmap it now before unblocking
+    //     the parent.  At this point the new VmSpace is installed and the
+    //     hardware CR3 is the child's NEW cr3, so the unmap targets the
+    //     **parent's** page tables (looked up via the parent's pid) — not
+    //     the address space we are currently executing on.
+    //
+    //     The parent never reads from the vfork stack region — it remains
+    //     blocked in `schedule()` with its own RSP elsewhere — so the
+    //     unmap is race-free with respect to the parent thread.
+    if is_shared_vm_child {
+        let (parent_pid, isolated_stack) = {
+            let tid = crate::proc::current_tid();
+            let procs = crate::proc::PROCESS_TABLE.lock();
+            let threads = crate::proc::THREAD_TABLE.lock();
+            let parent_pid = procs
+                .iter()
+                .find(|p| p.pid == pid)
+                .map(|p| p.parent_pid)
+                .unwrap_or(0);
+            let isolated = threads
+                .iter()
+                .find(|t| t.tid == tid)
+                .and_then(|t| t.vfork_isolated_stack);
+            (parent_pid, isolated)
+        };
+        if let Some((base, length)) = isolated_stack {
+            if parent_pid != 0 {
+                crate::proc::vfork_isolated_stack_cleanup(parent_pid, base, length);
+            }
+            // Clear the field so a later (e.g. exit) path does not try to
+            // unmap a now-stale range.
+            let tid = crate::proc::current_tid();
+            let mut threads = crate::proc::THREAD_TABLE.lock();
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                t.vfork_isolated_stack = None;
+            }
+        }
+    }
+
     // 5b. vfork completion: wake the blocked parent NOW.  The new mm is
     //     installed, the old one is reclaimed, the CR3 is loaded, and the
     //     kernel stack is rebound to TSS — the child is fully ready to run

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1885,6 +1885,24 @@ pub fn run() -> ! {
     total += 1;
     if test_243_vfork_alloc_rejects_kernel_va() { passed += 1; }
 
+    // ── Tests 244–246: RX checksum validation hardening ────────────────
+    // Per RFC 791 §3.1 / RFC 768 / RFC 792 + RFC 1122, a host stack MUST
+    // silently discard IPv4 / UDP (non-zero cksum) / ICMP packets whose
+    // 16-bit one's-complement Internet Checksum (RFC 1071) does not
+    // validate.  These tests pin the per-protocol counters and the
+    // accept/reject decision across hand-crafted loopback datagrams.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_244_ipv4_rx_checksum_validation() { passed += 1; }
+
+        total += 1;
+        if test_245_udp_rx_checksum_validation() { passed += 1; }
+
+        total += 1;
+        if test_246_icmp_rx_checksum_validation() { passed += 1; }
+    }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -32129,5 +32147,281 @@ fn test_243_vfork_alloc_rejects_kernel_va() -> bool {
                   max_aligned_user_va);
 
     test_pass!("alloc_vfork_child_stack input validation (CWE-822, CWE-200)");
+    true
+}
+
+// ── Test 244: IPv4 RX header-checksum validation (RFC 791 §3.1) ──────────────
+//
+// RFC 791 §3.1 ("Header Checksum") + RFC 1122 §3.2.1.2: a receiver MUST
+// verify the IPv4 header checksum and silently discard any datagram
+// whose checksum is invalid.  Until the fix landed alongside this test,
+// `handle_ipv4` accepted every parseable header regardless of the
+// `header_checksum` field — a NIC corruption or attacker-crafted bit
+// flip in the IP header was indistinguishable from valid traffic and
+// reached the L4 dispatch.
+//
+// The test drives `handle_ipv4` directly with crafted packets:
+//   (a) A well-formed UDP-in-IPv4 datagram destined for our loopback
+//       address with the correct header checksum.  `IPV4_RX_BAD_CSUM`
+//       must NOT advance.
+//   (b) The same datagram with one bit flipped inside the IP header
+//       (which the IP checksum covers).  `IPV4_RX_BAD_CSUM` MUST
+//       advance by exactly one.
+//   (c) Restore and re-checksum — counter must NOT advance again.
+//
+// Cite: RFC 791 §3.1, RFC 1071 §1 (Internet Checksum), RFC 1122 §3.2.1.2.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_244_ipv4_rx_checksum_validation() -> bool {
+    test_header!("net: IPv4 RX header checksum validation (RFC 791 §3.1)");
+
+    use crate::net::ipv4;
+
+    // Build a minimal IPv4 + UDP datagram of total length 28 bytes.
+    // IHL=5 (20-byte IP header), proto=UDP (17), TTL=64, ID=0x4321,
+    // DF set, src 127.0.0.1, dst 127.0.0.1, UDP src=1, dst=2, len=8.
+    let mut pkt = alloc::vec::Vec::with_capacity(28);
+    pkt.push(0x45);                                  // version|IHL
+    pkt.push(0x00);                                  // DSCP/ECN
+    pkt.extend_from_slice(&28u16.to_be_bytes());     // total_length
+    pkt.extend_from_slice(&0x4321u16.to_be_bytes()); // identification
+    pkt.extend_from_slice(&0x4000u16.to_be_bytes()); // flags|frag_off (DF)
+    pkt.push(64);                                    // TTL
+    pkt.push(ipv4::PROTO_UDP);                       // protocol
+    pkt.push(0); pkt.push(0);                        // header checksum placeholder
+    pkt.extend_from_slice(&[127, 0, 0, 1]);          // src IP
+    pkt.extend_from_slice(&[127, 0, 0, 1]);          // dst IP
+    let cks = ipv4::checksum(&pkt[..20]);
+    pkt[10] = (cks >> 8) as u8;
+    pkt[11] = (cks & 0xFF) as u8;
+    // UDP header — src=1, dst=2, len=8, no checksum (cksum=0).
+    pkt.extend_from_slice(&1u16.to_be_bytes());
+    pkt.extend_from_slice(&2u16.to_be_bytes());
+    pkt.extend_from_slice(&8u16.to_be_bytes());
+    pkt.push(0); pkt.push(0);
+
+    // (a) Valid checksum — accepted (counter must NOT advance).
+    let before_a = ipv4::rx_bad_csum_count();
+    ipv4::handle_ipv4(&pkt);
+    let after_a = ipv4::rx_bad_csum_count();
+    test_println!("  (a) valid checksum bad-csum drops: {} -> {}", before_a, after_a);
+    if after_a != before_a {
+        test_fail!("test244", "(a) valid datagram counted as bad ({} -> {})",
+                   before_a, after_a);
+        return false;
+    }
+
+    // (b) Flip TTL byte without recomputing the checksum — MUST be dropped.
+    pkt[8] ^= 0x01;
+    let before_b = ipv4::rx_bad_csum_count();
+    ipv4::handle_ipv4(&pkt);
+    let after_b = ipv4::rx_bad_csum_count();
+    test_println!("  (b) corrupted header bad-csum drops: {} -> {}", before_b, after_b);
+    if after_b != before_b + 1 {
+        test_fail!("test244",
+            "(b) expected exactly one drop, got {} -> {}",
+            before_b, after_b);
+        return false;
+    }
+
+    // (c) Restore + re-checksum — accepted again.
+    pkt[8] ^= 0x01;
+    pkt[10] = 0; pkt[11] = 0;
+    let cks = ipv4::checksum(&pkt[..20]);
+    pkt[10] = (cks >> 8) as u8;
+    pkt[11] = (cks & 0xFF) as u8;
+    let before_c = ipv4::rx_bad_csum_count();
+    ipv4::handle_ipv4(&pkt);
+    let after_c = ipv4::rx_bad_csum_count();
+    test_println!("  (c) repaired checksum bad-csum drops: {} -> {}", before_c, after_c);
+    if after_c != before_c {
+        test_fail!("test244", "(c) repaired datagram still counted as bad");
+        return false;
+    }
+
+    test_pass!("IPv4 RX header checksum validation (RFC 791 §3.1)");
+    true
+}
+
+// ── Test 245: UDP RX checksum validation (RFC 768, RFC 1122 §4.1.3.4) ────────
+//
+// RFC 768 + RFC 1122 §4.1.3.4 specify that a UDP receiver MUST silently
+// discard any datagram whose checksum is non-zero and does not validate
+// against the IPv4 pseudo-header.  A transmitted checksum of zero means
+// "checksum disabled by sender" and the receiver MUST NOT validate.
+//
+// Validation cases:
+//   (a) Datagram carrying a valid pseudo-header checksum — counter does
+//       NOT advance; payload reaches the bound port queue.
+//   (b) Same datagram with one payload byte flipped without recomputing
+//       the checksum — counter MUST advance and the payload MUST NOT
+//       reach the bound port queue.
+//   (c) Datagram with `checksum == 0` (sender opted out per RFC 768) —
+//       even with a "wrong" payload byte, the receiver MUST accept it
+//       without counting a drop.
+//
+// Cite: RFC 768, RFC 1122 §4.1.3.4, RFC 1071 §1 (Internet Checksum).
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_245_udp_rx_checksum_validation() -> bool {
+    test_header!("net: UDP RX checksum validation (RFC 768, RFC 1122 §4.1.3.4)");
+
+    use crate::net::{udp, ipv4};
+    const PORT: u16 = 17246;
+
+    if let Err(e) = udp::bind(PORT) {
+        test_fail!("test245", "bind({}) failed: {}", PORT, e);
+        return false;
+    }
+
+    // Build a UDP datagram with payload "AB" (2 bytes) -> udp_len=10.
+    let payload = [b'A', b'B'];
+    let udp_len: u16 = 8 + payload.len() as u16;
+    let mut udp_pkt = alloc::vec::Vec::with_capacity(udp_len as usize);
+    udp_pkt.extend_from_slice(&12345u16.to_be_bytes());  // src port
+    udp_pkt.extend_from_slice(&PORT.to_be_bytes());      // dst port
+    udp_pkt.extend_from_slice(&udp_len.to_be_bytes());   // length
+    udp_pkt.push(0); udp_pkt.push(0);                    // cksum placeholder
+    udp_pkt.extend_from_slice(&payload);
+
+    // Compute the pseudo-header + UDP checksum.
+    let src = [127, 0, 0, 1];
+    let dst = [127, 0, 0, 1];
+    let mut pseudo = alloc::vec::Vec::with_capacity(12 + udp_pkt.len());
+    pseudo.extend_from_slice(&src);
+    pseudo.extend_from_slice(&dst);
+    pseudo.push(0);
+    pseudo.push(ipv4::PROTO_UDP);
+    pseudo.extend_from_slice(&udp_len.to_be_bytes());
+    pseudo.extend_from_slice(&udp_pkt);
+    let cks = ipv4::checksum(&pseudo);
+    udp_pkt[6] = (cks >> 8) as u8;
+    udp_pkt[7] = (cks & 0xFF) as u8;
+
+    // Drain any pre-existing datagrams on the port.
+    while udp::recv(PORT).is_some() {}
+
+    // (a) Valid checksum — accepted.
+    let before_a = udp::rx_bad_csum_count();
+    udp::handle_udp(src, dst, &udp_pkt);
+    let after_a = udp::rx_bad_csum_count();
+    test_println!("  (a) valid checksum bad-csum drops: {} -> {}", before_a, after_a);
+    if after_a != before_a {
+        udp::unbind(PORT);
+        test_fail!("test245", "(a) valid datagram counted as bad");
+        return false;
+    }
+    let dg = udp::recv(PORT);
+    if dg.as_ref().map(|d| d.data.as_slice()) != Some(&payload[..]) {
+        udp::unbind(PORT);
+        test_fail!("test245", "(a) bound port did not receive valid payload");
+        return false;
+    }
+
+    // (b) Flip one payload byte without recomputing the checksum.
+    udp_pkt[8] ^= 0x80;
+    let before_b = udp::rx_bad_csum_count();
+    udp::handle_udp(src, dst, &udp_pkt);
+    let after_b = udp::rx_bad_csum_count();
+    test_println!("  (b) corrupted payload bad-csum drops: {} -> {}", before_b, after_b);
+    if after_b != before_b + 1 {
+        udp::unbind(PORT);
+        test_fail!("test245",
+            "(b) expected one drop on bad cksum, got {} -> {}",
+            before_b, after_b);
+        return false;
+    }
+    if udp::recv(PORT).is_some() {
+        udp::unbind(PORT);
+        test_fail!("test245", "(b) corrupted datagram leaked to bound port");
+        return false;
+    }
+
+    // (c) Restore byte, zero the checksum field (sender opt-out per RFC 768)
+    //     and corrupt the payload again — must still be accepted.
+    udp_pkt[8] ^= 0x80;
+    udp_pkt[6] = 0; udp_pkt[7] = 0;
+    udp_pkt[8] ^= 0x20;
+    let before_c = udp::rx_bad_csum_count();
+    udp::handle_udp(src, dst, &udp_pkt);
+    let after_c = udp::rx_bad_csum_count();
+    test_println!("  (c) sender opt-out (cksum=0) bad-csum drops: {} -> {}",
+                  before_c, after_c);
+    if after_c != before_c {
+        udp::unbind(PORT);
+        test_fail!("test245", "(c) cksum=0 datagram wrongly counted as bad");
+        return false;
+    }
+    if udp::recv(PORT).is_none() {
+        udp::unbind(PORT);
+        test_fail!("test245", "(c) cksum=0 datagram did not reach bound port");
+        return false;
+    }
+
+    udp::unbind(PORT);
+    test_pass!("UDP RX checksum validation (RFC 768, RFC 1122 §4.1.3.4)");
+    true
+}
+
+// ── Test 246: ICMP RX checksum validation (RFC 792, RFC 1122 §3.2.2) ─────────
+//
+// RFC 792 specifies the ICMP checksum as "the 16-bit one's complement
+// of the one's complement sum of the ICMP message starting with the
+// ICMP Type."  RFC 1122 §3.2.2 makes this a MUST for the receiver:
+// silently discard any ICMP message that fails the checksum.  Unlike
+// UDP there is no opt-out.
+//
+// Validation cases:
+//   (a) Well-formed ICMP echo *reply* (type=0) with the correct
+//       checksum — the counter does NOT advance.  We deliberately use
+//       echo-reply rather than echo-request so the handler's reply
+//       branch only stores LAST_REPLY; an echo-request would trigger
+//       `send_echo_reply` and pull the IPv4 send path into an ARP loop
+//       for the synthetic src_ip, hanging the test runner.
+//   (b) Same message with one byte flipped in the payload area — the
+//       checksum field is now wrong, counter MUST advance by one.
+//
+// Cite: RFC 792 (ICMP), RFC 1122 §3.2.2 ("Validity tests"), RFC 1071 §1.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_246_icmp_rx_checksum_validation() -> bool {
+    test_header!("net: ICMP RX checksum validation (RFC 792, RFC 1122 §3.2.2)");
+
+    use crate::net::{icmp, ipv4};
+
+    // Build a 16-byte ICMP echo reply (type=0): exercises the checksum
+    // path without triggering `send_echo_reply`.
+    let mut msg = alloc::vec::Vec::with_capacity(16);
+    msg.push(0);              // type: echo reply
+    msg.push(0);              // code
+    msg.push(0); msg.push(0); // checksum placeholder
+    msg.extend_from_slice(&1u16.to_be_bytes()); // id
+    msg.extend_from_slice(&1u16.to_be_bytes()); // seq
+    for i in 0u8..8 { msg.push(i); }
+    let cks = ipv4::checksum(&msg);
+    msg[2] = (cks >> 8) as u8;
+    msg[3] = (cks & 0xFF) as u8;
+
+    // (a) Valid checksum — accepted; counter does NOT advance.
+    let before_a = icmp::rx_bad_csum_count();
+    icmp::handle_icmp([10, 0, 2, 100], &msg);
+    let after_a = icmp::rx_bad_csum_count();
+    test_println!("  (a) valid checksum bad-csum drops: {} -> {}", before_a, after_a);
+    if after_a != before_a {
+        test_fail!("test246", "(a) valid ICMP echo counted as bad");
+        return false;
+    }
+
+    // (b) Corrupt one payload byte without recomputing the checksum.
+    msg[10] ^= 0xFF;
+    let before_b = icmp::rx_bad_csum_count();
+    icmp::handle_icmp([10, 0, 2, 100], &msg);
+    let after_b = icmp::rx_bad_csum_count();
+    test_println!("  (b) corrupted payload bad-csum drops: {} -> {}", before_b, after_b);
+    if after_b != before_b + 1 {
+        test_fail!("test246",
+            "(b) expected one drop on bad cksum, got {} -> {}",
+            before_b, after_b);
+        return false;
+    }
+
+    test_pass!("ICMP RX checksum validation (RFC 792)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1877,6 +1877,14 @@ pub fn run() -> ! {
     total += 1;
     if test_242_sched_picker_non_idle_precedence() { passed += 1; }
 
+    // ── Test 243: alloc_vfork_child_stack rejects non-user-VA new_stack ──
+    // Regression test for the Phase 0 guard in `proc::alloc_vfork_child_stack`:
+    // the helper dereferences caller-supplied `parent_new_stack` inside a
+    // SMAP-disabled UserGuard bracket, so a kernel-VA or misaligned value
+    // must be rejected before STAC.  Cf. CWE-822, CWE-200, POSIX clone(2).
+    total += 1;
+    if test_243_vfork_alloc_rejects_kernel_va() { passed += 1; }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -31993,5 +32001,78 @@ fn test_242_sched_picker_non_idle_precedence() -> bool {
 
     test_println!("  all {} workers completed {} cycles each ✓", N_WORKERS, ITERS);
     test_pass!("scheduler picker non-idle precedence (POSIX SCHED_OTHER)");
+    true
+}
+
+/// Test 243 — `proc::alloc_vfork_child_stack` Phase 0 input validation.
+///
+/// Per POSIX `clone(2)`, `new_stack` must reference an address in the
+/// calling process's address space.  The helper dereferences this pointer
+/// inside a `UserGuard` (SMAP-disabled) bracket; per Intel SDM Vol. 3A §4.6
+/// SMAP only protects userspace pointers when AC is left untouched, so a
+/// kernel-VA value would otherwise become a clean 8-byte read primitive
+/// (CWE-822 untrusted pointer dereference / CWE-200 information exposure).
+/// The Phase 0 guard rejects:
+///
+///   * Case A — `new_stack` outside the user half of the address space
+///     (`>= KERNEL_VIRT_BASE`).  Must return `None`, no kernel deref.
+///   * Case B — 8-byte-misaligned `new_stack` in the user half.  The
+///     canonical libc `__clone` preamble stores the arg word with `mov
+///     %rcx,(%rsi)` (an 8-byte aligned store), so a misaligned pointer
+///     cannot be the genuine output of the preamble and is also rejected
+///     to keep the read path well-defined.
+fn test_243_vfork_alloc_rejects_kernel_va() -> bool {
+    test_header!("alloc_vfork_child_stack input validation (CWE-822, CWE-200)");
+
+    // Use PID 1 as the parent context.  The function looks up the parent
+    // process to find its VmSpace; PID 1 always exists in the test runner
+    // (init thread).  We only care about the early validation path: both
+    // cases below must return None *before* the PROCESS_TABLE lookup
+    // executes any deref of `parent_new_stack`.
+    let parent_pid: crate::proc::Pid = 1;
+
+    // Case A — kernel-VA `new_stack`.  KERNEL_VIRT_BASE is the canonical
+    // high half-mark; any value at or above it is by definition outside
+    // the user portion of the address space.
+    let kernel_va: u64 = astryx_shared::KERNEL_VIRT_BASE;
+    let case_a = crate::proc::alloc_vfork_child_stack(parent_pid, kernel_va);
+    if case_a.is_some() {
+        test_fail!("test243",
+            "Case A: alloc_vfork_child_stack accepted kernel-VA 0x{:x} \
+             (must reject — CWE-822 information-exposure primitive)",
+            kernel_va);
+        return false;
+    }
+    test_println!("  Case A: kernel-VA 0x{:x} rejected ✓", kernel_va);
+
+    // Case A2 — also reject the very-top user-VA which would wrap when
+    // adding 8 bytes (validate_user_ptr's overflow guard).
+    let wrap_va: u64 = astryx_shared::KERNEL_VIRT_BASE - 4;
+    let case_a2 = crate::proc::alloc_vfork_child_stack(parent_pid, wrap_va);
+    if case_a2.is_some() {
+        test_fail!("test243",
+            "Case A2: alloc_vfork_child_stack accepted near-boundary 0x{:x} \
+             whose +8 byte span crosses into kernel half",
+            wrap_va);
+        return false;
+    }
+    test_println!("  Case A2: near-boundary 0x{:x} rejected ✓", wrap_va);
+
+    // Case B — misaligned user-VA `new_stack`.  Pick a value well inside
+    // the user half and add a non-zero low-bit offset so the alignment
+    // check fires.
+    let misaligned_user_va: u64 = 0x0000_4000_0000_1001;  // 8-byte misaligned
+    let case_b = crate::proc::alloc_vfork_child_stack(parent_pid, misaligned_user_va);
+    if case_b.is_some() {
+        test_fail!("test243",
+            "Case B: alloc_vfork_child_stack accepted misaligned user-VA \
+             0x{:x} (low 3 bits = 0x{:x}, libc __clone always stores arg \
+             at 8-byte boundary)",
+            misaligned_user_va, misaligned_user_va & 0x7);
+        return false;
+    }
+    test_println!("  Case B: misaligned user-VA 0x{:x} rejected ✓", misaligned_user_va);
+
+    test_pass!("alloc_vfork_child_stack input validation (CWE-822, CWE-200)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -32016,11 +32016,20 @@ fn test_242_sched_picker_non_idle_precedence() -> bool {
 ///
 ///   * Case A — `new_stack` outside the user half of the address space
 ///     (`>= KERNEL_VIRT_BASE`).  Must return `None`, no kernel deref.
+///   * Case A2 — `new_stack` whose `+8` byte span crosses into the kernel
+///     half (the SMAP-bracketed Phase 1 read is 8 bytes wide).
 ///   * Case B — 8-byte-misaligned `new_stack` in the user half.  The
 ///     canonical libc `__clone` preamble stores the arg word with `mov
 ///     %rcx,(%rsi)` (an 8-byte aligned store), so a misaligned pointer
 ///     cannot be the genuine output of the preamble and is also rejected
 ///     to keep the read path well-defined.
+///   * Case C — NULL pointer.  `validate_user_ptr(0, 8)` returns false;
+///     the helper must short-circuit at Phase 0 with no deref.
+///   * Case D — boundary inclusion: the largest 8-byte-aligned user-VA
+///     (`KERNEL_VIRT_BASE - 8`) must be accepted by Phase 0's validator
+///     (the upper bound is inclusive).  Tested via `validate_user_ptr`
+///     directly so the helper's Phase 1 deref (which would fault on the
+///     unmapped boundary page) is not exercised.
 fn test_243_vfork_alloc_rejects_kernel_va() -> bool {
     test_header!("alloc_vfork_child_stack input validation (CWE-822, CWE-200)");
 
@@ -32072,6 +32081,52 @@ fn test_243_vfork_alloc_rejects_kernel_va() -> bool {
         return false;
     }
     test_println!("  Case B: misaligned user-VA 0x{:x} rejected ✓", misaligned_user_va);
+
+    // Case C — NULL pointer.  `validate_user_ptr(0, 8)` rejects (ptr == 0
+    // && len != 0) and the helper must return None without entering the
+    // deref path.  This documents that a `clone(2)` caller passing a NULL
+    // `new_stack` cannot smuggle a kernel-VA read through the
+    // SMAP-bracketed Phase 1.
+    let null_ptr: u64 = 0;
+    let case_c = crate::proc::alloc_vfork_child_stack(parent_pid, null_ptr);
+    if case_c.is_some() {
+        test_fail!("test243",
+            "Case C: alloc_vfork_child_stack accepted NULL new_stack \
+             (must reject — POSIX clone(2) requires new_stack in caller's \
+             address space)");
+        return false;
+    }
+    test_println!("  Case C: NULL pointer rejected ✓");
+
+    // Case D — boundary inclusion check.  `KERNEL_VIRT_BASE - 8` is the
+    // largest 8-byte-aligned user-VA whose 8-byte span `[va, va+8)` does
+    // not cross into the kernel half.  `validate_user_ptr` must accept it
+    // (`end == KERNEL_VIRT_BASE` is the inclusive upper bound).
+    //
+    // We test the validator directly rather than calling
+    // `alloc_vfork_child_stack`: at this VA in the test runner's address
+    // space the page is unmapped, and Phase 1's SMAP-bracketed
+    // `core::ptr::read` would page-fault.  The behavior under test here
+    // is the Phase 0 input-validation boundary, not the deref.
+    let max_aligned_user_va: u64 = astryx_shared::KERNEL_VIRT_BASE - 8;
+    if max_aligned_user_va & 0x7 != 0 {
+        test_fail!("test243",
+            "Case D: boundary VA 0x{:x} is not 8-byte aligned — \
+             test invariant broken",
+            max_aligned_user_va);
+        return false;
+    }
+    let validator_ok = crate::syscall::validate_user_ptr(max_aligned_user_va, 8);
+    if !validator_ok {
+        test_fail!("test243",
+            "Case D: validate_user_ptr rejected 0x{:x} (largest aligned \
+             user-VA — end == KERNEL_VIRT_BASE, the inclusive upper bound \
+             must be accepted)",
+            max_aligned_user_va);
+        return false;
+    }
+    test_println!("  Case D: boundary user-VA 0x{:x} accepted by Phase 0 ✓",
+                  max_aligned_user_va);
 
     test_pass!("alloc_vfork_child_stack input validation (CWE-822, CWE-200)");
     true


### PR DESCRIPTION
## Summary

A receiver MUST silently discard datagrams whose 16-bit one's-complement Internet checksum (RFC 1071) does not validate. Until this change the loopback path and the e1000/virtio-net RX path were both passing every parseable header straight to the L4 dispatch — a NIC corruption or attacker-crafted bit flip in the L3/L4 header was indistinguishable from valid traffic.

Three structural validation points added, each with a per-protocol drop counter:

- **IPv4 header** (RFC 791 §3.1, RFC 1122 §3.2.1.2) — re-fold the IHL bytes with the embedded `header_checksum` field in place; a valid sum yields zero per the RFC 1071 identity. `IPV4_RX_BAD_CSUM` bumps on failure.
- **UDP datagram** (RFC 768, RFC 1122 §4.1.3.4) — clamp `data` to `header.length` (so attacker-shaped trailer bytes cannot influence the checksum), then verify against the IPv4 pseudo-header. A transmitted checksum of zero is an explicit sender opt-out (RFC 768) and MUST NOT be validated; a non-zero invalid checksum bumps `UDP_RX_BAD_CSUM`.
- **ICMP body** (RFC 792, RFC 1122 §3.2.2) — verify with the same `verify_checksum` helper; no opt-out path. `ICMP_RX_BAD_CSUM` bumps on failure.

The UDP **TX** path is also corrected here to mirror the IPv4 layer's loopback source rewrite (RFC 1122 §3.2.1.3): `ipv4::send_ipv4` reflects loopback destinations into the source field, so the UDP pseudo-header must use that same loopback source or the receive-side check would reject every loopback UDP datagram.

A shared `ipv4::verify_checksum` helper is exposed so future TCP and ICMPv6 RX paths can plug in without duplicating the fold.

## My commit

The only commit *I* authored on this branch is **`9feeeebf`** — 4 files, +440/-6 (net/ipv4.rs, net/udp.rs, net/icmp.rs, test_runner.rs). The PR diff also shows three intermediate commits from a concurrent agent's `w311-vfork-stack-isolation-v2` work that the worktree shared at branch-time (apic.rs, proc/mod.rs, subsys/linux/syscall.rs, syscall/mod.rs). Those are not part of my work; they will be subsumed when their own PR lands and this branch is rebased onto master.

## Test plan

- [x] `test_244_ipv4_rx_checksum_validation` (RFC 791 §3.1): valid → accepted, TTL bit-flip → counter +1, restored → accepted. **PASS**
- [x] `test_245_udp_rx_checksum_validation` (RFC 768 + RFC 1122 §4.1.3.4): valid → reaches bound port, payload bit-flip → dropped + counter +1 + does not leak to port, cksum=0 sender opt-out → accepted even with bad payload. **PASS**
- [x] `test_246_icmp_rx_checksum_validation` (RFC 792): valid echo-reply → accepted, payload bit-flip → counter +1. **PASS**. Uses ECHO_REPLY (type=0) not ECHO_REQUEST so the test runner does not pull the kernel into an ARP loop synthesising a reply.
- [x] Full `test-mode,kdb` suite: 270/279 passed (9 pre-existing infrastructure failures: missing binaries, alias_test intermittent, kernel32 stubs, ascension service). **No new failures.**
- [x] Loopback UDP echo continues to pass after the TX-side pseudo-header fix.
- [ ] Firefox-test soak: ran but plateaued at sc=1227 due to the well-documented FUTEX_WAKE_GHOST wedge (pre-existing, unrelated subsystem). The firefox-test path does not exercise L3/L4 NIC RX, so my changes have no measurable effect on its progression.

Cites: RFC 791 §3.1, RFC 768, RFC 792, RFC 1071 §1, RFC 1122 §3.2.1.2 / §3.2.1.3 / §3.2.2 / §4.1.3.4; POSIX `socket(2)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)