### PR TITLE
kernel/main+test_runner: use stat() for FF binary existence probe

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -515,7 +515,23 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // to firefox-test's --headless --screenshot pipeline.
             const CMDLINE_MUSL:  &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
             const CMDLINE_GLIBC: &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
-            let cmdline = if crate::vfs::read_file("/disk/usr/lib/firefox-esr/firefox-bin").is_ok() {
+            // Use stat() (resolve_path + FileSystemOps::stat) for the existence
+            // probe instead of read_file().  read_file() allocates a Vec sized
+            // to the full file (~795 KB for firefox-bin), reads every byte, and
+            // inserts into FILE_READ_CACHE; any transient failure in that
+            // pipeline (short read, allocator pressure, cache lock contention)
+            // reports Err here even though the file is reachable.  POSIX
+            // stat(2) semantics: success iff the named file is reachable; no
+            // content is read.  Emit both probe results so future qa runs can
+            // see at a glance which build was chosen.
+            let musl_stat  = crate::vfs::stat("/disk/usr/lib/firefox-esr/firefox-bin");
+            let glibc_stat = crate::vfs::stat("/disk/opt/firefox/firefox-bin");
+            serial_println!(
+                "[FFTEST] FF binary probe: musl={:?} glibc={:?}",
+                musl_stat.as_ref().map(|s| s.size).map_err(|e| *e),
+                glibc_stat.as_ref().map(|s| s.size).map_err(|e| *e),
+            );
+            let cmdline = if musl_stat.is_ok() {
                 CMDLINE_MUSL
             } else {
                 CMDLINE_GLIBC

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -22071,14 +22071,18 @@ fn test_firefox_launch_progress() -> bool {
         "/disk/opt/firefox/firefox",           // Mozilla glibc build (fallback)
     ];
 
+    // Pick via stat() (POSIX stat(2) semantics — success iff the named file is
+    // reachable; no content read).  read_file() on the multi-MB firefox binary
+    // can fail transiently for reasons unrelated to existence (allocator
+    // pressure, short read, cache lock contention), which would silently
+    // demote musl→glibc in earlier runs.  Stat-first decouples selection from
+    // read latency, then we read_file() the single chosen candidate.
     let mut chosen_path: &str = "";
-    let mut ff_bin: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
     for cand in FF_CANDIDATES {
-        match crate::vfs::read_file(cand) {
-            Ok(data) => {
-                test_println!("  {}: {} bytes ✓", cand, data.len());
+        match crate::vfs::stat(cand) {
+            Ok(st) => {
+                test_println!("  {}: stat OK ({} bytes) ✓", cand, st.size);
                 chosen_path = cand;
-                ff_bin = data;
                 break;
             }
             Err(e) => {
@@ -22086,6 +22090,17 @@ fn test_firefox_launch_progress() -> bool {
             }
         }
     }
+    let ff_bin: alloc::vec::Vec<u8> = if chosen_path.is_empty() {
+        alloc::vec::Vec::new()
+    } else {
+        match crate::vfs::read_file(chosen_path) {
+            Ok(data) => { test_println!("  {} read {} bytes", chosen_path, data.len()); data }
+            Err(e)   => {
+                test_fail!("firefox_oracle", "stat OK but read_file({}) failed: {:?}", chosen_path, e);
+                return false;
+            }
+        }
+    };
     if chosen_path.is_empty() {
         test_println!("  SKIP: no Firefox binary present at any known location");
         test_println!("        Tried: {:?}", FF_CANDIDATES);


### PR DESCRIPTION
## Summary

Both Firefox-binary selection points used \`vfs::read_file()\` as an existence probe and silently demoted musl→glibc on any Err. read_file() reads the entire ~795 KB binary into a Vec and goes through FILE_READ_CACHE; transient failures in that pipeline (short read, allocator pressure, cache lock contention) reported Err here even though the file was reachable, so recent KVM trials launched the glibc build despite the musl path being the intended target.

- \`main.rs:518\` — replace \`read_file(...).is_ok()\` with \`stat(...).is_ok()\`. Emit a single \`[FFTEST] FF binary probe: musl=... glibc=...\` line with both probe results so future qa runs can see at a glance which build was chosen.
- \`test_runner.rs:22070\` — pick the candidate via \`stat()\` in the loop, then \`read_file()\` the single chosen path once (still needed for ELF sanity + spawn). A stat-OK / read-Err split is now a hard test failure rather than silent demotion to glibc.

POSIX stat(2) semantics — success iff the named file is reachable, no content read — match the shape of an existence probe. The launch-path warm-cache behaviour for libxul / dependentlibs is unchanged.

Spec: POSIX stat(2) — https://pubs.opengroup.org/onlinepubs/9699919799/functions/stat.html

## Test plan
- [ ] \`cargo check\` clean with default features and \`firefox-test,kdb\` (verified locally — both rc=0).
- [ ] Next firefox-test KVM run prints \`[FFTEST] FF binary probe: musl=Ok(795328) glibc=Ok(...)\` and launches \`/disk/usr/lib/firefox-esr/firefox-bin\`.
- [ ] Test 139 reports \`stat OK (795328 bytes) ✓\` for the musl candidate and reads from it, not glibc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)