### PR TITLE
kernel/subsys/linux/ssp_diag: drop rotted VMA-name gate (PR #339 follow-up)

### DIFF
--- a/kernel/src/subsys/linux/ssp_diag.rs
+++ b/kernel/src/subsys/linux/ssp_diag.rs
@@ -202,23 +202,36 @@ fn reserve_reject_slot() -> bool {
     n < SSP_REJECT_MAX
 }
 
-/// Resolve the base VA of the `ld-musl-x86_64.so.1` text mapping that
-/// covers `rip`.  Looks up the per-process VMA list under a
-/// `try_lock()` so the hook never blocks the trap path.  Accepts any
-/// VMA whose `name` field contains the substring `"ld-musl"` and whose
-/// `base` is a sane user VA.
+/// Resolve the load-relative base VA of whatever user mapping covers
+/// `rip`.  Looks up the per-process VMA list under a `try_lock()` so
+/// the hook never blocks the trap path.
 ///
-/// Returns `Some(base)` only when the VMA is valid and `rip - base` is
-/// a small offset consistent with a `.text` mapping (`< 0x80_0000`,
-/// i.e. within the first 8 MiB of the library — ld-musl is ~650 KiB so
-/// this is generous).
+/// Per saga discipline (prefer content gates over symbolic ones), this
+/// function deliberately does NOT filter by VMA name: the AstryxOS ELF
+/// loader names PT_LOAD segments `"[elf]"` and PT_INTERP segments
+/// `"[interp]"` (see `proc/elf.rs`), neither of which contains the
+/// substring `"ld-musl"`.  A name-based gate is therefore brittle by
+/// construction.  The upstream gates that protect this hook are:
+///   * `idt.rs` only calls the hook on `vector == 13 && CS&3 == 3`
+///     (user-mode `#GP`, Intel SDM Vol. 3A §6.15).
+///   * The caller-side content gate then requires the 2 bytes at `rip`
+///     to be `HLT; RET` (`0xF4 0xC3`).  Per Intel SDM Vol. 2A `HLT`
+///     is a privileged instruction; executing it at CPL 3 raises `#GP`.
+/// Combined, those two conditions uniquely identify a musl
+/// `__stack_chk_fail`-shaped stub regardless of which mapping it lives
+/// in, so the VMA name is irrelevant.
+///
+/// Returns `Some(base)` when a VMA covers `rip`, its `base` is a sane
+/// user VA, and `rip - base < 0x80_0000` (8 MiB — generous bound for
+/// any reasonable shared library `.text` segment).  Emits a bounded
+/// `reject` line when the lock is contended or no VMA covers `rip`,
+/// so a verifier can distinguish "hook never reached the precondition"
+/// from "hook reached but content gate said no".
 fn resolve_ld_musl_base(rip: u64) -> Option<u64> {
     let pid = crate::proc::current_pid_lockless();
     let procs = match crate::proc::PROCESS_TABLE.try_lock() {
         Some(g) => g,
         None => {
-            // PR #338 N1 MED: emit a one-shot marker so a verifier can
-            // distinguish "VMA lookup deadlock-averted" from "no match".
             if reserve_reject_slot() {
                 crate::serial_println!(
                     "[SSP-DIAG] reject reason=lock_busy rip={:#x}",
@@ -230,12 +243,18 @@ fn resolve_ld_musl_base(rip: u64) -> Option<u64> {
     };
     let proc_entry = procs.iter().find(|p| p.pid == pid)?;
     let vm_space = proc_entry.vm_space.as_ref()?;
-    let vma = vm_space.find_vma(rip)?;
-    // Name match is conservative: accept either "ld-musl" or "libc.musl"
-    // (the symlink target some processes mmap by canonical-path).
-    if !(vma.name.contains("ld-musl") || vma.name.contains("libc.musl")) {
-        return None;
-    }
+    let vma = match vm_space.find_vma(rip) {
+        Some(v) => v,
+        None => {
+            if reserve_reject_slot() {
+                crate::serial_println!(
+                    "[SSP-DIAG] reject reason=no_vma rip={:#x}",
+                    rip,
+                );
+            }
+            return None;
+        }
+    };
     let base = vma.base;
     if base < USER_VA_MIN || base >= USER_VA_LIMIT {
         return None;


### PR DESCRIPTION
## Summary

Second rotted-symbolic-invariant fix in the SSP-canary diagnostic, parented on PR #339 (`1a69247`).

PR #339 (`1a69247`) closed the file-offset-vs-VMA-offset rot in the SSP-DIAG opcode gate but left an earlier rotted symbolic invariant inside `resolve_ld_musl_base()`: the function required the covering VMA's `name` field to contain `"ld-musl"` or `"libc.musl"`. The AstryxOS ELF loader names PT_LOAD segments `"[elf]"` and PT_INTERP segments `"[interp]"` (`kernel/src/proc/elf.rs:722, :1451`) — neither substring matches, so the function silently returned `None` on every `#GP` and the content gate added in PR #339 was never reached. A 3-trial qa verifier on the merged PR #339 saw zero `[SSP-DIAG]` lines (not even bounded `reject` markers, because the only emission path before the name check was `lock_busy`).

This is the **same class of bug** as PR #338→#339: a hard-coded symbolic invariant that did not match runtime reality. Per project saga discipline (prefer content gates over symbolic gates that can rot under future rebuilds or loader renames), this PR **removes** the predicate rather than swapping it for another set of strings that could rot again.

The upstream gates already narrow scope correctly without any name match:

- `idt.rs` only calls the hook on `vector == 13 && CS&3 == 3` (user-mode `#GP`, Intel SDM Vol. 3A §6.15).
- The caller-side content gate from PR #339 requires the 2 bytes at `rip` to be `HLT; RET` (`0xF4 0xC3`). Per Intel SDM Vol. 2A, `HLT` is a privileged instruction; executing it at CPL 3 raises `#GP`. There is no other `0xF4`-shaped CPL-3 `#GP` path.

Combined, those two conditions uniquely identify a musl `__stack_chk_fail`-shaped stub regardless of which mapping the stub lives in — the VMA name is irrelevant.

## Change

- `resolve_ld_musl_base()` now accepts any VMA covering `rip`, applies the existing user-VA and 8 MiB offset bounds, and returns the VMA base for the `vma_offset` column.
- New bounded `[SSP-DIAG] reject reason=no_vma` line covers the "no VMA covers `rip`" case, against the existing `SSP_REJECT_MAX = 4` budget.
- Module-level docs updated to record that this is a content-gated diagnostic.
- All changes remain under `#[cfg(feature = "ssp-canary-diag")]`. Default build byte-identical.

Diff: 1 file, +36 / -17.

## Refs

- Intel SDM Vol. 2A — HLT opcode `0xF4`, privilege check
- Intel SDM Vol. 3A §6.15 — `#GP` exception vector 13
- SysV gABI / elf(5) — PT_LOAD / PT_INTERP segment kinds

## Test plan

- [x] `python3 scripts/qemu-harness.py check` — rc=0 (default build)
- [x] `python3 scripts/qemu-harness.py check --features ssp-canary-diag` — rc=0
- [ ] qa-engineer 3-trial verifier on the musl firefox-test path expecting `[SSP-DIAG] match=1` lines at the `__stack_chk_fail` HLT;RET stub