### PR TITLE
kernel/signal: STAC/CLAC bracket SIGSEGV/SIGNAL user-stack writes

### DIFF
--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -8,6 +8,8 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::sync::atomic::{AtomicU64, Ordering};
 
+use crate::arch::x86_64::smap::UserGuard;
+
 // Signal numbers (Linux x86_64 compatible)
 pub const SIGHUP: u8 = 1;
 pub const SIGINT: u8 = 2;
@@ -704,6 +706,13 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
             );
 
             // Write the signal frame to user memory.
+            // Per Intel SDM Vol. 3A §4.6.1: with CR4.SMAP=1 a supervisor
+            // store to a user-mapped page raises #PF unless EFLAGS.AC=1.
+            // The syscall-entry path runs with AC=0, so this bracket is
+            // required for every store via `sig_frame_ptr` / `ucontext_ptr`
+            // / `siginfo_ptr` below.  Pointer math is bounded by `total`
+            // (≤ 664) starting at the user-supplied `saved_rsp`.
+            let _smap_g = unsafe { UserGuard::new() };
             unsafe {
                 (*sig_frame_ptr).restorer   = restorer_addr;
                 (*sig_frame_ptr).sig_num    = sig as u64;
@@ -973,6 +982,12 @@ pub unsafe fn deliver_sigsegv_from_isr(
     );
 
     // ── Write SignalFrame ─────────────────────────────────────────────────────
+    // Per Intel SDM Vol. 3A §4.6.1: CR4.SMAP=1 raises #PF on any supervisor
+    // access to a user-mapped page unless EFLAGS.AC=1.  This ISR path runs
+    // with AC=0 (interrupts/exceptions clear AC per §6.8.3), so the user-VA
+    // stores below would fault without the bracket.  Pointer was already
+    // range-validated via `virt_to_phys_in(cr3, new_rsp)` above.
+    let _smap_g = UserGuard::new();
     (*sig_frame_ptr).restorer    = restorer_addr;
     (*sig_frame_ptr).sig_num     = SIGSEGV as u64;
     (*sig_frame_ptr).saved_mask  = saved_mask;


### PR DESCRIPTION
## Summary

Closes the SMAP `[SMAP/FAULT]` BUGCHECK reported by qa diagnostic re-soak:

```
[SMAP/FAULT] supervisor access to user page
             cr2=0x7ffffffea278 rip=0xffff800000170d04
             code=0x3 pid=1 tid=1
```

At RIP `0xffff800000170d04` the disassembly is `mov %rbp,(%r12)` — the first store into the `SignalFrame` on the user stack from `signal::deliver_sigsegv_from_isr`. With CR4.SMAP=1 (enabled in #276) the supervisor-mode write raises #PF because EFLAGS.AC=0 (the ISR path runs with AC cleared per Intel SDM Vol. 3A §6.8.3). The function had a `virt_to_phys_in` mapped-page check but no STAC bracket.

The companion `signal_check_on_syscall_return`'s `SigAction::Handler` arm has the identical bug class (writes `SignalFrame`/`ucontext_t`/`siginfo_t` to user stack from a syscall context with AC=0). Not yet observed faulting but the same primitive would trip on any handled signal posted via `kill(2)`/`tgkill(2)`/`sigqueue(2)`.

Both writer regions are now wrapped in `arch::x86_64::smap::UserGuard` (helper from #276, made nest-safe in #302). Guards span exactly the user-VA store windows; subsequent writes to `(*frame)` and `frame.add(N)` target the ISR/syscall kernel stack (PTE.U=0) which SMAP does not gate per Intel SDM Vol. 3A §4.6.1. CLAC fires at end of scope via `UserGuard::Drop`, well before `iretq`/`sysretq`.

References: Intel SDM Vol. 3A §4.6 (SMAP/STAC/CLAC), §6.8.3 (interrupts clear AC); Intel SDM Vol. 2A (STAC/CLAC); x86_64 System V psABI §3.4; POSIX.1-2017 sigaction(2).

LOC: +15 (well under the 30-LOC soft cap).

## Test plan
- [x] Default build clean (no features)
- [x] `firefox-test` feature build clean
- [x] `kdb,firefox-test` feature build clean
- [x] `test-mode` suite: 279/286 pass — same 7 pre-existing failures as master baseline (missing `/disk/bin/hello`, `/disk/bin/tcc`, `/disk/bin/busybox`, `unix socketpair EPOLLIN` flake, `monotonic-rate` flake). Test 76 (SIGSEGV signal handler infrastructure) PASS.
- [ ] qa re-runs the diagnostic soak that produced the original `[SMAP/FAULT]` to confirm the BUGCHECK no longer fires at RIP `0xffff800000170d04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)