### PR TITLE
kernel/proc+signal+idt+linux: vfork canary diag + printer parent-VmSpace fallback (diag-only, unmasks real CLONE_VM gate)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -140,6 +140,17 @@ vfs-trace = []
 # bugcheck (sc=1161 under firefox-test).  Off by default — the runtime
 # cost is one extra `try_lock` per device call.
 vfs-debug = []
+# Vfork canary snapshot-pair + sibling-syscall tagger diagnostic
+# (kernel/src/subsys/linux/vfork_diag.rs).  Emits `[VFORK-CANARY-PRE/POST]`,
+# `[VFORK-FSCANARY-PRE/POST]`, and `[VFORK-SIB]` lines around the
+# `CLONE_VM|CLONE_VFORK` parent-block window so a post-processor can
+# attribute any SSP-canary divergence to a specific writer thread.
+# Diagnostic-only — no functional behaviour change.  Implies `firefox-test`
+# (the snapshot helper rides the same gated emit path) and `syscall-trace`
+# (the SIB tagger leans on `get_user_rip` / `get_user_rsp_rbp`, both
+# unconditional pubs but heavily exercised under syscall-trace).
+# See docs/HARNESS.md and POSIX vfork(2) / clone(2) / Intel SDM Vol. 3A §6.8.
+vfork-canary-diag = ["firefox-test", "syscall-trace"]
 # LLVM source-based code-coverage instrumentation (test-coverage audit
 # session 5 / docs/TEST_COVERAGE_AUDIT_2026-05-16.md).  When enabled, the
 # kernel must additionally be built with `-C instrument-coverage` (see

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -773,52 +773,54 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             let rip = frame.rip;
             let pid = crate::proc::current_pid_lockless();
             let tid = crate::proc::current_tid();
-            let procs = crate::proc::PROCESS_TABLE.lock();
-            if let Some(proc_entry) = procs.iter().find(|p| p.pid == pid) {
-                if let Some(vm_space) = proc_entry.vm_space.as_ref() {
-                    if let Some(vma) = vm_space.find_vma(rip) {
-                        use crate::mm::vma::VmBacking;
-                        let (file_name, file_offset, elf_load_delta) = match &vma.backing {
-                            VmBacking::File { offset, elf_load_delta, .. } => {
-                                (vma.name, *offset, *elf_load_delta)
-                            }
-                            _ => ("<anon>", 0u64, 0u64),
-                        };
-                        let offset_in_vma  = rip - vma.base;
-                        let offset_in_file = file_offset + offset_in_vma;
-                        // vaddr_in_elf: the link-time ELF virtual address, i.e. the
-                        // value addr2line expects.  Defined by ELF-64 §3 (Program
-                        // Loading): for each PT_LOAD segment, runtime_va - bias =
-                        // p_vaddr, and file_offset = p_offset + (runtime_va - bias -
-                        // p_vaddr + p_offset_page).  The delta encodes
-                        // (p_vaddr_page - p_offset_page) which is constant for the
-                        // segment.
-                        if elf_load_delta != 0 {
-                            let vaddr_in_elf = offset_in_file.wrapping_add(elf_load_delta);
-                            crate::serial_println!(
-                                "[UD/VMA] pid={} tid={} rip={:#x} vma_base={:#x} vma_end={:#x} \
-                                 file={} offset_in_file={:#x} offset_in_vma={:#x} vaddr_in_elf={:#x}",
-                                pid, tid, rip, vma.base, vma.end(),
-                                file_name, offset_in_file, offset_in_vma, vaddr_in_elf,
-                            );
-                        } else {
-                            crate::serial_println!(
-                                "[UD/VMA] pid={} tid={} rip={:#x} vma_base={:#x} vma_end={:#x} \
-                                 file={} offset_in_file={:#x} offset_in_vma={:#x}",
-                                pid, tid, rip, vma.base, vma.end(),
-                                file_name, offset_in_file, offset_in_vma,
-                            );
-                        }
+            // CLONE_VM-aware lookup: falls through to the parent's VmSpace
+            // for a vfork / posix_spawn child whose own bookkeeping is None
+            // by design (see `clone(2)` "CLONE_VM").  Returns owned data so
+            // PROCESS_TABLE is released before the prints.
+            let hit = crate::proc::find_vma_with_parent_fallback(pid, rip);
+            match hit {
+                Some(v) => {
+                    let file_name = if v.file_backed { v.name } else { "<anon>" };
+                    let offset_in_vma  = rip - v.vma_base;
+                    let offset_in_file = if v.file_backed {
+                        v.file_offset + offset_in_vma
+                    } else {
+                        0
+                    };
+                    // vaddr_in_elf: the link-time ELF virtual address, i.e. the
+                    // value addr2line expects.  Defined by ELF-64 §3 (Program
+                    // Loading): for each PT_LOAD segment, runtime_va - bias =
+                    // p_vaddr, and file_offset = p_offset + (runtime_va - bias -
+                    // p_vaddr + p_offset_page).  The delta encodes
+                    // (p_vaddr_page - p_offset_page) which is constant for the
+                    // segment.
+                    let suffix = if v.inherited { " inherited_from_parent=1" } else { "" };
+                    if v.file_backed && v.elf_load_delta != 0 {
+                        let vaddr_in_elf = offset_in_file.wrapping_add(v.elf_load_delta);
+                        crate::serial_println!(
+                            "[UD/VMA] pid={} tid={} rip={:#x} vma_base={:#x} vma_end={:#x} \
+                             file={} offset_in_file={:#x} offset_in_vma={:#x} vaddr_in_elf={:#x}{}",
+                            pid, tid, rip, v.vma_base, v.vma_end,
+                            file_name, offset_in_file, offset_in_vma, vaddr_in_elf, suffix,
+                        );
                     } else {
                         crate::serial_println!(
-                            "[UD/VMA] pid={} tid={} rip={:#x} no_vma_match=1",
-                            pid, tid, rip,
+                            "[UD/VMA] pid={} tid={} rip={:#x} vma_base={:#x} vma_end={:#x} \
+                             file={} offset_in_file={:#x} offset_in_vma={:#x}{}",
+                            pid, tid, rip, v.vma_base, v.vma_end,
+                            file_name, offset_in_file, offset_in_vma, suffix,
                         );
                     }
                 }
+                None => {
+                    crate::serial_println!(
+                        "[UD/VMA] pid={} tid={} rip={:#x} no_vma_match=1",
+                        pid, tid, rip,
+                    );
+                }
             }
-            // Drop PROCESS_TABLE — all subsequent work uses ud_cr3 directly.
-            drop(procs);
+            // PROCESS_TABLE was released by find_vma_with_parent_fallback
+            // before it returned; subsequent work uses ud_cr3 directly.
 
             // ── [UD/RIP-BYTES]: 16 bytes at RIP ────────────────────────────────
             // Allows instant classification:

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1932,6 +1932,107 @@ pub fn get_process_cr3(pid: Pid) -> Option<u64> {
     procs.iter().find(|p| p.pid == pid).map(|p| p.cr3)
 }
 
+/// Result of a VMA lookup that transparently falls back to the parent's
+/// bookkeeping for a CLONE_VM child.
+///
+/// Per `clone(2)` "CLONE_VM" + `vfork(2)`, the child runs with the parent's
+/// page tables (same CR3) but the kernel records its `Process.vm_space` as
+/// `None` so the parent retains exclusive ownership of the VMA list and the
+/// child's exit path is a no-op for the parent's address space.  That works
+/// for fault handling (the PFH already has the parent-CR3 fallback path,
+/// see `arch/x86_64/idt.rs::handle_page_fault`), but it misleads the
+/// **diagnostic** printers: a fault inside the parent's text segment in a
+/// shared-VM child reports `no_vma=1` / `vma_offset=NO_VMA` even though the
+/// physical mapping is valid — because the lookup short-circuits on the
+/// child's empty VMA list before consulting the parent's.
+///
+/// This helper does the obvious thing: try the child's VmSpace first, then
+/// — if the child is in the `CLONE_VM` shared-VM state (no VmSpace + same
+/// CR3 as the parent) — re-try against the parent's.  The `inherited` flag
+/// lets the caller annotate the diagnostic line so a reader can tell at a
+/// glance which address space the VMA came from.
+#[derive(Copy, Clone, Default)]
+pub struct VmaLookupHit {
+    pub vma_base: u64,
+    pub vma_end:  u64,
+    pub prot:     u32,
+    pub name:     &'static str,
+    pub file_backed: bool,
+    pub file_offset: u64,
+    pub elf_load_delta: u64,
+    pub mount_idx: usize,
+    pub inode: u64,
+    /// True when the VMA was resolved via the parent's VmSpace (the calling
+    /// process is a CLONE_VM child whose own bookkeeping is empty).
+    pub inherited: bool,
+}
+
+/// Look up `addr` in `pid`'s VmSpace, transparently falling back to the
+/// parent's when `pid` is a CLONE_VM child (no own VmSpace, same CR3 as
+/// parent).
+///
+/// `None` means neither child nor parent has a VMA covering `addr`.
+///
+/// Acquires `PROCESS_TABLE` briefly; the returned value owns no borrows so
+/// the caller can use it after the lock is dropped.  Diagnostic-only — the
+/// PFH at `arch/x86_64/idt.rs::handle_page_fault` performs its own
+/// parent-VmSpace fallback for the actual fault path and does not call
+/// this helper.
+pub fn find_vma_with_parent_fallback(pid: Pid, addr: u64) -> Option<VmaLookupHit> {
+    use crate::mm::vma::VmBacking;
+
+    fn extract(vma: &crate::mm::vma::VmArea, inherited: bool) -> VmaLookupHit {
+        let (file_backed, file_offset, elf_load_delta, mount_idx, inode) = match vma.backing {
+            VmBacking::File { offset, elf_load_delta, mount_idx, inode } => {
+                (true, offset, elf_load_delta, mount_idx, inode)
+            }
+            _ => (false, 0u64, 0u64, 0usize, 0u64),
+        };
+        VmaLookupHit {
+            vma_base: vma.base,
+            vma_end:  vma.end(),
+            prot:     vma.prot,
+            name:     vma.name,
+            file_backed,
+            file_offset,
+            elf_load_delta,
+            mount_idx,
+            inode,
+            inherited,
+        }
+    }
+
+    let procs = PROCESS_TABLE.lock();
+    let child = procs.iter().find(|p| p.pid == pid)?;
+
+    // Direct hit on the child's own VmSpace.
+    if let Some(space) = child.vm_space.as_ref() {
+        if let Some(vma) = space.find_vma(addr) {
+            return Some(extract(vma, false));
+        }
+        // Child has its own VmSpace but it doesn't cover `addr`.  Do NOT
+        // fall back to the parent: that child has diverged (post-execve or
+        // fork-with-CoW) and its VMA list is authoritative.
+        return None;
+    }
+
+    // Child has no VmSpace (CLONE_VM shared-VM state).  Try the parent if
+    // the CR3 matches — otherwise the relationship is something else
+    // (kernel thread, idle, AP) and we have no VMA list to consult.
+    let child_cr3 = child.cr3;
+    let parent_pid = child.parent_pid;
+    if child_cr3 == 0 || parent_pid == 0 {
+        return None;
+    }
+    let parent = procs.iter().find(|p| p.pid == parent_pid)?;
+    if parent.cr3 != child_cr3 {
+        return None;
+    }
+    let parent_space = parent.vm_space.as_ref()?;
+    let vma = parent_space.find_vma(addr)?;
+    Some(extract(vma, true))
+}
+
 /// Store the clear_child_tid address in a thread for CLONE_CHILD_CLEARTID.
 /// When that thread exits, the kernel will write 0 to that address and wake futex.
 pub fn set_clear_child_tid(pid: Pid, tid: Tid, tidptr: u64) {

--- a/kernel/src/proc/stack_walk.rs
+++ b/kernel/src/proc/stack_walk.rs
@@ -117,102 +117,70 @@ fn read_user_u64_safe(cr3: u64, va: u64) -> Result<u64, ()> {
     Ok(u64::from_le_bytes(buf))
 }
 
-/// Compact VMA data for a single `rip`, extracted under `PROCESS_TABLE` lock
-/// and used for the `[STACK/VMA]` line after the lock is dropped.
-#[derive(Copy, Clone)]
-struct StackVmaInfo {
-    vma_base:       u64,
-    vma_end:        u64,
-    offset_in_vma:  u64,
-    /// Non-zero only for file-backed VMAs.
-    offset_in_file: u64,
-    /// Non-zero only for ELF PT_LOAD segments.
-    vaddr_in_elf:   u64,
-    /// `&'static str` from `VmArea::name` — valid for the kernel's lifetime.
-    name:           &'static str,
-    is_file:        bool,
-}
-
 /// Emit a `[STACK/VMA]` line for the given `rip` at the specified `depth`.
 ///
-/// Acquires `PROCESS_TABLE` briefly to snapshot the VMA covering `rip`, then
-/// drops the lock before calling `serial_println!` (COM1 is slow and must not
-/// be held across the spinlock; identical discipline to `emit_signal_vma_banner`).
+/// Acquires `PROCESS_TABLE` briefly via `find_vma_with_parent_fallback`,
+/// which transparently consults the parent's VmSpace for a CLONE_VM child
+/// (whose own bookkeeping is intentionally empty — see `clone(2)` /
+/// `vfork(2)` "CLONE_VM").  The lock is dropped before calling
+/// `serial_println!` (COM1 is slow and must not be held across the
+/// spinlock; identical discipline to `emit_signal_vma_banner`).
 fn emit_stack_vma_line(pid: u64, tid: u64, depth: usize, rip: u64) {
-    use crate::mm::vma::VmBacking;
-
     // ── Phase 1: snapshot VMA data under the lock ────────────────────────────
-    let info: Option<StackVmaInfo> = {
-        let procs = crate::proc::PROCESS_TABLE.lock();
-        procs
-            .iter()
-            .find(|p| p.pid == pid)
-            .and_then(|proc_entry| proc_entry.vm_space.as_ref())
-            .and_then(|vs| vs.find_vma(rip))
-            .map(|vma| {
-                let offset_in_vma = rip - vma.base;
-                let (is_file, offset_in_file, vaddr_in_elf) = match &vma.backing {
-                    VmBacking::File { offset, elf_load_delta, .. } => {
-                        let off_file = offset + offset_in_vma;
-                        let vaddr    = if *elf_load_delta != 0 {
-                            off_file.wrapping_add(*elf_load_delta)
-                        } else {
-                            0
-                        };
-                        (true, off_file, vaddr)
-                    }
-                    _ => (false, 0, 0),
-                };
-                StackVmaInfo {
-                    vma_base:      vma.base,
-                    vma_end:       vma.end(),
-                    name:          vma.name,
-                    offset_in_vma,
-                    offset_in_file,
-                    vaddr_in_elf,
-                    is_file,
-                }
-            })
-        // lock dropped here
-    };
+    let hit = crate::proc::find_vma_with_parent_fallback(pid, rip);
 
     // ── Phase 2: emit after the lock is released ─────────────────────────────
-    match info {
+    let v = match hit {
         None => {
             crate::serial_println!(
                 "[STACK/VMA] pid={} tid={} depth={} rip={:#x} no_vma=1",
                 pid, tid, depth, rip,
             );
+            return;
         }
-        Some(v) if v.is_file && v.vaddr_in_elf != 0 => {
-            crate::serial_println!(
-                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
-                 vma_base={:#x} vma_end={:#x} file={} \
-                 offset_in_vma={:#x} offset_in_file={:#x} vaddr_in_elf={:#x}",
-                pid, tid, depth, rip,
-                v.vma_base, v.vma_end, v.name,
-                v.offset_in_vma, v.offset_in_file, v.vaddr_in_elf,
-            );
-        }
-        Some(v) if v.is_file => {
-            crate::serial_println!(
-                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
-                 vma_base={:#x} vma_end={:#x} file={} \
-                 offset_in_vma={:#x} offset_in_file={:#x}",
-                pid, tid, depth, rip,
-                v.vma_base, v.vma_end, v.name,
-                v.offset_in_vma, v.offset_in_file,
-            );
-        }
-        Some(v) => {
-            // Anonymous or device mapping.
-            crate::serial_println!(
-                "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
-                 vma_base={:#x} vma_end={:#x} file=<anon> offset_in_vma={:#x}",
-                pid, tid, depth, rip,
-                v.vma_base, v.vma_end, v.offset_in_vma,
-            );
-        }
+        Some(v) => v,
+    };
+    let offset_in_vma = rip - v.vma_base;
+    let offset_in_file = if v.file_backed {
+        v.file_offset + offset_in_vma
+    } else {
+        0
+    };
+    let vaddr_in_elf = if v.file_backed && v.elf_load_delta != 0 {
+        offset_in_file.wrapping_add(v.elf_load_delta)
+    } else {
+        0
+    };
+    // Suffix marks a parent-inherited (CLONE_VM child) resolution so a
+    // reader can tell at a glance that the diagnostic walked the parent's
+    // bookkeeping rather than the child's own.
+    let suffix = if v.inherited { " inherited_from_parent=1" } else { "" };
+    if v.file_backed && vaddr_in_elf != 0 {
+        crate::serial_println!(
+            "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
+             vma_base={:#x} vma_end={:#x} file={} \
+             offset_in_vma={:#x} offset_in_file={:#x} vaddr_in_elf={:#x}{}",
+            pid, tid, depth, rip,
+            v.vma_base, v.vma_end, v.name,
+            offset_in_vma, offset_in_file, vaddr_in_elf, suffix,
+        );
+    } else if v.file_backed {
+        crate::serial_println!(
+            "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
+             vma_base={:#x} vma_end={:#x} file={} \
+             offset_in_vma={:#x} offset_in_file={:#x}{}",
+            pid, tid, depth, rip,
+            v.vma_base, v.vma_end, v.name,
+            offset_in_vma, offset_in_file, suffix,
+        );
+    } else {
+        // Anonymous or device mapping.
+        crate::serial_println!(
+            "[STACK/VMA] pid={} tid={} depth={} rip={:#x} \
+             vma_base={:#x} vma_end={:#x} file=<anon> offset_in_vma={:#x}{}",
+            pid, tid, depth, rip,
+            v.vma_base, v.vma_end, offset_in_vma, suffix,
+        );
     }
 }
 

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1353,10 +1353,31 @@ fn vma_file_key(vma: &VmaSnap, fault_va: u64) -> Option<(usize, u64, u64)> {
 /// here without re-acquiring locks already dropped).
 pub fn emit_fault_phys_for_fatal(pid: u64, user_rip: u64, cr2: u64, cr3: u64) {
     // Snapshot under the PROCESS_TABLE lock, then release before printing.
+    //
+    // For a CLONE_VM child (`vm_space == None`, shared CR3 with parent —
+    // see `clone(2)` "CLONE_VM" + `vfork(2)`) the child's own VMA list is
+    // empty by design.  Fall back to the parent's VmSpace so the
+    // `[FAULT/PHYS]` diagnostic reports `vma_offset=<off>` instead of
+    // `vma_offset=NO_VMA` when the fault lies inside a parent-mapped
+    // segment (library text, anon code page, etc.).  The PFH itself
+    // already does this fallback for the actual fault path — see
+    // `arch/x86_64/idt.rs::handle_page_fault` (the target_pid switch).
     let snap = {
         let procs = crate::proc::PROCESS_TABLE.lock();
-        let space = procs.iter().find(|p| p.pid == pid).and_then(|p| p.vm_space.as_ref());
-        signal_vma_snapshot(space, user_rip, cr2)
+        let child = procs.iter().find(|p| p.pid == pid);
+        let direct_space = child.and_then(|p| p.vm_space.as_ref());
+        if let Some(space) = direct_space {
+            signal_vma_snapshot(Some(space), user_rip, cr2)
+        } else if let Some(c) = child {
+            let parent_pid = c.parent_pid;
+            let cr3_child = c.cr3;
+            let parent_space = procs.iter()
+                .find(|p| p.pid == parent_pid && p.cr3 == cr3_child && cr3_child != 0)
+                .and_then(|p| p.vm_space.as_ref());
+            signal_vma_snapshot(parent_space, user_rip, cr2)
+        } else {
+            signal_vma_snapshot(None, user_rip, cr2)
+        }
     };
     emit_fault_phys_diagnostic(pid, user_rip, cr3, &snap);
 }

--- a/kernel/src/subsys/linux/mod.rs
+++ b/kernel/src/subsys/linux/mod.rs
@@ -34,6 +34,14 @@ pub mod errno;
 /// Extracted from `kernel/src/syscall/mod.rs` in Phase 0.2.
 pub mod syscall;
 
+/// Vfork canary snapshot-pair + sibling-syscall tagger diagnostic.  See
+/// the module docstring (`vfork_diag.rs`) for the three channels and the
+/// reference set (POSIX vfork(2) / clone(2), Intel SDM Vol. 3A §6.8,
+/// System V AMD64 ABI §3.4.5.2).  Gated entirely behind `vfork-canary-diag`
+/// so master builds are byte-identical.
+#[cfg(feature = "vfork-canary-diag")]
+pub mod vfork_diag;
+
 /// Bounded broadcast-within-cluster compensation for FUTEX_WAKE.  Mitigates
 /// the older-glibc `pthread_cond_signal` race
 /// (<https://sourceware.org/bugzilla/show_bug.cgi?id=25847>) by

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -734,6 +734,15 @@ pub fn test_write_sockaddr_in(addr_ptr: u64, addrlen_ptr: *mut u32,
 /// Maps Linux syscall numbers to AstryxOS handlers, handling differences
 /// in argument encoding (e.g., C strings vs ptr+len for paths).
 pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64, arg6: u64) -> i64 {
+    // ── Vfork sibling-syscall tagger (diagnostic-only) ──────────────────────
+    // Fires exactly once per syscall entry.  Off-path cost is a single
+    // relaxed atomic load + branch (no VFORK window active → returns
+    // immediately).  When a window IS active, any thread that shares the
+    // parent's PID but is not the parent itself logs one bounded
+    // `[VFORK-SIB]` line.  See `vfork_diag.rs` for the full rationale.
+    #[cfg(feature = "vfork-canary-diag")]
+    crate::subsys::linux::vfork_diag::maybe_log_sibling_syscall(num);
+
     // ── Tier-0 trace: one self-contained line per syscall entry ──────────────
     // Grepped by qemu-harness.py via `^\[SC\] `.  User RIP comes from the
     // per-CPU syscall_entry stash (set by the naked-asm stub before dispatch).
@@ -2321,9 +2330,24 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             drop(threads);
                             // VFORK/CANARY pre-block snapshot — see helper.
                             vfork_canary_snapshot("pre_block.clone", pid as u32, parent_tid);
+                            // Three-channel snapshot + open the sibling-syscall
+                            // window.  Diagnostic-only; see `vfork_diag.rs`.
+                            #[cfg(feature = "vfork-canary-diag")]
+                            {
+                                crate::subsys::linux::vfork_diag::snapshot_canaries(
+                                    "PRE", pid, parent_tid);
+                                crate::subsys::linux::vfork_diag::enter_vfork_window(
+                                    pid, parent_tid);
+                            }
                             crate::sched::schedule();
                             // Resumed: child called exec/exit, or timeout expired.
                             // VFORK/CANARY post-wake snapshot.
+                            #[cfg(feature = "vfork-canary-diag")]
+                            {
+                                crate::subsys::linux::vfork_diag::exit_vfork_window();
+                                crate::subsys::linux::vfork_diag::snapshot_canaries(
+                                    "POST", pid, parent_tid);
+                            }
                             vfork_canary_snapshot("post_wake.clone", pid as u32, parent_tid);
                         }
                         child_pid as i64
@@ -3173,8 +3197,23 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             drop(threads);
                             // VFORK/CANARY pre-block snapshot — see helper.
                             vfork_canary_snapshot("pre_block.clone3", pid as u32, parent_tid);
+                            // Three-channel snapshot + open the sibling-syscall
+                            // window.  Diagnostic-only; see `vfork_diag.rs`.
+                            #[cfg(feature = "vfork-canary-diag")]
+                            {
+                                crate::subsys::linux::vfork_diag::snapshot_canaries(
+                                    "PRE", pid, parent_tid);
+                                crate::subsys::linux::vfork_diag::enter_vfork_window(
+                                    pid, parent_tid);
+                            }
                             crate::sched::schedule();
                             // VFORK/CANARY post-wake snapshot.
+                            #[cfg(feature = "vfork-canary-diag")]
+                            {
+                                crate::subsys::linux::vfork_diag::exit_vfork_window();
+                                crate::subsys::linux::vfork_diag::snapshot_canaries(
+                                    "POST", pid, parent_tid);
+                            }
                             vfork_canary_snapshot("post_wake.clone3", pid as u32, parent_tid);
                         }
                         child_pid as i64

--- a/kernel/src/subsys/linux/vfork_diag.rs
+++ b/kernel/src/subsys/linux/vfork_diag.rs
@@ -1,0 +1,257 @@
+//! Vfork canary snapshot-pair + sibling-syscall tagger diagnostic.
+//!
+//! Diagnostic-only instrumentation that names the writer of the parent's SSP
+//! canary slots during the `CLONE_VM|CLONE_VFORK` window.  No functional
+//! behaviour change — every code path here is gated behind the
+//! `vfork-canary-diag` Cargo feature.
+//!
+//! # Channels
+//!
+//!  1. **Parent saved-canary `[rbp-8]` snapshot pair** — at vfork pre-block /
+//!     post-wake, read the canary slot that the parent's *caller* frame
+//!     stored in its function prologue (`mov rax, fs:0x28 ; mov [rbp-8], rax`).
+//!     The parent's RBP at syscall entry points at the libc syscall wrapper's
+//!     frame; chasing one saved-RBP link lands at the libxul caller's frame,
+//!     whose `[rbp-8]` slot is the SSP location the epilogue will re-read.
+//!     Per System V AMD64 ABI §3.4.5.2 + GCC SSP convention.
+//!
+//!  2. **Master canary `%fs:0x28` snapshot pair** — at the same two points,
+//!     re-read the live `IA32_FS_BASE` MSR (Intel SDM Vol. 3A §6.8) plus
+//!     `*(fs_base + 0x28)`.  Divergence across the window means the master
+//!     canary itself was rewritten, not just an individual stack copy.
+//!
+//!  3. **Sibling-thread syscall tagging** — between the vfork-block and the
+//!     parent's wake, every syscall entry from a thread whose
+//!     `(tid != parent.tid && pid == parent.pid)` emits a `[VFORK-SIB]`
+//!     line carrying its RIP, RSP, syscall number, and CR3.  Bounded at
+//!     200 lines per vfork window via a `static AtomicUsize` counter that
+//!     is reset on each window enter.
+//!
+//! # Why a separate module
+//!
+//! This file owns all of the vfork-window state so the snapshot helper can
+//! call `enter_vfork_window` / `exit_vfork_window` without crossing module
+//! boundaries, and so the per-syscall hot path
+//! (`maybe_log_sibling_syscall`) can be a single inline atomic load with
+//! no string formatting on the off-path (i.e. when no vfork is active).
+//!
+//! # Refs
+//!  - POSIX vfork(2): pubs.opengroup.org/onlinepubs/9699919799/functions/vfork.html
+//!  - POSIX clone(2): linux man-pages-5.13 clone(2)
+//!  - Intel SDM Vol. 3A §6.8 (IA32_FS_BASE MSR)
+//!  - System V AMD64 ABI §3.4.5.2 (SSP / stack-protector frame layout)
+
+#![cfg(feature = "vfork-canary-diag")]
+
+extern crate alloc;
+
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+/// Active vfork-window parent identity, packed as `(pid << 32) | (tid & 0xFFFF_FFFF)`.
+/// Zero = no vfork in flight.  Single AtomicU64 instead of two atomics so that
+/// `maybe_log_sibling_syscall` can do a single relaxed load on the fast path.
+static VFORK_ACTIVE_PACKED: AtomicU64 = AtomicU64::new(0);
+
+/// Bounded per-window sibling-syscall log counter.  Reset to 0 on
+/// `enter_vfork_window`.  Capped at `MAX_SIB_LOGS` to keep serial-log volume
+/// bounded even if the parent stays blocked for many seconds.
+static SIB_LOG_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Hard cap on `[VFORK-SIB]` lines per vfork window.
+const MAX_SIB_LOGS: usize = 200;
+
+/// Begin tracking the vfork window.  Stores the parent's identity for the
+/// sibling-syscall tagger and resets the per-window log budget.
+///
+/// Safe to call from the parent's syscall body just before `schedule()`.
+pub fn enter_vfork_window(parent_pid: u64, parent_tid: u64) {
+    let packed = (parent_pid << 32) | (parent_tid & 0xFFFF_FFFF);
+    VFORK_ACTIVE_PACKED.store(packed, Ordering::Release);
+    SIB_LOG_COUNT.store(0, Ordering::Release);
+    crate::serial_println!(
+        "[VFORK-WIN-ENTER] parent_pid={} parent_tid={}",
+        parent_pid, parent_tid
+    );
+}
+
+/// End tracking.  Subsequent sibling-syscall checks become no-ops.
+pub fn exit_vfork_window() {
+    let prev = VFORK_ACTIVE_PACKED.swap(0, Ordering::AcqRel);
+    let logs = SIB_LOG_COUNT.load(Ordering::Acquire);
+    let prev_pid = prev >> 32;
+    let prev_tid = prev & 0xFFFF_FFFF;
+    crate::serial_println!(
+        "[VFORK-WIN-EXIT] parent_pid={} parent_tid={} sib_logs_total={}",
+        prev_pid, prev_tid, logs
+    );
+}
+
+/// Sibling-syscall tagger.  Called once per syscall entry from the Linux
+/// dispatcher.  Off-path cost is a single relaxed atomic load + branch.
+///
+/// When a vfork window is active AND the calling thread is in the parent's
+/// process AND the calling thread is NOT the parent thread itself, emit one
+/// `[VFORK-SIB]` line (bounded at `MAX_SIB_LOGS` lines per window).
+///
+/// `caller_rip` is the leaf user RIP (from `get_user_rip`) — i.e. the
+/// instruction immediately after the `syscall` instruction.  `user_rsp` is
+/// the userland stack pointer at syscall entry.
+#[inline]
+pub fn maybe_log_sibling_syscall(syscall_nr: u64) {
+    let packed = VFORK_ACTIVE_PACKED.load(Ordering::Acquire);
+    if packed == 0 {
+        return; // No vfork window active — fast path.
+    }
+    let parent_pid = packed >> 32;
+    let parent_tid = packed & 0xFFFF_FFFF;
+
+    let my_pid = crate::proc::current_pid_lockless();
+    let my_tid = crate::proc::current_tid();
+
+    // Same-process, different-thread (the parent itself is blocked on
+    // schedule() while the window is open, so its own syscalls cannot reach
+    // here; but the explicit tid check guards against any future relaxation
+    // of that invariant).
+    if my_pid != parent_pid || my_tid == parent_tid {
+        return;
+    }
+
+    let n = SIB_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
+    if n >= MAX_SIB_LOGS {
+        // Once cap is hit, emit one summary line and then silently drop.
+        if n == MAX_SIB_LOGS {
+            crate::serial_println!(
+                "[VFORK-SIB-CAP] parent_pid={} parent_tid={} cap={}",
+                parent_pid, parent_tid, MAX_SIB_LOGS
+            );
+        }
+        return;
+    }
+
+    // Read the sibling thread's userland frame.  `get_user_rsp_rbp` returns
+    // (user_rsp, user_rbp); `get_user_rip` returns the RIP stashed by the
+    // syscall stub before dispatch.
+    let user_rip = unsafe { crate::syscall::get_user_rip() };
+    let (user_rsp, user_rbp) = crate::syscall::get_user_rsp_rbp();
+    let cr3 = crate::mm::vmm::get_cr3();
+
+    crate::serial_println!(
+        "[VFORK-SIB] parent_pid={} parent_tid={} sib_tid={} sib_pid={} \
+         nr={} rip={:#x} rsp={:#x} rbp={:#x} cr3={:#x} idx={}",
+        parent_pid, parent_tid, my_tid, my_pid,
+        syscall_nr, user_rip, user_rsp, user_rbp, cr3, n
+    );
+}
+
+/// Three-channel canary snapshot.  Emits:
+///   `[VFORK-CANARY-PRE/POST]   pid=… tid=… rbp=… saved_canary_addr=… \
+///                              saved_canary_val=… saved_canary_phys=…`
+///   `[VFORK-FSCANARY-PRE/POST] pid=… tid=… fs_base=… fs28_addr=… \
+///                              fs28_val=… fs28_phys=…`
+///
+/// `label` is one of `"PRE"` / `"POST"` and selects the line-tag suffix.
+/// The function reads the parent's userland frame to locate `[rbp-8]`; if
+/// the chain cannot be walked it emits a `state=…` diagnostic in place of
+/// the missing values so the post-processor still gets a row.
+pub fn snapshot_canaries(label: &str, parent_pid: u64, parent_tid: u64) {
+    // ── Channel 2: master canary (fs:0x28) ───────────────────────────────────
+    let fs_base = unsafe { crate::hal::rdmsr(0xC000_0100) };
+    let fs28_addr = fs_base.wrapping_add(0x28);
+    let (fs28_val_str, fs28_phys_str) = read_userland_qword(fs28_addr);
+
+    crate::serial_println!(
+        "[VFORK-FSCANARY-{}] pid={} tid={} fs_base={:#x} fs28_addr={:#x} \
+         fs28_val={} fs28_phys={}",
+        label, parent_pid, parent_tid,
+        fs_base, fs28_addr, fs28_val_str, fs28_phys_str
+    );
+
+    // ── Channel 1: parent saved-canary [rbp-8] ────────────────────────────────
+    //
+    // `get_user_rsp_rbp` returns the (user_rsp, user_rbp) pair saved on this
+    // CPU's syscall frame at entry.  user_rbp at this point is the libc
+    // syscall wrapper's frame pointer; the wrapper's prologue did `push rbp;
+    // mov rbp, rsp`, so `*(user_rbp) = saved_RBP_of_caller`.  The caller is
+    // typically the libxul function that issued the spawn — and ITS `[rbp-8]`
+    // slot (= `*(user_rbp) - 8`) is the SSP slot the epilogue will compare
+    // against `fs:0x28`.  We dump BOTH the wrapper-frame `[rbp-8]` and the
+    // caller-frame `[rbp-8]` so the post-processor can pick whichever frame
+    // the SSP-instrumented function actually owns.
+    let (user_rsp, user_rbp) = crate::syscall::get_user_rsp_rbp();
+    if user_rbp == 0 {
+        crate::serial_println!(
+            "[VFORK-CANARY-{}] pid={} tid={} state=no_user_frame rsp={:#x}",
+            label, parent_pid, parent_tid, user_rsp
+        );
+        return;
+    }
+
+    // Wrapper-frame [rbp-8]: the SSP slot of the libc syscall wrapper itself.
+    let wrap_canary_addr = user_rbp.wrapping_sub(8);
+    let (wrap_val_str, wrap_phys_str) = read_userland_qword(wrap_canary_addr);
+
+    // Walk one frame up: saved_caller_rbp = *(user_rbp).
+    let caller_rbp_opt = read_userland_qword_raw(user_rbp);
+    let (caller_rbp_str, caller_canary_addr_str,
+         caller_val_str, caller_phys_str) = match caller_rbp_opt {
+        Some(0) | None => (
+            alloc::string::String::from("?"),
+            alloc::string::String::from("?"),
+            alloc::string::String::from("?"),
+            alloc::string::String::from("?"),
+        ),
+        Some(crbp) => {
+            let caller_addr = crbp.wrapping_sub(8);
+            let (val_s, phys_s) = read_userland_qword(caller_addr);
+            (
+                alloc::format!("{:#x}", crbp),
+                alloc::format!("{:#x}", caller_addr),
+                val_s,
+                phys_s,
+            )
+        }
+    };
+
+    crate::serial_println!(
+        "[VFORK-CANARY-{}] pid={} tid={} rsp={:#x} rbp={:#x} \
+         wrap_addr={:#x} wrap_val={} wrap_phys={} \
+         caller_rbp={} caller_addr={} caller_val={} caller_phys={}",
+        label, parent_pid, parent_tid,
+        user_rsp, user_rbp,
+        wrap_canary_addr, wrap_val_str, wrap_phys_str,
+        caller_rbp_str, caller_canary_addr_str, caller_val_str, caller_phys_str
+    );
+}
+
+/// Read a userland u64 + resolve its physical address.  Returns
+/// `("?", "?")` if the address is unmapped / non-canonical.
+///
+/// Both halves go through `validate_user_ptr` and `virt_to_phys_in` so that
+/// a corrupt RBP chain cannot fault the snapshot helper.
+fn read_userland_qword(addr: u64) -> (alloc::string::String, alloc::string::String) {
+    if !crate::syscall::validate_user_ptr(addr, 8) {
+        return (
+            alloc::string::String::from("?"),
+            alloc::string::String::from("?"),
+        );
+    }
+    let cr3 = crate::mm::vmm::get_cr3();
+    let phys_str = match crate::mm::vmm::virt_to_phys_in(cr3, addr) {
+        Some(p) => alloc::format!("{:#x}", p),
+        None => alloc::string::String::from("?"),
+    };
+    let val_str = match unsafe { crate::syscall::user_read_u64(addr) } {
+        Some(v) => alloc::format!("{:#x}", v),
+        None => alloc::string::String::from("?"),
+    };
+    (val_str, phys_str)
+}
+
+/// Same as `read_userland_qword` but returns the raw value if successful, so
+/// the caller can do arithmetic on it (used for the saved-RBP chain walk).
+fn read_userland_qword_raw(addr: u64) -> Option<u64> {
+    if !crate::syscall::validate_user_ptr(addr, 8) {
+        return None;
+    }
+    unsafe { crate::syscall::user_read_u64(addr) }
+}


### PR DESCRIPTION
## Summary

Two diagnostic-only commits that together unmask the real CLONE_VM child failure that has been blocking the musl FF demo since PR #305.

### Commit 1 (c5472cd) — VFORK canary snapshot-pair + sibling-syscall tagger
Direct measurement of saved canary (`[rbp-8]`) and master canary (`%fs:0x28`) across the vfork window, plus 8 KB stack-window CRC pre/post and per-syscall sibling-TID tagger.

**Verdict E3 from the diagnostic**: neither canary diverged; parent's 8 KB stack window CRC byte-identical pre/post; no sibling-TID wrote into parent's stack range. The entire "SSP canary failure at `RIP=0x7f000001c7f9`" framing was a misattribution — bytes `f4 c3` are musl's generic `a_crash()` HLT;RET, not exclusively `__stack_chk_fail`.

### Commit 2 (17bbe05) — Parent-VmSpace fallback in fault diagnostic printers
For CLONE_VM children, `Process.vm_space = None` by design (`fork_process_share_vm`, kernel/src/proc/mod.rs:2440), so three diagnostic printers — `[STACK/VMA]` (proc/stack_walk.rs:146), `[FAULT/PHYS]` (signal.rs:1358), `[UD/VMA]` (arch/x86_64/idt.rs:778) — short-circuited to `no_vma=1` / `vma_offset=NO_VMA` even when the parent's VMA list could resolve the fault address. The actual PF handler (`handle_page_fault`, arch/x86_64/idt.rs:1082) already routes to parent's VmSpace when CR3 matches; the bookkeeping gap was diagnostic-only.

New helper `proc::find_vma_with_parent_fallback(pid, addr)` (kernel/src/proc/mod.rs:1981) consults parent when child has no VmSpace, `parent_pid != 0`, and `parent.cr3 == child.cr3`. Parent-resolved lines suffix `inherited_from_parent=1`.

## Real next gate (uncovered by this diagnostic, not fixed in this PR)

Post-fix log shows the child crashes at `RIP=0x7f000005b524`, instruction bytes `64 48 8b 2c 25 00 00 00 00` = `mov rbp, fs:[0]` (musl's per-thread cancellable-syscall wrapper reading `__pthread_self()`). The child's `tls_base = 0` per PR #311 invariant, so `fs:0` dereferences VA 0 → page fault → SIGSEGV.

The musl `posix_spawn` child helper invokes `__syscall_cp`-flavoured calls (`close`, `__libc_sigaction`, `pthread_sigmask`) before `execve`, all of which need TLS. This is a real conflict between two invariants:
- PR #311: "child must not inherit `fs.base` so SSP-canary corruption can't happen"
- POSIX: "cancellable syscalls must be able to read cancel state"

Real fix-shape (separate PR): provision a minimal anonymous TLS page (zero-init TCB with self-pointer at `fs:0` and zero canary at `fs:0x28`) in the shared address space during the vfork window.

## Sc plateau
Pre-fix: 1234. Post-fix: 1235. Diagnostic-only change — no path alteration, no regression.

## Test plan
- [x] Tests 244 (libsys), 245-247 (net RX checksums), 248-250 (Linux ABI), 257-258 (UMIP/getrandom) pass
- [x] CLONE_VM child PF lines now print `inherited_from_parent=1`
- [x] Non-CLONE_VM children unchanged (no parent fallback consulted)
- [x] Master canary diagnostic ran 1 KVM trial (sc=1235, identical to baseline)

## References
- clone(2) `CLONE_VM` semantics
- vfork(2) "Linux Notes"
- musl posix_spawn man page section 3 (cancellable syscalls in child path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)