### PR TITLE
kernel/subsys/linux: vfork-child inherits parent FS_BASE (fix glibc/musl SSP-trap)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2333,34 +2333,45 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             }
                         }
 
-                        // Provision a minimal per-vfork-child TLS page so the
-                        // child's first cancellable libc syscall (e.g.
-                        // `close(2)` from the `posix_spawn(3)` child helper)
-                        // can read `%fs:0` without faulting.  See
-                        // `proc::alloc_vfork_child_tls` for the layout
-                        // rationale and the canary-isolation argument.  The
-                        // page is unmapped on `execve(2)` / vfork-child exit
-                        // via `vfork_isolated_tls_cleanup`.  Best-effort: if
-                        // allocation fails we leave `tls_base = 0` and the
-                        // child will fault on its first TLS-relative read —
-                        // matching the pre-fix behaviour rather than masking
-                        // an OOM as a different error.
-                        match crate::proc::alloc_vfork_child_tls(pid) {
-                            Some(tls_base) => {
-                                const VFORK_TLS_SIZE: u64 = 4096;
-                                let mut threads = crate::proc::THREAD_TABLE.lock();
-                                if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
-                                    t.tls_base = tls_base;
-                                    t.vfork_isolated_tls = Some((tls_base, VFORK_TLS_SIZE));
-                                }
-                            }
-                            None => {
-                                crate::serial_println!(
-                                    "[VFORK] WARN: failed to allocate isolated TLS page; \
-                                     child_tls_base=0 (first cancellable libc syscall will fault)"
-                                );
+                        // Per POSIX vfork(2) and clone(2) `CLONE_VM`, the
+                        // child shares the parent's address space — including
+                        // the parent's TLS region.  Inherit the parent's
+                        // FS_BASE so the child's first TLS-relative read
+                        // (e.g. `%fs:0x28` SSP-canary load, `%fs:0` TCB
+                        // self-pointer in the cancellable-syscall wrapper)
+                        // resolves against the parent's TCB, which is mapped
+                        // and live throughout the vfork window.  The earlier
+                        // `alloc_vfork_child_tls` approach (private TCB page
+                        // with zero canary) is no longer used: the SSP
+                        // contract requires the value at `%fs:0x28` to match
+                        // what the function's prologue pushed, and within a
+                        // shared address space that value is the parent's
+                        // process-wide canary by construction.  If the
+                        // caller supplied `CLONE_SETTLS`, the explicit value
+                        // wins.  Refs: AMD64 SysV ABI §3.4.6 (Thread Local
+                        // Storage / Variant II); POSIX vfork(2), clone(2);
+                        // Intel SDM Vol. 3A §3.4.4.1 (IA32_FS_BASE MSR
+                        // 0xC000_0100).
+                        let child_tls_base = if flags & CLONE_SETTLS != 0 {
+                            tls
+                        } else {
+                            let threads = crate::proc::THREAD_TABLE.lock();
+                            threads.iter().find(|t| t.tid == parent_tid)
+                                .map(|t| t.tls_base).unwrap_or(0)
+                        };
+                        {
+                            let mut threads = crate::proc::THREAD_TABLE.lock();
+                            if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                t.tls_base = child_tls_base;
                             }
                         }
+                        crate::serial_println!(
+                            "[VFORK/TLS] pid={} child_tid={} child_tls_base={:#x} \
+                             via={} (inherited from parent_tid={} unless CLONE_SETTLS)",
+                            pid, child_tid, child_tls_base,
+                            if flags & CLONE_SETTLS != 0 { "CLONE_SETTLS" } else { "parent" },
+                            parent_tid,
+                        );
 
                         // Unblock the child so the scheduler can run it.
                         crate::proc::unblock_process(child_pid);
@@ -3262,6 +3273,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             crate::proc::clear_sighand(child_pid);
                         }
 
+                        // Inherit parent's FS_BASE for the vfork child (or
+                        // honour CLONE_SETTLS when supplied).  Mirrors the
+                        // legacy clone(56) path's TLS-inheritance block: per
+                        // POSIX vfork(2)/clone(2) `CLONE_VM` the child shares
+                        // the parent's address space, so the parent's TLS
+                        // region is the correct backing for the child's
+                        // `%fs:0`-relative reads (TCB self-pointer, SSP
+                        // canary at `%fs:0x28`, cancellable-syscall state).
+                        // Refs: AMD64 SysV ABI §3.4.6; POSIX vfork(2),
+                        // clone(2), clone3(2); Intel SDM Vol. 3A §3.4.4.1
+                        // (IA32_FS_BASE MSR 0xC000_0100).
+                        let child_tls_base = if clone_flags & CLONE_SETTLS != 0 {
+                            tls
+                        } else {
+                            let threads = crate::proc::THREAD_TABLE.lock();
+                            threads.iter().find(|t| t.tid == parent_tid)
+                                .map(|t| t.tls_base).unwrap_or(0)
+                        };
+
                         // Set func/arg and original RIP BEFORE unblocking
                         {
                             let mut threads = crate::proc::THREAD_TABLE.lock();
@@ -3272,11 +3302,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                 if sp != 0 {
                                     t.user_entry_rsp = sp; // use the new_stack from clone3
                                 }
+                                t.tls_base = child_tls_base;
                             }
                         }
                         crate::serial_println!(
-                            "[CLONE3-VM] child PID {} TID {} rdx={:#x} r8={:#x} rip={:#x} rsp={:#x}",
-                            child_pid, child_tid, func, thread_arg, original_rip, sp);
+                            "[CLONE3-VM] child PID {} TID {} rdx={:#x} r8={:#x} rip={:#x} rsp={:#x} tls_base={:#x} via={}",
+                            child_pid, child_tid, func, thread_arg, original_rip, sp,
+                            child_tls_base,
+                            if clone_flags & CLONE_SETTLS != 0 { "CLONE_SETTLS" } else { "parent" });
 
                         // NOW unblock the child
                         crate::proc::unblock_process(child_pid);


### PR DESCRIPTION
## Summary

vfork-child (both legacy `clone(56)` and `clone3(2)` arms) now inherits
the parent's `FS_BASE` instead of running with `tls_base = 0` or a
private zero-canary TCB page.  Closes the FS_BASE=0 trap at
`mov %fs:0x28, %rax` that PSE observed in glibc Firefox demo path
(QA sid `2468f15ff6b3`, trap RIP `0x7effffaf3ef2` =
`libc.so.6 + 0x11bef2`, SSP canary load).

## Root cause (case (c) from the audit)

Two convergent gaps:

1. **clone3(2) vfork-arm never set `tls_base`** — it only populated
   `user_entry_rdx/r8/rip/rsp`.  `fork_process_share_vm` initialises
   `tls_base = 0` (canary-isolation default), and nothing overrode that
   for clone3.  Result: child entered Ring 3 with `FS_BASE = 0`; the
   first SSP-instrumented function's `mov %fs:0x28, %rax` resolved to
   user VA `0x28` (unmapped) and trapped.

2. **clone(56) vfork-arm relied on `alloc_vfork_child_tls`** which mapped
   a private TCB page with a *zero* canary at +0x28.  The SSP contract
   requires the value at `%fs:0x28` at epilogue to match what the
   prologue pushed; within a vfork window the SSP-instrumented libc
   functions assume the process-wide canary value, so the private-page
   zero canary still failed `__stack_chk_fail` whenever the child
   transited a function whose prologue had already executed in the
   parent's canary frame of reference.

Tech-lead cross-walk on PSE F3-c (PR #343 follow-up) chose the
"inherit parent FS_BASE when no `CLONE_SETTLS` is supplied" fix shape
per POSIX vfork(2) and clone(2) `CLONE_VM` semantics — the address
space (including the TLS region) is shared until execve(2), so the
parent's TCB is the correct backing.

## Change

Both vfork-arms now compute:

```rust
let child_tls_base = if flags & CLONE_SETTLS != 0 {
    tls                       // explicit user-supplied TLS wins
} else {
    parent.tls_base           // inherit (default for vfork)
};
child.tls_base = child_tls_base;
```

The `alloc_vfork_child_tls` helper is left in place — test 264 still
exercises it directly and the `vfork_isolated_tls` cleanup hooks at
exec/exit remain wired in case a future call-site needs it — but no
syscall arm invokes it any more.  The `vfork_isolated_tls` field stays
`None`, so cleanup is a no-op for the new flow.

## Diagnostics

- `[VFORK/CHILD-STACK]` (in `fork_process_share_vm`) still fires with
  the pre-override snapshot for the historical record.
- New `[VFORK/TLS]` line (clone 56) and extended `[CLONE3-VM]` line
  (clone3) print the runtime inheritance:
  ```
  [VFORK/TLS] pid=… child_tid=… child_tls_base=… via=parent|CLONE_SETTLS (inherited from parent_tid=…)
  [CLONE3-VM] child PID … TID … rdx=… r8=… rip=… rsp=… tls_base=… via=parent|CLONE_SETTLS
  ```

Soak runs can confirm the fix took effect by grepping for
`child_tls_base=` and verifying the value matches `parent_tls_base=`.

## Test plan

- [x] Default build (`scripts/qemu-harness.py check`) clean.
- [x] firefox-test build clean.
- [x] firefox-test + vfork-canary-diag build clean.
- [x] Test 0bc3 (`fork_process_share_vm` child `tls_base = 0`
      invariant) still passes — helper unchanged.
- [ ] Soak: glibc Firefox demo path (the sid 2468f15ff6b3 wedge) — QA
      to verify `[VFORK/TLS]` reports non-zero `child_tls_base` and
      the `0x7effffaf3ef2` trap no longer fires.

## References

- POSIX `vfork(2)`, `clone(2)`, `clone3(2)`, `posix_spawn(3)`
- AMD64 System V ABI §3.4.6 (Thread Local Storage / Variant II)
- Intel SDM Vol. 3A §3.4.4.1 (IA32_FS_BASE MSR 0xC000_0100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)