### PR TITLE
scripts/qemu-harness + CI: structured allow-fail + soak runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,33 +198,55 @@ jobs:
       # tests passed; anything else fails the job.  GitHub runners have
       # no /dev/kvm, so expect ~8–15 minutes without KVM acceleration.
       #
-      # Known pre-existing gap (audit HIGH-5): tests `pie_elf`,
-      # `TCC compile`, and `firefox_oracle` depend on pre-built binaries
-      # (`ld-musl-x86_64.so.1`, `/disk/bin/tcc`, firefox ESR) that this
-      # job does NOT build.  The first time this workflow runs in CI it
-      # is expected to surface those gaps — fixing them is a follow-up
-      # to the testing-infra audit and is tracked separately.
+      # The allow-fail list is structured: ci/allow-fail.json carries one
+      # entry per tolerated [FAIL], each with a reason and tracking
+      # reference.  `qemu-harness.py allowlist regex` renders it into the
+      # regex consumed by `ci-run --allow-fail`.  Anything not in the list
+      # still gates the job.  Use `allowlist add/remove` to update (no need
+      # to edit this workflow file when an entry shifts).
+      #
+      # Note: we keep using watch-test.py here to preserve historical exit
+      # code shape (the CI parser expects the watch-test output banner);
+      # ci-run is exposed for parity and used by `soak`.  Migrating fully
+      # to `ci-run` is tracked separately.
+      - name: Render allow-fail regex from ci/allow-fail.json
+        id: allowlist
+        run: |
+          set -euo pipefail
+          REGEX=$(python3 scripts/qemu-harness.py allowlist regex)
+          # GHA: write to GITHUB_OUTPUT so the next step can use it
+          {
+            echo "regex<<EOF"
+            echo "$REGEX"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          NUM=$(python3 -c 'import json,sys; print(len(json.load(open("ci/allow-fail.json"))["entries"]))')
+          echo "[ci] rendered allow-fail regex from $NUM entries"
+
       - name: Run headless test suite
-        # --allow-fail tolerates known pre-existing gaps:
-        #
-        # Issue #41 env-gap group (NotFound /disk/bin/* fixtures + firefox_oracle
-        # SIGSEGV): CI does not build the userspace binary fixtures (musl, tcc,
-        # busybox, hello) or Firefox, so those tests are expected to fail here.
-        #
-        # unix socketpair EPOLLIN gating: AF_UNIX epoll EPOLLIN edge-trigger has
-        # been failing on every CI run since the workflow was introduced
-        # (pre-W216).  This is a real kernel bug being tracked separately; it is
-        # not caused by any W216 change.
-        #
-        # alias_test: added by PR #221 as a deterministic page-aliasing reproducer
-        # for the W8 race.  Currently --allow-fail on TCG CI runners due to the
-        # in-flight W215 page-aliasing race investigation.  Restore enforcement
-        # after W215 closure (tracked as task #328).
-        #
-        # Any failure NOT in this list still gates the job.
         run: |
           python3 scripts/watch-test.py --no-build --hard-timeout 900 \
-            --allow-fail '\[FAIL\] (Musl hello|dynamic_elf|pie_elf|TCC compile|busybox basic|sigchld|ascension|firefox_oracle|unix socketpair EPOLLIN gating|alias_test)'
+            --allow-fail "\[FAIL\] (${{ steps.allowlist.outputs.regex }})"
+
+      - name: Allowlist drift check (informational, always runs)
+        # If any allowlist entry did NOT match a failure this run, flag it
+        # — the underlying gap may have closed and the entry can come out.
+        # Informational only: does not fail the job.
+        if: always()
+        run: |
+          set -uo pipefail
+          # Prefer the harness session log (when ci-run is used in future);
+          # fall back to watch-test's build/test-serial.log.
+          for c in ~/.astryx-harness/*.serial.log build/test-serial.log; do
+            for f in $c; do
+              if [ -e "$f" ]; then
+                echo "[ci] drift check against $f"
+                python3 scripts/qemu-harness.py allowlist check --serial-log "$f" || true
+                exit 0
+              fi
+            done
+          done
+          echo "[ci] no serial log found — skipping drift check"
 
       - name: Upload serial logs on failure
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,18 @@ jobs:
         run: |
           set -euo pipefail
           REGEX=$(python3 scripts/qemu-harness.py allowlist regex)
+          # Defence-in-depth: refuse to spliced an empty regex into the next
+          # step's --allow-fail "\[FAIL\] (REGEX)" template.  Empty would
+          # become "\[FAIL\] ()" which matches every [FAIL] line and turns
+          # a wiped or malformed allowlist into a silent green build.  The
+          # harness emits a never-match sentinel `(?!)` for the empty case
+          # so this branch is a guard against future render regressions.
+          if [ -z "$REGEX" ]; then
+            echo "[ci] FATAL: allowlist regex rendered empty — aborting." >&2
+            echo "[ci] Splicing an empty regex into '\\[FAIL\\] (REGEX)' would" >&2
+            echo "[ci] match every [FAIL] line and produce a silently green CI." >&2
+            exit 1
+          fi
           # GHA: write to GITHUB_OUTPUT so the next step can use it
           {
             echo "regex<<EOF"

--- a/ci/allow-fail.json
+++ b/ci/allow-fail.json
@@ -1,0 +1,75 @@
+{
+  "_comment": [
+    "Structured allow-fail list for the kernel-smoke CI job.",
+    "",
+    "Each entry is a kernel test name (the string after [FAIL] / [PASS] in the",
+    "serial log) together with a short reason and an optional tracking issue.",
+    "The CI workflow renders this file into a regex via the harness:",
+    "",
+    "    python3 scripts/qemu-harness.py allowlist regex",
+    "",
+    "and passes the result to `ci-run --allow-fail`. Anything not in the list",
+    "still gates the job.",
+    "",
+    "When you ADD an entry, include a 'reason' and (if possible) a 'tracking'",
+    "field so future agents can decide whether the entry is still load-bearing.",
+    "When you REMOVE an entry, the change should be visible in `git log -- ci/`",
+    "so we can audit drift — see `allowlist drift` in the harness.",
+    "",
+    "Note: names are matched as substrings (regex-quoted), so 'Musl hello'",
+    "matches [FAIL] Musl hello. If a test name contains regex metacharacters,",
+    "set 'regex': true and write the entry as a regex; otherwise it is escaped."
+  ],
+  "entries": [
+    {
+      "name": "Musl hello",
+      "reason": "env-gap: CI does not build /disk/bin/* fixtures (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "dynamic_elf",
+      "reason": "env-gap: requires ld-musl-x86_64.so.1 fixture (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "pie_elf",
+      "reason": "env-gap: requires PIE musl binary fixture (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "TCC compile",
+      "reason": "env-gap: requires /disk/bin/tcc fixture (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "busybox basic",
+      "reason": "env-gap: requires busybox fixture (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "sigchld",
+      "reason": "env-gap: SIGSEGV on missing userspace fixture (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "ascension",
+      "reason": "env-gap: requires hello fixture (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "firefox_oracle",
+      "reason": "env-gap: CI does not build Firefox ESR (issue #41)",
+      "tracking": "#41"
+    },
+    {
+      "name": "unix socketpair EPOLLIN gating",
+      "reason": "pre-existing kernel bug: AF_UNIX epoll EPOLLIN edge-trigger; predates W216",
+      "tracking": null
+    },
+    {
+      "name": "alias_test",
+      "reason": "deterministic page-aliasing reproducer for W8 race; tolerated on TCG CI until W215 closure",
+      "tracking": "#328"
+    }
+  ]
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,25 @@
+# AstryxOS Rust toolchain
+# ─────────────────────────────────────────────────────────────────────────────
+# Channel policy:
+#   AstryxOS pins to the floating `nightly` channel because the kernel relies
+#   on several -Z flags (`-Zbuild-std`, `-Zbuild-std-features`,
+#   `-Zjson-target-spec`) that are not yet stabilised.  Nightly drift can
+#   break the build at any time — when it does, the fix is to pin to the
+#   last-good dated nightly here while upstream lands the regression fix,
+#   e.g.:
+#
+#     channel = "nightly-2026-04-30"
+#
+#   Local devs should `rustup toolchain install nightly` periodically and
+#   CI uses `dtolnay/rust-toolchain@nightly` (always pulls the latest
+#   nightly) — so a date pin here is the chokepoint when CI starts failing
+#   for toolchain reasons rather than code reasons.  After landing a date
+#   pin, mirror it into `.github/workflows/build.yml` (`toolchain:` field
+#   on each `dtolnay/rust-toolchain` step) to keep CI and local in sync.
+#
+# Required components / targets are listed below; do NOT remove them
+# without first confirming each consumer (kernel ELF target spec,
+# UEFI bootloader, `objcopy` in `build.sh`) is happy.
 [toolchain]
 channel = "nightly"
 components = ["rust-src", "llvm-tools-preview"]

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -436,6 +436,105 @@ def run_staleness_check():
     print()
 
 
+def run_allowlist_check():
+    """
+    Tier 1.5 host-only check: exercise `allowlist` subcommands directly.
+
+    Validates:
+      * `allowlist regex` produces a non-empty alternation regex
+      * `allowlist list` returns a JSON envelope with an entries list
+      * `allowlist check --serial-log` correctly classifies known [FAIL]
+        lines as allowed vs. unallowed
+      * `allowlist add/remove` round-trip preserves the file _comment
+
+    No QEMU launched; runs in < 1s.  Locked down so future refactors of
+    qemu-harness.py cannot silently break the CI-side rendering of
+    ci/allow-fail.json.
+    """
+    import tempfile
+    print("=== Tier 1.5: ci/allow-fail.json allowlist (host-only) ===")
+    print()
+
+    # ── list ──────────────────────────────────────────────────────────────────
+    obj, raw, rc = _h("allowlist", "list")
+    check("allowlist list returns JSON",   obj is not None, raw[:120])
+    check("allowlist list rc=0",           rc == 0, f"rc={rc}")
+    if obj is not None:
+        check("allowlist.entries is a list",
+              isinstance(obj.get("entries"), list),
+              str(type(obj.get("entries"))))
+
+    # ── regex (printed verbatim, no trailing newline) ─────────────────────────
+    # _h() parses stdout as JSON; allowlist regex prints a raw string, so we
+    # need to call it without parsing.
+    import subprocess
+    r = subprocess.run([PYTHON, str(HARNESS), "allowlist", "regex"],
+                       capture_output=True, text=True)
+    check("allowlist regex rc=0",  r.returncode == 0, f"rc={r.returncode}")
+    check("allowlist regex non-empty",
+          len(r.stdout) > 0, f"stdout={r.stdout[:80]!r}")
+    check("allowlist regex no trailing newline",
+          not r.stdout.endswith("\n"), repr(r.stdout[-10:]))
+
+    # ── check against a synthetic serial log ──────────────────────────────────
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as fh:
+        fh.write("[OK] something\n")
+        fh.write("[PASS] another\n")
+        fh.write("[FAIL] Musl hello: errno 2\n")
+        fh.write("[FAIL] WriteConsoleA: stub not registered\n")
+        synthetic = fh.name
+    try:
+        obj, raw, rc = _h("allowlist", "check", "--serial-log", synthetic)
+        check("allowlist check returns JSON", obj is not None, raw[:120])
+        if obj is not None:
+            check("allowlist check found 1 allowed",
+                  len(obj.get("allowed_failures", [])) == 1,
+                  f"allowed={obj.get('allowed_failures')}")
+            check("allowlist check found 1 unallowed (WriteConsoleA)",
+                  len(obj.get("unallowed_failures", [])) == 1,
+                  f"unallowed={obj.get('unallowed_failures')}")
+            check("allowlist check rc=1 (drift)",
+                  rc == 1, f"rc={rc}")
+    finally:
+        Path(synthetic).unlink(missing_ok=True)
+
+    # ── add/remove round-trip (against a temp copy so we don't touch ci/) ────
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fh:
+        # Seed with a _comment to confirm preservation across edits.
+        fh.write('{"_comment": "test", "entries": []}\n')
+        tmp_path = fh.name
+    try:
+        obj, raw, rc = _h("allowlist", "--file", tmp_path,
+                          "add", "--name", "smoke_x", "--reason", "test",
+                          "--tracking", "#999")
+        check("allowlist add ok=true",
+              bool(obj and obj.get("ok")), str(obj))
+        # Duplicate add → ok=false
+        obj, raw, rc = _h("allowlist", "--file", tmp_path,
+                          "add", "--name", "smoke_x")
+        check("allowlist add duplicate ok=false",
+              bool(obj and obj.get("ok") is False), str(obj))
+        # _comment preserved
+        with open(tmp_path) as f:
+            data = json.load(f)
+        check("allowlist add preserves _comment",
+              data.get("_comment") == "test", str(data))
+        # Remove
+        obj, raw, rc = _h("allowlist", "--file", tmp_path,
+                          "remove", "--name", "smoke_x")
+        check("allowlist remove ok=true",
+              bool(obj and obj.get("ok")), str(obj))
+        with open(tmp_path) as f:
+            data = json.load(f)
+        check("allowlist remove leaves 0 entries",
+              len(data.get("entries", [])) == 0, str(data))
+        check("allowlist remove preserves _comment",
+              data.get("_comment") == "test", str(data))
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="AstryxOS qemu-harness smoke test")
@@ -460,15 +559,18 @@ def main():
         print(f"[{INFO}] Tier 3 kdb hostfwd smoke enabled")
     print()
 
-    # Always run the host-only staleness detector check — it's < 1 second and
-    # protects the W7 silent-wedge guard against future refactors.
+    # Always run the host-only checks — each is < 1 second and protects
+    # the corresponding silent-wedge guards (W7 staleness; ci/allow-fail
+    # registry) against future refactors of qemu-harness.py.
     run_staleness_check()
+    run_allowlist_check()
 
     if args.staleness_only:
-        # Early exit for CI cycles that just want the cheap detector check.
+        # Early exit for CI cycles that just want the cheap host-only checks.
+        # (Name retained for back-compat; now covers all Tier-1.5 host checks.)
         n_fail = len(failures)
         if n_fail == 0:
-            print(f"\033[32m\nStaleness check passed.\033[0m")
+            print(f"\033[32m\nHost-only checks passed.\033[0m")
             sys.exit(0)
         else:
             print(f"\033[31m\n{n_fail} check(s) FAILED:\033[0m")

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -1533,7 +1533,16 @@ def _allowlist_path(args) -> Path:
 
 
 def _allowlist_load(path: Path) -> dict:
-    """Load and minimally validate the allowlist JSON file."""
+    """Load and minimally validate the allowlist JSON file.
+
+    Duplicate entries (same name + same regex-flag) are silently dropped,
+    keeping the first occurrence and emitting a warning to stderr per
+    dropped duplicate.  Without dedup the rendered regex would contain
+    repeated alternatives (``x|x``); harmless to the matcher but a sign
+    the file has been edited concurrently or by hand-merge.  Warn-and-
+    keep-first chosen over hard-reject so a live CI run is not blocked by
+    a typo a human can fix at leisure.
+    """
     try:
         with path.open("r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -1546,8 +1555,27 @@ def _allowlist_load(path: Path) -> dict:
     entries = data.get("entries", [])
     if not isinstance(entries, list):
         _err(f"allowlist {path}: 'entries' is not a list")
+    # De-duplicate, keeping first occurrence.  Key on (name, regex-flag)
+    # so a literal-name entry and a regex-name entry that happen to share
+    # the same string are not collapsed (they target different patterns).
+    seen: set = set()
+    deduped: list = []
+    for e in entries:
+        if not isinstance(e, dict):
+            # Preserve odd entries so the validation path stays loud
+            # downstream rather than silently dropping malformed data.
+            deduped.append(e)
+            continue
+        key = (e.get("name", ""), bool(e.get("regex")))
+        if key in seen:
+            print(f"[allowlist] {path}: dropping duplicate entry "
+                  f"name={key[0]!r} regex={key[1]} (keeping first)",
+                  file=sys.stderr)
+            continue
+        seen.add(key)
+        deduped.append(e)
     # Drop any inline _comment field for consumers; tolerate extras.
-    return {"entries": entries}
+    return {"entries": deduped}
 
 
 def _allowlist_save(path: Path, data: dict, preserve_comment: bool = True) -> None:
@@ -1576,15 +1604,34 @@ def _allowlist_save(path: Path, data: dict, preserve_comment: bool = True) -> No
     tmp.replace(path)
 
 
+_ALLOWLIST_NEVER_MATCH_SENTINEL = "(?!)"
+"""Sentinel regex returned when the allowlist renders to no usable entries.
+
+`(?!)` is a negative lookahead with an empty inner pattern; the empty
+pattern always matches, so the negative lookahead can never succeed.
+Spliced into the workflow's `--allow-fail "\\[FAIL\\] (...)"` template it
+yields a pattern that matches nothing — the only safe default when the
+allowlist is empty.
+
+Using a sentinel (rather than the empty string) closes a silent-CI-green
+hole: bash splicing `""` into `(...)` produces `()`, an empty group which
+matches every `[FAIL]` line.  See workflow comment in build.yml.
+"""
+
+
 def _allowlist_to_regex(entries: list) -> str:
     """Render entries → an alternation regex suitable for ci-run --allow-fail.
 
     Each entry's "name" is escaped (re.escape) unless "regex": true is set,
-    in which case it is taken verbatim.  Empty list → empty string (no
-    failures are tolerated).
+    in which case it is taken verbatim.
+
+    When there are no usable entries we return a never-match sentinel
+    (``(?!)``) rather than an empty string — splicing ``""`` into the
+    workflow's ``\\[FAIL\\] (REGEX)`` template would produce ``()``, an
+    empty group that matches every ``[FAIL]`` line and silently turns a
+    wiped allowlist into a green CI build.  The sentinel matches nothing,
+    preserving the intended "tolerate no failures" semantics.
     """
-    if not entries:
-        return ""
     parts = []
     for e in entries:
         name = e.get("name", "")
@@ -1594,6 +1641,8 @@ def _allowlist_to_regex(entries: list) -> str:
             parts.append(f"(?:{name})")
         else:
             parts.append(re.escape(name))
+    if not parts:
+        return _ALLOWLIST_NEVER_MATCH_SENTINEL
     return "|".join(parts)
 
 
@@ -1818,18 +1867,66 @@ def cmd_soak(args):
         )
         # Capture ci-run's stdout JSON (the function prints the JSON itself).
         # Redirect stdout to a buffer, then parse it back.
+        #
+        # cmd_ci_run delegates to cmd_start, which calls _err() / sys.exit()
+        # on hard errors (QEMU spawn failure, missing data.img, frozen-ESP
+        # FileNotFoundError, etc.).  Without the outer try/except the first
+        # such failure would abort the entire soak before any aggregation —
+        # the worst possible outcome for a cross-walk diagnostic where the
+        # whole point is repeat sampling.  Catch SystemExit (and any other
+        # BaseException short of KeyboardInterrupt) and synthesise a
+        # trial_aborted record so the remaining trials still run.
         _orig_stdout = sys.stdout
         captured = io.StringIO()
         sys.stdout = captured
+        # Snapshot sessions before the trial so we can best-effort clean up
+        # a session that the failing cmd_start may have left behind.
+        sids_before = {p.stem for p in HARNESS_DIR.glob("*.json")}
+        rc: int = 0
+        aborted_cause: str = ""
         try:
-            rc = cmd_ci_run(ci_args)
-        finally:
+            try:
+                rc = cmd_ci_run(ci_args)
+            finally:
+                sys.stdout = _orig_stdout
+        except SystemExit as ex:
+            rc = int(ex.code) if isinstance(ex.code, int) else 1
+            aborted_cause = f"system_exit code={ex.code!r}"
+        except KeyboardInterrupt:
+            # Honour Ctrl-C immediately — don't bury it as a trial abort.
             sys.stdout = _orig_stdout
+            raise
+        except BaseException as ex:  # noqa: BLE001 — intentional broad catch
+            rc = 1
+            aborted_cause = f"{type(ex).__name__}: {ex}"
         raw = captured.getvalue().strip()
-        try:
-            obj = json.loads(raw) if raw else {}
-        except json.JSONDecodeError:
-            obj = {"_unparsable_stdout": raw[:400]}
+        if aborted_cause:
+            # Best-effort: tear down any QEMU session the failing trial
+            # leaked so we don't accumulate zombies across trials.  Any
+            # new session file appearing during the trial is presumed
+            # ours (concurrent dispatch on this host is rare and the
+            # alternative is a leak).
+            sids_after = {p.stem for p in HARNESS_DIR.glob("*.json")}
+            for leaked_sid in sids_after - sids_before:
+                try:
+                    cmd_stop(types.SimpleNamespace(sid=leaked_sid))
+                except BaseException as cleanup_ex:  # noqa: BLE001
+                    print(f"[soak] cleanup of leaked sid={leaked_sid} "
+                          f"failed: {cleanup_ex}", file=sys.stderr)
+            obj = {
+                "ok": False,
+                "error": "trial_aborted",
+                "exit_cause": "trial_aborted",
+                "abort_cause": aborted_cause,
+                "stdout_tail": raw[:400],
+            }
+            print(f"[soak] trial {i} aborted: {aborted_cause}",
+                  file=sys.stderr)
+        else:
+            try:
+                obj = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                obj = {"_unparsable_stdout": raw[:400]}
         obj["trial"] = i
         obj["rc"] = rc
         per_trial.append(obj)

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -62,6 +62,19 @@ QGA bridge (requires --features qga on start):
     python3 scripts/qemu-harness.py qga-info <sid> [--timeout S]
     python3 scripts/qemu-harness.py qga-sync <sid> [--id N] [--timeout S]
     python3 scripts/qemu-harness.py qga-file-read <sid> --path <P> [--max-bytes N]
+
+CI / multi-trial aggregation:
+    python3 scripts/qemu-harness.py ci-run [--features F] [--timeout-ms MS]
+                                           [--allow-fail REGEX] [--no-kvm]
+    python3 scripts/qemu-harness.py soak --trials N [--features F]
+                                           [--use-allowlist] [--allow-fail R]
+                                           [--timeout-ms MS] [--no-kvm]
+    python3 scripts/qemu-harness.py allowlist list
+    python3 scripts/qemu-harness.py allowlist regex
+    python3 scripts/qemu-harness.py allowlist add --name N --reason R
+                                                    [--tracking T] [--regex]
+    python3 scripts/qemu-harness.py allowlist remove --name N
+    python3 scripts/qemu-harness.py allowlist check --serial-log PATH
 """
 
 import argparse
@@ -1471,6 +1484,394 @@ def cmd_ci_run(args):
             f"{len(real_failures)} real-fail",
             file=sys.stderr,
         )
+
+    return 0 if overall_ok else 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# allowlist — manage ci/allow-fail.json (structured CI expected-fail registry)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Replaces a hand-edited regex string baked into .github/workflows/build.yml
+# with a structured JSON file at ci/allow-fail.json.  Agents and CI can
+# query / edit entries through one-shot argv calls (no manual YAML editing
+# in the workflow when a test like WriteConsoleA legitimately flips to
+# expected-fail mode while a fix lands).
+#
+# File schema:
+#   {
+#     "entries": [
+#       {"name": "<test name substring>",
+#        "reason": "<one-liner>",
+#        "tracking": "<issue / PR ref>" | null,
+#        "regex": false}              # optional; if true, name is a regex
+#     ]
+#   }
+#
+# The workflow renders this into the regex that `ci-run --allow-fail`
+# consumes by invoking `qemu-harness.py allowlist regex`.
+
+_ALLOWLIST_PATH_DEFAULT = "ci/allow-fail.json"
+
+
+def _allowlist_path(args) -> Path:
+    """Resolve the allowlist file path.
+
+    Order of precedence:
+      1. --file argument
+      2. ASTRYX_ALLOWLIST environment variable
+      3. <repo root>/ci/allow-fail.json   (repo root inferred from this script)
+    """
+    p = getattr(args, "file", None)
+    if p:
+        return Path(p).expanduser().resolve()
+    env = os.environ.get("ASTRYX_ALLOWLIST")
+    if env:
+        return Path(env).expanduser().resolve()
+    # Two levels up from scripts/qemu-harness.py → repo root.
+    return (Path(__file__).resolve().parent.parent / _ALLOWLIST_PATH_DEFAULT).resolve()
+
+
+def _allowlist_load(path: Path) -> dict:
+    """Load and minimally validate the allowlist JSON file."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return {"entries": []}
+    except (OSError, json.JSONDecodeError) as e:
+        _err(f"cannot read allowlist {path}: {e}")
+    if not isinstance(data, dict):
+        _err(f"allowlist {path} is not a JSON object")
+    entries = data.get("entries", [])
+    if not isinstance(entries, list):
+        _err(f"allowlist {path}: 'entries' is not a list")
+    # Drop any inline _comment field for consumers; tolerate extras.
+    return {"entries": entries}
+
+
+def _allowlist_save(path: Path, data: dict, preserve_comment: bool = True) -> None:
+    """Save the allowlist back to disk.
+
+    Preserves any top-level "_comment" field that may already be present in
+    the file (the schema is described in a "_comment" array at the head of
+    ci/allow-fail.json — we don't want one-off edits to wipe it).
+    """
+    existing_comment = None
+    if preserve_comment and path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                old = json.load(fh)
+            if isinstance(old, dict) and "_comment" in old:
+                existing_comment = old["_comment"]
+        except (OSError, json.JSONDecodeError):
+            pass
+    out: dict = {}
+    if existing_comment is not None:
+        out["_comment"] = existing_comment
+    out["entries"] = data.get("entries", [])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(out, indent=2) + "\n")
+    tmp.replace(path)
+
+
+def _allowlist_to_regex(entries: list) -> str:
+    """Render entries → an alternation regex suitable for ci-run --allow-fail.
+
+    Each entry's "name" is escaped (re.escape) unless "regex": true is set,
+    in which case it is taken verbatim.  Empty list → empty string (no
+    failures are tolerated).
+    """
+    if not entries:
+        return ""
+    parts = []
+    for e in entries:
+        name = e.get("name", "")
+        if not name:
+            continue
+        if e.get("regex"):
+            parts.append(f"(?:{name})")
+        else:
+            parts.append(re.escape(name))
+    return "|".join(parts)
+
+
+def cmd_allowlist(args):
+    """
+    Manage ci/allow-fail.json (the structured CI expected-fail registry).
+
+    Subcommands:
+      list                     — print all entries as JSON
+      regex                    — print the rendered allow-fail regex string
+                                 (stdout has NO trailing newline; suitable
+                                 for `$(... allowlist regex)` in shell).
+      add --name N [--reason R] [--tracking T] [--regex]
+                               — append a new entry; refuses duplicates
+      remove --name N          — remove the first matching entry
+      check --serial-log P     — scan a serial log and report which [FAIL]
+                                 lines are matched by the allowlist, which
+                                 are not, and any entries that did NOT match
+                                 anything (potential drift).
+
+    All forms accept --file PATH to override the default ci/allow-fail.json.
+    """
+    sub = getattr(args, "alsub", None)
+    path = _allowlist_path(args)
+    data = _allowlist_load(path)
+    entries = data["entries"]
+
+    if sub == "list":
+        _out({"path": str(path), "entries": entries})
+        return 0
+
+    if sub == "regex":
+        # Print verbatim (no trailing newline) so callers can splice into
+        # other commands without trimming.  Also expose a JSON form on
+        # stderr so the call is debuggable.
+        rx = _allowlist_to_regex(entries)
+        sys.stdout.write(rx)
+        sys.stdout.flush()
+        print(f"[allowlist] {len(entries)} entry/entries, regex len={len(rx)}",
+              file=sys.stderr)
+        return 0
+
+    if sub == "add":
+        name = getattr(args, "name", "") or ""
+        if not name:
+            _err("allowlist add: --name is required")
+        for e in entries:
+            if e.get("name") == name and bool(e.get("regex")) == bool(getattr(args, "regex_flag", False)):
+                _out({"ok": False, "error": "duplicate", "entry": e,
+                      "path": str(path)})
+                return 1
+        new_entry: dict = {
+            "name": name,
+            "reason": getattr(args, "reason", "") or "",
+            "tracking": getattr(args, "tracking", None),
+        }
+        if getattr(args, "regex_flag", False):
+            new_entry["regex"] = True
+        entries.append(new_entry)
+        _allowlist_save(path, {"entries": entries})
+        _out({"ok": True, "added": new_entry, "total": len(entries),
+              "path": str(path)})
+        return 0
+
+    if sub == "remove":
+        name = getattr(args, "name", "") or ""
+        if not name:
+            _err("allowlist remove: --name is required")
+        for i, e in enumerate(entries):
+            if e.get("name") == name:
+                removed = entries.pop(i)
+                _allowlist_save(path, {"entries": entries})
+                _out({"ok": True, "removed": removed,
+                      "remaining": len(entries), "path": str(path)})
+                return 0
+        _out({"ok": False, "error": "not_found", "name": name,
+              "path": str(path)})
+        return 1
+
+    if sub == "check":
+        serial = getattr(args, "serial_log", "") or ""
+        if not serial:
+            _err("allowlist check: --serial-log is required")
+        if not Path(serial).exists():
+            _err(f"allowlist check: serial log {serial} does not exist")
+        # Compile per-entry regexes so we can attribute matches back to the
+        # specific allowlist line.
+        compiled: list = []
+        for e in entries:
+            pat = e.get("name", "")
+            if not pat:
+                continue
+            if not e.get("regex"):
+                pat = re.escape(pat)
+            try:
+                compiled.append((re.compile(pat), e))
+            except re.error as ex:
+                _err(f"allowlist check: bad regex for {e!r}: {ex}")
+        fail_re = re.compile(r"\[FAIL\]\s*(.+?)\s*$")
+        matched_entries: set = set()
+        allowed: list = []
+        unallowed: list = []
+        try:
+            with open(serial, "r", errors="replace") as fh:
+                for ln in fh:
+                    m = fail_re.search(ln)
+                    if not m:
+                        continue
+                    name = m.group(1)
+                    hit = None
+                    for (rx, e) in compiled:
+                        if rx.search(name):
+                            hit = e
+                            break
+                    if hit is not None:
+                        matched_entries.add(hit.get("name", ""))
+                        allowed.append({"name": name, "by": hit.get("name", "")})
+                    else:
+                        unallowed.append({"name": name})
+        except OSError as ex:
+            _err(f"allowlist check: cannot read {serial}: {ex}")
+        unused = [e for e in entries
+                  if e.get("name", "") and e.get("name") not in matched_entries]
+        _out({
+            "ok": len(unallowed) == 0,
+            "serial_log": serial,
+            "allowed_failures": allowed,
+            "unallowed_failures": unallowed,
+            "unused_entries": unused,
+            "total_entries": len(entries),
+        })
+        return 0 if len(unallowed) == 0 else 1
+
+    _err(f"allowlist: unknown subcommand {sub!r}")
+    return 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# soak — run N trials of ci-run and aggregate results
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Cross-walk diagnostics repeatedly need 3–5 sequential ci-run invocations
+# with the results aggregated.  Doing this by hand wastes dispatch time and
+# the resulting per-trial JSON has to be glued together manually.
+#
+# `soak` does it once, structurally:
+#   * runs N trials of ci-run with the same features + allow-fail
+#   * builds the kernel ONCE up front (--no-build for the trials themselves)
+#   * collects per-trial pass / fail / real_failures + exit_cause
+#   * computes a flake report: tests that pass in some trials and fail in
+#     others (the most actionable signal for race investigations)
+#
+# Output schema (additive — extra keys are fine for callers):
+#   {
+#     "ok":              bool,                  # all N trials had ok=true
+#     "trials":          int,                   # N
+#     "trials_ok":       int,                   # how many had ok=true
+#     "features":        str,
+#     "per_trial":       [{"trial": i, "ok": ..., "passed": ..., ...}, ...],
+#     "flaky_tests":     [{"name": "...", "pass": k, "fail": N-k}, ...],
+#     "consistent_fail": [{"name": "...", "trials": N}, ...],
+#     "exit_causes":     {"clean": k, "panic": j, ...}
+#   }
+
+def cmd_soak(args):
+    """
+    Run ci-run N times and aggregate results.
+
+    Example:
+      python3 scripts/qemu-harness.py soak \\
+          --trials 3 \\
+          --features test-mode \\
+          --timeout-ms 900000 \\
+          --use-allowlist
+    """
+    import types
+    import io
+
+    trials = max(1, int(getattr(args, "trials", 3) or 3))
+    features = args.features or "test-mode"
+    timeout_ms = int(getattr(args, "timeout_ms", 900000) or 900000)
+    no_kvm = bool(getattr(args, "no_kvm", False))
+
+    # Resolve allow-fail: either explicit --allow-fail, or render from the
+    # allowlist file if --use-allowlist was passed.  An explicit --allow-fail
+    # always wins.
+    allow_fail = getattr(args, "allow_fail", "") or ""
+    if not allow_fail and getattr(args, "use_allowlist", False):
+        path = _allowlist_path(args)
+        data = _allowlist_load(path)
+        allow_fail = _allowlist_to_regex(data["entries"])
+        print(f"[soak] using allowlist {path} → {len(data['entries'])} entries",
+              file=sys.stderr)
+
+    # Single up-front build (mirrors what ci-run would do on trial 1) so the
+    # trials only differ in QEMU launch.  --no-build is force-passed to the
+    # per-trial ci-run calls.
+    no_build_outer = bool(getattr(args, "no_build", False))
+    if not no_build_outer:
+        print(f"[soak] building kernel once for {trials} trials ...",
+              file=sys.stderr)
+        ok = _build(features)
+        if not ok:
+            result = {"ok": False, "error": "build_failed",
+                      "features": features, "trials": trials}
+            print(json.dumps(result, indent=2))
+            return 1
+
+    per_trial: list = []
+    exit_causes: dict = {}
+    # Per-test fail counts across trials, indexed by test name.
+    fail_counts: dict = {}
+
+    for i in range(1, trials + 1):
+        print(f"[soak] === trial {i}/{trials} ===", file=sys.stderr)
+        ci_args = types.SimpleNamespace(
+            features=features,
+            no_build=True,            # always reuse the up-front build
+            timeout_ms=timeout_ms,
+            allow_fail=allow_fail,
+            no_kvm=no_kvm,
+        )
+        # Capture ci-run's stdout JSON (the function prints the JSON itself).
+        # Redirect stdout to a buffer, then parse it back.
+        _orig_stdout = sys.stdout
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            rc = cmd_ci_run(ci_args)
+        finally:
+            sys.stdout = _orig_stdout
+        raw = captured.getvalue().strip()
+        try:
+            obj = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            obj = {"_unparsable_stdout": raw[:400]}
+        obj["trial"] = i
+        obj["rc"] = rc
+        per_trial.append(obj)
+
+        cause = obj.get("exit_cause", "unknown")
+        exit_causes[cause] = exit_causes.get(cause, 0) + 1
+
+        for name in obj.get("real_failures", []) or []:
+            fail_counts[name] = fail_counts.get(name, 0) + 1
+
+    # Flake report: tests that failed in some but not all trials.
+    flaky: list = []
+    consistent_fail: list = []
+    for name, fc in fail_counts.items():
+        if fc == trials:
+            consistent_fail.append({"name": name, "trials": fc})
+        else:
+            flaky.append({"name": name, "fail": fc, "pass": trials - fc})
+
+    trials_ok = sum(1 for t in per_trial if t.get("ok") is True)
+    overall_ok = trials_ok == trials
+
+    result = {
+        "ok": overall_ok,
+        "trials": trials,
+        "trials_ok": trials_ok,
+        "features": features,
+        "allow_fail": allow_fail,
+        "per_trial": per_trial,
+        "flaky_tests": sorted(flaky, key=lambda x: (-x["fail"], x["name"])),
+        "consistent_fail": consistent_fail,
+        "exit_causes": exit_causes,
+    }
+    print(json.dumps(result, indent=2))
+
+    if not overall_ok:
+        print(f"[soak] FAILED — {trials_ok}/{trials} trials ok; "
+              f"flaky={len(flaky)} consistent_fail={len(consistent_fail)}",
+              file=sys.stderr)
+    else:
+        print(f"[soak] PASSED — {trials_ok}/{trials} trials ok",
+              file=sys.stderr)
 
     return 0 if overall_ok else 1
 
@@ -7553,6 +7954,65 @@ def main():
     p_ci.add_argument("--no-kvm", dest="no_kvm", action="store_true",
                       help="Disable KVM (GitHub runners have no /dev/kvm)")
 
+    # allowlist — manage ci/allow-fail.json (structured CI expected-fail list)
+    p_al = sub.add_parser(
+        "allowlist",
+        help="Manage ci/allow-fail.json (the structured CI expected-fail "
+             "registry). Render to regex, add/remove entries, audit a serial "
+             "log for drift. Replaces hand-edited regex in workflow files.",
+    )
+    p_al.add_argument("--file", default=None,
+                       help="Override allowlist path (default: ci/allow-fail.json)")
+    al_sub = p_al.add_subparsers(dest="alsub", required=True)
+    al_sub.add_parser("list", help="Print all entries as JSON")
+    al_sub.add_parser("regex", help="Render entries → alternation regex on stdout")
+    p_al_add = al_sub.add_parser("add", help="Append a new entry")
+    p_al_add.add_argument("--name", required=True,
+                          help="Test name (or regex if --regex)")
+    p_al_add.add_argument("--reason", default="",
+                          help="Short reason for tolerating the failure")
+    p_al_add.add_argument("--tracking", default=None,
+                          help="Issue or PR reference (e.g. #41)")
+    p_al_add.add_argument("--regex", dest="regex_flag", action="store_true",
+                          help="Treat --name as a regex, not a literal substring")
+    p_al_rm = al_sub.add_parser("remove", help="Remove the first matching entry")
+    p_al_rm.add_argument("--name", required=True,
+                         help="Test name to remove (exact match against 'name' field)")
+    p_al_chk = al_sub.add_parser(
+        "check",
+        help="Audit a serial log: which [FAIL] lines are/aren't covered, "
+             "and which allowlist entries did NOT match anything (drift).",
+    )
+    p_al_chk.add_argument("--serial-log", dest="serial_log", required=True,
+                          help="Path to a serial log to scan")
+
+    # soak — run N trials of ci-run and aggregate results (flake report)
+    p_soak = sub.add_parser(
+        "soak",
+        help="Run ci-run N times, aggregate pass/fail counts, detect "
+             "flaky tests (pass in some trials and fail in others). "
+             "Builds the kernel once up front; trials reuse the build.",
+    )
+    p_soak.add_argument("--trials", type=int, default=3,
+                         help="Number of ci-run trials to execute (default: 3)")
+    p_soak.add_argument("--features", default="test-mode", metavar="FLAGS",
+                         help="Kernel feature flags (default: test-mode)")
+    p_soak.add_argument("--no-build", action="store_true", dest="no_build",
+                         help="Skip the up-front build; reuse existing kernel.bin")
+    p_soak.add_argument("--timeout-ms", type=int, default=900000,
+                         dest="timeout_ms",
+                         help="Per-trial budget in ms (default 900000 = 15 min)")
+    p_soak.add_argument("--allow-fail", default="", metavar="REGEX",
+                         dest="allow_fail",
+                         help="Explicit allow-fail regex (overrides --use-allowlist)")
+    p_soak.add_argument("--use-allowlist", action="store_true",
+                         dest="use_allowlist",
+                         help="Render ci/allow-fail.json into the allow-fail regex")
+    p_soak.add_argument("--file", default=None,
+                         help="Override allowlist path (used with --use-allowlist)")
+    p_soak.add_argument("--no-kvm", dest="no_kvm", action="store_true",
+                         help="Disable KVM (GitHub runners have no /dev/kvm)")
+
     # check: run `cargo check` against a feature-flag combination without
     # spinning up QEMU.  Used by hotfix verification sweeps that need to
     # confirm a regression is closed across N feature combos before
@@ -7584,8 +8044,10 @@ def main():
     args = parser.parse_args()
 
     dispatch = {
-        "ci-run": cmd_ci_run,
-        "check":  cmd_check,
+        "ci-run":    cmd_ci_run,
+        "allowlist": cmd_allowlist,
+        "soak":      cmd_soak,
+        "check":     cmd_check,
         "start":  cmd_start,
         "stop":   cmd_stop,
         "list":   cmd_list,


### PR DESCRIPTION
## Summary

Three cycle-2 toolchain improvements driven by observed dispatch pain:

- **Structured CI allow-fail registry** (`ci/allow-fail.json`) replacing the hand-edited regex baked into the workflow YAML. Each tolerated `[FAIL]` carries a `reason` and `tracking` reference. Agents add/remove entries through one-shot argv calls (`qemu-harness.py allowlist add/remove`), and a drift check flags allowlist entries that didn't match anything (the underlying gap may have closed).
- **Soak runner** (`qemu-harness.py soak --trials N`): one up-front build, N sequential `ci-run` trials, per-trial pass/fail/exit-cause, plus a flake report (tests that fail in some trials and pass in others). Replaces the manual N-trial cross-walk pattern.
- **CI + smoke-test integration**: `kernel-smoke` now renders the allow-fail regex from JSON and runs a drift check; `harness-smoke` exercises the new allowlist paths host-side. `rust-toolchain.toml` gains a documentation comment explaining the floating-nightly policy and the date-pin escape hatch.

All additions are **additive** — no breaking changes to existing JSON shapes or subcommand signatures.

## New subcommands

```
qemu-harness.py allowlist list                                    # JSON envelope
qemu-harness.py allowlist regex                                   # raw stdout
qemu-harness.py allowlist add --name N [--reason R] [--tracking T] [--regex]
qemu-harness.py allowlist remove --name N
qemu-harness.py allowlist check --serial-log P                    # drift audit
qemu-harness.py soak --trials N [--features F] [--use-allowlist]
                  [--allow-fail R] [--timeout-ms MS] [--no-kvm]
```

## Diff

5 files changed, +713/-30 LOC (within the 300-500 LOC soft budget after the 1.5x harness-extension burst).

## Test plan

- [x] `python3 scripts/qemu-harness-smoke.py --staleness-only` — all 26 host-only checks pass (10 staleness + 16 allowlist).
- [x] `allowlist regex` output validated against the existing hand-edited workflow regex (10/10 entries match the same names; `WriteConsoleA` correctly does NOT match).
- [x] `allowlist check` against a synthetic serial log correctly classifies 1 allowed + 1 unallowed (drift detected, rc=1).
- [x] `allowlist add/remove` round-trip preserves the schema `_comment` field; duplicates are rejected; missing-name removes return `ok: false`.
- [x] YAML parse: `.github/workflows/build.yml` valid, 4 jobs preserved (cargo-check, kernel-build, kernel-smoke, harness-smoke).
- [ ] CI run on PR — `kernel-smoke` exercises the rendered regex against a real boot.
- [ ] CI run on PR — `harness-smoke` exercises `run_allowlist_check()` end-to-end on the GHA runner.

## Notes for downstream agents

- `soak` is retroactively useful for outstanding cross-walks (e.g. the sc=2650 observation from W101 saga): drop in `python3 scripts/qemu-harness.py soak --trials 3 --features firefox-test,kdb,syscall-trace --use-allowlist` to get aggregated flake data without hand-rolling the loop.
- `allowlist add --name "<TestName>" --reason "<why>" --tracking "#NNN"` is the new way to flip a test to expected-fail while a fix lands. The CI workflow re-renders on every run, so no workflow edit is needed.
- Drift check output (`unused_entries`) is the right way to find allowlist entries to retire after a kernel fix lands — runs unconditionally in `kernel-smoke` and surfaces in the job log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)