### PR TITLE
kernel/toolchain: stage Alpine debug-symbol packages for FF SSP attribution

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -492,6 +492,70 @@ not the F3 stack-frame-identity gate).
 
 ---
 
+## Data image — debug-symbol companions (musl variant)
+
+When attributing captured RIPs to named functions (`addr2line`,
+`rip-trace-resolve`, ad-hoc `nm` lookups, K-class hardware-watchpoint fires)
+the stripped Alpine binaries in `/disk/lib/` and `/disk/usr/lib/` carry only
+`.dynsym` — which names exported symbols but not internal functions and
+provides no line-number information. Setting `ASTRYXOS_FIREFOX_DEBUG` opts the
+build into staging Alpine's `-dbg` companion packages alongside the stripped
+binaries in the standard `/usr/lib/debug/<absolute-path>/<basename>.debug`
+layout, so binutils tools find them automatically via the binaries'
+`.gnu_debuglink` sections.
+
+```bash
+# musl-only (default opt-in; ~2.8 MiB on data.img)
+ASTRYXOS_FIREFOX_VARIANT=musl ASTRYXOS_FIREFOX_DEBUG=musl \
+    bash scripts/create-data-disk.sh --force
+
+# full GTK stack (~54 MiB on data.img)
+ASTRYXOS_FIREFOX_VARIANT=musl ASTRYXOS_FIREFOX_DEBUG=1 \
+    bash scripts/create-data-disk.sh --force
+
+# explicit off (default, unchanged from prior behaviour)
+ASTRYXOS_FIREFOX_VARIANT=musl bash scripts/create-data-disk.sh --force
+```
+
+Coverage matrix (Alpine v3.20, x86_64):
+
+| `ASTRYXOS_FIREFOX_DEBUG` | data.img Δ | Covers |
+|---|---|---|
+| unset / `0` (off, default) | 0 | — |
+| `musl` | ~2.8 MiB | `ld-musl-x86_64.so.1`, `libc.musl-x86_64.so.1` (musl-dbg) |
+| `1` / `full` | ~54 MiB | + libglib/gobject/gio, libgdk_pixbuf, libcairo, libgtk-3/libgdk-3 |
+
+`libxul.so` is **not** covered — Alpine's `firefox-esr` package does not ship a
+`-dbg` subpackage (verified against Alpine v3.20 community APKBUILD). For
+coarse function-level libxul attribution under the musl variant, run
+`scripts/inject-libxul-symbols.sh` against the musl libxul path
+(`build/disk/usr/lib/firefox-esr/libxul.so`); note that VMAs drift a few bytes
+per function vs Mozilla's reference build due to Alpine's rebuild — function
+*names* are usually correct but per-line attribution is not byte-precise.
+
+The companion files land at `/usr/lib/debug/<path>` on the guest filesystem.
+For host-side resolution use a temporary verification root (the install
+script does this internally for its own end-to-end check):
+
+```bash
+# Host-side: addr2line a RIP in the staged musl ld-musl
+VERIFY="$(mktemp -d)"
+ln -sf "$(pwd)/build/disk/lib/ld-musl-x86_64.so.1"                "${VERIFY}/ld-musl-x86_64.so.1"
+ln -sf "$(pwd)/build/disk/usr/lib/debug/lib/ld-musl-x86_64.so.1.debug" \
+       "${VERIFY}/ld-musl-x86_64.so.1.debug"
+addr2line --inlines --functions --demangle \
+    -e "${VERIFY}/ld-musl-x86_64.so.1" 0x5e880
+# → __unmapself
+rm -rf "${VERIFY}"
+```
+
+The opt-in is silently ignored under `ASTRYXOS_FIREFOX_VARIANT=glibc` — Alpine
+-dbg packages are companions to Alpine binaries; the glibc Firefox debug-symbol
+track is owned by `scripts/inject-libxul-symbols.sh` (Mozilla Breakpad `.sym`
+injection into `libxul.so` as a `.symtab`).
+
+---
+
 ## Use cases
 
 ### Debugging a kernel hang

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -40,12 +40,38 @@ FIREFOX=false
 # Selectable via CLI arg or env var; env var loses to explicit CLI arg.
 FIREFOX_VARIANT="${ASTRYXOS_FIREFOX_VARIANT:-glibc}"
 
+# Firefox debug-symbols opt-in.  When set, stages Alpine -dbg debug companion
+# files (musl-dbg + optionally glib/gdk-pixbuf/cairo/gtk+3.0-dbg) into
+# build/disk/usr/lib/debug/ and into data.img so that addr2line / objdump
+# (and equivalent guest-side tooling) can attribute captured RIPs to function
+# names and source lines.  Targets the K-class watchpoint attribution flow.
+#
+#   unset / 0   — no debug companions staged (default; data.img footprint
+#                  unchanged from the variant baseline)
+#   musl        — stage musl-dbg only (~2.8 MiB).  Covers ld-musl-x86_64.so.1
+#                  + libc.musl-x86_64.so.1 (libc is a symlink to ld-musl).
+#   1 / full    — stage musl-dbg + glib-dbg + gdk-pixbuf-dbg + cairo-dbg +
+#                  gtk+3.0-dbg (~54 MiB).  Covers ld-musl + libc + the GTK3
+#                  stack libxul transitively depends on.
+#
+# Constraints:
+#   - Only meaningful when FIREFOX_VARIANT=musl (Alpine -dbg packages are
+#     companions to Alpine binaries).  Setting under glibc is silently
+#     ignored; the glibc Firefox debug-symbol track is owned by the
+#     inject-libxul-symbols.sh / Mozilla Breakpad .sym path instead.
+#   - Alpine does NOT ship a firefox-esr-dbg subpackage; libxul.so debug
+#     attribution under the musl variant is on a separate path
+#     (see scripts/install-firefox-musl-debug.sh for the documented gap).
+FIREFOX_DEBUG="${ASTRYXOS_FIREFOX_DEBUG:-}"
+
 for arg in "$@"; do
     case "$arg" in
         --force) FORCE=true ;;
         --firefox) FIREFOX=true; FORCE=true ;;
         --firefox-variant=*) FIREFOX_VARIANT="${arg#--firefox-variant=}" ;;
         --firefox-variant) :;;   # next arg consumed by trailing path
+        --firefox-debug=*) FIREFOX_DEBUG="${arg#--firefox-debug=}" ;;
+        --firefox-debug)   FIREFOX_DEBUG=1 ;;
         [0-9]*) SIZE_MB="$arg" ;;
     esac
 done
@@ -58,6 +84,21 @@ case "${FIREFOX_VARIANT}" in
         ;;
 esac
 echo "[DATA-DISK] Firefox variant: ${FIREFOX_VARIANT}"
+
+case "${FIREFOX_DEBUG}" in
+    ''|0)        FIREFOX_DEBUG_MODE=off ;;
+    musl)        FIREFOX_DEBUG_MODE=musl ;;
+    1|full|yes)  FIREFOX_DEBUG_MODE=full ;;
+    *)
+        echo "[DATA-DISK] ERROR: unknown FIREFOX_DEBUG='${FIREFOX_DEBUG}' (expected unset|0|musl|1|full)"
+        exit 1
+        ;;
+esac
+if [ "${FIREFOX_DEBUG_MODE}" != off ] && [ "${FIREFOX_VARIANT}" != musl ]; then
+    echo "[DATA-DISK] NOTE: ASTRYXOS_FIREFOX_DEBUG=${FIREFOX_DEBUG} ignored — only applies to FIREFOX_VARIANT=musl"
+    FIREFOX_DEBUG_MODE=off
+fi
+echo "[DATA-DISK] Firefox debug-symbols: ${FIREFOX_DEBUG_MODE}"
 
 # ── Stage at least one TTF font for Mozilla's font-list init ─────────────────
 # Mozilla's gfxFcPlatformFontList walks the FcFontSet returned by
@@ -240,6 +281,23 @@ if [ -f "${ROOT_DIR}/scripts/install-firefox-musl.sh" ]; then
     [ "${FORCE}" = true ] && MUSL_FLAGS="--force"
     bash "${ROOT_DIR}/scripts/install-firefox-musl.sh" ${MUSL_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
         { echo "[DATA-DISK] FATAL: install-firefox-musl.sh failed"; exit 1; }
+fi
+
+# ── Optional: stage Alpine -dbg debug companions ─────────────────────────────
+# When ASTRYXOS_FIREFOX_DEBUG is set, run install-firefox-musl-debug.sh to
+# pull the per-library debug-info companion files into
+# build/disk/usr/lib/debug/.  The script reuses install-firefox-musl.sh's
+# shared apk rootfs (~/.cache/astryxos-firefox-musl/rootfs) so debug-info
+# package versions match the binary versions exactly.
+if [ "${FIREFOX_DEBUG_MODE}" != off ] && \
+   [ -f "${ROOT_DIR}/scripts/install-firefox-musl-debug.sh" ]; then
+    DBG_FLAGS=""
+    [ "${FORCE}" = true ] && DBG_FLAGS="--force"
+    if [ "${FIREFOX_DEBUG_MODE}" = musl ]; then
+        DBG_FLAGS="${DBG_FLAGS} --musl-only"
+    fi
+    bash "${ROOT_DIR}/scripts/install-firefox-musl-debug.sh" ${DBG_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+        echo "[DATA-DISK] WARNING: install-firefox-musl-debug.sh failed — /usr/lib/debug not staged"
 fi
 
 # Stage a /tmp/hello.html for the headless oracle test — install-firefox.sh
@@ -498,6 +556,25 @@ EOF
             echo "[DATA-DISK] Copied /usr/lib/firefox-esr/ to data image (DT_RUNPATH target)"
         else
             echo "[DATA-DISK] WARNING: ${MUSL_FF_ESR} missing — musl FF DT_RUNPATH lookup will fail"
+        fi
+
+        # ── Optional: /usr/lib/debug/ debug-info companion tree ─────────────
+        # Staged by install-firefox-musl-debug.sh when ASTRYXOS_FIREFOX_DEBUG
+        # is set.  Layout per binutils convention: /usr/lib/debug/<abs-binary-
+        # path>/<basename>.debug.  Mirrors into the data image so addr2line /
+        # objdump (or equivalent guest-side tooling) can resolve captured
+        # RIPs to function + source-line via the binaries' .gnu_debuglink
+        # sections without further host coupling.
+        MUSL_DEBUG="${BUILD_DIR}/disk/usr/lib/debug"
+        if [ "${FIREFOX_DEBUG_MODE}" != off ] && [ -d "${MUSL_DEBUG}" ]; then
+            DBG_SIZE="$(du -sh "${MUSL_DEBUG}" | cut -f1)"
+            DBG_FILES="$(find "${MUSL_DEBUG}" -type f -name '*.debug' | wc -l)"
+            echo "[DATA-DISK] Copying /usr/lib/debug (${DBG_SIZE}, ${DBG_FILES} files) to data image..."
+            mmd -i "${DATA_IMG}" "::usr/lib/debug" 2>/dev/null || true
+            mcopy -s -o -i "${DATA_IMG}" "${MUSL_DEBUG}/." \
+                "::usr/lib/debug/" 2>&1 | \
+                grep -v "^$" | grep -iv "^skipping" | head -20 || true
+            echo "[DATA-DISK] Copied /usr/lib/debug/ to data image (${FIREFOX_DEBUG_MODE} coverage)"
         fi
     fi
     HOST_FONTS="${BUILD_DIR}/disk/usr/share/fonts"

--- a/scripts/install-firefox-musl-debug.sh
+++ b/scripts/install-firefox-musl-debug.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+#
+# install-firefox-musl-debug.sh — Stage Alpine debug-symbol companion packages
+# alongside the musl Firefox install so that addr2line / nm can attribute RIPs
+# captured at runtime (e.g. by the K-class DR hardware watchpoint and the
+# rip-trace-resolve harness subcommand) to named functions.
+#
+# Background
+# ----------
+#
+# Alpine ships per-package "-dbg" subpackages whose contents live under
+# /usr/lib/debug/<original-path>/<name>.debug.  The corresponding stripped
+# binaries carry a .gnu_debuglink section pointing at <name>.debug, so binutils
+# tools (addr2line, objdump --line-numbers, gdb, nm) automatically locate the
+# companion debug file when it is present in the standard debug-info search
+# path (binary dir, .debug/, or /usr/lib/debug/<binary's absolute path>/).
+#
+# Coverage matrix for the musl Firefox stack
+# ------------------------------------------
+#
+#   Package                 Ships -dbg?  Stages
+#   ──────────────────────  ───────────  ──────────────────────────────────────
+#   musl                    YES          /usr/lib/debug/lib/ld-musl-x86_64.so.1.debug
+#                                          (also covers libc.musl-x86_64.so.1 —
+#                                          libc is a symlink to ld-musl)
+#   glib                    YES          /usr/lib/debug/usr/lib/libglib-2.0.so.*.debug
+#                                          /usr/lib/debug/usr/lib/libgobject-2.0.so.*.debug
+#                                          /usr/lib/debug/usr/lib/libgio-2.0.so.*.debug
+#   gdk-pixbuf              YES          /usr/lib/debug/usr/lib/libgdk_pixbuf-2.0.so.*.debug
+#   cairo                   YES          /usr/lib/debug/usr/lib/libcairo.so.*.debug
+#   gtk+3.0                 YES          /usr/lib/debug/usr/lib/libgtk-3.so.*.debug
+#                                          /usr/lib/debug/usr/lib/libgdk-3.so.*.debug
+#   firefox-esr             NO           — Alpine does not ship a -dbg subpackage
+#                                          for firefox-esr in v3.20.  See the
+#                                          APKBUILD at community/firefox-esr/:
+#                                          subpackages="$pkgname-intl" only.
+#                                          (Compare community/firefox/ which DOES
+#                                          ship firefox-dbg.)
+#
+# Implication for libxul.so attribution
+# -------------------------------------
+#
+# Because Alpine does not ship debug symbols for firefox-esr, addr2line cannot
+# resolve RIPs inside libxul.so by .gnu_debuglink alone.  Three options exist:
+#
+#   1. Coarse function-level names via Mozilla's official Breakpad .sym file
+#      (Firefox 115.24.0esr) injected as a .symtab.  This is what
+#      scripts/inject-libxul-symbols.sh does — but note that Alpine rebuilds
+#      libxul from source with its own toolchain, so VMAs in Mozilla's .sym
+#      will drift from Alpine's libxul by a few bytes per function; the
+#      resolved function NAME is usually correct, but the line/file mapping
+#      is not.  Pragmatic for K-class watchpoint attribution; not byte-precise.
+#
+#   2. Build firefox-esr from source inside an Alpine builder with
+#      --disable-strip and --disable-install-strip.  Multi-hour, multi-GiB.
+#      Out of scope for this script.
+#
+#   3. Switch the data-disk from firefox-esr-115.x to firefox-132.x and use
+#      Alpine's firefox-dbg (47.9 MiB installed).  Changes the reproducer.
+#      Coordinator-level decision; not done by this script.
+#
+# Layout written to build/disk/
+# -----------------------------
+#
+# The Alpine apk packages already place files at /usr/lib/debug/<...>; we
+# preserve that layout in build/disk/ so the kernel VFS maps /usr/lib/debug
+# the same way it maps /usr/lib/ (via the /usr → /disk/usr symlink).  No
+# .gnu_debuglink rewrites are required.  Per binutils' debug-info-resolution
+# algorithm (see GDB §18.2 "Debugging Information in Separate Files"), tools
+# search in this order when a .gnu_debuglink section names "X.debug":
+#
+#   (a) <binary-dir>/X.debug
+#   (b) <binary-dir>/.debug/X.debug
+#   (c) <global-debug-dir>/<absolute-path-of-binary>/X.debug
+#
+# Alpine packages target (c) with global-debug-dir = /usr/lib/debug.
+#
+# Size budget on the FAT32 data image (2 GiB total)
+# -------------------------------------------------
+#
+# Empirical sizes (Alpine v3.20 main + community, x86_64) when staged:
+#
+#   musl-dbg                ~ 2.8 MiB  ← always staged (target use-case)
+#   glib-dbg                ~ 12 MiB
+#   gdk-pixbuf-dbg          ~  1 MiB
+#   cairo-dbg               ~  5 MiB
+#   gtk+3.0-dbg             ~ 21 MiB
+#   ──────────────────────  ────────
+#   TOTAL                   ~ 42 MiB
+#
+# Within the current ~360 MiB musl FF data-image footprint, leaving headroom
+# for kernel binaries, fonts, busybox, and FAT32 metadata overhead.
+#
+# Usage
+# -----
+#
+#   bash scripts/install-firefox-musl-debug.sh           # idempotent install
+#   bash scripts/install-firefox-musl-debug.sh --force   # re-download + restage
+#   bash scripts/install-firefox-musl-debug.sh --musl-only
+#                                                        # stage musl-dbg only
+#                                                        # (~2.8 MiB, target the
+#                                                        #  K-class SSP fires)
+#
+# Environment
+# -----------
+#
+#   ASTRYXOS_FIREFOX_DEBUG=1   set by create-data-disk.sh when the caller wants
+#                              the debug companions included in data.img.
+#
+# References (public)
+# -------------------
+#
+#   - GDB §18.2 "Debugging Information in Separate Files":
+#     https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html
+#   - Alpine package index:
+#     https://pkgs.alpinelinux.org/packages?name=*-dbg&branch=v3.20&arch=x86_64
+#   - Mozilla Breakpad symbol format:
+#     https://chromium.googlesource.com/breakpad/breakpad/+/HEAD/docs/symbol_files.md
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/build"
+DISK_DIR="${BUILD_DIR}/disk"
+DISK_DEBUG_DIR="${DISK_DIR}/usr/lib/debug"
+
+CACHE_DIR="${HOME}/.cache/astryxos-firefox-musl"
+APK_BIN="${CACHE_DIR}/apk-tools/sbin/apk.static"
+ROOTFS="${CACHE_DIR}/rootfs"
+
+# Pinned set of -dbg packages we know Alpine v3.20 ships for the FF stack.
+# Adding a package here is a deliberate act; the script verifies each one
+# landed under ${ROOTFS}/usr/lib/debug/ after `apk add`.
+ALL_DBG_PKGS=(musl-dbg glib-dbg gdk-pixbuf-dbg cairo-dbg gtk+3.0-dbg)
+MUSL_ONLY_DBG_PKGS=(musl-dbg)
+
+FORCE=false
+MUSL_ONLY=false
+for arg in "$@"; do
+    case "${arg}" in
+        --force) FORCE=true ;;
+        --musl-only) MUSL_ONLY=true ;;
+        -h|--help)
+            sed -n '2,90p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "[FF-MUSL-DBG] ERROR: unknown arg '${arg}'" >&2
+            exit 2
+            ;;
+    esac
+done
+
+DBG_PKGS=("${ALL_DBG_PKGS[@]}")
+if [ "${MUSL_ONLY}" = true ]; then
+    DBG_PKGS=("${MUSL_ONLY_DBG_PKGS[@]}")
+fi
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+# install-firefox-musl.sh must have run first (we share its rootfs + apk.static
+# cache so debug companion versions are guaranteed to match the binaries).
+if [ ! -x "${APK_BIN}" ]; then
+    echo "[FF-MUSL-DBG] ERROR: ${APK_BIN} not present."
+    echo "[FF-MUSL-DBG]        Run scripts/install-firefox-musl.sh first."
+    exit 1
+fi
+if [ ! -d "${ROOTFS}/lib/apk/db" ]; then
+    echo "[FF-MUSL-DBG] ERROR: Alpine rootfs at ${ROOTFS} not initialised."
+    echo "[FF-MUSL-DBG]        Run scripts/install-firefox-musl.sh first."
+    exit 1
+fi
+
+# ── Idempotency check ─────────────────────────────────────────────────────────
+# We consider the install up-to-date when every requested -dbg package's
+# top-level marker file exists under ${DISK_DEBUG_DIR}.  musl-dbg is the
+# canonical marker (always staged); the others only when full mode requested.
+if [ "${FORCE}" = false ] && \
+   [ -f "${DISK_DEBUG_DIR}/lib/ld-musl-x86_64.so.1.debug" ]; then
+    if [ "${MUSL_ONLY}" = true ]; then
+        echo "[FF-MUSL-DBG] musl-dbg already staged at ${DISK_DEBUG_DIR}/lib/ — skipping (use --force to reinstall)"
+        exit 0
+    fi
+    # In full mode also require one GTK-stack marker to consider it complete.
+    if compgen -G "${DISK_DEBUG_DIR}/usr/lib/libgtk-3.so.*.debug" > /dev/null; then
+        echo "[FF-MUSL-DBG] full debug stack already staged at ${DISK_DEBUG_DIR}/ — skipping (use --force to reinstall)"
+        exit 0
+    fi
+fi
+
+echo "[FF-MUSL-DBG] Staging Alpine debug companions: ${DBG_PKGS[*]}"
+
+# ── Step 1: apk add the -dbg packages into the shared Alpine rootfs ──────────
+# install-firefox-musl.sh already created the rootfs, signing key, and
+# repositories file.  We reuse them so debug-symbol package versions are
+# guaranteed to match the binary versions exactly (apk's solver picks the
+# same release).
+#
+# We intentionally do NOT pass --no-cache here so apk re-uses any downloads
+# left behind by install-firefox-musl.sh; for forced runs the script's
+# upstream --force handling already wipes the rootfs.
+"${APK_BIN}" \
+    --root="${ROOTFS}" \
+    --arch=x86_64 \
+    --no-progress \
+    add "${DBG_PKGS[@]}" 2>&1 \
+    | sed 's/^/[FF-MUSL-DBG apk] /' \
+    | tail -40 || true
+
+# Verify musl-dbg landed (canonical marker; the rest are best-effort because
+# Alpine's solver may resolve different transitive deps on different days).
+if [ ! -f "${ROOTFS}/usr/lib/debug/lib/ld-musl-x86_64.so.1.debug" ]; then
+    echo "[FF-MUSL-DBG] ERROR: musl-dbg did not deposit ld-musl-x86_64.so.1.debug"
+    echo "[FF-MUSL-DBG]        ${ROOTFS}/usr/lib/debug/lib/ contents:"
+    ls -la "${ROOTFS}/usr/lib/debug/lib/" 2>&1 | sed 's/^/[FF-MUSL-DBG]   /'
+    exit 1
+fi
+
+# ── Step 2: Stage /usr/lib/debug/ tree into build/disk/ ──────────────────────
+# Alpine's apk places every -dbg payload under /usr/lib/debug/<abs-binary-path>/.
+# We mirror those payloads — and ONLY those — into build/disk/usr/lib/debug/.
+# Idempotency note: install-firefox-musl-debug.sh shares the rootfs with
+# install-firefox-musl.sh; prior `--force` invocations or earlier full-mode
+# runs may leave -dbg packages installed that the current invocation did NOT
+# request.  Blanket-copying ${ROOTFS}/usr/lib/debug/ would stage those into
+# data.img.  Instead we read apk's per-package file list and copy only the
+# files that belong to the packages requested on this invocation.
+#
+# `apk info -L <pkg>` prints the absolute (rootfs-relative) paths of every
+# file in <pkg>; lines starting with the package header and blank lines are
+# filtered.  No .gnu_debuglink rewrites are required — the binaries already
+# have the section pointing at the correct basename, and binutils' debug-info
+# search algorithm finds the file at /usr/lib/debug/<bin-abs-path>/<basename>.
+mkdir -p "${DISK_DEBUG_DIR}"
+
+# Wipe a prior stage tree before re-staging so a `--musl-only` invocation
+# following a full-mode one drops the previously-staged gtk/glib/cairo/
+# pixbuf debug files.  Done before the per-package copy loop, not as part
+# of the loop, so a single file-system pass replaces the whole tree.
+rm -rf "${DISK_DEBUG_DIR}"
+mkdir -p "${DISK_DEBUG_DIR}"
+
+copied_count=0
+for pkg in "${DBG_PKGS[@]}"; do
+    # apk info -L lists owned files, one per line, sans leading slash.
+    # Header line "<pkg> contains:" is dropped by tail -n +2.
+    while IFS= read -r relpath; do
+        [ -z "${relpath}" ] && continue
+        # We only care about files under usr/lib/debug/ — the rest of the
+        # -dbg package's payload (typically empty) goes nowhere useful.
+        case "${relpath}" in
+            usr/lib/debug/*) ;;
+            *) continue ;;
+        esac
+        src="${ROOTFS}/${relpath}"
+        # In Alpine -dbg packages, usr/lib/debug entries are mostly regular
+        # files (the .debug data) plus a few directory entries (which we
+        # create implicitly via `mkdir -p` below).
+        if [ -f "${src}" ]; then
+            # Strip the leading "usr/lib/debug/" so we land at
+            # ${DISK_DEBUG_DIR}/<rest>.
+            rest="${relpath#usr/lib/debug/}"
+            mkdir -p "${DISK_DEBUG_DIR}/$(dirname "${rest}")"
+            cp -fL "${src}" "${DISK_DEBUG_DIR}/${rest}"
+            copied_count=$((copied_count + 1))
+        fi
+    done < <("${APK_BIN}" --root="${ROOTFS}" info -L "${pkg}" 2>/dev/null | tail -n +2)
+done
+
+DBG_FILE_COUNT="$(find "${DISK_DEBUG_DIR}" -type f -name '*.debug' 2>/dev/null | wc -l)"
+DBG_TREE_SIZE="$(du -sh "${DISK_DEBUG_DIR}" 2>/dev/null | cut -f1)"
+echo "[FF-MUSL-DBG] Staged ${DBG_FILE_COUNT} .debug files to ${DISK_DEBUG_DIR} (${DBG_TREE_SIZE})"
+
+# ── Step 3: Sanity-check addr2line resolution (host-side) ────────────────────
+# binutils' addr2line searches for the .gnu_debuglink companion in three places
+# (see GDB §18.2 "Debugging Information in Separate Files"):
+#   (a) the binary's directory                <bin-dir>/<name>.debug
+#   (b) the binary's .debug subdirectory       <bin-dir>/.debug/<name>.debug
+#   (c) the global debug-info directory        /usr/lib/debug/<abs-bin-path>/<name>.debug
+#
+# Path (c) on the host points at the host's /usr/lib/debug — not our staging
+# tree.  addr2line has no CLI flag to override (c) (objdump and gdb both do via
+# --debug-file-directory, but addr2line does not as of binutils 2.42).
+#
+# To verify resolution without polluting build/disk/ with adjacent symlinks
+# that would inflate data.img (FAT32 has no symlinks, mcopy dereferences), we
+# stage a temporary verification root under a host-only mktemp dir, symlink the
+# binary and its companion into the binutils-friendly layout, and run
+# addr2line there.  No on-disk artefact is left behind in build/disk/.
+STAGED_LD_MUSL="${DISK_DIR}/lib/ld-musl-x86_64.so.1"
+STAGED_LD_MUSL_DBG="${DISK_DEBUG_DIR}/lib/ld-musl-x86_64.so.1.debug"
+if [ -f "${STAGED_LD_MUSL}" ] && [ -f "${STAGED_LD_MUSL_DBG}" ] && \
+   command -v addr2line >/dev/null 2>&1; then
+    VERIFY_DIR="$(mktemp -d -t astryxos-ff-musl-dbg-verify-XXXXXX)"
+    trap 'rm -rf "${VERIFY_DIR}"' EXIT
+    ln -sf "${STAGED_LD_MUSL}"     "${VERIFY_DIR}/ld-musl-x86_64.so.1"
+    ln -sf "${STAGED_LD_MUSL_DBG}" "${VERIFY_DIR}/ld-musl-x86_64.so.1.debug"
+    # 0x5e880 sits inside __unmapself in musl 1.2.5 (the symbol observed by
+    # the K-class watchpoint investigation).  Failure here means the
+    # .gnu_debuglink section is corrupt or the companion file did not stage.
+    RESOLVED="$(addr2line --inlines --functions --demangle \
+        -e "${VERIFY_DIR}/ld-musl-x86_64.so.1" 0x5e880 2>&1 | head -1)"
+    if [ -n "${RESOLVED}" ] && [ "${RESOLVED}" != "??" ]; then
+        echo "[FF-MUSL-DBG] addr2line verification: 0x5e880 → ${RESOLVED}"
+    else
+        echo "[FF-MUSL-DBG] WARNING: addr2line could not resolve 0x5e880 in ld-musl (got '${RESOLVED}')"
+        echo "[FF-MUSL-DBG]          .gnu_debuglink lookup chain may be broken — check"
+        echo "[FF-MUSL-DBG]          readelf --string-dump=.gnu_debuglink ${STAGED_LD_MUSL}"
+    fi
+    rm -rf "${VERIFY_DIR}"
+    trap - EXIT
+else
+    echo "[FF-MUSL-DBG] NOTE: skipped addr2line check (ld-musl staged: $([ -f ${STAGED_LD_MUSL} ] && echo yes || echo no); addr2line: $(command -v addr2line >/dev/null 2>&1 && echo yes || echo no))"
+fi
+
+echo "[FF-MUSL-DBG] Done."
+echo "[FF-MUSL-DBG]   Layout: ${DISK_DEBUG_DIR}/<abs-binary-path>/<basename>.debug"
+echo "[FF-MUSL-DBG]   Total:  ${DBG_TREE_SIZE} across ${DBG_FILE_COUNT} files"
+echo "[FF-MUSL-DBG]   Coverage: musl libc + ld-musl; +GTK/glib/cairo/pixbuf when not --musl-only"
+echo "[FF-MUSL-DBG]   Gap:    firefox-esr — Alpine does not ship firefox-esr-dbg;"
+echo "[FF-MUSL-DBG]           run scripts/inject-libxul-symbols.sh against the musl libxul"
+echo "[FF-MUSL-DBG]           for coarse function-level names via Mozilla's Breakpad .sym"
+echo "[FF-MUSL-DBG]           (function names usually correct, VMAs drift vs Mozilla build)."


### PR DESCRIPTION
## Summary

Adds `ASTRYXOS_FIREFOX_DEBUG` opt-in to the musl Firefox data-image build.
When set, `scripts/install-firefox-musl-debug.sh` pulls Alpine's per-package
`-dbg` companion files (`musl-dbg`, optionally `glib-dbg` / `gdk-pixbuf-dbg`
/ `cairo-dbg` / `gtk+3.0-dbg`) into `build/disk/usr/lib/debug/` and into
data.img at `/usr/lib/debug/<absolute-binary-path>/<basename>.debug` —
the standard binutils layout, so `addr2line` / `objdump` / `nm` auto-resolve
via the binaries' existing `.gnu_debuglink` sections.

Targets the K-class watchpoint attribution flow per the F3 saga endpoint —
with `musl-dbg` staged, `addr2line --inlines --functions` resolves captured
RIPs in `ld-musl`/`libc` to named functions + source lines (verified
end-to-end: `0x5e880 → __unmapself` in musl 1.2.5).

## Coverage matrix (Alpine v3.20, x86_64)

| `ASTRYXOS_FIREFOX_DEBUG` | data.img Δ | Covers |
|---|---|---|
| unset / `0` (off, default) | 0 | — |
| `musl` | ~2.8 MiB | `ld-musl-x86_64.so.1`, `libc.musl-x86_64.so.1` (musl-dbg) |
| `1` / `full` | ~54 MiB / 72 files | + libglib/gobject/gio, libgdk_pixbuf, libcairo, libgtk-3/libgdk-3 |

## Known gap — `libxul.so` not covered

Alpine's `firefox-esr` package does **not** ship a `-dbg` subpackage
(verified against `community/firefox-esr/APKBUILD` — `subpackages="$pkgname-intl"`
only; compare `community/firefox/APKBUILD` for 132.x which sets
`subpackages="$subpackages $pkgname-dbg"` and uses `--disable-strip`).

For `libxul.so` attribution under the musl variant the existing
`scripts/inject-libxul-symbols.sh` Mozilla Breakpad `.sym` injection path
remains — function names are usually correct but VMAs drift a few bytes
per function vs Mozilla's reference build because Alpine rebuilds from
source. Documented inline in the new script and `docs/HARNESS.md`.

## Files

- `scripts/install-firefox-musl-debug.sh` (new) — pulls + stages `-dbg`
  payloads with per-package precision (reads `apk info -L` rather than
  blanket-copying, so `--musl-only` after `--full` is deterministic, not
  cumulative). Includes host-side `addr2line` verification using a
  `mktemp -d` root (no stray symlinks left in `build/disk/`).
- `scripts/create-data-disk.sh` — `ASTRYXOS_FIREFOX_DEBUG`/`--firefox-debug=`
  parsing, musl-branch hookup, FAT32 staging of `/usr/lib/debug/`.
  Silently ignored under `FIREFOX_VARIANT=glibc` (the glibc track owns
  the Mozilla Breakpad injection path).
- `docs/HARNESS.md` — new "Data image — debug-symbol companions (musl
  variant)" subsection alongside the existing variant-selection docs.

## References (public)

- GDB §18.2 [Debugging Information in Separate Files](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html)
- ELF gABI section `.gnu_debuglink` layout
- [Alpine `*-dbg` package index](https://pkgs.alpinelinux.org/packages?name=*-dbg&branch=v3.20&arch=x86_64)

## Test plan

- [x] `bash scripts/install-firefox-musl-debug.sh --musl-only` — stages 1 file
      (2.8 MiB), addr2line verification PASS (`0x5e880 → __unmapself`)
- [x] `bash scripts/install-firefox-musl-debug.sh` (full) — stages 72 files
      (54 MiB), addr2line verification PASS
- [x] Idempotency: `--musl-only` after `--full` correctly produces 1 file
      (not 72) — per-package staging precision works
- [x] FAT32 `mcopy -s` of `build/disk/usr/lib/debug/` to data.img verified
- [x] `bash -n` syntax-check on both touched scripts PASS
- [x] `qemu-harness.py --help` still loads (no harness regressions)
- [ ] QA: re-run firefox-test with `ssp-canary-diag,f3-watch` features +
      `ASTRYXOS_FIREFOX_DEBUG=musl` data.img; confirm K2b fires now
      addr2line-resolve to named ld-musl functions