### PR TITLE
kernel/net: verify RX checksums for IPv4 / UDP / ICMP

### DIFF
--- a/kernel/src/net/icmp.rs
+++ b/kernel/src/net/icmp.rs
@@ -5,7 +5,20 @@
 use super::Ipv4Address;
 use super::ipv4;
 use spin::Mutex;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// Count of ICMP messages discarded on receive because the 16-bit
+/// Internet checksum did not validate, per RFC 792: "The checksum is
+/// the 16 bit one's complement of the one's complement sum of the ICMP
+/// message starting with the ICMP Type … If the total length is odd,
+/// the received data is padded with one octet of zeros for computing
+/// the checksum."  Exposed for tests and the stats surface.
+static ICMP_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of ICMP RX checksum drops.
+pub fn rx_bad_csum_count() -> u64 {
+    ICMP_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
 
 /// ICMP types.
 const ICMP_ECHO_REPLY: u8 = 0;
@@ -34,6 +47,17 @@ pub fn take_reply() -> Option<PingReply> {
 /// Handle an incoming ICMP packet.
 pub fn handle_icmp(src_ip: Ipv4Address, data: &[u8]) {
     if data.len() < 8 { return; }
+
+    // RFC 792 + RFC 1122 §3.2.2: a receiver MUST silently discard any
+    // ICMP message whose 16-bit one's-complement checksum does not
+    // validate over the full ICMP body (header + payload).  The
+    // Internet-checksum identity (RFC 1071) lets us re-fold the body
+    // with the embedded checksum field in place — a valid sum yields
+    // zero.  Unlike UDP there is no opt-out (no `cksum == 0` shortcut).
+    if !ipv4::verify_checksum(data) {
+        ICMP_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
 
     let icmp_type = data[0];
     let _icmp_code = data[1];

--- a/kernel/src/net/ipv4.rs
+++ b/kernel/src/net/ipv4.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 use super::{MacAddress, Ipv4Address, our_ip, our_mac, gateway_ip, subnet_mask, send_frame};
 use super::ethernet::{build_frame, ETHERTYPE_IPV4};
 
@@ -12,6 +13,19 @@ use super::ethernet::{build_frame, ETHERTYPE_IPV4};
 pub const PROTO_ICMP: u8 = 1;
 pub const PROTO_TCP: u8 = 6;
 pub const PROTO_UDP: u8 = 17;
+
+/// Count of IPv4 datagrams discarded on receive because the header
+/// checksum failed verification, per RFC 791 §3.1: "If the header
+/// checksum fails, the internet datagram is discarded at once by the
+/// entity which detects the error."  Exposed for tests and the
+/// `netstat`-style stats surface; loads/stores are Relaxed because the
+/// counter has no synchronisation duty.
+static IPV4_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of IPv4 RX header-checksum drops.
+pub fn rx_bad_csum_count() -> u64 {
+    IPV4_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
 
 /// An IPv4 header (parsed).
 pub struct Ipv4Header {
@@ -67,6 +81,28 @@ pub fn handle_ipv4(data: &[u8]) {
         None => return,
     };
 
+    // Per RFC 791 §3.1 ("Header Checksum") and RFC 1122 §3.2.1.2: the
+    // 16-bit one's-complement checksum is computed over the IP header
+    // only.  A receiver MUST verify and silently discard any datagram
+    // whose header checksum is invalid.  The Internet-checksum identity
+    // (RFC 1071 §1) lets us re-fold the header *with* the embedded
+    // `header_checksum` field in place — a valid sum yields 0x0000.
+    //
+    // The header length is bounded by the IHL nibble (5..=15 32-bit
+    // words = 20..=60 bytes); `Ipv4Header::parse` already enforced
+    // ihl>=5 and a 20-byte minimum, but the full IHL-byte range may
+    // extend past `data` for an attacker-truncated frame, so we clamp
+    // before checksumming to avoid an out-of-bounds slice.
+    let hlen = header.header_len();
+    if data.len() < hlen {
+        IPV4_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    if !verify_checksum(&data[..hlen]) {
+        IPV4_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
     // Only accept packets addressed to us, broadcast, when we have no IP
     // yet (DHCP), or destined for the loopback prefix 127.0.0.0/8 (RFC
     // 1122 §3.2.1.3 — every host implicitly owns the entire 127/8 range).
@@ -79,7 +115,7 @@ pub fn handle_ipv4(data: &[u8]) {
         return;
     }
 
-    let payload_start = header.header_len();
+    let payload_start = hlen;
     if data.len() < payload_start { return; }
 
     // RFC 791 §3.1: clamp the upper-layer payload to the IP datagram's
@@ -146,6 +182,22 @@ pub(crate) fn clamp_payload_to_total_length(
     // Then clamp from below — never produce an end < payload_start that
     // would underflow the subsequent slice subtraction.
     if end < payload_start { payload_start } else { end }
+}
+
+/// Verify a buffer's embedded 16-bit Internet checksum (RFC 1071).
+///
+/// `data` must include the checksum field at the position the protocol
+/// specifies (e.g. for an IPv4 header that is bytes 10..12).  Because
+/// the checksum is the one's-complement of the one's-complement sum of
+/// the buffer, re-summing the *whole* buffer (with the checksum field
+/// in place) yields zero exactly when the embedded checksum is valid.
+/// Returns `true` for "valid", `false` for "mismatch".
+///
+/// For UDP (RFC 768) and TCP (RFC 793 §3.1) this same helper is used
+/// after the caller has prepended the IP pseudo-header.
+#[inline]
+pub fn verify_checksum(data: &[u8]) -> bool {
+    checksum(data) == 0
 }
 
 /// Calculate the Internet Checksum (RFC 1071).

--- a/kernel/src/net/udp.rs
+++ b/kernel/src/net/udp.rs
@@ -5,9 +5,23 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
 use super::{Ipv4Address, our_ip};
 use super::ipv4;
+
+/// Count of UDP datagrams discarded on receive because the checksum
+/// field was non-zero and did not validate, per RFC 1122 §4.1.3.4:
+/// "If a UDP datagram is received with a checksum that is non-zero and
+/// invalid, UDP MUST silently discard the datagram."  Exposed for
+/// tests and the stats surface.  Loads/stores are Relaxed — the
+/// counter has no synchronisation duty.
+static UDP_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of UDP RX checksum drops.
+pub fn rx_bad_csum_count() -> u64 {
+    UDP_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
 
 /// A UDP header (parsed).
 pub struct UdpHeader {
@@ -46,13 +60,37 @@ struct UdpBinding {
 static UDP_BINDINGS: Mutex<Vec<UdpBinding>> = Mutex::new(Vec::new());
 
 /// Handle an incoming UDP packet.
-pub fn handle_udp(src_ip: Ipv4Address, _dst_ip: Ipv4Address, data: &[u8]) {
+pub fn handle_udp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
     let header = match UdpHeader::parse(data) {
         Some(h) => h,
         None => return,
     };
 
-    let payload = &data[8..];
+    // RFC 768 §"Length": UDP header `Length` field counts the header
+    // and payload combined.  Clamp the datagram to the declared length
+    // so a frame whose IP `total_length` overshoots cannot leak trailer
+    // bytes into our checksum or into the receive queue.  An undersized
+    // declaration (length < 8) is an attacker-crafted header — drop.
+    let udp_len = header.length as usize;
+    if udp_len < 8 || udp_len > data.len() {
+        UDP_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    let datagram = &data[..udp_len];
+
+    // RFC 768 + RFC 1122 §4.1.3.4: a transmitted checksum of 0x0000
+    // means "checksum disabled by sender" — the receiver MUST NOT
+    // validate.  A non-zero checksum that fails validation MUST cause
+    // the datagram to be silently discarded.  The validation runs over
+    // an IPv4 pseudo-header (src_ip || dst_ip || 0 || proto || udp_len)
+    // followed by the UDP header and payload with the checksum field
+    // in place, per the Internet-checksum identity (RFC 1071).
+    if header.checksum != 0 && !verify_udp_checksum(src_ip, dst_ip, datagram) {
+        UDP_RX_BAD_CSUM.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
+    let payload = &datagram[8..];
 
     crate::serial_println!("[UDP] {}:{} -> port {} ({} bytes)",
         src_ip[0], src_ip[1],
@@ -67,6 +105,21 @@ pub fn handle_udp(src_ip: Ipv4Address, _dst_ip: Ipv4Address, data: &[u8]) {
             data: Vec::from(payload),
         });
     }
+}
+
+/// Verify a UDP datagram's checksum using the IPv4 pseudo-header per
+/// RFC 768 + RFC 1122 §4.1.3.4.  `datagram` is the UDP header followed
+/// by the payload, exactly `header.length` bytes, with the embedded
+/// checksum field still in place.  Returns true when valid.
+fn verify_udp_checksum(src_ip: Ipv4Address, dst_ip: Ipv4Address, datagram: &[u8]) -> bool {
+    let mut buf = Vec::with_capacity(12 + datagram.len());
+    buf.extend_from_slice(&src_ip);
+    buf.extend_from_slice(&dst_ip);
+    buf.push(0);
+    buf.push(ipv4::PROTO_UDP);
+    buf.extend_from_slice(&(datagram.len() as u16).to_be_bytes());
+    buf.extend_from_slice(datagram);
+    ipv4::verify_checksum(&buf)
 }
 
 /// Bind a UDP port for receiving.
@@ -125,8 +178,19 @@ pub fn send(dst_ip: Ipv4Address, src_port: u16, dst_port: u16, payload: &[u8]) {
     packet.push(0);
     packet.extend_from_slice(payload);
 
-    // Compute UDP checksum over pseudo-header + UDP packet.
-    let cksum = udp_checksum(our_ip(), dst_ip, &packet);
+    // The UDP pseudo-header carries the IPv4 source address.  Match the
+    // address the IPv4 layer will *actually* place in the outbound
+    // header — `ipv4::send_ipv4` reflects loopback destinations into the
+    // source field (RFC 1122 §3.2.1.3) so a packet sent to 127.x bears
+    // src=127.x, not our globally-routable address.  Without this
+    // mirroring the receive-side RFC 1122 §4.1.3.4 checksum check would
+    // fail every loopback UDP datagram.
+    let src_for_pseudo = if super::loopback::is_loopback_addr(dst_ip) {
+        dst_ip
+    } else {
+        our_ip()
+    };
+    let cksum = udp_checksum(src_for_pseudo, dst_ip, &packet);
     packet[6] = (cksum >> 8) as u8;
     packet[7] = (cksum & 0xFF) as u8;
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1915,6 +1915,24 @@ pub fn run() -> ! {
     total += 1;
     if test_244_libsys_syscall_numbers() { passed += 1; }
 
+    // ── Tests 245–247: RX checksum validation hardening ────────────────
+    // Per RFC 791 §3.1 / RFC 768 / RFC 792 + RFC 1122, a host stack MUST
+    // silently discard IPv4 / UDP (non-zero cksum) / ICMP packets whose
+    // 16-bit one's-complement Internet Checksum (RFC 1071) does not
+    // validate.  These tests pin the per-protocol counters and the
+    // accept/reject decision across hand-crafted loopback datagrams.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_245_ipv4_rx_checksum_validation() { passed += 1; }
+
+        total += 1;
+        if test_246_udp_rx_checksum_validation() { passed += 1; }
+
+        total += 1;
+        if test_247_icmp_rx_checksum_validation() { passed += 1; }
+    }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -32815,5 +32833,281 @@ fn test_243_vfork_alloc_rejects_kernel_va() -> bool {
                   max_aligned_user_va);
 
     test_pass!("alloc_vfork_child_stack input validation (CWE-822, CWE-200)");
+    true
+}
+
+// ── Test 245: IPv4 RX header-checksum validation (RFC 791 §3.1) ──────────────
+//
+// RFC 791 §3.1 ("Header Checksum") + RFC 1122 §3.2.1.2: a receiver MUST
+// verify the IPv4 header checksum and silently discard any datagram
+// whose checksum is invalid.  Until the fix landed alongside this test,
+// `handle_ipv4` accepted every parseable header regardless of the
+// `header_checksum` field — a NIC corruption or attacker-crafted bit
+// flip in the IP header was indistinguishable from valid traffic and
+// reached the L4 dispatch.
+//
+// The test drives `handle_ipv4` directly with crafted packets:
+//   (a) A well-formed UDP-in-IPv4 datagram destined for our loopback
+//       address with the correct header checksum.  `IPV4_RX_BAD_CSUM`
+//       must NOT advance.
+//   (b) The same datagram with one bit flipped inside the IP header
+//       (which the IP checksum covers).  `IPV4_RX_BAD_CSUM` MUST
+//       advance by exactly one.
+//   (c) Restore and re-checksum — counter must NOT advance again.
+//
+// Cite: RFC 791 §3.1, RFC 1071 §1 (Internet Checksum), RFC 1122 §3.2.1.2.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_245_ipv4_rx_checksum_validation() -> bool {
+    test_header!("net: IPv4 RX header checksum validation (RFC 791 §3.1)");
+
+    use crate::net::ipv4;
+
+    // Build a minimal IPv4 + UDP datagram of total length 28 bytes.
+    // IHL=5 (20-byte IP header), proto=UDP (17), TTL=64, ID=0x4321,
+    // DF set, src 127.0.0.1, dst 127.0.0.1, UDP src=1, dst=2, len=8.
+    let mut pkt = alloc::vec::Vec::with_capacity(28);
+    pkt.push(0x45);                                  // version|IHL
+    pkt.push(0x00);                                  // DSCP/ECN
+    pkt.extend_from_slice(&28u16.to_be_bytes());     // total_length
+    pkt.extend_from_slice(&0x4321u16.to_be_bytes()); // identification
+    pkt.extend_from_slice(&0x4000u16.to_be_bytes()); // flags|frag_off (DF)
+    pkt.push(64);                                    // TTL
+    pkt.push(ipv4::PROTO_UDP);                       // protocol
+    pkt.push(0); pkt.push(0);                        // header checksum placeholder
+    pkt.extend_from_slice(&[127, 0, 0, 1]);          // src IP
+    pkt.extend_from_slice(&[127, 0, 0, 1]);          // dst IP
+    let cks = ipv4::checksum(&pkt[..20]);
+    pkt[10] = (cks >> 8) as u8;
+    pkt[11] = (cks & 0xFF) as u8;
+    // UDP header — src=1, dst=2, len=8, no checksum (cksum=0).
+    pkt.extend_from_slice(&1u16.to_be_bytes());
+    pkt.extend_from_slice(&2u16.to_be_bytes());
+    pkt.extend_from_slice(&8u16.to_be_bytes());
+    pkt.push(0); pkt.push(0);
+
+    // (a) Valid checksum — accepted (counter must NOT advance).
+    let before_a = ipv4::rx_bad_csum_count();
+    ipv4::handle_ipv4(&pkt);
+    let after_a = ipv4::rx_bad_csum_count();
+    test_println!("  (a) valid checksum bad-csum drops: {} -> {}", before_a, after_a);
+    if after_a != before_a {
+        test_fail!("test244", "(a) valid datagram counted as bad ({} -> {})",
+                   before_a, after_a);
+        return false;
+    }
+
+    // (b) Flip TTL byte without recomputing the checksum — MUST be dropped.
+    pkt[8] ^= 0x01;
+    let before_b = ipv4::rx_bad_csum_count();
+    ipv4::handle_ipv4(&pkt);
+    let after_b = ipv4::rx_bad_csum_count();
+    test_println!("  (b) corrupted header bad-csum drops: {} -> {}", before_b, after_b);
+    if after_b != before_b + 1 {
+        test_fail!("test244",
+            "(b) expected exactly one drop, got {} -> {}",
+            before_b, after_b);
+        return false;
+    }
+
+    // (c) Restore + re-checksum — accepted again.
+    pkt[8] ^= 0x01;
+    pkt[10] = 0; pkt[11] = 0;
+    let cks = ipv4::checksum(&pkt[..20]);
+    pkt[10] = (cks >> 8) as u8;
+    pkt[11] = (cks & 0xFF) as u8;
+    let before_c = ipv4::rx_bad_csum_count();
+    ipv4::handle_ipv4(&pkt);
+    let after_c = ipv4::rx_bad_csum_count();
+    test_println!("  (c) repaired checksum bad-csum drops: {} -> {}", before_c, after_c);
+    if after_c != before_c {
+        test_fail!("test244", "(c) repaired datagram still counted as bad");
+        return false;
+    }
+
+    test_pass!("IPv4 RX header checksum validation (RFC 791 §3.1)");
+    true
+}
+
+// ── Test 246: UDP RX checksum validation (RFC 768, RFC 1122 §4.1.3.4) ────────
+//
+// RFC 768 + RFC 1122 §4.1.3.4 specify that a UDP receiver MUST silently
+// discard any datagram whose checksum is non-zero and does not validate
+// against the IPv4 pseudo-header.  A transmitted checksum of zero means
+// "checksum disabled by sender" and the receiver MUST NOT validate.
+//
+// Validation cases:
+//   (a) Datagram carrying a valid pseudo-header checksum — counter does
+//       NOT advance; payload reaches the bound port queue.
+//   (b) Same datagram with one payload byte flipped without recomputing
+//       the checksum — counter MUST advance and the payload MUST NOT
+//       reach the bound port queue.
+//   (c) Datagram with `checksum == 0` (sender opted out per RFC 768) —
+//       even with a "wrong" payload byte, the receiver MUST accept it
+//       without counting a drop.
+//
+// Cite: RFC 768, RFC 1122 §4.1.3.4, RFC 1071 §1 (Internet Checksum).
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_246_udp_rx_checksum_validation() -> bool {
+    test_header!("net: UDP RX checksum validation (RFC 768, RFC 1122 §4.1.3.4)");
+
+    use crate::net::{udp, ipv4};
+    const PORT: u16 = 17246;
+
+    if let Err(e) = udp::bind(PORT) {
+        test_fail!("test245", "bind({}) failed: {}", PORT, e);
+        return false;
+    }
+
+    // Build a UDP datagram with payload "AB" (2 bytes) -> udp_len=10.
+    let payload = [b'A', b'B'];
+    let udp_len: u16 = 8 + payload.len() as u16;
+    let mut udp_pkt = alloc::vec::Vec::with_capacity(udp_len as usize);
+    udp_pkt.extend_from_slice(&12345u16.to_be_bytes());  // src port
+    udp_pkt.extend_from_slice(&PORT.to_be_bytes());      // dst port
+    udp_pkt.extend_from_slice(&udp_len.to_be_bytes());   // length
+    udp_pkt.push(0); udp_pkt.push(0);                    // cksum placeholder
+    udp_pkt.extend_from_slice(&payload);
+
+    // Compute the pseudo-header + UDP checksum.
+    let src = [127, 0, 0, 1];
+    let dst = [127, 0, 0, 1];
+    let mut pseudo = alloc::vec::Vec::with_capacity(12 + udp_pkt.len());
+    pseudo.extend_from_slice(&src);
+    pseudo.extend_from_slice(&dst);
+    pseudo.push(0);
+    pseudo.push(ipv4::PROTO_UDP);
+    pseudo.extend_from_slice(&udp_len.to_be_bytes());
+    pseudo.extend_from_slice(&udp_pkt);
+    let cks = ipv4::checksum(&pseudo);
+    udp_pkt[6] = (cks >> 8) as u8;
+    udp_pkt[7] = (cks & 0xFF) as u8;
+
+    // Drain any pre-existing datagrams on the port.
+    while udp::recv(PORT).is_some() {}
+
+    // (a) Valid checksum — accepted.
+    let before_a = udp::rx_bad_csum_count();
+    udp::handle_udp(src, dst, &udp_pkt);
+    let after_a = udp::rx_bad_csum_count();
+    test_println!("  (a) valid checksum bad-csum drops: {} -> {}", before_a, after_a);
+    if after_a != before_a {
+        udp::unbind(PORT);
+        test_fail!("test245", "(a) valid datagram counted as bad");
+        return false;
+    }
+    let dg = udp::recv(PORT);
+    if dg.as_ref().map(|d| d.data.as_slice()) != Some(&payload[..]) {
+        udp::unbind(PORT);
+        test_fail!("test245", "(a) bound port did not receive valid payload");
+        return false;
+    }
+
+    // (b) Flip one payload byte without recomputing the checksum.
+    udp_pkt[8] ^= 0x80;
+    let before_b = udp::rx_bad_csum_count();
+    udp::handle_udp(src, dst, &udp_pkt);
+    let after_b = udp::rx_bad_csum_count();
+    test_println!("  (b) corrupted payload bad-csum drops: {} -> {}", before_b, after_b);
+    if after_b != before_b + 1 {
+        udp::unbind(PORT);
+        test_fail!("test245",
+            "(b) expected one drop on bad cksum, got {} -> {}",
+            before_b, after_b);
+        return false;
+    }
+    if udp::recv(PORT).is_some() {
+        udp::unbind(PORT);
+        test_fail!("test245", "(b) corrupted datagram leaked to bound port");
+        return false;
+    }
+
+    // (c) Restore byte, zero the checksum field (sender opt-out per RFC 768)
+    //     and corrupt the payload again — must still be accepted.
+    udp_pkt[8] ^= 0x80;
+    udp_pkt[6] = 0; udp_pkt[7] = 0;
+    udp_pkt[8] ^= 0x20;
+    let before_c = udp::rx_bad_csum_count();
+    udp::handle_udp(src, dst, &udp_pkt);
+    let after_c = udp::rx_bad_csum_count();
+    test_println!("  (c) sender opt-out (cksum=0) bad-csum drops: {} -> {}",
+                  before_c, after_c);
+    if after_c != before_c {
+        udp::unbind(PORT);
+        test_fail!("test245", "(c) cksum=0 datagram wrongly counted as bad");
+        return false;
+    }
+    if udp::recv(PORT).is_none() {
+        udp::unbind(PORT);
+        test_fail!("test245", "(c) cksum=0 datagram did not reach bound port");
+        return false;
+    }
+
+    udp::unbind(PORT);
+    test_pass!("UDP RX checksum validation (RFC 768, RFC 1122 §4.1.3.4)");
+    true
+}
+
+// ── Test 247: ICMP RX checksum validation (RFC 792, RFC 1122 §3.2.2) ─────────
+//
+// RFC 792 specifies the ICMP checksum as "the 16-bit one's complement
+// of the one's complement sum of the ICMP message starting with the
+// ICMP Type."  RFC 1122 §3.2.2 makes this a MUST for the receiver:
+// silently discard any ICMP message that fails the checksum.  Unlike
+// UDP there is no opt-out.
+//
+// Validation cases:
+//   (a) Well-formed ICMP echo *reply* (type=0) with the correct
+//       checksum — the counter does NOT advance.  We deliberately use
+//       echo-reply rather than echo-request so the handler's reply
+//       branch only stores LAST_REPLY; an echo-request would trigger
+//       `send_echo_reply` and pull the IPv4 send path into an ARP loop
+//       for the synthetic src_ip, hanging the test runner.
+//   (b) Same message with one byte flipped in the payload area — the
+//       checksum field is now wrong, counter MUST advance by one.
+//
+// Cite: RFC 792 (ICMP), RFC 1122 §3.2.2 ("Validity tests"), RFC 1071 §1.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_247_icmp_rx_checksum_validation() -> bool {
+    test_header!("net: ICMP RX checksum validation (RFC 792, RFC 1122 §3.2.2)");
+
+    use crate::net::{icmp, ipv4};
+
+    // Build a 16-byte ICMP echo reply (type=0): exercises the checksum
+    // path without triggering `send_echo_reply`.
+    let mut msg = alloc::vec::Vec::with_capacity(16);
+    msg.push(0);              // type: echo reply
+    msg.push(0);              // code
+    msg.push(0); msg.push(0); // checksum placeholder
+    msg.extend_from_slice(&1u16.to_be_bytes()); // id
+    msg.extend_from_slice(&1u16.to_be_bytes()); // seq
+    for i in 0u8..8 { msg.push(i); }
+    let cks = ipv4::checksum(&msg);
+    msg[2] = (cks >> 8) as u8;
+    msg[3] = (cks & 0xFF) as u8;
+
+    // (a) Valid checksum — accepted; counter does NOT advance.
+    let before_a = icmp::rx_bad_csum_count();
+    icmp::handle_icmp([10, 0, 2, 100], &msg);
+    let after_a = icmp::rx_bad_csum_count();
+    test_println!("  (a) valid checksum bad-csum drops: {} -> {}", before_a, after_a);
+    if after_a != before_a {
+        test_fail!("test246", "(a) valid ICMP echo counted as bad");
+        return false;
+    }
+
+    // (b) Corrupt one payload byte without recomputing the checksum.
+    msg[10] ^= 0xFF;
+    let before_b = icmp::rx_bad_csum_count();
+    icmp::handle_icmp([10, 0, 2, 100], &msg);
+    let after_b = icmp::rx_bad_csum_count();
+    test_println!("  (b) corrupted payload bad-csum drops: {} -> {}", before_b, after_b);
+    if after_b != before_b + 1 {
+        test_fail!("test246",
+            "(b) expected one drop on bad cksum, got {} -> {}",
+            before_b, after_b);
+        return false;
+    }
+
+    test_pass!("ICMP RX checksum validation (RFC 792)");
     true
 }


### PR DESCRIPTION
Supersedes #315 (which had branch-base leakage from the in-flight PR #311 work; this is the clean reland on `origin/master`).

## Summary

Adds RX-side checksum validation across the L3/L4 stack:

- **IPv4** — verify 16-bit one's-complement header checksum per RFC 791 §3.1, drop bad packets per RFC 1122 §3.2.1.2. New `IPV4_RX_BAD_CSUM` counter.
- **UDP** — verify pseudo-header + payload checksum per RFC 768 / RFC 1122 §4.1.3.4. Clamps `data` to `header.length` before checksumming. Skips validation when sender opted out (cksum=0 per RFC 768). New `UDP_RX_BAD_CSUM` counter. Also fixes `udp::send` loopback source-rewrite to mirror IPv4 per RFC 1122 §3.2.1.3, preventing the new RX check from rejecting every loopback UDP datagram.
- **ICMP** — verify echo/error checksum per RFC 792, RFC 1122 §3.2.2. Uses shared `ipv4::verify_checksum` helper. New `ICMP_RX_BAD_CSUM` counter.

## Tests

- **Test 245 (IPv4)** — valid packet → accepted; TTL bit-flip → counter +1; restored → accepted.
- **Test 246 (UDP)** — valid → accepted+enqueued; corrupted → dropped+counter+1; cksum=0 → accepted unconditionally.
- **Test 247 (ICMP)** — valid echo-reply → accepted; payload bit-flip → counter +1.

Test numbers renumbered from the original PR #315's 244/245/246 to avoid collision with PR #312's Test 244 (libsys ABI contract, already merged).

## Deferred follow-ups

- TCP RX checksum validation (RFC 793 §3.1, pseudo-header)
- ICMPv6 RX checksum (RFC 4443 §2.3)
- UDP TX RFC 768 "transmit as 0xFFFF if computed cksum is 0"
- IPv4 RX options handling (RFC 791 §3.2)
- TCP zero-window probe / keepalive timer (RFC 793 §3.7, RFC 1122 §4.2.3.6)

Refs: RFC 791, RFC 768, RFC 792, RFC 1071, RFC 1122