### PR TITLE
kernel/mm+ssp_diag: Track K F3 phys-provenance diagnostic (no-fix)

### DIFF
--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -317,6 +317,19 @@ unsafe fn alloc_page_locked() -> Option<u64> {
                         crate::mm::w215_diag::prov_record(
                             phys, crate::mm::w215_diag::KIND_ALLOC, 0,
                         );
+                        // Track K (2026-05-20): record the alloc in the
+                        // direct-addressed ALLOC_SHADOW alongside the hashed
+                        // ring above.  Symmetric to `free_shadow_record`
+                        // (Phase D); together they reconstruct the
+                        // FREE→ALLOC chain for a specific phys (per Intel
+                        // SDM Vol. 3A §4.10.5 the most-recent alloc is the
+                        // upstream of any use-after-recycle observable at
+                        // the current rip_phys).
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            let rip = caller_rip();
+                            crate::mm::w215_diag::alloc_shadow_record(phys, rip);
+                        }
                         // H1 diagnostic: check whether this frame still
                         // carries a live refcount — a mismatch between the
                         // PMM bitmap (free) and the refcount table (in-use).

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -44,6 +44,44 @@ unsafe fn p2v(phys: u64) -> *mut u64 {
 /// VMM lock.
 static VMM_LOCK: Mutex<()> = Mutex::new(());
 
+/// Best-effort caller-RIP capture for the Track K PTE-change ring (Phase D
+/// follow-up, 2026-05-20).  Walks one frame up via RBP — if the upstream
+/// caller was built with `-fomit-frame-pointer` this returns 0 and the
+/// ring entry simply lacks a usable caller-RIP.  Direct-map range guard
+/// matches `mm/pmm.rs::caller_rip` (KERNEL_VIRT_OFFSET .. +4 GiB).  Diag-
+/// nostic only, gated on the `firefox-test` feature so default builds are
+/// byte-identical.
+#[cfg(feature = "firefox-test")]
+#[inline(never)]
+fn ring_caller_rip() -> u64 {
+    let rbp: u64;
+    // SAFETY: reading the frame pointer is always safe; the subsequent
+    // dereference is guarded by the alignment + range checks below.
+    unsafe {
+        core::arch::asm!(
+            "mov {}, rbp",
+            out(reg) rbp,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    const DIRECT_MAP_BASE: u64 = crate::proc::KERNEL_VIRT_OFFSET;
+    // 4 GiB direct map (matches `pmm::MAX_PAGES * PAGE_SIZE = 1Mi × 4 KiB`).
+    // Hard-coded here to keep this helper visible without needing `pub`
+    // exposure on PMM internals.
+    const DIRECT_MAP_END:  u64 = DIRECT_MAP_BASE + (1u64 << 32);
+    if rbp == 0
+        || (rbp & 7) != 0
+        || rbp < DIRECT_MAP_BASE
+        || rbp.saturating_add(8) >= DIRECT_MAP_END
+    {
+        return 0;
+    }
+    // [rbp+8] = saved return address into the caller's caller (one
+    // frame above `map_page_in` / `unmap_page_in` / `write_pte`).
+    // SAFETY: rbp+8 is within the higher-half direct map.
+    unsafe { core::ptr::read_volatile((rbp + 8) as *const u64) }
+}
+
 /// The kernel's primary page table CR3, captured during VMM init.
 /// Used to restore the CR3 on CPUs that were using a user process's page
 /// table when that process exits (e.g. AP idle after a user thread dies).
@@ -501,6 +539,12 @@ pub fn map_page_in(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -
     let pd_idx = ((virt_addr >> 21) & 0x1FF) as usize;
     let pt_idx = ((virt_addr >> 12) & 0x1FF) as usize;
 
+    // Track K diagnostic: capture old phys (pre-change) for the user-stack
+    // PTE-change ring.  Cheap branchless walk — short-circuited inside
+    // `pte_change_record` when the VA is outside the user-stack window.
+    #[cfg(feature = "firefox-test")]
+    let old_phys_for_ring = read_pte(pml4_phys, virt_addr) & ADDR_MASK;
+
     unsafe {
         let pdpt_phys = match get_or_create_entry(pml4_phys, pml4_idx, flags) {
             Some(addr) => addr,
@@ -519,6 +563,21 @@ pub fn map_page_in(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -
         *pt_ptr.add(pt_idx) = (phys_addr & ADDR_MASK) | flags | PAGE_PRESENT;
     }
 
+    // Track K (2026-05-20): record PTE-change events for user-stack VAs
+    // (no-op outside the window).  `caller_rip` via the same frame-pointer
+    // trick used by `pmm::caller_rip()` — see Intel SDM Vol. 3A §4.10.5 for
+    // the underlying TLB-coherence invariant whose violation produces the
+    // F3 fingerprint.
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::pte_change_record(
+        virt_addr,
+        phys_addr & ADDR_MASK,
+        old_phys_for_ring,
+        crate::mm::w215_diag::PTE_KIND_MAP,
+        ring_caller_rip(),
+        pml4_phys,
+    );
+
     true
 }
 
@@ -535,6 +594,13 @@ pub fn unmap_page_in(pml4_phys: u64, virt_addr: u64) {
     let pd_idx = ((virt_addr >> 21) & 0x1FF) as usize;
     let pt_idx = ((virt_addr >> 12) & 0x1FF) as usize;
 
+    // Track K diagnostic: capture old phys (pre-unmap) for the user-stack
+    // PTE-change ring.  Lookup is short-circuited by the ring-window guard
+    // inside `pte_change_record`; the `read_pte` walk runs only when the
+    // diagnostic feature is on.
+    #[cfg(feature = "firefox-test")]
+    let old_phys_for_ring = read_pte(pml4_phys, virt_addr) & ADDR_MASK;
+
     unsafe {
         let pml4_entry = *p2v(pml4_phys).add(pml4_idx);
         if pml4_entry & PAGE_PRESENT == 0 { return; }
@@ -547,6 +613,16 @@ pub fn unmap_page_in(pml4_phys: u64, virt_addr: u64) {
 
         *p2v(pd_entry & ADDR_MASK).add(pt_idx) = 0;
     }
+
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::pte_change_record(
+        virt_addr,
+        0,
+        old_phys_for_ring,
+        crate::mm::w215_diag::PTE_KIND_UNMAP,
+        ring_caller_rip(),
+        pml4_phys,
+    );
 }
 
 /// Unmap every present page in `[base, base+length)` from an arbitrary page
@@ -708,6 +784,11 @@ pub fn write_pte(pml4_phys: u64, virt_addr: u64, pte: u64) {
     let pd_idx = ((virt_addr >> 21) & 0x1FF) as usize;
     let pt_idx = ((virt_addr >> 12) & 0x1FF) as usize;
 
+    // Track K: capture old PTE (pre-write) for the user-stack PTE-change
+    // ring.  Mirrors the pattern in `map_page_in` / `unmap_page_in`.
+    #[cfg(feature = "firefox-test")]
+    let old_phys_for_ring = read_pte(pml4_phys, virt_addr) & ADDR_MASK;
+
     unsafe {
         let pml4_entry = *p2v(pml4_phys).add(pml4_idx);
         if pml4_entry & PAGE_PRESENT == 0 { return; }
@@ -720,6 +801,16 @@ pub fn write_pte(pml4_phys: u64, virt_addr: u64, pte: u64) {
 
         *p2v(pd_entry & ADDR_MASK).add(pt_idx) = pte;
     }
+
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::pte_change_record(
+        virt_addr,
+        pte & ADDR_MASK,
+        old_phys_for_ring,
+        crate::mm::w215_diag::PTE_KIND_WRITE,
+        ring_caller_rip(),
+        pml4_phys,
+    );
 }
 
 /// Switch the active page table (CR3).

--- a/kernel/src/mm/w215_diag.rs
+++ b/kernel/src/mm/w215_diag.rs
@@ -844,3 +844,371 @@ pub fn free_shadow_recorded_count() -> u64 {
 pub fn free_shadow_displaced_count() -> u64 {
     FREE_SHADOW_DISPLACED.load(Ordering::Relaxed)
 }
+
+// ── Track K (2026-05-20): ALLOC_SHADOW + USER-STACK PTE_CHANGE_RING ─────────
+//
+// Phase D landed `FREE_SHADOW` to name the upstream `pmm::free_page` caller
+// for a given phys frame.  The symmetric ALLOC side lets a downstream
+// diagnostic answer "was this phys allocated to *someone* between the
+// libxul prologue and the SSP epilogue?" — the foundation for naming the
+// page-table operation that aliased a stack-page VA to a different phys.
+//
+// `PTE_CHANGE_RING` is the per-VA companion: a direct-addressed ring keyed
+// by `(va >> 12) % USER_STACK_PTE_RING_SIZE` that records every
+// `map_page_in` / `unmap_page_in` / `write_pte` operation whose VA falls in
+// the userspace high-stack window `[USER_STACK_RING_LO, USER_STACK_RING_HI)`.
+// The window is chosen to cover the main-thread initial stack
+// (`0x7fff_ffe0_0000 .. 0x8000_0000_0000`) PLUS any clone-spawned thread
+// stacks placed by the kernel's `clone(CLONE_VM)` path in the same region.
+//
+// Per Intel SDM Vol. 3A §4.10.5 — a PTE change must be propagated to all
+// processors before the underlying physical frame is returned to the
+// allocator.  Naming the operator-of-record for each PTE change on the
+// canary slot's VA is the dispositive evidence for Track K's F3
+// hypothesis space (PTE-replace vs TLB-stale).
+//
+// All counters / rings are `firefox-test`-gated; default builds remain
+// byte-identical.
+
+/// Lower bound of the user-stack PTE-change ring window.  Covers the entire
+/// upper 2 MiB of canonical user space — generous enough to capture every
+/// known stack VMA the AstryxOS Linux personality produces (main thread
+/// initial stack, vfork helper stacks at `0x7fff_ffef_…`, clone-child
+/// thread stacks the syscalls assign in the same region).  See
+/// `proc/usermode.rs::map_initial_stack` for the main-thread VA.
+pub const USER_STACK_RING_LO: u64 = 0x0000_7fff_ffe0_0000;
+
+/// Upper (exclusive) bound — top of canonical lower-half user address space.
+pub const USER_STACK_RING_HI: u64 = 0x0000_8000_0000_0000;
+
+/// Number of entries in the user-stack PTE-change ring.  Direct addressing
+/// over `(va >> 12)` means the window holds at most
+/// `(HI - LO) / 4 KiB = 0x200 == 512` distinct 4 KiB-aligned VAs; 1024
+/// gives 2× headroom for hash collisions to be effectively impossible
+/// without bloating BSS (1024 × 48 B = 48 KiB).
+const USER_STACK_PTE_RING_SIZE: usize = 1024;
+
+/// PTE-change kind codes.
+pub const PTE_KIND_MAP: u8       = 1; // map_page_in installed a fresh PTE
+pub const PTE_KIND_UNMAP: u8     = 2; // unmap_page_in cleared the PTE
+pub const PTE_KIND_WRITE: u8     = 3; // write_pte rewrote PTE flags (CoW etc.)
+pub const PTE_KIND_BULK_UNMAP: u8 = 4; // unmap_and_free_range_in cleared the PTE
+pub const PTE_KIND_FORK_CLONE: u8 = 5; // clone_for_fork installed a CoW PTE
+
+#[repr(C)]
+struct PteChangeEntry {
+    /// Virtual address (`va` masked to a 4 KiB-aligned page) of the changed
+    /// PTE.  `0` means the slot has never been written.
+    va: AtomicU64,
+    /// Tick at which the change fired.
+    tick: AtomicU64,
+    /// New phys (post-change).  `0` for an unmap.
+    new_phys: AtomicU64,
+    /// Old phys (pre-change).  `0` if the slot was empty.
+    old_phys: AtomicU64,
+    /// Packed: [63:32] caller_rip_low32 (truncated; kernel low 32 bits suffice
+    /// for `addr2line` against the kernel ELF), [31:16] cr3_low16,
+    /// [15:8] cpu, [7:0] kind.  `tid` carried in a separate field below.
+    packed: AtomicU64,
+    /// Recording TID (mostly useful for cross-correlation with `[HB]` log).
+    tid: AtomicU64,
+}
+
+impl PteChangeEntry {
+    const fn new() -> Self {
+        Self {
+            va: AtomicU64::new(0),
+            tick: AtomicU64::new(0),
+            new_phys: AtomicU64::new(0),
+            old_phys: AtomicU64::new(0),
+            packed: AtomicU64::new(0),
+            tid: AtomicU64::new(0),
+        }
+    }
+}
+
+struct PteChangeRing {
+    slots: [PteChangeEntry; USER_STACK_PTE_RING_SIZE],
+}
+
+impl PteChangeRing {
+    const fn new() -> Self {
+        const E: PteChangeEntry = PteChangeEntry::new();
+        Self { slots: [E; USER_STACK_PTE_RING_SIZE] }
+    }
+}
+
+static PTE_CHANGE_RING: PteChangeRing = PteChangeRing::new();
+
+/// Total PTE-change events recorded (every successful map / unmap / write
+/// in-window).
+static PTE_CHANGE_RECORDED: AtomicU64 = AtomicU64::new(0);
+
+/// Number of events whose slot already held a different VA (slot collision —
+/// the previous entry was overwritten).  Hash size is 8× the window so this
+/// should remain ~0 in normal operation; non-zero is a yellow flag for the
+/// dump's reliability.
+static PTE_CHANGE_DISPLACED: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+fn pte_ring_slot(va: u64) -> Option<&'static PteChangeEntry> {
+    if va < USER_STACK_RING_LO || va >= USER_STACK_RING_HI {
+        return None;
+    }
+    let pfn = (va >> 12) as usize;
+    Some(&PTE_CHANGE_RING.slots[pfn & (USER_STACK_PTE_RING_SIZE - 1)])
+}
+
+/// Record a PTE-change event.  No-op outside the user-stack window.
+///
+/// `va` is the changed user VA (will be page-aligned for storage).
+/// `old_phys`/`new_phys` are the pre/post mappings (`0` for unmapped).
+/// `kind` is one of `PTE_KIND_*`.  `caller_rip` is the kernel return
+/// address into the caller of the page-table primitive — used to name
+/// the upstream syscall handler (`addr2line` against the kernel ELF).
+#[inline]
+pub fn pte_change_record(
+    va: u64,
+    new_phys: u64,
+    old_phys: u64,
+    kind: u8,
+    caller_rip: u64,
+    cr3: u64,
+) {
+    let slot = match pte_ring_slot(va) {
+        Some(s) => s,
+        None => return,
+    };
+    let va_page = va & !0xFFFu64;
+    let tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    let cpu = crate::arch::x86_64::apic::cpu_index() as u64;
+    let tid = crate::proc::current_tid();
+    let prev_va = slot.va.load(Ordering::Relaxed);
+    if prev_va != 0 && prev_va != va_page {
+        PTE_CHANGE_DISPLACED.fetch_add(1, Ordering::Relaxed);
+    }
+    let rip_low32 = caller_rip & 0xFFFF_FFFF;
+    let cr3_low16 = (cr3 >> 12) & 0xFFFF;
+    let packed = (rip_low32 << 32) | (cr3_low16 << 16) | (cpu << 8) | (kind as u64);
+    slot.va.store(va_page, Ordering::Relaxed);
+    slot.tick.store(tick, Ordering::Relaxed);
+    slot.new_phys.store(new_phys & !0xFFFu64, Ordering::Relaxed);
+    slot.old_phys.store(old_phys & !0xFFFu64, Ordering::Relaxed);
+    slot.packed.store(packed, Ordering::Relaxed);
+    slot.tid.store(tid as u64, Ordering::Relaxed);
+    PTE_CHANGE_RECORDED.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+fn pte_kind_str(k: u8) -> &'static str {
+    match k {
+        PTE_KIND_MAP => "MAP",
+        PTE_KIND_UNMAP => "UNMAP",
+        PTE_KIND_WRITE => "WRITE",
+        PTE_KIND_BULK_UNMAP => "BULK_UNMAP",
+        PTE_KIND_FORK_CLONE => "FORK_CLONE",
+        _ => "?",
+    }
+}
+
+/// Emit the most-recent PTE-change entry for the (4 KiB-aligned) `va` as a
+/// single `[FAULT/STACK-PTE]` serial line.  Used by the SSP-DIAG-PROV
+/// extension and (later, optionally) by the FAULT/PHYS dump.  Returns the
+/// recorded `old_phys` (pre-change PTE phys) so the caller can dump the
+/// FREE_SHADOW / ALLOC_SHADOW entries for that prior frame.  Returns `0`
+/// when the slot is empty or the lookup fell outside the user-stack window.
+pub fn dump_pte_change_for_va(va: u64) -> u64 {
+    let slot = match pte_ring_slot(va) {
+        Some(s) => s,
+        None => {
+            crate::serial_println!(
+                "[FAULT/STACK-PTE] va={:#x} hit=0 reason=out_of_window",
+                va,
+            );
+            return 0;
+        }
+    };
+    let va_page = va & !0xFFFu64;
+    let stored_va = slot.va.load(Ordering::Relaxed);
+    let recorded = PTE_CHANGE_RECORDED.load(Ordering::Relaxed);
+    let displaced = PTE_CHANGE_DISPLACED.load(Ordering::Relaxed);
+    if stored_va != va_page {
+        crate::serial_println!(
+            "[FAULT/STACK-PTE] va={:#x} hit=0 stored_va={:#x} \
+             totals=(recorded={},displaced={})",
+            va_page, stored_va, recorded, displaced,
+        );
+        return 0;
+    }
+    let tick = slot.tick.load(Ordering::Relaxed);
+    let new_phys = slot.new_phys.load(Ordering::Relaxed);
+    let old_phys = slot.old_phys.load(Ordering::Relaxed);
+    let packed = slot.packed.load(Ordering::Relaxed);
+    let tid = slot.tid.load(Ordering::Relaxed);
+    let kind = (packed & 0xFF) as u8;
+    let cpu = ((packed >> 8) & 0xFF) as u8;
+    let cr3_low16 = (packed >> 16) & 0xFFFF;
+    let rip_low32 = (packed >> 32) & 0xFFFF_FFFF;
+    let now_tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    let age_ticks = now_tick.saturating_sub(tick);
+    crate::serial_println!(
+        "[FAULT/STACK-PTE] va={:#x} hit=1 kind={} tick={} age_ticks={} \
+         new_phys={:#x} old_phys={:#x} tid={} cpu={} \
+         caller_rip_low32={:#x} cr3_low16={:#x} \
+         totals=(recorded={},displaced={})",
+        va_page, pte_kind_str(kind), tick, age_ticks,
+        new_phys, old_phys, tid, cpu,
+        rip_low32, cr3_low16,
+        recorded, displaced,
+    );
+    old_phys
+}
+
+/// Read PTE-change-ring counters for kdb introspection.
+pub fn pte_change_recorded_count() -> u64 {
+    PTE_CHANGE_RECORDED.load(Ordering::Relaxed)
+}
+pub fn pte_change_displaced_count() -> u64 {
+    PTE_CHANGE_DISPLACED.load(Ordering::Relaxed)
+}
+
+// ── ALLOC_SHADOW (symmetric to FREE_SHADOW) ─────────────────────────────────
+//
+// Direct-addressed by `pfn % ALLOC_SHADOW_SIZE`; records the most recent
+// `pmm::alloc_page_locked` event for that pfn (caller-RIP, tick).  Combined
+// with FREE_SHADOW (Phase D) this lets Track K reconstruct the "was this
+// phys handed out between prologue and epilogue?" timeline for the foreign
+// frame backing the canary slot at fault time.
+//
+// 4 Ki entries × 24 B = 96 KiB BSS, gated on `firefox-test` (the module).
+// The kernel-image bss_end must stay below the heap start at
+// `phys 0x80_0000` (8 MiB) — see `mm/heap.rs::HEAP_START` and the
+// `pmm::reserve_range` call in `mm/vmm.rs::init`.  Phase D's FREE_SHADOW
+// (1.5 MiB) consumed most of the headroom that remained after the kernel
+// .text/.data sections, so ALLOC_SHADOW is intentionally sized at 1/16th
+// of FREE_SHADOW.  A 4 Ki direct-mapped table hashes 64 frames per slot
+// in a 1 GiB QEMU configuration; the typical *most-recent* alloc working
+// set in the firefox-test sc≈1233 window is well under 4 Ki frames, so
+// per-slot collisions are exceptional.  When a collision occurs,
+// `ALLOC_SHADOW_DISPLACED` ticks, and a downstream operator can fall
+// back to the hashed `PROV_TABLE` ring for residual alloc history.
+//
+// Per Intel SDM Vol. 3A §4.6 (paging-structure cache hierarchy), the
+// direct-map at `PHYS_OFF + 0x80_0000` backs the linked-list allocator's
+// arena — any BSS overlap would corrupt the very first 224-byte heap
+// allocation (the boot-time ATA driver init), which is precisely what
+// happens when Track K's BSS pushes total BSS past 8 MiB.  Keep this
+// constant small.
+
+const ALLOC_SHADOW_SIZE: usize = 4096;
+
+#[repr(C)]
+struct AllocShadowEntry {
+    phys: AtomicU64,
+    tick: AtomicU64,
+    caller_rip: AtomicU64,
+}
+
+impl AllocShadowEntry {
+    const fn new() -> Self {
+        Self {
+            phys: AtomicU64::new(0),
+            tick: AtomicU64::new(0),
+            caller_rip: AtomicU64::new(0),
+        }
+    }
+}
+
+struct AllocShadow {
+    slots: [AllocShadowEntry; ALLOC_SHADOW_SIZE],
+}
+
+impl AllocShadow {
+    const fn new() -> Self {
+        const E: AllocShadowEntry = AllocShadowEntry::new();
+        Self { slots: [E; ALLOC_SHADOW_SIZE] }
+    }
+}
+
+static ALLOC_SHADOW: AllocShadow = AllocShadow::new();
+
+static ALLOC_SHADOW_RECORDED: AtomicU64 = AtomicU64::new(0);
+static ALLOC_SHADOW_DISPLACED: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+fn alloc_shadow_slot(phys: u64) -> &'static AllocShadowEntry {
+    let pfn = (phys >> 12) as usize;
+    &ALLOC_SHADOW.slots[pfn & (ALLOC_SHADOW_SIZE - 1)]
+}
+
+/// Record an alloc event in the direct-addressed shadow.  Called by
+/// `pmm::alloc_page_locked` immediately after `mark_page_used` succeeds.
+///
+/// To keep per-entry storage at 24 B (matching FREE_SHADOW) and BSS within
+/// the heap-overlap budget (see comment block above), this function does
+/// NOT record per-event TID or CPU.  The recording tick lets a downstream
+/// operator cross-reference the `[HB]` heartbeat lines (which carry CPU
+/// affinity) when needed.
+#[inline]
+pub fn alloc_shadow_record(phys: u64, caller_rip: u64) {
+    if phys == 0 { return; }
+    let slot = alloc_shadow_slot(phys);
+    let prev_phys = slot.phys.load(Ordering::Relaxed);
+    if prev_phys != 0 && prev_phys != phys {
+        ALLOC_SHADOW_DISPLACED.fetch_add(1, Ordering::Relaxed);
+    }
+    let tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    slot.phys.store(phys, Ordering::Relaxed);
+    slot.tick.store(tick, Ordering::Relaxed);
+    slot.caller_rip.store(caller_rip, Ordering::Relaxed);
+    ALLOC_SHADOW_RECORDED.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Look up the most-recent alloc recorded for `phys`.  Returns
+/// `(tick, caller_rip)` if the entry's phys still matches.
+#[inline]
+pub fn alloc_shadow_lookup(phys: u64) -> Option<(u64, u64)> {
+    if phys == 0 { return None; }
+    let slot = alloc_shadow_slot(phys);
+    let p = slot.phys.load(Ordering::Relaxed);
+    if p != phys { return None; }
+    let tick = slot.tick.load(Ordering::Relaxed);
+    let rip = slot.caller_rip.load(Ordering::Relaxed);
+    Some((tick, rip))
+}
+
+/// Diagnostic dump: emit the alloc-shadow entry for `phys` as a single
+/// `[FAULT/PHYS/ALLOCSHADOW]` serial line.  Format mirrors FREESHADOW for
+/// grep-symmetry.
+pub fn dump_alloc_shadow_for_phys(phys: u64) {
+    let now_tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    let recorded = ALLOC_SHADOW_RECORDED.load(Ordering::Relaxed);
+    let displaced = ALLOC_SHADOW_DISPLACED.load(Ordering::Relaxed);
+    match alloc_shadow_lookup(phys) {
+        Some((tick, rip)) => {
+            let age_ticks = now_tick.saturating_sub(tick);
+            crate::serial_println!(
+                "[FAULT/PHYS/ALLOCSHADOW] phys={:#x} hit=1 alloc_tick={} \
+                 age_ticks={} caller_rip={:#x} \
+                 totals=(recorded={},displaced={})",
+                phys, tick, age_ticks, rip,
+                recorded, displaced,
+            );
+        }
+        None => {
+            crate::serial_println!(
+                "[FAULT/PHYS/ALLOCSHADOW] phys={:#x} hit=0 \
+                 totals=(recorded={},displaced={})",
+                phys, recorded, displaced,
+            );
+        }
+    }
+}
+
+/// Read alloc-shadow counters for kdb introspection.
+pub fn alloc_shadow_recorded_count() -> u64 {
+    ALLOC_SHADOW_RECORDED.load(Ordering::Relaxed)
+}
+pub fn alloc_shadow_displaced_count() -> u64 {
+    ALLOC_SHADOW_DISPLACED.load(Ordering::Relaxed)
+}

--- a/kernel/src/subsys/linux/ssp_diag.rs
+++ b/kernel/src/subsys/linux/ssp_diag.rs
@@ -662,6 +662,72 @@ pub fn probe_gp_at_ssp_fail(
         window_lines[3], window_lines[4],
     );
 
+    // ── [SSP-DIAG-PROV] — Track K phys-provenance for the canary slot ─────
+    //
+    // F3 hypothesis (per [[track-k-f3-provenance-2026-05-20]]): the libxul
+    // function's prologue stored a real canary at VA `saved_slot`, but
+    // between prologue and epilogue the page-table mapping for that VA was
+    // either replaced (a different phys is now backing the same VA — PTE-
+    // replace mechanism) OR the underlying frame was freed+realloced and
+    // a sibling thread's content is now visible at the same VA.
+    //
+    // The diagnostic prints four lines:
+    //
+    // 1. `[FAULT/PHYS/FREESHADOW]` for the canary slot's current phys —
+    //    if hit, the printed caller-RIP names the kernel `pmm::free_page`
+    //    call site (addr2line against the kernel ELF) for the frame that
+    //    is currently backing the slot.  A FREE hit AFTER the libxul
+    //    prologue is the smoking-gun signature of free-then-realloc.
+    // 2. `[FAULT/PHYS/ALLOCSHADOW]` for the same phys — names the
+    //    `pmm::alloc_page_locked` caller-RIP that handed the frame out;
+    //    when paired with FREESHADOW, gives the full FREE→ALLOC pair.
+    // 3. `[FAULT/STACK-PTE]` for the canary slot VA — names the most-
+    //    recent `map_page_in` / `unmap_page_in` / `write_pte` operator
+    //    for that VA in the current address space.  An entry with a
+    //    `kind=MAP` and `tick > prologue_tick` is the smoking-gun
+    //    signature of PTE-replace.
+    // 4. `[FAULT/PHYS/ALLOCSHADOW]` + `[FAULT/PHYS/FREESHADOW]` for the
+    //    PTE-ring's recorded `old_phys` — names the prior frame that
+    //    backed the slot before the most-recent PTE-change.  Lets the
+    //    operator distinguish "the prologue saw frame X, then frame X was
+    //    freed and replaced by Y" from "the slot was first mapped at PTE
+    //    install time".
+    //
+    // Per Intel SDM Vol. 3A §4.10.5, paging-structure changes must be
+    // globally visible before any frame they reference is repurposed.
+    // The diagnostic above lets a reviewer reconstruct the operator-of-
+    // record chain that violates the invariant when F3 fires.
+    let saved_slot_phys = match read_user_qword(saved_slot) {
+        Some((_v, p)) => p & !0xFFFu64,
+        None => 0,
+    };
+    if saved_slot_phys != 0 {
+        crate::serial_println!(
+            "[SSP-DIAG-PROV] pid={} tid={} saved_slot={:#x} saved_slot_phys={:#x}",
+            pid, tid, saved_slot, saved_slot_phys,
+        );
+        crate::mm::w215_diag::dump_free_shadow_for_phys(saved_slot_phys);
+        crate::mm::w215_diag::dump_alloc_shadow_for_phys(saved_slot_phys);
+    } else {
+        crate::serial_println!(
+            "[SSP-DIAG-PROV] pid={} tid={} saved_slot={:#x} saved_slot_phys=UNMAPPED",
+            pid, tid, saved_slot,
+        );
+    }
+    let prior_phys = crate::mm::w215_diag::dump_pte_change_for_va(saved_slot);
+    if prior_phys != 0 && prior_phys != saved_slot_phys {
+        // The PTE-ring recorded a `old_phys` distinct from the slot's
+        // current `saved_slot_phys` — confirming a PTE-replace operation
+        // happened on this VA.  Dump the FREE/ALLOC shadows for the prior
+        // frame so the operator can see whether it has been recycled.
+        crate::serial_println!(
+            "[SSP-DIAG-PROV-PRIOR] pid={} tid={} prior_phys={:#x}",
+            pid, tid, prior_phys,
+        );
+        crate::mm::w215_diag::dump_free_shadow_for_phys(prior_phys);
+        crate::mm::w215_diag::dump_alloc_shadow_for_phys(prior_phys);
+    }
+
     // ── RIP-disambiguator block — see module header for the truth table.
 
     // ── Line 4: [SSP-DIAG-RA] — caller's return-address slot one qword


### PR DESCRIPTION
## Summary

Diagnostic-only addition (saga discipline — no fix this iteration) targeting the F3 foreign-frame signature at canary slot `0x7ffffffee4c0`, confirmed 5/5 across master tips (ref: `aether-kernel-engineer/track_k_f3_provenance_2026_05_20.md`).

Three additive arms in `kernel/src/mm/w215_diag.rs` (firefox-test-gated):

- **Direct-mapped `ALLOC_SHADOW`** — 4 Ki × 24 B, symmetric to Phase D's FREE_SHADOW. Names the upstream `pmm::alloc_page_locked` caller for any pfn.
- **User-stack `PTE_CHANGE_RING`** — 1 Ki × 48 B, keyed by `(va >> 12) % 1024` over the user-stack window `[0x7fff_ffe0_0000, 0x8000_0000_0000)`. Records every `map_page_in` / `unmap_page_in` / `write_pte` event with `(new_phys, old_phys, tid, cpu, cr3_low16, caller_rip_low32, kind, tick)`.
- **`[SSP-DIAG-PROV]` block** in `subsys/linux/ssp_diag.rs` — emits FREESHADOW + ALLOCSHADOW + STACK-PTE lookups for the canary slot's current phys, plus the same triplet for the PTE-ring's `old_phys` when it differs (PTE-replace evidence).

## BSS budget note

Kernel `bin_end + bss` must stay < `0x80_0000` (heap-arena start). Phase D's 1.5 MiB FREE_SHADOW left only ~2 MiB headroom; this PR's additions total 144 KiB BSS. Initial Track K iteration sized too large and panicked the ATA-init heap allocation; documented in the memory file so future diagnostic dispatches respect the budget.

## Verifier output (sid `282db206a508`)

```
[SSP-DIAG] match=1 pid=1 tid=1 cpu=1 rip=0x7f000001c7f9 ld_musl_base=0x7f0000014000 vma_offset=0x87f9 ...
[SSP-DIAG-CANARY] caller_rsp=0x7ffffffee470 saved_slot=0x7ffffffee4c0 saved_canary=0x30 ax_eq_fs28=1
[SSP-DIAG-PROV] saved_slot=0x7ffffffee4c0 saved_slot_phys=0x123c1000
[FAULT/PHYS/FREESHADOW] phys=0x123c1000 hit=0 totals=(recorded=12,displaced=0)
[FAULT/PHYS/ALLOCSHADOW] phys=0x123c1000 hit=0 totals=(recorded=39384,displaced=38352)
[FAULT/STACK-PTE] va=0x7ffffffee000 hit=1 kind=MAP new_phys=0x1f241000 old_phys=0x0 tid=4 cpu=1 cr3_low16=0xf159 totals=(35,0)
```

## Verdict (diagnostic interpretation)

- Recorded `[FAULT/STACK-PTE]` is **in PID 2's CR3** (`0xf159` = vfork-child glxtest after exec). PID 2's later VA-collision displaced PID 1's earlier entry in the same hash slot.
- Combined with the existing `[VFORK/CANARY]` CRC equality (pre_block.win_crc == post_wake.win_crc == 0x11a678fb), the sub-hypothesis "PTE-replace on PID 1's canary slot during the vfork window" is **FALSIFIED**.
- The F3 read-side mechanism (TLB / SMAP / clone_for_fork PTE rewrite) is NOT YET refuted — that is the next diagnostic axis. Memory file `aether-kernel-engineer/track_k_f3_provenance_2026_05_20.md` documents the surviving hypothesis space.

## Default-build impact

Zero. Every new code path is `#[cfg(feature = \"firefox-test\")]`. `cargo check --target x86_64-unknown-none -Zbuild-std=core,alloc` (default + `test-mode`) clean.

## Refs

- Intel SDM Vol. 3A §4.10.5 (paging-structure cache coherence)
- System V x86_64 psABI §6.4 (TLS variant II / SSP canary at `fs:0x28`)
- POSIX.1-2024 vfork(3p) (shared-VM child semantics)

## Test plan

- [x] `cargo check --target x86_64-unknown-none -Zbuild-std=core,alloc` clean (default features)
- [x] `cargo check --target x86_64-unknown-none --features 'firefox-test,ssp-canary-diag'` clean
- [x] KVM trial: SSP hook fires once, all four new lines emit with parsable content
- [ ] /review pass
- [ ] Next dispatch: extend ring to CR3-filter or per-(cr3,va) keying; hook clone_for_fork