### PR TITLE
kernel: bundled review nit follow-ups (#352/#354/#355/#356)

### DIFF
--- a/kernel/src/mm/file_buf_witness.rs
+++ b/kernel/src/mm/file_buf_witness.rs
@@ -29,7 +29,7 @@
 //!
 //!   [F_BUF_DELTA] pid=<n> fd=<n> page=<#x> pre_buf=<#x> pre_size=<#x>
 //!                 post_buf=<#x> post_size=<#x> n_read=<n>
-//!   [F_BUF_ZERO]  pid=<n> fd=<n> page=<#x> when=<pre|post> n_read=<n>
+//!   [F_BUF_ZERO_TRANSITION] pid=<n> fd=<n> page=<#x> ... n_read=<n>
 //!
 //! All emissions are bounded by a per-witness fire cap (16 first hits,
 //! then every 1024th) so the serial log cannot be flooded by a tight
@@ -57,7 +57,6 @@ const SAMPLED_FIRE_MOD: u64 = 1024;
 // ── Counters ──────────────────────────────────────────────────────────────
 
 static F_BUF_DELTA_FIRES: AtomicU64 = AtomicU64::new(0);
-static F_BUF_ZERO_PRE_FIRES: AtomicU64 = AtomicU64::new(0);
 static F_BUF_ZERO_POST_FIRES: AtomicU64 = AtomicU64::new(0);
 static F_BUF_SNAPSHOT_FAILS: AtomicU64 = AtomicU64::new(0);
 
@@ -205,12 +204,11 @@ pub fn post_read(snap: Snapshot, n_read: i64) {
 }
 
 /// Counters dump for the `kdb` introspection layer.  Returns
-/// `(delta, zero_pre, zero_post, snap_fails)`.
+/// `(delta, zero_post, snap_fails)`.
 #[cfg(feature = "file-buf-witness")]
-pub fn counters() -> (u64, u64, u64, u64) {
+pub fn counters() -> (u64, u64, u64) {
     (
         F_BUF_DELTA_FIRES.load(Ordering::Relaxed),
-        F_BUF_ZERO_PRE_FIRES.load(Ordering::Relaxed),
         F_BUF_ZERO_POST_FIRES.load(Ordering::Relaxed),
         F_BUF_SNAPSHOT_FAILS.load(Ordering::Relaxed),
     )
@@ -235,4 +233,4 @@ pub fn post_read(_snap: Snapshot, _n_read: i64) {}
 
 #[cfg(not(feature = "file-buf-witness"))]
 #[inline(always)]
-pub fn counters() -> (u64, u64, u64, u64) { (0, 0, 0, 0) }
+pub fn counters() -> (u64, u64, u64) { (0, 0, 0) }

--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -67,6 +67,8 @@ impl RecentFreeRing {
 }
 
 #[cfg(feature = "firefox-test")]
+// See FREE_SHADOW in mm/w215_diag.rs for a parallel direct-addressed
+// tracer; future consolidation opportunity.
 static RECENT_FREE_RING: Mutex<RecentFreeRing> = Mutex::new(RecentFreeRing::new());
 
 /// H2 diagnostic counter: physical frames re-allocated within

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -76,8 +76,9 @@ fn ring_caller_rip() -> u64 {
     {
         return 0;
     }
-    // [rbp+8] = saved return address into the caller's caller (one
-    // frame above `map_page_in` / `unmap_page_in` / `write_pte`).
+    // [rbp+8] is the return address INTO map_page_in/unmap_page_in/
+    // write_pte itself. addr2line + #[inline(never)] on these wrappers
+    // ensures the symbol resolves cleanly.
     // SAFETY: rbp+8 is within the higher-half direct map.
     unsafe { core::ptr::read_volatile((rbp + 8) as *const u64) }
 }
@@ -542,6 +543,9 @@ pub fn map_page_in(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -
     // Track K diagnostic: capture old phys (pre-change) for the user-stack
     // PTE-change ring.  Cheap branchless walk — short-circuited inside
     // `pte_change_record` when the VA is outside the user-stack window.
+    // Best-effort pre-mutation snapshot: a concurrent CPU may race between
+    // snapshot and the write below, so old_phys_for_ring can be stale.
+    // Diagnostic-only.
     #[cfg(feature = "firefox-test")]
     let old_phys_for_ring = read_pte(pml4_phys, virt_addr) & ADDR_MASK;
 
@@ -598,6 +602,9 @@ pub fn unmap_page_in(pml4_phys: u64, virt_addr: u64) {
     // PTE-change ring.  Lookup is short-circuited by the ring-window guard
     // inside `pte_change_record`; the `read_pte` walk runs only when the
     // diagnostic feature is on.
+    // Best-effort pre-mutation snapshot: a concurrent CPU may race between
+    // snapshot and the write below, so old_phys_for_ring can be stale.
+    // Diagnostic-only.
     #[cfg(feature = "firefox-test")]
     let old_phys_for_ring = read_pte(pml4_phys, virt_addr) & ADDR_MASK;
 
@@ -786,6 +793,9 @@ pub fn write_pte(pml4_phys: u64, virt_addr: u64, pte: u64) {
 
     // Track K: capture old PTE (pre-write) for the user-stack PTE-change
     // ring.  Mirrors the pattern in `map_page_in` / `unmap_page_in`.
+    // Best-effort pre-mutation snapshot: a concurrent CPU may race between
+    // snapshot and the write below, so old_phys_for_ring can be stale.
+    // Diagnostic-only.
     #[cfg(feature = "firefox-test")]
     let old_phys_for_ring = read_pte(pml4_phys, virt_addr) & ADDR_MASK;
 

--- a/kernel/src/mm/w215_diag.rs
+++ b/kernel/src/mm/w215_diag.rs
@@ -792,6 +792,9 @@ pub fn free_shadow_record(phys: u64, caller_rip: u64) {
         FREE_SHADOW_DISPLACED.fetch_add(1, Ordering::Relaxed);
     }
     let tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    // Note: relaxed writes — diagnostic readers may observe a torn
+    // (phys, tick, rip) tuple. Acceptable for a best-effort tracer; do
+    // not promote to load-bearing.
     slot.phys.store(phys, Ordering::Relaxed);
     slot.tick.store(tick, Ordering::Relaxed);
     slot.caller_rip.store(caller_rip, Ordering::Relaxed);
@@ -984,6 +987,9 @@ pub fn pte_change_record(
     let cpu = crate::arch::x86_64::apic::cpu_index() as u64;
     let tid = crate::proc::current_tid();
     let prev_va = slot.va.load(Ordering::Relaxed);
+    // Note: displacement counter uses relaxed-order writes; concurrent
+    // same-slot frees from different phys may undercount. Informational
+    // only.
     if prev_va != 0 && prev_va != va_page {
         PTE_CHANGE_DISPLACED.fetch_add(1, Ordering::Relaxed);
     }

--- a/kernel/src/subsys/linux/f3_watch.rs
+++ b/kernel/src/subsys/linux/f3_watch.rs
@@ -143,10 +143,31 @@ static F3_ARM_COUNT: AtomicU32 = AtomicU32::new(0);
 /// the worst case.
 const FIREFOX_BIN_SUBSTRING: &str = "firefox-bin";
 
-/// Path-substring gate.  Lowercase compare against the supplied final-path
-/// argument.  Returns `true` if the substring is present.
+/// Path-substring gate.  Case-sensitive path match — the firefox-bin path
+/// is canonical lowercase, so this is intentional.
 fn path_matches(path: &str) -> bool {
     path.contains(FIREFOX_BIN_SUBSTRING)
+}
+
+/// Atomically claim an arm-cycle index in the range `[0, F3_ARM_MAX)`.
+/// Returns `Ok(arm_idx)` if a slot was claimed, or `Err(())` if the cap is
+/// already reached.  Uses `compare_exchange` (not `fetch_add`) so a
+/// refused-arm path never grows the counter past `F3_ARM_MAX` — the
+/// boot-bound on log emissions is then exactly `F3_ARM_MAX` accepted arms
+/// plus one `cap_reached` line.
+fn claim_arm_idx() -> Result<u32, ()> {
+    loop {
+        let cur = F3_ARM_COUNT.load(Ordering::Relaxed);
+        if cur >= F3_ARM_MAX {
+            return Err(());
+        }
+        if F3_ARM_COUNT
+            .compare_exchange(cur, cur + 1, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return Ok(cur);
+        }
+    }
 }
 
 /// Resolve the current backing phys for the canary slot VA under the
@@ -174,16 +195,26 @@ pub fn arm_after_execve(final_path: &str, cr3: u64, entry_rip: u64, entry_rsp: u
         return;
     }
 
-    let arm_idx = F3_ARM_COUNT.fetch_add(1, Ordering::Relaxed);
-    if arm_idx >= F3_ARM_MAX {
-        if arm_idx == F3_ARM_MAX {
-            crate::serial_println!(
-                "[F3-WATCH] state=cap_reached arm_idx={} cap={}",
-                arm_idx, F3_ARM_MAX,
-            );
+    let arm_idx = match claim_arm_idx() {
+        Ok(idx) => idx,
+        Err(()) => {
+            // First refused arm only: claim the one-shot transition
+            // emission via a separate AtomicBool so the cap_reached line
+            // fires exactly once even under concurrent execve races.
+            use core::sync::atomic::AtomicBool;
+            static CAP_REPORTED: AtomicBool = AtomicBool::new(false);
+            if CAP_REPORTED
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                crate::serial_println!(
+                    "[F3-WATCH] state=cap_reached arm_idx={} cap={}",
+                    F3_ARM_MAX, F3_ARM_MAX,
+                );
+            }
+            return;
         }
-        return;
-    }
+    };
 
     let pid = crate::proc::current_pid_lockless();
     let tid = crate::proc::current_tid();
@@ -258,21 +289,3 @@ pub fn arm_after_execve(final_path: &str, cr3: u64, entry_rip: u64, entry_rsp: u
     }
 }
 
-/// Final-report emission.  Called once at shutdown / harness-stop so the
-/// post-processor sees a closing summary regardless of how many arms /
-/// fires happened.
-///
-/// Currently a thin wrapper around `arch/x86_64/debug_reg.rs::stats()`
-/// because the per-slot fire counts are kept there; the F3 module's only
-/// owned state is `F3_ARM_COUNT`.
-pub fn final_report() {
-    let arms = F3_ARM_COUNT.load(Ordering::Relaxed);
-    let (dr_arms, dr_fires) = crate::arch::x86_64::debug_reg::stats();
-    let per_slot = crate::arch::x86_64::debug_reg::per_slot_fires();
-    crate::serial_println!(
-        "[F3-WATCH] kind=final f3_arms={} dr_arms={} dr_fires_total={} \
-         per_slot=[{},{},{},{}]",
-        arms, dr_arms, dr_fires,
-        per_slot[0], per_slot[1], per_slot[2], per_slot[3],
-    );
-}


### PR DESCRIPTION
## Summary

Bundles the safest mechanical /review nits from the four recent
diagnostic PRs (#352, #354, #355, #356) into one small follow-up so we
close the loop without trailing five separate single-nit PRs.

## Nits included (9)

### From PR #352 (mm/file_buf_witness.rs)
- **N1** — `F_BUF_ZERO_PRE_FIRES` was declared + exposed via `counters()`
  but never incremented. Deleted the counter; `counters()` now returns
  `(delta, zero_post, snap_fails)`. No external callers existed.

### From PR #354 (mm/w215_diag.rs + mm/pmm.rs)
- **N3** — `free_shadow_record` does four `Relaxed` stores; added a
  torn-tuple caveat comment so future readers do not assume snapshot
  atomicity.
- **N5** — `RECENT_FREE_RING` (pmm.rs) is parallel to `FREE_SHADOW`
  (w215_diag.rs); added a cross-reference comment for a future
  consolidation pass.

### From PR #355 (mm/vmm.rs + mm/w215_diag.rs)
- **N1** — `ring_caller_rip` `[rbp+8]` comment overpromised a two-frame
  walk. Rewrote to match the actual single-frame walk and the
  `#[inline(never)]` + addr2line resolution contract.
- **N4** — `read_pte` snapshots in `map_page_in` / `unmap_page_in` /
  `write_pte` can be stale (concurrent CPU writes between snapshot and
  the wrapped write). Added a diagnostic-only caveat at each site.
- **N5** — `PTE_CHANGE_DISPLACED` displacement counter uses
  relaxed-order writes; added an undercounting caveat.

### From PR #356 (subsys/linux/f3_watch.rs)
- **N2** — `final_report()` had zero callers and a misleading
  docstring. Deleted; `per_slot_fires()` / `stats()` remain (still
  consumed by `mm/w215_crc.rs`).
- **N3** — `path_matches` docstring said "Lowercase compare" but
  `contains()` is case-sensitive. Corrected to "Case-sensitive path
  match — the firefox-bin path is canonical lowercase".
- **N4** — `F3_ARM_COUNT.fetch_add(1)` grew the counter past
  `F3_ARM_MAX` on every refused arm. Replaced with a
  `compare_exchange` loop (`claim_arm_idx`) that only increments below
  the cap. The one-shot `cap_reached` emission is gated by a separate
  `AtomicBool` so it fires exactly once even under concurrent execve
  races.

## Out of scope (deliberately deferred)

- PR #352 N2 (post_read Err-path coverage) — design decision.
- PR #353 nits — separate consideration.
- PR #354 N1 MED (cfg-gate RAW16) — correctness change, design needed.
- PR #354 N2/N4 — already-acknowledged trade-offs.
- PR #355 N2 (read_pte VA-range filter) — perf optimisation, needs testing.
- PR #355 N3 (`PTE_KIND_FORK_CLONE` wire-up) — forward-looking infra.
- PR #356 N1 (TOCTOU retag window) — correctness change to arm protocol.

## Build verification

- `python3 scripts/qemu-harness.py check --features "firefox-test,file-buf-witness,f3-watch"` → `ok=true rc=0`
- `python3 scripts/qemu-harness.py check --features "test-mode"` → `ok=true rc=0`
- `python3 scripts/qemu-harness.py check --features ""` (default) → `ok=true rc=0`

## Diff size

`5 files changed, 66 insertions(+), 37 deletions(-)` — ~103 LOC,
mostly comments + small deletions + one compare_exchange loop. No new
locks, no API surface changes beyond the `file_buf_witness::counters()`
return-tuple shrink (which had zero external callers).

## Test plan
- [x] `firefox-test,file-buf-witness,f3-watch` clean build
- [x] `test-mode` clean build
- [x] default-feature clean build
- [ ] /review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)