### PR TITLE
kernel: axis-O bisect (EXIT-FINAL snapshot for post-vfork stack-page corruption)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -288,6 +288,46 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                     crate::serial_println!("[GPF-DBG]   [RSP+{:#03x}]={:#018x}", i*8, val);
                 }
             }
+
+            // Fletcher-32 CRC over the user-stack page containing fault RSP.
+            // Pairs with the `[STACK-CANARY-FINEGRAIN]` and `[STACK-PAGE-PROV]`
+            // snapshots emitted PRE/POST the vfork window by
+            // `subsys::linux::vfork_diag`.  A post-processor compares the
+            // `#GP`-time CRC against the POST snapshot at the same VA to
+            // discriminate:
+            //
+            //   * `crc == POST && phys == POST` → page contents stable from
+            //     POST through `#GP`; the faulting write came from userspace
+            //     after the vfork window closed (userspace memory-safety
+            //     bug — e.g. STL write past end overwriting saved SSP slot).
+            //   * `crc != POST && phys == POST` → kernel mutated the page
+            //     between POST snapshot and `#GP` (axis-O kernel-side
+            //     post-vfork stack-page corruption).
+            //   * `phys != POST`               → page aliasing (axis-N+1
+            //     class — VA stable but a different physical frame is now
+            //     mapped).
+            //
+            // Diagnostic-only; gated behind `vfork-canary-diag` so master
+            // builds remain byte-identical and the trap path retains its
+            // existing fault-immune shape.
+            //
+            // Refs: Intel SDM Vol. 3A §6.15 (#GP), RFC 1146 (Fletcher-32).
+            #[cfg(feature = "vfork-canary-diag")]
+            {
+                let stack_page = rsp & !0xFFFu64;
+                match crate::subsys::linux::vfork_diag::fletcher32_user_page(
+                    cr3, stack_page,
+                ) {
+                    Some((phys, crc)) => crate::serial_println!(
+                        "[GPF-STACK-CRC] tid={} stack_page={:#x} phys={:#x} crc={:#010x}",
+                        tid, stack_page, phys, crc,
+                    ),
+                    None => crate::serial_println!(
+                        "[GPF-STACK-CRC] tid={} stack_page={:#x} state=unmapped",
+                        tid, stack_page,
+                    ),
+                }
+            }
         }
     }
 

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -327,6 +327,20 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                         tid, stack_page,
                     ),
                 }
+                // Axis-O bisect: fire the post-vfork stack-watch check at
+                // `#GP` arrival so the final state of every armed slot is
+                // emitted alongside the per-syscall checks.  If the page
+                // first diverges HERE (and not on any prior `SC-ENTER` /
+                // `SC-RET` hook) the writer is in the `#GP` handler / IDT
+                // entry stub itself.  POSIX vfork(2); Intel SDM Vol. 3A §6.15.
+                crate::subsys::linux::vfork_diag::check_post_vfork_stack(
+                    "#GP", vector as u64);
+                // Best-effort disarm.  The `#GP` is the terminating event
+                // for the parent's vfork lifecycle in the dispositive
+                // trials; clearing the watch here prevents a stale arm
+                // from leaking into any subsequent vfork window if the
+                // process somehow continues.  No-op if already disarmed.
+                crate::subsys::linux::vfork_diag::disarm_post_vfork_stack_watch();
             }
         }
     }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -743,6 +743,16 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     #[cfg(feature = "vfork-canary-diag")]
     crate::subsys::linux::vfork_diag::maybe_log_sibling_syscall(num);
 
+    // ── Axis-O bisect: post-vfork parent-stack CRC check (entry) ────────────
+    // Off-path cost identical to the sibling-syscall tagger above.  When
+    // armed (after `arm_post_vfork_stack_watch` fired in the parent's
+    // clone / clone3 path), re-CRC every armed page and emit one
+    // `[POST-VFORK-CRC-DELTA]` line per state change so the post-processor
+    // can bisect the writer to a specific syscall.  Bounded at MAX_DELTAS.
+    // POSIX vfork(2); Intel SDM Vol. 3A §4.10.
+    #[cfg(feature = "vfork-canary-diag")]
+    crate::subsys::linux::vfork_diag::check_post_vfork_stack("SC-ENTER", num);
+
     // ── Tier-0 trace: one self-contained line per syscall entry ──────────────
     // Grepped by qemu-harness.py via `^\[SC\] `.  User RIP comes from the
     // per-CPU syscall_entry stash (set by the naked-asm stub before dispatch).
@@ -977,6 +987,14 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         num,
         ret as u64,
     );
+
+    // ── Axis-O bisect: post-vfork parent-stack CRC check (return) ───────────
+    // Pairs with the SC-ENTER check at the top of `dispatch()` so the
+    // post-processor can bracket each syscall's kernel-side window with a
+    // pre-call and post-call CRC.  A delta that appears only on `SC-RET`
+    // localises the writer to inside that specific syscall handler.
+    #[cfg(feature = "vfork-canary-diag")]
+    crate::subsys::linux::vfork_diag::check_post_vfork_stack("SC-RET", num);
 
     ret
 }
@@ -2396,6 +2414,18 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                     "post", pid, parent_tid);
                                 crate::subsys::linux::vfork_diag::snapshot_stack_page_prov(
                                     "post", pid, parent_tid);
+                                // Axis-O bisect — emit the EXIT-FINAL stack snapshot
+                                // (the LAST kernel point before SYSRET back to userspace)
+                                // and arm the per-page CRC watch on the parent's stack
+                                // VMA.  Subsequent syscall entries / returns plus the
+                                // `#GP` handler will fire `check_post_vfork_stack` to
+                                // bisect any in-window page mutation.  POSIX vfork(2);
+                                // Intel SDM Vol. 3A §4.10.
+                                crate::subsys::linux::vfork_diag::snapshot_stack_page_prov(
+                                    crate::subsys::linux::vfork_diag::EXIT_FINAL_LABEL,
+                                    pid, parent_tid);
+                                crate::subsys::linux::vfork_diag::arm_post_vfork_stack_watch(
+                                    pid, parent_tid);
                             }
                             vfork_canary_snapshot("post_wake.clone", pid as u32, parent_tid);
                         }
@@ -3276,6 +3306,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                     "post", pid, parent_tid);
                                 crate::subsys::linux::vfork_diag::snapshot_stack_page_prov(
                                     "post", pid, parent_tid);
+                                // Axis-O bisect — see clone (56) for rationale.
+                                crate::subsys::linux::vfork_diag::snapshot_stack_page_prov(
+                                    crate::subsys::linux::vfork_diag::EXIT_FINAL_LABEL,
+                                    pid, parent_tid);
+                                crate::subsys::linux::vfork_diag::arm_post_vfork_stack_watch(
+                                    pid, parent_tid);
                             }
                             vfork_canary_snapshot("post_wake.clone3", pid as u32, parent_tid);
                         }

--- a/kernel/src/subsys/linux/vfork_diag.rs
+++ b/kernel/src/subsys/linux/vfork_diag.rs
@@ -594,6 +594,39 @@ fn infer_writable(cr3: u64, va: u64) -> bool {
     }
 }
 
+/// Compute Fletcher-32 (RFC 1146, modulus 65535) over the 4-KiB user page
+/// containing `va` under the given `cr3`.  Returns `(phys, crc)` on a present
+/// page, or `None` if the page is unmapped.
+///
+/// Reads through the kernel direct physical map (no SMAP bracket required)
+/// so the helper is safe to call from a fault-immune ISR context.  The CRC
+/// formula matches the per-256 B `[STACK-CANARY-FINEGRAIN]` chunks and the
+/// 8 KiB-window `vfork_canary_snapshot` so the `#GP`-time value is
+/// directly comparable with the pre/post snapshot pair without
+/// re-implementing the hash.
+///
+/// Diagnostic-only.  Callers may pass an unaligned `va`; the helper masks
+/// to a page boundary internally.
+///
+/// Refs:
+///  - RFC 1146 §1 (Fletcher-32, mod 65535)
+///  - Intel SDM Vol. 3A §4.6 (paging, virt→phys translation)
+pub fn fletcher32_user_page(cr3: u64, va: u64) -> Option<(u64, u32)> {
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    let page_va = va & !0xFFFu64;
+    let phys = crate::mm::vmm::virt_to_phys_in(cr3, page_va)?;
+    let mut s1: u32 = 0;
+    let mut s2: u32 = 0;
+    for i in 0..4096u64 {
+        let b = unsafe {
+            core::ptr::read_volatile((PHYS_OFF + phys + i) as *const u8)
+        };
+        s1 = s1.wrapping_add(b as u32) % 65535;
+        s2 = s2.wrapping_add(s1) % 65535;
+    }
+    Some((phys, (s2 << 16) | s1))
+}
+
 /// Re-arm a hardware write-only watchpoint (8 bytes) on `fs:0x28`
 /// (the master canary slot, `__stack_chk_guard` per System V x86_64
 /// psABI §6.4) for the duration of the vfork window.  Any kernel-mode

--- a/kernel/src/subsys/linux/vfork_diag.rs
+++ b/kernel/src/subsys/linux/vfork_diag.rs
@@ -55,6 +55,16 @@
 //!     Any `#DB` from this region during vfork names the kernel-mode
 //!     writer corrupting the master canary.  Intel SDM Vol. 3B §17.2.4.
 //!
+//!  8. **`[POST-VFORK-CRC-DELTA]` (axis-O)** — after the POST snapshots
+//!     close the vfork window, arm a per-page Fletcher-32 watch on the
+//!     parent's stack VMA (16 pages = 64 KiB upward from RSP).  Hook
+//!     points (Linux syscall entry / return, `#GP` handler) re-CRC every
+//!     watched page on each fire and emit one `[POST-VFORK-CRC-DELTA]`
+//!     line per state change, bracketing the writer to a specific
+//!     `(SC-ENTER nr=N) ↔ (SC-RET nr=N)` or `#GP` span.  See
+//!     `arm_post_vfork_stack_watch` / `check_post_vfork_stack` below.
+//!     RFC 1146 (Fletcher-32); Intel SDM Vol. 3A §4.6 (paging).
+//!
 //! # Why a separate module
 //!
 //! This file owns all of the vfork-window state so the snapshot helper can
@@ -695,4 +705,273 @@ pub fn disarm_master_canary_watch() {
         return;
     }
     crate::arch::x86_64::debug_reg::release_slot(slot as usize);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Axis-O bisect: post-vfork parent-stack page watch
+// ───────────────────────────────────────────────────────────────────────────
+//
+// The PR #331 3-trial dispositive established that the parent's user-stack
+// page `0x7ffffffee000` changes contents between the `STACK-PAGE-PROV` /
+// `STACK-PAGE-CRC` snapshot taken at vfork-window-close and the
+// `GPF-STACK-CRC` snapshot taken at the eventual `#GP` arrival — with
+// identical `phys` (no aliasing).  The mutation therefore happens somewhere
+// in the kernel-and-user execution slice between those two points.
+//
+// `arm_post_vfork_stack_watch` snapshots up to `WATCH_SLOTS` pages of the
+// parent's stack VMA (starting at the RSP-aligned page from the POST
+// sample) and stores per-slot `(va, phys, crc)`.  `check_post_vfork_stack`
+// is invoked from the candidate writer-paths (syscall entry / return /
+// `#GP` handler) and emits one `[POST-VFORK-CRC-DELTA]` line per slot per
+// state change — bounded at `MAX_DELTAS` lines total so a wild post-vfork
+// loop cannot run away with the serial log.
+//
+// Refs: POSIX vfork(2); Intel SDM Vol. 3A §4.10 / §4.6 (TLB / SMAP);
+//       RFC 1146 (Fletcher-32).
+
+/// Maximum number of stack pages tracked per vfork window.  16 pages =
+/// 64 KiB — covers the libxul deep-frame range observed in the dispositive
+/// trials (POST-time RSP at `0x...ec708`, eventual `#GP` RSP at
+/// `0x...ee468`, span ≈ 8 KiB; 64 KiB gives 8× headroom).
+const WATCH_SLOTS: usize = 16;
+
+/// Hard cap on `[POST-VFORK-CRC-DELTA]` lines across all hook points
+/// within a single vfork window.  Keeps serial bounded if a tight
+/// user-mode loop keeps rewriting the same page.
+const MAX_DELTAS: usize = 32;
+
+/// Bisect snapshot label suffix used by the LAST kernel snapshot before
+/// SYSRET back to userspace.  Distinguishing label so the post-processor
+/// can identify the "kernel post-vfork final state".
+pub const EXIT_FINAL_LABEL: &str = "EXIT-FINAL";
+
+/// Active post-vfork watch identity, packed as `(pid << 32) | (tid & 0xFFFF_FFFF)`.
+/// Zero = no watch active.  Single `AtomicU64` so the per-syscall fast
+/// path is a single relaxed load + branch (matches the sibling-syscall
+/// tagger).
+static WATCH_ACTIVE_PACKED: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+
+/// Per-slot watched VA.  `0` = unused slot.
+static WATCH_VA: [core::sync::atomic::AtomicU64; WATCH_SLOTS] = [
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+];
+
+/// Per-slot watched physical address at arm time.  Used to discriminate
+/// "phys changed = aliasing" from "phys same, crc changed = in-place
+/// kernel/user write".
+static WATCH_PHYS: [core::sync::atomic::AtomicU64; WATCH_SLOTS] = [
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+];
+
+/// Per-slot Fletcher-32 CRC at arm time.  Stored in the low 32 bits of a
+/// `u64` for atomic-load uniformity with the other watch arrays.
+static WATCH_CRC: [core::sync::atomic::AtomicU64; WATCH_SLOTS] = [
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0), core::sync::atomic::AtomicU64::new(0),
+];
+
+/// Global delta counter — drives the `MAX_DELTAS` cap and gives every
+/// emitted line a monotonic index for log post-processing.
+static WATCH_DELTA_COUNT: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
+/// Arm the post-vfork parent-stack page watch.
+///
+/// Walks the parent's stack VMA (located via `get_parent_user_rsp_rbp`
+/// and the parent's CR3) and stores up to `WATCH_SLOTS` per-page
+/// `(va, phys, crc)` records.  After this call, `check_post_vfork_stack`
+/// is live for the parent tid until `disarm_post_vfork_stack_watch` or a
+/// new arm replaces the state.
+///
+/// One-line summary emitted via `[POST-VFORK-WATCH-ARM] …` regardless of
+/// outcome so the post-processor can correlate hook fires with the arm.
+///
+/// Diagnostic-only.  All reads route through `fletcher32_user_page` which
+/// uses `virt_to_phys_in` + the kernel direct map so a corrupt page-table
+/// entry cannot fault the arm path.  POSIX vfork(2); Intel SDM Vol. 3A
+/// §4.6.
+pub fn arm_post_vfork_stack_watch(parent_pid: u64, parent_tid: u64) {
+    use core::sync::atomic::Ordering;
+
+    // Reset any prior-window state first so a missed disarm cannot leak
+    // stale slots into this window.
+    for s in 0..WATCH_SLOTS {
+        WATCH_VA[s].store(0,   Ordering::Relaxed);
+        WATCH_PHYS[s].store(0, Ordering::Relaxed);
+        WATCH_CRC[s].store(0,  Ordering::Relaxed);
+    }
+    WATCH_DELTA_COUNT.store(0, Ordering::Relaxed);
+
+    let (rsp, _rbp) = get_parent_user_rsp_rbp(parent_tid);
+    // `USER_ADDR_END` matches the kernel-wide constant.
+    const USER_ADDR_END: u64 = 0x0000_8000_0000_0000;
+    const USER_ADDR_MIN: u64 = 0x1000;
+    const PAGE_SIZE_U64: u64 = 4096;
+    if rsp == 0 || rsp < USER_ADDR_MIN || rsp >= USER_ADDR_END {
+        crate::serial_println!(
+            "[POST-VFORK-WATCH-ARM] pid={} tid={} state=bad_rsp rsp={:#x}",
+            parent_pid, parent_tid, rsp,
+        );
+        return;
+    }
+
+    let cr3 = crate::mm::vmm::get_cr3();
+    let walk_low  = rsp & !(PAGE_SIZE_U64 - 1);
+    // 64-KiB window upward from the RSP-aligned page.  The dispositive
+    // trials show the eventual `#GP` RSP is ~8 KiB above the POST-time
+    // RSP, so 64 KiB covers any plausible later frame without depending
+    // on the parent's stack VMA bounds (which would require a
+    // `find_vma` snapshot under PROCESS_TABLE lock).
+    let walk_high = walk_low.saturating_add(WATCH_SLOTS as u64 * PAGE_SIZE_U64);
+
+    let mut armed: usize = 0;
+    let mut page_va = walk_low;
+    while page_va + PAGE_SIZE_U64 <= walk_high && armed < WATCH_SLOTS {
+        if let Some((phys, crc)) = fletcher32_user_page(cr3, page_va) {
+            WATCH_VA[armed].store(page_va, Ordering::Relaxed);
+            WATCH_PHYS[armed].store(phys, Ordering::Relaxed);
+            WATCH_CRC[armed].store(crc as u64, Ordering::Relaxed);
+            armed += 1;
+        }
+        // Unmapped page → skip; the walk continues so a mid-VMA hole
+        // doesn't truncate coverage.
+        page_va += PAGE_SIZE_U64;
+    }
+
+    // Publish the (pid, tid) atomic LAST, so `check_post_vfork_stack`
+    // never sees a half-initialised slot array (Release pairs with the
+    // Acquire load in the check path; Intel SDM Vol. 3A §8.2 — TSO
+    // makes this a compiler-fence in practice but the explicit
+    // ordering documents the intent).
+    let packed = (parent_pid << 32) | (parent_tid & 0xFFFF_FFFF);
+    WATCH_ACTIVE_PACKED.store(packed, Ordering::Release);
+
+    crate::serial_println!(
+        "[POST-VFORK-WATCH-ARM] pid={} tid={} rsp={:#x} walk=[{:#x},{:#x}) armed_slots={}",
+        parent_pid, parent_tid, rsp, walk_low, walk_high, armed,
+    );
+}
+
+/// Disarm the watch and emit a one-line summary.  Safe to call multiple
+/// times; the second call is a no-op.
+pub fn disarm_post_vfork_stack_watch() {
+    use core::sync::atomic::Ordering;
+    let prev = WATCH_ACTIVE_PACKED.swap(0, Ordering::AcqRel);
+    if prev == 0 {
+        return;
+    }
+    let pid = prev >> 32;
+    let tid = prev & 0xFFFF_FFFF;
+    let deltas = WATCH_DELTA_COUNT.load(Ordering::Acquire);
+    crate::serial_println!(
+        "[POST-VFORK-WATCH-DISARM] pid={} tid={} total_deltas={}",
+        pid, tid, deltas,
+    );
+}
+
+/// Bisect hook.  Called from chosen kernel points (syscall entry/return,
+/// `#GP` handler) — must be cheap on the off-path (no watch active or
+/// wrong tid → single relaxed load + branch + return).
+///
+/// `tag` is a short literal naming the call site (`"SC-ENTER"`,
+/// `"SC-RET"`, `"#GP"`).  `tag_val` is an optional integer (typically the
+/// syscall number) baked into the delta line.  Passing the value as a
+/// `u64` avoids any allocation on the fast path — `crate::serial_println!`
+/// only fires once a delta is actually detected.
+///
+/// On the on-path, walks each armed slot and re-reads `(phys, crc)`.  If
+/// either differs from the stored arm-time value AND we have not yet hit
+/// `MAX_DELTAS`, emits one `[POST-VFORK-CRC-DELTA]` line and updates the
+/// stored state so subsequent hooks emit the NEXT delta (rather than
+/// re-flagging the same one).  This bisects sequential writers along the
+/// kernel-to-user return path.
+#[inline]
+pub fn check_post_vfork_stack(tag: &str, tag_val: u64) {
+    use core::sync::atomic::Ordering;
+
+    let packed = WATCH_ACTIVE_PACKED.load(Ordering::Acquire);
+    if packed == 0 {
+        return; // No window active — fast path.
+    }
+    let watch_pid = packed >> 32;
+    let watch_tid = packed & 0xFFFF_FFFF;
+
+    // Tid filter: only the parent thread's path mutates a frame the
+    // parent will later read.  Sibling threads share CR3 but their
+    // writes are already named by the `[VFORK-SIB]` tagger.
+    let my_tid = crate::proc::current_tid();
+    if my_tid != watch_tid {
+        return;
+    }
+
+    // Capped total delta emissions per window.
+    let deltas_so_far = WATCH_DELTA_COUNT.load(Ordering::Relaxed);
+    if deltas_so_far >= MAX_DELTAS {
+        return;
+    }
+
+    let cr3 = crate::mm::vmm::get_cr3();
+    for s in 0..WATCH_SLOTS {
+        let va = WATCH_VA[s].load(Ordering::Relaxed);
+        if va == 0 {
+            continue;
+        }
+        let stored_phys = WATCH_PHYS[s].load(Ordering::Relaxed);
+        let stored_crc  = WATCH_CRC[s].load(Ordering::Relaxed) as u32;
+
+        let (phys_now, crc_now) = match fletcher32_user_page(cr3, va) {
+            Some(p) => p,
+            None => {
+                // Slot unmapped — emit one delta and clear so we don't
+                // re-flag.  An unmapped-after-arm slot is itself the
+                // bisect signal (e.g. a kernel path tore down the
+                // mapping).
+                if WATCH_DELTA_COUNT.fetch_add(1, Ordering::Relaxed) < MAX_DELTAS {
+                    crate::serial_println!(
+                        "[POST-VFORK-CRC-DELTA] tag={} val={} pid={} tid={} slot={} va={:#x} \
+                         phys_pre={:#x} phys_now=unmapped crc_pre={:#010x} crc_now=unmapped",
+                        tag, tag_val, watch_pid, watch_tid, s, va, stored_phys, stored_crc,
+                    );
+                }
+                WATCH_VA[s].store(0, Ordering::Relaxed);
+                continue;
+            }
+        };
+
+        if phys_now != stored_phys || crc_now != stored_crc {
+            if WATCH_DELTA_COUNT.fetch_add(1, Ordering::Relaxed) < MAX_DELTAS {
+                crate::serial_println!(
+                    "[POST-VFORK-CRC-DELTA] tag={} val={} pid={} tid={} slot={} va={:#x} \
+                     phys_pre={:#x} phys_now={:#x} crc_pre={:#010x} crc_now={:#010x}",
+                    tag, tag_val, watch_pid, watch_tid, s, va,
+                    stored_phys, phys_now, stored_crc, crc_now,
+                );
+            }
+            // Update stored state so the NEXT delta is reported by the
+            // NEXT hook, not the same write.
+            WATCH_PHYS[s].store(phys_now, Ordering::Relaxed);
+            WATCH_CRC[s].store(crc_now as u64, Ordering::Relaxed);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1 diagnostic for the W215 axis-O class established by PR #331's
3-trial dispositive: the parent's user-stack page (`0x7ffffffee000` in
the libxul `posix_spawn` path) changes contents between the
vfork-window-close `STACK-PAGE-CRC POST` snapshot and the eventual
`#GP` arrival, with identical phys throughout (no aliasing).

This PR adds three things, all gated on the existing `vfork-canary-diag`
feature so non-diagnostic builds remain byte-identical:

- **`EXIT-FINAL` snapshot** — `[STACK-PAGE-PROV]` page-provenance dump
  at the LAST kernel point before SYSRET back to userspace, after the
  existing POST triple.  Localises any mutation that happens between
  the POST sample and the actual return.
- **`arm_post_vfork_stack_watch` / `disarm_post_vfork_stack_watch`** —
  per-page Fletcher-32 (RFC 1146) CRCs of up to 16 4-KiB pages of the
  parent's stack VMA, lock-free via `[AtomicU64; 16]`.
- **`check_post_vfork_stack(tag, tag_val)`** — bisect hook called from
  Linux syscall entry, syscall return, and the `#GP` handler.  Off-path
  cost is one relaxed atomic load + branch.  On the on-path, emits a
  bounded `[POST-VFORK-CRC-DELTA]` line per slot per state change with
  the syscall number / vector, bracketing the writer to a specific
  `SC-ENTER ↔ SC-RET` interval or pinning it on the `#GP` path.

Bisect predicate post-soak:

- `[POST-VFORK-CRC-DELTA] tag=SC-ENTER nr=N` after an earlier
  `SC-RET nr=M` → writer is **userspace** between syscall M and N.
- `[POST-VFORK-CRC-DELTA] tag=SC-RET nr=N` without paired entry delta
  → writer is the **kernel-side handler of syscall N**.
- `[POST-VFORK-CRC-DELTA] tag=#GP` with no earlier delta → writer is
  the **`#GP` handler / IDT entry stub**.
- `phys_now != phys_pre` at any tag → page aliasing (axis-N+1 class,
  not axis-O).

Refs: POSIX vfork(2); Intel SDM Vol. 3A §4.6 / §4.10 / §6.15; System V
x86_64 psABI §6.4; RFC 1146 §1.

## Test plan

- [ ] 3-trial KVM soak with `firefox-test,kdb,vfork-canary-diag,syscall-trace`.
- [ ] Confirm `[POST-VFORK-WATCH-ARM]` fires post-`POST` triple in each trial.
- [ ] Locate the first `[POST-VFORK-CRC-DELTA]` line and apply the bisect
      predicate above to attribute the writer.
- [ ] Phase 2 (~150 LOC fix): once writer attributed, audit and patch
      the offending path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)