### PR TITLE
kernel: #GP handler stack-page CRC dump (decisive userspace-vs-kernel discriminator)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -288,6 +288,46 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                     crate::serial_println!("[GPF-DBG]   [RSP+{:#03x}]={:#018x}", i*8, val);
                 }
             }
+
+            // Fletcher-32 CRC over the user-stack page containing fault RSP.
+            // Pairs with the `[STACK-CANARY-FINEGRAIN]` and `[STACK-PAGE-PROV]`
+            // snapshots emitted PRE/POST the vfork window by
+            // `subsys::linux::vfork_diag`.  A post-processor compares the
+            // `#GP`-time CRC against the POST snapshot at the same VA to
+            // discriminate:
+            //
+            //   * `crc == POST && phys == POST` → page contents stable from
+            //     POST through `#GP`; the faulting write came from userspace
+            //     after the vfork window closed (userspace memory-safety
+            //     bug — e.g. STL write past end overwriting saved SSP slot).
+            //   * `crc != POST && phys == POST` → kernel mutated the page
+            //     between POST snapshot and `#GP` (axis-O kernel-side
+            //     post-vfork stack-page corruption).
+            //   * `phys != POST`               → page aliasing (axis-N+1
+            //     class — VA stable but a different physical frame is now
+            //     mapped).
+            //
+            // Diagnostic-only; gated behind `vfork-canary-diag` so master
+            // builds remain byte-identical and the trap path retains its
+            // existing fault-immune shape.
+            //
+            // Refs: Intel SDM Vol. 3A §6.15 (#GP), RFC 1146 (Fletcher-32).
+            #[cfg(feature = "vfork-canary-diag")]
+            {
+                let stack_page = rsp & !0xFFFu64;
+                match crate::subsys::linux::vfork_diag::fletcher32_user_page(
+                    cr3, stack_page,
+                ) {
+                    Some((phys, crc)) => crate::serial_println!(
+                        "[GPF-STACK-CRC] tid={} stack_page={:#x} phys={:#x} crc={:#010x}",
+                        tid, stack_page, phys, crc,
+                    ),
+                    None => crate::serial_println!(
+                        "[GPF-STACK-CRC] tid={} stack_page={:#x} state=unmapped",
+                        tid, stack_page,
+                    ),
+                }
+            }
         }
     }
 

--- a/kernel/src/subsys/linux/vfork_diag.rs
+++ b/kernel/src/subsys/linux/vfork_diag.rs
@@ -594,6 +594,39 @@ fn infer_writable(cr3: u64, va: u64) -> bool {
     }
 }
 
+/// Compute Fletcher-32 (RFC 1146, modulus 65535) over the 4-KiB user page
+/// containing `va` under the given `cr3`.  Returns `(phys, crc)` on a present
+/// page, or `None` if the page is unmapped.
+///
+/// Reads through the kernel direct physical map (no SMAP bracket required)
+/// so the helper is safe to call from a fault-immune ISR context.  The CRC
+/// formula matches the per-256 B `[STACK-CANARY-FINEGRAIN]` chunks and the
+/// 8 KiB-window `vfork_canary_snapshot` so the `#GP`-time value is
+/// directly comparable with the pre/post snapshot pair without
+/// re-implementing the hash.
+///
+/// Diagnostic-only.  Callers may pass an unaligned `va`; the helper masks
+/// to a page boundary internally.
+///
+/// Refs:
+///  - RFC 1146 §1 (Fletcher-32, mod 65535)
+///  - Intel SDM Vol. 3A §4.6 (paging, virt→phys translation)
+pub fn fletcher32_user_page(cr3: u64, va: u64) -> Option<(u64, u32)> {
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    let page_va = va & !0xFFFu64;
+    let phys = crate::mm::vmm::virt_to_phys_in(cr3, page_va)?;
+    let mut s1: u32 = 0;
+    let mut s2: u32 = 0;
+    for i in 0..4096u64 {
+        let b = unsafe {
+            core::ptr::read_volatile((PHYS_OFF + phys + i) as *const u8)
+        };
+        s1 = s1.wrapping_add(b as u32) % 65535;
+        s2 = s2.wrapping_add(s1) % 65535;
+    }
+    Some((phys, (s2 << 16) | s1))
+}
+
 /// Re-arm a hardware write-only watchpoint (8 bytes) on `fs:0x28`
 /// (the master canary slot, `__stack_chk_guard` per System V x86_64
 /// psABI §6.4) for the duration of the vfork window.  Any kernel-mode


### PR DESCRIPTION
## Summary

- Adds `subsys::linux::vfork_diag::fletcher32_user_page(cr3, va) -> Option<(u64, u32)>` returning `(phys, crc)` of the 4 KiB user page containing `va`. Reuses the existing Fletcher-32 formula (RFC 1146, modulus 65535) so the new value is directly comparable with the PRE/POST snapshot pair already emitted by `vfork_diag`.
- Extends the user-mode `#GP` block in `arch::x86_64::idt::exception_dispatch` to emit a `[GPF-STACK-CRC] tid={} stack_page={:#x} phys={:#x} crc={:#010x}` line on every `#GP`. Gated behind `vfork-canary-diag`; master builds byte-identical.
- Decisive discriminator for the post-#328 wedge per the abi-compat verdict (musl has zero SSP instrumentation; `__stack_chk_fail@0x1c7f9` is a 2-byte `hlt; ret` stub; the caller is libxul's `std::_Rb_tree<...>::_M_get_insert_hint_unique_pos`, not musl).

## Decision tree on output

For a given `#GP` at `RIP=0x7f000001c7f9 RSP=0x7ffffffeeXXX`, compare the new `[GPF-STACK-CRC]` against the `[STACK-PAGE-CRC] POST` line for `va = RSP & ~0xFFF`:

| `crc` vs POST | `phys` vs POST | Verdict |
|---|---|---|
| equal | equal | page content stable POST→#GP; faulting write came from userspace after vfork window → **userspace memory-safety bug in libxul** |
| **differs** | equal | kernel mutated the same physical frame between POST and #GP → **kernel-side post-vfork stack-page corruption (axis-O)** |
| any | **differs** | a different physical frame is now mapped at the same VA → **page aliasing (axis-N+1 class)** |

## 3-trial KVM soak (post-#328 tip + this PR + `firefox-test,w215-diag,vfork-canary-diag,kdb`)

All three trials hit `#GP` at `RIP=0x7f000001c7f9 RSP=0x7ffffffee468`. Raw serial logs at `~/.astryx-harness/{5372ca7f0bcf,ba2d325fe6e8,0930d10167fe}.serial.log`.

For the stack page containing the fault RSP (`va=0x7ffffffee000`):

| trial | session sid | PRE phys | PRE crc | POST phys | POST crc | GPF phys | GPF crc |
|---|---|---|---|---|---|---|---|
| 1 | 5372ca7f0bcf | 0x12471000 | 0xb32da1af | 0x12471000 | 0xb32da1af | 0x12471000 | 0x862682a4 |
| 2 | ba2d325fe6e8 | 0x12471000 | 0x816c9d5d | 0x12471000 | 0x816c9d5d | 0x12471000 | 0xa3527ef2 |
| 3 | 0930d10167fe | 0x12479000 | 0x2af89e0e | 0x12479000 | 0x2af89e0e | 0x12479000 | 0x614d8012 |

**3/3 trials**: `PRE == POST` (no write during vfork window), `POST != GPF` (content of the same physical frame changed between vfork-window close and the eventual #GP), `phys identical across PRE/POST/GPF` (no aliasing).

This matches **row 2 of the decision tree → kernel-side post-vfork stack-page corruption (axis-O)**.

## Next dispatch shape (recommended)

Aether-kernel-engineer to audit the post-vfork munmap + close-stdin epilog. Specifically `proc::vfork::exit_window` (or whichever function calls `unmap_and_free_range_in` for the kernel's isolated vfork stack at `0x3ff593e000` per PR #311). Verify the unmap range cannot accidentally include any portion of the parent's main user stack mapped near `0x7ffff...`. Likely candidates:

1. Range arithmetic off-by-one — unmap end accidentally extends into parent's stack VMA.
2. CR3 confusion — unmap walks the parent's PML4 instead of the (now-exited) child's, with a stale `cr3` value.
3. Refcount underflow on a shared page that the parent still has mapped, causing PMM to recycle the parent's frame.
4. POST snapshot races a later kernel write — re-verify by extending `full_stack_vma_provenance` to emit a third snapshot at vfork-window EXIT-FINAL (after the close-stdin + munmap epilog completes).

The new `[GPF-STACK-CRC]` channel lets the next investigation iterate quickly: every candidate fix is provable by a CRC=POST result on the same 3-trial soak.

## Test plan

- [x] Master byte-identical without `vfork-canary-diag` (gate verified at idt.rs:328).
- [x] Build clean under `firefox-test,w215-diag,vfork-canary-diag,kdb`.
- [x] 3-trial KVM soak: all three trials emit `[GPF-STACK-CRC]` line and trip the discriminator (see table above).
- [x] Diff under 80 LOC cap: +73 / -0 across 2 files.
- [ ] (Follow-up dispatch) Aether-kernel-engineer audits `unmap_and_free_range_in` for the vfork-stack range.

## Refs

- Intel SDM Vol. 3A §6.15 (#GP exception)
- Intel SDM Vol. 3A §4.6 (paging / virtual-to-physical translation)
- RFC 1146 §1 (Fletcher-32 checksum, modulus 65535)
- System V AMD64 ABI §3.4.5.2 (SSP / stack-protector frame layout)