### PR TITLE
toolchain/scripts+docs: extend inject-libxul-symbols.sh for Alpine musl libxul

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -525,13 +525,19 @@ Coverage matrix (Alpine v3.20, x86_64):
 | `musl` | ~2.8 MiB | `ld-musl-x86_64.so.1`, `libc.musl-x86_64.so.1` (musl-dbg) |
 | `1` / `full` | ~54 MiB | + libglib/gobject/gio, libgdk_pixbuf, libcairo, libgtk-3/libgdk-3 |
 
-`libxul.so` is **not** covered — Alpine's `firefox-esr` package does not ship a
-`-dbg` subpackage (verified against Alpine v3.20 community APKBUILD). For
-coarse function-level libxul attribution under the musl variant, run
-`scripts/inject-libxul-symbols.sh` against the musl libxul path
-(`build/disk/usr/lib/firefox-esr/libxul.so`); note that VMAs drift a few bytes
-per function vs Mozilla's reference build due to Alpine's rebuild — function
-*names* are usually correct but per-line attribution is not byte-precise.
+`libxul.so` is **not** covered by Alpine's `-dbg` packages — Alpine's
+`firefox-esr` does not ship a `-dbg` subpackage (verified against Alpine v3.20
+community APKBUILD). It is instead handled by
+`scripts/inject-libxul-symbols.sh --musl`, which `create-data-disk.sh` invokes
+automatically whenever `ASTRYXOS_FIREFOX_DEBUG` is set in the musl variant.
+The script derives a Breakpad GUID from the libxul `NT_GNU_BUILD_ID` note and
+fetches the matching `.sym.gz` from Mozilla's tecken symbol server (Alpine
+uploads symbols there), so VMAs match the staged Alpine libxul byte-for-byte.
+Coverage is PUBLIC-only (Alpine builds without DWARF): ~8,600 entry-point
+names with the same VMAs `nm`/`addr2line` would read from a hypothetical
+`.dynsym` lookup, sufficient to attribute a sampled RIP to the nearest
+exported function. File and line numbers are **not** recoverable — that
+requires option 2 (Alpine source build with `--disable-strip`).
 
 The companion files land at `/usr/lib/debug/<path>` on the guest filesystem.
 For host-side resolution use a temporary verification root (the install

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -300,6 +300,28 @@ if [ "${FIREFOX_DEBUG_MODE}" != off ] && \
         echo "[DATA-DISK] WARNING: install-firefox-musl-debug.sh failed — /usr/lib/debug not staged"
 fi
 
+# ── Optional: inject .symtab into the musl libxul.so ─────────────────────────
+# Alpine's firefox-esr does NOT ship a -dbg subpackage (verified vs
+# community/firefox 132.x which DOES; see scripts/install-firefox-musl-debug.sh
+# "Implication for libxul.so attribution").  Instead, Mozilla's symbol server
+# (tecken) indexes the exact Alpine BuildID and serves a gzipped Breakpad
+# .sym (~9 MiB compressed) that lists every .dynsym entry as a PUBLIC record.
+# scripts/inject-libxul-symbols.sh --musl downloads the .sym, derives the
+# Breakpad GUID from the libxul BuildID, and splices an Elf64_Sym .symtab
+# into libxul.so.  The .text section is byte-identical pre/post (verified
+# by SHA256 inside the script) — no upstream-binary edit.
+#
+# Triggered together with the -dbg companion stage so a single
+# ASTRYXOS_FIREFOX_DEBUG=musl|1|full request gets all attribution avenues.
+if [ "${FIREFOX_DEBUG_MODE}" != off ] && \
+   [ -f "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ] && \
+   [ -f "${BUILD_DIR}/disk/usr/lib/firefox-esr/libxul.so" ]; then
+    MUSL_SYM_FLAGS="--musl"
+    [ "${FORCE}" = true ] && MUSL_SYM_FLAGS="${MUSL_SYM_FLAGS} --force"
+    bash "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ${MUSL_SYM_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+        echo "[DATA-DISK] WARNING: inject-libxul-symbols.sh --musl failed — libxul.so will lack .symtab"
+fi
+
 # Stage a /tmp/hello.html for the headless oracle test — install-firefox.sh
 # does this in the glibc path, but we skipped that script.
 mkdir -p "${BUILD_DIR}/disk/tmp"

--- a/scripts/inject-libxul-symbols.sh
+++ b/scripts/inject-libxul-symbols.sh
@@ -1,62 +1,120 @@
 #!/usr/bin/env bash
 #
-# inject-libxul-symbols.sh — Download Mozilla's official debug-symbol package
-# for Firefox ESR 115.15.0 and splice a .symtab into the libxul.so that is
-# staged in build/disk/opt/firefox/.
+# inject-libxul-symbols.sh — Download Mozilla's official debug-symbol data and
+# splice an ELF .symtab into a stripped libxul.so so that nm / addr2line /
+# kdb rip-trace-resolve can name functions inside it.
+#
+# Two modes are supported:
+#
+#   (default, --glibc)
+#       Target: build/disk/opt/firefox/libxul.so
+#       Source: Firefox ESR 115.15.0 crashreporter-symbols ZIP (Mozilla CDN),
+#               sliced by HTTP-range to the libxul.so.sym entry, raw-DEFLATE
+#               decompressed.  ~135 MiB compressed, ~690 MiB decompressed,
+#               ~353,947 FUNC records.
+#
+#   --musl
+#       Target: build/disk/usr/lib/firefox-esr/libxul.so   (Alpine package)
+#       Source: Mozilla symbol server keyed by the ELF Build ID converted to
+#               a Breakpad GUID.  Alpine community/firefox-esr's exact
+#               BuildID is indexed by Mozilla's tecken — a gzipped libxul.so.sym
+#               (~9 MiB compressed, ~88 MiB decompressed) is downloaded as a
+#               single GET.  Records are PUBLIC-only (Alpine builds without
+#               DWARF), so the .symtab carries function-entry-point names only;
+#               this is sufficient for K-class RIP attribution.
 #
 # Background:
-#   Mozilla ships Breakpad-format .sym files for every release.  These contain
-#   FUNC records mapping ELF VMAs to demangled C++/Rust function names.
-#   This script downloads the libxul.so.sym file for the exact Build ID of the
-#   locally installed libxul.so, then calls inject-libxul-symtab.py to build a
-#   proper Elf64_Sym array and splice it into libxul.so as .symtab + .strtab.
+#   Mozilla ships Breakpad-format .sym files for every release and every
+#   third-party rebuild that uploads to its symbol server.  The .sym contains
+#   FUNC and/or PUBLIC records mapping ELF VMAs to demangled C++/Rust names.
+#   This script downloads the .sym matching the local libxul.so's BuildID,
+#   then calls inject-libxul-symtab.py to build a proper Elf64_Sym array and
+#   splice it into libxul.so as .symtab + .strtab.
 #
-# The resulting libxul.so has identical executable code (verified by Build ID
-# preservation) and can be queried with `nm --defined-only` for 353,947 named
-# functions.  The qemu-harness.py `rip-trace-resolve` subcommand uses this
-# .symtab to resolve sampled RIPs to named functions.
+# The resulting libxul.so has byte-identical executable code (verified by
+# BuildID preservation and the .text section SHA256), and the qemu-harness.py
+# `rip-trace-resolve` subcommand uses this .symtab to resolve sampled RIPs
+# to named functions.
 #
 # References:
 #   - Mozilla Breakpad symbol format:
 #     https://chromium.googlesource.com/breakpad/breakpad/+/HEAD/docs/symbol_files.md
 #   - Mozilla Firefox ESR 115.15.0 release:
 #     https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/
+#   - Mozilla symbol server (tecken):
+#     https://symbols.mozilla.org/
 #   - binutils objcopy(1), nm(1)
 #
 # Usage:
-#   bash scripts/inject-libxul-symbols.sh            # splice if absent
-#   bash scripts/inject-libxul-symbols.sh --force    # re-download and re-splice
+#   bash scripts/inject-libxul-symbols.sh                 # default glibc mode
+#   bash scripts/inject-libxul-symbols.sh --musl          # Alpine musl libxul
+#   bash scripts/inject-libxul-symbols.sh --force         # re-download + splice
+#   bash scripts/inject-libxul-symbols.sh --musl --force  # both
 #
-# Idempotent: exits 0 immediately if libxul.so already has .symtab
-# (unless --force is passed).
+# Idempotent: exits 0 immediately if the target libxul.so already has a
+# .symtab section (unless --force is passed).
 #
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-LIBXUL="${ROOT_DIR}/build/disk/opt/firefox/libxul.so"
-SYM_DIR="${HOME}/.cache/astryxos-firefox/dbg-symbols"
-SYM_FILE="${SYM_DIR}/libxul.so.sym"
-SYM_COMPRESSED="${SYM_DIR}/libxul_sym_compressed.bin"
 INJECT_SCRIPT="${ROOT_DIR}/scripts/inject-libxul-symtab.py"
 
-# Firefox ESR 115.15.0 crashreporter symbols ZIP on Mozilla's CDN.
-# This is the official build1 artifact published at:
-# https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/
-SYMBOLS_ZIP_URL="https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/linux-x86_64/en-US/firefox-115.15.0esr.crashreporter-symbols.zip"
-
-# Byte range of the compressed libxul.so.sym entry within the ZIP.
-# File: libxul.so/05D92C491C2758BAD3544DCBC1D3DE790/libxul.so.sym
-# Matches Build ID 492cd905271cba58d3544dcbc1d3de79e9319d2b.
-# Computed by parsing the ZIP central directory (ELF build-id → breakpad GUID).
-ZIP_DATA_BYTE_OFFSET=246431325
-ZIP_DATA_BYTE_SIZE=135889978   # 129.6 MiB compressed
-
+# ── Argument parsing ─────────────────────────────────────────────────────────
 FORCE=false
+MODE=glibc
 for arg in "$@"; do
     case "${arg}" in
         --force) FORCE=true ;;
+        --musl)  MODE=musl ;;
+        --glibc) MODE=glibc ;;
+        -h|--help)
+            sed -n '2,60p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "[INJECT-SYMS] ERROR: unknown arg '${arg}'" >&2
+            exit 2
+            ;;
     esac
 done
+
+# ── Mode-specific paths and URLs ─────────────────────────────────────────────
+if [ "${MODE}" = "glibc" ]; then
+    LIBXUL="${ROOT_DIR}/build/disk/opt/firefox/libxul.so"
+    SYM_DIR="${HOME}/.cache/astryxos-firefox/dbg-symbols"
+    SYM_FILE="${SYM_DIR}/libxul.so.sym"
+    SYM_COMPRESSED="${SYM_DIR}/libxul_sym_compressed.bin"
+
+    # Firefox ESR 115.15.0 crashreporter symbols ZIP on Mozilla's CDN.
+    # This is the official build1 artifact published at:
+    # https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/
+    SYMBOLS_ZIP_URL="https://ftp.mozilla.org/pub/firefox/candidates/115.15.0esr-candidates/build1/linux-x86_64/en-US/firefox-115.15.0esr.crashreporter-symbols.zip"
+
+    # Byte range of the compressed libxul.so.sym entry within the ZIP.
+    # File: libxul.so/05D92C491C2758BAD3544DCBC1D3DE790/libxul.so.sym
+    # Matches Build ID 492cd905271cba58d3544dcbc1d3de79e9319d2b.
+    # Computed by parsing the ZIP central directory (ELF build-id → breakpad GUID).
+    ZIP_DATA_BYTE_OFFSET=246431325
+    ZIP_DATA_BYTE_SIZE=135889978   # 129.6 MiB compressed
+else
+    # --musl
+    LIBXUL="${ROOT_DIR}/build/disk/usr/lib/firefox-esr/libxul.so"
+    SYM_DIR="${HOME}/.cache/astryxos-firefox-musl/dbg-symbols"
+    SYM_FILE="${SYM_DIR}/libxul.so.sym"
+    SYM_GZ="${SYM_DIR}/libxul.so.sym.gz"
+fi
+
+# ── Sanity: target libxul must exist ─────────────────────────────────────────
+if [ ! -f "${LIBXUL}" ]; then
+    echo "[INJECT-SYMS] ERROR: target libxul.so not found: ${LIBXUL}"
+    if [ "${MODE}" = "musl" ]; then
+        echo "[INJECT-SYMS]        Run scripts/install-firefox-musl.sh first"
+        echo "[INJECT-SYMS]        (or set ASTRYXOS_FIREFOX_VARIANT=musl in create-data-disk.sh)"
+    else
+        echo "[INJECT-SYMS]        Run scripts/install-firefox.sh first"
+    fi
+    exit 1
+fi
 
 # ── Idempotency check ─────────────────────────────────────────────────────────
 if [ "${FORCE}" = false ]; then
@@ -67,43 +125,58 @@ if [ "${FORCE}" = false ]; then
     fi
 fi
 
+echo "[INJECT-SYMS] Mode: ${MODE}"
 echo "[INJECT-SYMS] Injecting Mozilla debug symbols into libxul.so..."
 echo "[INJECT-SYMS]   Target: ${LIBXUL}"
 
 mkdir -p "${SYM_DIR}"
 
-# ── Step 1: Download compressed symbol data via HTTP range request ────────────
-ACTUAL_SIZE=0
-if [ -f "${SYM_COMPRESSED}" ]; then
-    ACTUAL_SIZE=$(stat -c%s "${SYM_COMPRESSED}" 2>/dev/null || echo 0)
-fi
-
-if [ "${FORCE}" = true ] || [ "${ACTUAL_SIZE}" -ne "${ZIP_DATA_BYTE_SIZE}" ]; then
-    echo "[INJECT-SYMS] Downloading libxul.so.sym from Mozilla CDN (~130 MiB)..."
-    RANGE_END=$(( ZIP_DATA_BYTE_OFFSET + ZIP_DATA_BYTE_SIZE - 1 ))
-    if command -v curl &>/dev/null; then
-        curl -L --max-time 600 \
-            -H "Range: bytes=${ZIP_DATA_BYTE_OFFSET}-${RANGE_END}" \
-            "${SYMBOLS_ZIP_URL}" \
-            -o "${SYM_COMPRESSED}"
-    elif command -v wget &>/dev/null; then
-        wget --header="Range: bytes=${ZIP_DATA_BYTE_OFFSET}-${RANGE_END}" \
-             --timeout=600 -q \
-             -O "${SYM_COMPRESSED}" \
-             "${SYMBOLS_ZIP_URL}"
-    else
-        echo "[INJECT-SYMS] ERROR: curl or wget is required" >&2
-        exit 1
+# ── Pre-injection .text section SHA256 (architectural invariant probe) ───────
+# AstryxOS invariant: never edit upstream binaries.  Splicing a .symtab is
+# adding metadata sections, which does NOT touch .text — verify byte-identical
+# .text content after injection.
+PRE_TEXT_SHA=""
+if command -v objcopy >/dev/null 2>&1 && command -v sha256sum >/dev/null 2>&1; then
+    PRE_TEXT_TMP="$(mktemp -t libxul_pre_text.XXXXXX)"
+    if objcopy --dump-section .text="${PRE_TEXT_TMP}" "${LIBXUL}" 2>/dev/null; then
+        PRE_TEXT_SHA="$(sha256sum "${PRE_TEXT_TMP}" | cut -d' ' -f1)"
+        echo "[INJECT-SYMS]   Pre  .text SHA256: ${PRE_TEXT_SHA}"
     fi
-    echo "[INJECT-SYMS] Downloaded $(du -sh "${SYM_COMPRESSED}" | cut -f1)"
-else
-    echo "[INJECT-SYMS] Using cached compressed symbols (${SYM_COMPRESSED})"
+    rm -f "${PRE_TEXT_TMP}"
 fi
 
-# ── Step 2: Decompress raw DEFLATE stream to libxul.so.sym ────────────────────
-if [ "${FORCE}" = true ] || [ ! -f "${SYM_FILE}" ]; then
-    echo "[INJECT-SYMS] Decompressing libxul.so.sym (~690 MiB)..."
-    python3 -c "
+if [ "${MODE}" = "glibc" ]; then
+    # ── glibc mode: HTTP-range-slice the crashreporter ZIP ───────────────────
+    ACTUAL_SIZE=0
+    if [ -f "${SYM_COMPRESSED}" ]; then
+        ACTUAL_SIZE=$(stat -c%s "${SYM_COMPRESSED}" 2>/dev/null || echo 0)
+    fi
+
+    if [ "${FORCE}" = true ] || [ "${ACTUAL_SIZE}" -ne "${ZIP_DATA_BYTE_SIZE}" ]; then
+        echo "[INJECT-SYMS] Downloading libxul.so.sym from Mozilla CDN (~130 MiB)..."
+        RANGE_END=$(( ZIP_DATA_BYTE_OFFSET + ZIP_DATA_BYTE_SIZE - 1 ))
+        if command -v curl &>/dev/null; then
+            curl -L --max-time 600 \
+                -H "Range: bytes=${ZIP_DATA_BYTE_OFFSET}-${RANGE_END}" \
+                "${SYMBOLS_ZIP_URL}" \
+                -o "${SYM_COMPRESSED}"
+        elif command -v wget &>/dev/null; then
+            wget --header="Range: bytes=${ZIP_DATA_BYTE_OFFSET}-${RANGE_END}" \
+                 --timeout=600 -q \
+                 -O "${SYM_COMPRESSED}" \
+                 "${SYMBOLS_ZIP_URL}"
+        else
+            echo "[INJECT-SYMS] ERROR: curl or wget is required" >&2
+            exit 1
+        fi
+        echo "[INJECT-SYMS] Downloaded $(du -sh "${SYM_COMPRESSED}" | cut -f1)"
+    else
+        echo "[INJECT-SYMS] Using cached compressed symbols (${SYM_COMPRESSED})"
+    fi
+
+    if [ "${FORCE}" = true ] || [ ! -f "${SYM_FILE}" ]; then
+        echo "[INJECT-SYMS] Decompressing libxul.so.sym (~690 MiB)..."
+        python3 -c "
 import zlib, time, sys
 compressed_file = sys.argv[1]
 output_file     = sys.argv[2]
@@ -116,14 +189,98 @@ with open(output_file, 'wb') as f:
     f.write(out)
 print(f'[INJECT-SYMS] Decompressed {len(out)/1024/1024:.1f} MiB in {time.time()-start:.1f}s')
 " "${SYM_COMPRESSED}" "${SYM_FILE}"
+    else
+        echo "[INJECT-SYMS] Using cached ${SYM_FILE} ($(wc -l < "${SYM_FILE}") lines)"
+    fi
 else
-    echo "[INJECT-SYMS] Using cached ${SYM_FILE} ($(wc -l < "${SYM_FILE}") lines)"
+    # ── musl mode: query Mozilla symbol server by BuildID-derived GUID ───────
+    BUILD_ID="$(readelf -n "${LIBXUL}" 2>/dev/null | awk '/Build ID:/ {print $NF}')"
+    if [ -z "${BUILD_ID}" ] || [ "${#BUILD_ID}" -lt 32 ]; then
+        echo "[INJECT-SYMS] ERROR: could not read Build ID from ${LIBXUL}" >&2
+        exit 1
+    fi
+    echo "[INJECT-SYMS]   BuildID: ${BUILD_ID}"
+
+    # Breakpad GUID convention: first 16 bytes of BuildID as a Microsoft GUID
+    # (LE quad/word/word reorder for the first 8 bytes, then 8 bytes verbatim),
+    # uppercase hex with a trailing "0" pad making it 33 chars total.
+    # Reference: https://chromium.googlesource.com/breakpad/breakpad/+/HEAD/docs/symbol_files.md#the-module-record
+    GUID="$(python3 -c "
+import sys
+bid = sys.argv[1]
+b = bytes.fromhex(bid[:32])
+g = b[0:4][::-1] + b[4:6][::-1] + b[6:8][::-1] + b[8:16]
+print(g.hex().upper() + '0')
+" "${BUILD_ID}")"
+    echo "[INJECT-SYMS]   Breakpad GUID: ${GUID}"
+
+    SYM_URL="https://symbols.mozilla.org/libxul.so/${GUID}/libxul.so.sym"
+
+    if [ "${FORCE}" = true ] || [ ! -f "${SYM_GZ}" ]; then
+        echo "[INJECT-SYMS] Downloading libxul.so.sym from Mozilla tecken (~9 MiB gz)..."
+        # Mozilla's symbol server returns 200 with a redirect Location header
+        # even for unknown GUIDs (it always replies with the CDN URL).  We must
+        # follow the redirect (-L) and inspect the actual response to detect
+        # MISS vs HIT.  A HIT returns gzip-magic (\037\213) bytes; a MISS
+        # returns text "Symbol not found" / 404 from the CDN.
+        SYM_GZ_TMP="${SYM_GZ}.tmp"
+        if command -v curl &>/dev/null; then
+            HTTP_CODE="$(curl -sL --max-time 120 \
+                -w '%{http_code}' \
+                -o "${SYM_GZ_TMP}" \
+                "${SYM_URL}")"
+        elif command -v wget &>/dev/null; then
+            wget --timeout=120 -q -O "${SYM_GZ_TMP}" "${SYM_URL}" \
+                && HTTP_CODE=200 || HTTP_CODE=404
+        else
+            echo "[INJECT-SYMS] ERROR: curl or wget is required" >&2
+            exit 1
+        fi
+        if [ "${HTTP_CODE}" != "200" ]; then
+            echo "[INJECT-SYMS] ERROR: Mozilla symbol server returned HTTP ${HTTP_CODE}" >&2
+            echo "[INJECT-SYMS]        URL: ${SYM_URL}" >&2
+            echo "[INJECT-SYMS]        The Alpine libxul BuildID is not in Mozilla's index." >&2
+            echo "[INJECT-SYMS]        Consider scripts/install-firefox-musl-debug.sh for non-libxul" >&2
+            echo "[INJECT-SYMS]        coverage, or building firefox-esr from Alpine source." >&2
+            rm -f "${SYM_GZ_TMP}"
+            exit 1
+        fi
+        # Verify the payload is actually gzip (first two bytes 0x1f 0x8b).
+        MAGIC_HEX="$(head -c2 "${SYM_GZ_TMP}" | od -An -tx1 | tr -d ' \n')"
+        if [ "${MAGIC_HEX}" != "1f8b" ]; then
+            echo "[INJECT-SYMS] ERROR: downloaded payload is not gzip (magic=${MAGIC_HEX})" >&2
+            echo "[INJECT-SYMS]        First 200 bytes:" >&2
+            head -c200 "${SYM_GZ_TMP}" >&2
+            rm -f "${SYM_GZ_TMP}"
+            exit 1
+        fi
+        mv "${SYM_GZ_TMP}" "${SYM_GZ}"
+        echo "[INJECT-SYMS] Downloaded $(du -sh "${SYM_GZ}" | cut -f1)"
+    else
+        echo "[INJECT-SYMS] Using cached compressed symbols (${SYM_GZ})"
+    fi
+
+    if [ "${FORCE}" = true ] || [ ! -f "${SYM_FILE}" ]; then
+        echo "[INJECT-SYMS] Decompressing libxul.so.sym ..."
+        gunzip -c "${SYM_GZ}" > "${SYM_FILE}"
+        echo "[INJECT-SYMS] Decompressed $(du -sh "${SYM_FILE}" | cut -f1)"
+    else
+        echo "[INJECT-SYMS] Using cached ${SYM_FILE} ($(wc -l < "${SYM_FILE}") lines)"
+    fi
+
+    # Sanity: the .sym file should carry the same Build ID we read from libxul.
+    SYM_MODULE_LINE="$(head -2 "${SYM_FILE}")"
+    SYM_CODE_ID="$(echo "${SYM_MODULE_LINE}" | awk '/^INFO CODE_ID/ {print tolower($3)}')"
+    if [ -n "${SYM_CODE_ID}" ] && [ "${SYM_CODE_ID}" != "${BUILD_ID}" ]; then
+        echo "[INJECT-SYMS] WARNING: .sym CODE_ID=${SYM_CODE_ID} does not match libxul BuildID=${BUILD_ID}" >&2
+        echo "[INJECT-SYMS]          GUID derivation or Mozilla index lookup is inconsistent." >&2
+    fi
 fi
 
 echo "[INJECT-SYMS] libxul.so.sym: $(wc -l < "${SYM_FILE}") lines, \
-$(grep -c '^FUNC ' "${SYM_FILE}") FUNC records"
+$(grep -c '^FUNC ' "${SYM_FILE}") FUNC + $(grep -c '^PUBLIC ' "${SYM_FILE}") PUBLIC records"
 
-# ── Step 3: Splice .symtab into libxul.so (in-place via temp file) ────────────
+# ── Splice .symtab into libxul.so (in-place via temp file) ───────────────────
 echo "[INJECT-SYMS] Running inject-libxul-symtab.py..."
 python3 "${INJECT_SCRIPT}" \
     --sym    "${SYM_FILE}" \
@@ -134,10 +291,34 @@ python3 "${INJECT_SCRIPT}" \
 chmod --reference="${LIBXUL}" "${LIBXUL}.tmp"
 mv "${LIBXUL}.tmp" "${LIBXUL}"
 
+# ── Post-injection .text SHA256 — must equal pre-injection ───────────────────
+if [ -n "${PRE_TEXT_SHA}" ]; then
+    POST_TEXT_TMP="$(mktemp -t libxul_post_text.XXXXXX)"
+    if objcopy --dump-section .text="${POST_TEXT_TMP}" "${LIBXUL}" 2>/dev/null; then
+        POST_TEXT_SHA="$(sha256sum "${POST_TEXT_TMP}" | cut -d' ' -f1)"
+        echo "[INJECT-SYMS]   Post .text SHA256: ${POST_TEXT_SHA}"
+        if [ "${POST_TEXT_SHA}" != "${PRE_TEXT_SHA}" ]; then
+            echo "[INJECT-SYMS] FATAL: .text section was modified by injection!" >&2
+            echo "[INJECT-SYMS]        Upstream-binary-edit invariant violated." >&2
+            rm -f "${POST_TEXT_TMP}"
+            exit 1
+        fi
+    fi
+    rm -f "${POST_TEXT_TMP}"
+fi
+
 echo "[INJECT-SYMS] Done."
 echo "[INJECT-SYMS]   ${LIBXUL}: $(du -sh "${LIBXUL}" | cut -f1)"
 NM_COUNT=$(nm --defined-only "${LIBXUL}" 2>/dev/null | wc -l)
 echo "[INJECT-SYMS]   nm --defined-only | wc -l: ${NM_COUNT}"
-if [ "${NM_COUNT}" -lt 300000 ]; then
-    echo "[INJECT-SYMS] WARNING: expected ~353,947 symbols, got ${NM_COUNT}" >&2
+# Glibc mode expects ~353,947 FUNC records.  Musl mode is PUBLIC-only and
+# carries ~8,000 records (Alpine builds without DWARF).  Warn only if the
+# count falls below mode-specific lower bounds — a hard floor catches
+# malformed .sym fetches without alarming on the legitimate PUBLIC-only case.
+if [ "${MODE}" = "glibc" ]; then
+    [ "${NM_COUNT}" -lt 300000 ] && \
+        echo "[INJECT-SYMS] WARNING: expected ~353,947 symbols (glibc), got ${NM_COUNT}" >&2
+else
+    [ "${NM_COUNT}" -lt 5000 ] && \
+        echo "[INJECT-SYMS] WARNING: expected ~8,000 symbols (musl PUBLIC-only), got ${NM_COUNT}" >&2
 fi

--- a/scripts/inject-libxul-symbols.sh
+++ b/scripts/inject-libxul-symbols.sh
@@ -104,6 +104,19 @@ else
     SYM_GZ="${SYM_DIR}/libxul.so.sym.gz"
 fi
 
+# ── Required-tools check (defensive: keep .text-SHA invariant probe intact) ──
+# The architectural invariant (no upstream-binary edits) is enforced by the
+# pre/post .text SHA256 comparison below; that comparison silently no-ops if
+# objcopy or sha256sum is missing, which would let a regression slip through
+# unnoticed.  Require both upfront so the invariant probe is always exercised.
+for tool in objcopy sha256sum readelf; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "[INJECT-SYMS] ERROR: required tool '${tool}' not found in PATH" >&2
+        echo "[INJECT-SYMS]        Install binutils + coreutils (Debian: 'apt install binutils coreutils')" >&2
+        exit 1
+    fi
+done
+
 # ── Sanity: target libxul must exist ─────────────────────────────────────────
 if [ ! -f "${LIBXUL}" ]; then
     echo "[INJECT-SYMS] ERROR: target libxul.so not found: ${LIBXUL}"
@@ -136,14 +149,16 @@ mkdir -p "${SYM_DIR}"
 # adding metadata sections, which does NOT touch .text — verify byte-identical
 # .text content after injection.
 PRE_TEXT_SHA=""
-if command -v objcopy >/dev/null 2>&1 && command -v sha256sum >/dev/null 2>&1; then
-    PRE_TEXT_TMP="$(mktemp -t libxul_pre_text.XXXXXX)"
-    if objcopy --dump-section .text="${PRE_TEXT_TMP}" "${LIBXUL}" 2>/dev/null; then
-        PRE_TEXT_SHA="$(sha256sum "${PRE_TEXT_TMP}" | cut -d' ' -f1)"
-        echo "[INJECT-SYMS]   Pre  .text SHA256: ${PRE_TEXT_SHA}"
-    fi
+PRE_TEXT_TMP="$(mktemp -t libxul_pre_text.XXXXXX)"
+if objcopy --dump-section .text="${PRE_TEXT_TMP}" "${LIBXUL}" 2>/dev/null; then
+    PRE_TEXT_SHA="$(sha256sum "${PRE_TEXT_TMP}" | cut -d' ' -f1)"
+    echo "[INJECT-SYMS]   Pre  .text SHA256: ${PRE_TEXT_SHA}"
+else
+    echo "[INJECT-SYMS] ERROR: failed to dump .text from ${LIBXUL}" >&2
     rm -f "${PRE_TEXT_TMP}"
+    exit 1
 fi
+rm -f "${PRE_TEXT_TMP}"
 
 if [ "${MODE}" = "glibc" ]; then
     # ── glibc mode: HTTP-range-slice the crashreporter ZIP ───────────────────
@@ -268,12 +283,18 @@ print(g.hex().upper() + '0')
         echo "[INJECT-SYMS] Using cached ${SYM_FILE} ($(wc -l < "${SYM_FILE}") lines)"
     fi
 
-    # Sanity: the .sym file should carry the same Build ID we read from libxul.
+    # Sanity: the .sym file MUST carry the same Build ID we read from libxul.
+    # A mismatch means tecken returned the wrong .sym (GUID derivation bug,
+    # index inconsistency, or the .sym was rebuilt against a different binary).
+    # Splicing a mismatched .symtab produces nonsense rip-trace attributions —
+    # hard-fail rather than warn.
     SYM_MODULE_LINE="$(head -2 "${SYM_FILE}")"
     SYM_CODE_ID="$(echo "${SYM_MODULE_LINE}" | awk '/^INFO CODE_ID/ {print tolower($3)}')"
     if [ -n "${SYM_CODE_ID}" ] && [ "${SYM_CODE_ID}" != "${BUILD_ID}" ]; then
-        echo "[INJECT-SYMS] WARNING: .sym CODE_ID=${SYM_CODE_ID} does not match libxul BuildID=${BUILD_ID}" >&2
-        echo "[INJECT-SYMS]          GUID derivation or Mozilla index lookup is inconsistent." >&2
+        echo "[INJECT-SYMS] ERROR: .sym CODE_ID=${SYM_CODE_ID} does not match libxul BuildID=${BUILD_ID}" >&2
+        echo "[INJECT-SYMS]        GUID derivation or Mozilla index lookup is inconsistent." >&2
+        echo "[INJECT-SYMS]        Refusing to inject — would produce wrong rip-trace attributions." >&2
+        exit 1
     fi
 fi
 

--- a/scripts/inject-libxul-symtab.py
+++ b/scripts/inject-libxul-symtab.py
@@ -11,15 +11,27 @@ Usage:
         --output <path/to/libxul.sym.so>
 
 The Breakpad .sym format (see https://chromium.googlesource.com/breakpad/) has
-FUNC records of the form:
+two relevant per-symbol record types:
 
-    FUNC <hex_offset> <size_hex> <param_size_hex> <demangled_name>
+    FUNC   <hex_offset> <size_hex> <param_size_hex> <demangled_name>
+    PUBLIC [m] <hex_offset> <param_size_hex> <demangled_name>
 
-where <hex_offset> is the ELF VMA (load-time address for a PIE/shared object,
+`FUNC` records carry an explicit byte size and are produced when the upstream
+build was compiled with DWARF debug info (Mozilla's release builds for the
+official Firefox channels).  `PUBLIC` records are derived from the dynamic
+symbol table (.dynsym) plus per-platform demanglers and are emitted by
+dump_syms when no DWARF is available — for example, third-party rebuilds
+(Alpine's community/firefox-esr, Debian's firefox-esr, distro packages
+generally).  PUBLIC carries no size; we set st_size = 0 and let nm / addr2line
+treat the entry as a function-entry-point address.  The optional "m" token
+flags a multiple-definition symbol; we ignore it (objcopy/nm handle dupes
+correctly because we use STB_LOCAL).
+
+`<hex_offset>` is the ELF VMA (load-time address for a PIE/shared object,
 i.e. the same value you'd find in .symtab st_value for a shared library).
 
 This script:
-  1. Parses FUNC records from the .sym file.
+  1. Parses FUNC and PUBLIC records from the .sym file.
   2. Builds an Elf64_Sym array (.symtab) and a null-terminated string table
      (.strtab).
   3. Appends both sections to the ELF using objcopy --add-section.
@@ -78,30 +90,83 @@ SHN_ABS = 0xfff1
 
 def parse_sym(sym_path: Path) -> list[tuple[int, int, str]]:
     """
-    Parse FUNC records from a Mozilla Breakpad .sym file.
+    Parse FUNC and PUBLIC records from a Mozilla Breakpad .sym file.
 
-    Returns a list of (vma, size, name) tuples, one per FUNC record.
+    Returns a list of (vma, size, name) tuples, one per FUNC or PUBLIC record.
     Names are already demangled in the .sym file.
+
+    PUBLIC records carry no explicit size (Breakpad spec: size field absent —
+    PUBLIC tokens are entry-point pointers, not extents).  We set size=0 for
+    those entries.  nm and addr2line treat STT_FUNC symbols with st_size=0 as
+    entry-point markers and still resolve names via the nearest-below lookup
+    that binutils performs internally, which is sufficient for kdb
+    rip-trace-resolve attribution.
+
+    FUNC and PUBLIC are not mutually exclusive in a well-formed .sym; in
+    practice Mozilla's release builds emit FUNC only, and dump_syms builds
+    against stripped third-party binaries (Alpine, Debian) emit PUBLIC only.
+    We accept both so a single injection pass handles either source.
     """
     funcs: list[tuple[int, int, str]] = []
-    # The .sym file may be large (690 MiB) — read line-by-line to avoid
-    # loading the whole thing into memory at once.
+    # The .sym file may be large (690 MiB for Mozilla release builds, ~90 MiB
+    # for Alpine PUBLIC-only) — read line-by-line to avoid loading it whole.
+    n_func = 0
+    n_public = 0
     with open(sym_path, "r", encoding="utf-8", errors="replace") as fh:
         for line in fh:
-            if not line.startswith("FUNC "):
-                continue
-            # FUNC <addr_hex> <size_hex> <param_size_hex> <name>
-            parts = line.split(None, 4)
-            if len(parts) < 5:
-                continue
-            try:
-                vma = int(parts[1], 16)
-                size = int(parts[2], 16)
-            except ValueError:
-                continue
-            name = parts[4].rstrip("\n")
-            if name:
-                funcs.append((vma, size, name))
+            if line.startswith("FUNC "):
+                # FUNC [m] <addr_hex> <size_hex> <param_size_hex> <name>
+                # The "m" multiple-definition flag is optional (sits at
+                # parts[1]); when absent the address is at parts[1] and the
+                # name at parts[4].  Mozilla release builds emit FUNC without
+                # the m flag; we accept both to be tolerant of future format
+                # variants.
+                parts = line.split(None, 5)
+                if len(parts) < 5:
+                    continue
+                if parts[1] == "m":
+                    if len(parts) < 6:
+                        continue
+                    addr_field, size_field = parts[2], parts[3]
+                    name = parts[5].rstrip("\n")
+                else:
+                    addr_field, size_field = parts[1], parts[2]
+                    name = parts[4].rstrip("\n")
+                try:
+                    vma = int(addr_field, 16)
+                    size = int(size_field, 16)
+                except ValueError:
+                    continue
+                if name:
+                    funcs.append((vma, size, name))
+                    n_func += 1
+            elif line.startswith("PUBLIC "):
+                # PUBLIC [m] <addr_hex> <param_size_hex> <name>
+                # The optional "m" multiple-definition flag sits at parts[1];
+                # the address is then at parts[2] and the name at parts[4].
+                # Without "m" the address is at parts[1] and the name at
+                # parts[3].
+                parts = line.split(None, 4)
+                if len(parts) < 4:
+                    continue
+                if parts[1] == "m":
+                    if len(parts) < 5:
+                        continue
+                    addr_field = parts[2]
+                    name = parts[4].rstrip("\n")
+                else:
+                    addr_field = parts[1]
+                    name = parts[3].rstrip("\n")
+                try:
+                    vma = int(addr_field, 16)
+                except ValueError:
+                    continue
+                if name and vma != 0:
+                    # st_size = 0 — PUBLIC has no size; nm / addr2line tolerate
+                    # this and treat the symbol as an entry-point marker.
+                    funcs.append((vma, 0, name))
+                    n_public += 1
+    print(f"      Parsed FUNC={n_func:,}  PUBLIC={n_public:,}")
     return funcs
 
 

--- a/scripts/inject-libxul-symtab.py
+++ b/scripts/inject-libxul-symtab.py
@@ -117,19 +117,29 @@ def parse_sym(sym_path: Path) -> list[tuple[int, int, str]]:
             if line.startswith("FUNC "):
                 # FUNC [m] <addr_hex> <size_hex> <param_size_hex> <name>
                 # The "m" multiple-definition flag is optional (sits at
-                # parts[1]); when absent the address is at parts[1] and the
-                # name at parts[4].  Mozilla release builds emit FUNC without
-                # the m flag; we accept both to be tolerant of future format
-                # variants.
-                parts = line.split(None, 5)
-                if len(parts) < 5:
+                # parts[1]).  We must redo the split with the correct maxsplit
+                # depending on whether "m" is present, so that the demangled
+                # C++ name (which contains spaces from templates, `const`,
+                # multi-arg lists, etc.) is captured as one final token rather
+                # than truncated at its first whitespace.
+                #
+                #   With m:    FUNC m <addr> <size> <psize> <name...>
+                #              → split(None, 5), name = parts[5]
+                #   Without:   FUNC   <addr> <size> <psize> <name...>
+                #              → split(None, 4), name = parts[4]
+                first_split = line.split(None, 2)
+                if len(first_split) < 2:
                     continue
-                if parts[1] == "m":
+                if first_split[1] == "m":
+                    parts = line.split(None, 5)
                     if len(parts) < 6:
                         continue
                     addr_field, size_field = parts[2], parts[3]
                     name = parts[5].rstrip("\n")
                 else:
+                    parts = line.split(None, 4)
+                    if len(parts) < 5:
+                        continue
                     addr_field, size_field = parts[1], parts[2]
                     name = parts[4].rstrip("\n")
                 try:
@@ -142,19 +152,27 @@ def parse_sym(sym_path: Path) -> list[tuple[int, int, str]]:
                     n_func += 1
             elif line.startswith("PUBLIC "):
                 # PUBLIC [m] <addr_hex> <param_size_hex> <name>
-                # The optional "m" multiple-definition flag sits at parts[1];
-                # the address is then at parts[2] and the name at parts[4].
-                # Without "m" the address is at parts[1] and the name at
-                # parts[3].
-                parts = line.split(None, 4)
-                if len(parts) < 4:
+                # Same demangled-name-with-spaces concern as FUNC: redo the
+                # split with the correct maxsplit so the full name lands in
+                # the final token.
+                #
+                #   With m:    PUBLIC m <addr> <psize> <name...>
+                #              → split(None, 4), name = parts[4]
+                #   Without:   PUBLIC   <addr> <psize> <name...>
+                #              → split(None, 3), name = parts[3]
+                first_split = line.split(None, 2)
+                if len(first_split) < 2:
                     continue
-                if parts[1] == "m":
+                if first_split[1] == "m":
+                    parts = line.split(None, 4)
                     if len(parts) < 5:
                         continue
                     addr_field = parts[2]
                     name = parts[4].rstrip("\n")
                 else:
+                    parts = line.split(None, 3)
+                    if len(parts) < 4:
+                        continue
                     addr_field = parts[1]
                     name = parts[3].rstrip("\n")
                 try:
@@ -396,7 +414,69 @@ def verify_output(output_path: Path) -> None:
         print("[WARN] nm returned no symbols!", file=sys.stderr)
 
 
+def _selftest() -> int:
+    """
+    Round-trip parse_sym() against representative FUNC/PUBLIC records that
+    exercise the demangled-name-with-spaces edge cases (templates, references,
+    `const`, multi-arg).  Catches the regression where the optional `m` flag
+    branch truncates names at the first whitespace.
+    """
+    cases = [
+        # (line, expected_vma, expected_size, expected_name)
+        ("FUNC 1500 80 0 mozilla::dom::Document::GetElementById(nsAString const&)\n",
+         0x1500, 0x80,
+         "mozilla::dom::Document::GetElementById(nsAString const&)"),
+        ("FUNC m 1500 80 0 mozilla::Foo::Bar(int const&)\n",
+         0x1500, 0x80,
+         "mozilla::Foo::Bar(int const&)"),
+        ("PUBLIC 1430 0 std::vector<int, std::allocator<int> >::push_back(int const&)\n",
+         0x1430, 0,
+         "std::vector<int, std::allocator<int> >::push_back(int const&)"),
+        ("PUBLIC m 1430 0 std::vector<int>::clear()\n",
+         0x1430, 0,
+         "std::vector<int>::clear()"),
+        # No-flag simple case (no internal spaces) — sanity check that the
+        # common path still works.
+        ("FUNC 2000 10 0 _start\n",
+         0x2000, 0x10, "_start"),
+        ("PUBLIC 3000 0 main\n",
+         0x3000, 0, "main"),
+    ]
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sym_path = Path(tmpdir) / "selftest.sym"
+        with open(sym_path, "w", encoding="utf-8") as f:
+            f.write("MODULE Linux x86_64 0000 libxul.so\n")
+            for line, _, _, _ in cases:
+                f.write(line)
+        # Suppress the "Parsed FUNC=... PUBLIC=..." print during self-test.
+        import io, contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            parsed = parse_sym(sym_path)
+    if len(parsed) != len(cases):
+        print(f"[SELFTEST] FAIL: expected {len(cases)} records, got {len(parsed)}")
+        return 1
+    for (line, exp_vma, exp_size, exp_name), got in zip(cases, parsed):
+        got_vma, got_size, got_name = got
+        if (got_vma, got_size, got_name) != (exp_vma, exp_size, exp_name):
+            print(f"[SELFTEST] FAIL: {line.rstrip()}")
+            print(f"           expected (vma={exp_vma:#x}, size={exp_size:#x}, name={exp_name!r})")
+            print(f"           got      (vma={got_vma:#x}, size={got_size:#x}, name={got_name!r})")
+            failures += 1
+    if failures == 0:
+        print(f"[SELFTEST] OK: {len(cases)} round-trip cases passed")
+        return 0
+    return 1
+
+
 def main() -> None:
+    # Hidden --self-test entry point for round-tripping parse_sym() against
+    # representative demangled-name shapes.  Used in CI and by reviewers; does
+    # not require any external .sym or libxul.so input.
+    if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
+        sys.exit(_selftest())
+
     parser = argparse.ArgumentParser(
         description="Splice Breakpad FUNC symbols into a stripped libxul.so as .symtab"
     )

--- a/scripts/install-firefox-musl-debug.sh
+++ b/scripts/install-firefox-musl-debug.sh
@@ -43,13 +43,15 @@
 # Because Alpine does not ship debug symbols for firefox-esr, addr2line cannot
 # resolve RIPs inside libxul.so by .gnu_debuglink alone.  Three options exist:
 #
-#   1. Coarse function-level names via Mozilla's official Breakpad .sym file
-#      (Firefox 115.24.0esr) injected as a .symtab.  This is what
-#      scripts/inject-libxul-symbols.sh does — but note that Alpine rebuilds
-#      libxul from source with its own toolchain, so VMAs in Mozilla's .sym
-#      will drift from Alpine's libxul by a few bytes per function; the
-#      resolved function NAME is usually correct, but the line/file mapping
-#      is not.  Pragmatic for K-class watchpoint attribution; not byte-precise.
+#   1. Coarse function-level names via Mozilla's tecken symbol server.  Alpine
+#      uploads to tecken keyed by its exact ELF BuildID, so the .sym matches
+#      the Alpine libxul byte-for-byte (no VMA drift).  The .sym contains
+#      PUBLIC-only records (Alpine builds without DWARF), so coverage is
+#      .dynsym names plus their entry-point VMAs — ~8,600 symbols, enough to
+#      attribute K-class RIP fires to within a function (file/line not
+#      recoverable).  scripts/inject-libxul-symbols.sh --musl handles this
+#      automatically; create-data-disk.sh wires it whenever
+#      ASTRYXOS_FIREFOX_DEBUG is set with FIREFOX_VARIANT=musl.
 #
 #   2. Build firefox-esr from source inside an Alpine builder with
 #      --disable-strip and --disable-install-strip.  Multi-hour, multi-GiB.
@@ -316,7 +318,6 @@ echo "[FF-MUSL-DBG] Done."
 echo "[FF-MUSL-DBG]   Layout: ${DISK_DEBUG_DIR}/<abs-binary-path>/<basename>.debug"
 echo "[FF-MUSL-DBG]   Total:  ${DBG_TREE_SIZE} across ${DBG_FILE_COUNT} files"
 echo "[FF-MUSL-DBG]   Coverage: musl libc + ld-musl; +GTK/glib/cairo/pixbuf when not --musl-only"
-echo "[FF-MUSL-DBG]   Gap:    firefox-esr — Alpine does not ship firefox-esr-dbg;"
-echo "[FF-MUSL-DBG]           run scripts/inject-libxul-symbols.sh against the musl libxul"
-echo "[FF-MUSL-DBG]           for coarse function-level names via Mozilla's Breakpad .sym"
-echo "[FF-MUSL-DBG]           (function names usually correct, VMAs drift vs Mozilla build)."
+echo "[FF-MUSL-DBG]   libxul: handled by scripts/inject-libxul-symbols.sh --musl"
+echo "[FF-MUSL-DBG]           (Mozilla tecken keyed by Alpine ELF BuildID; PUBLIC-only,"
+echo "[FF-MUSL-DBG]            ~8,600 entries; VMAs byte-exact vs Alpine libxul)."


### PR DESCRIPTION
## Summary

Demo pivot Phase 1.5 (Option α): extend `scripts/inject-libxul-symbols.sh`
with a `--musl` mode so the Alpine `community/firefox-esr` libxul gets a
proper ELF `.symtab` for K-class RIP attribution. Closes the libxul gap
that `install-firefox-musl-debug.sh` (PR #359) left open because Alpine's
firefox-esr APKBUILD ships no `-dbg` subpackage.

Mozilla's tecken symbol server indexes Alpine's exact ELF BuildID
(`a5376fe04c6356fa322d30858e9e36a468f9a897`, Breakpad GUID
`E06F37A5634CFA56322D30858E9E36A40`) and serves a gzipped Breakpad `.sym`
on a single GET (~9 MiB on the wire, ~88 MiB after gunzip), so VMAs match
the staged Alpine libxul byte-for-byte. Coverage is PUBLIC-only (Alpine
builds without DWARF): ~8,600 entry-point names sufficient for nearest-below
RIP attribution from the qemu-harness.py `rip-trace-resolve` subcommand.

`scripts/inject-libxul-symtab.py` learns to parse PUBLIC records alongside
FUNC; PUBLIC entries get `st_size = 0` which `nm`/`addr2line` tolerate as
entry-point markers. FUNC parsing also tolerates the optional `m`
multiple-definition flag for forward compatibility.

`scripts/create-data-disk.sh` wires `--musl` automatically when
`ASTRYXOS_FIREFOX_DEBUG` is set in the musl variant — composes with the
existing `-dbg` companion staging so the two attribution avenues cover
ld-musl/GTK/glib/cairo/pixbuf (companions) **plus** libxul (this PR).

## Why this works

The dispatch's α-feasibility check predicted Mozilla would *not* have Alpine
symbols ("Alpine rebuilds with its own toolchain → different BuildID, unlikely
to be in Mozilla's index"). That turned out wrong — Alpine uploads symbols
to tecken keyed by its exact ELF BuildID. HIT verified by HTTP GET against
`https://symbols.mozilla.org/libxul.so/E06F37A5634CFA56322D30858E9E36A40/libxul.so.sym`
(gzip magic in response, CODE_ID `A5376FE04C6356FA322D30858E9E36A468F9A897`
matching libxul's BuildID byte-for-byte after the case-fold).

The dispatch's β fallback (Alpine source rebuild with `--disable-strip`) is
unneeded for the K2b attribution use case; remains documented in
`install-firefox-musl-debug.sh` and HARNESS.md as the explicit escalation
path when file/line numbers (not just function names) are required.

## Architectural invariant

`build-scripts wrap upstream binaries — they do not patch them`. The musl
mode adds a defensive pre/post `.text` SHA256 check via
`objcopy --dump-section .text=`: the script aborts before overwriting the
staged libxul.so if the section bytes diverge. End-to-end run on the staged
Alpine libxul confirmed byte-identical .text:
`08fb1caea7a84684e2af2c7f43f2ed297f5b55d9a02ded0b6d62eeb19674b665`
pre and post.

## End-to-end verification

```
[INJECT-SYMS]   BuildID: a5376fe04c6356fa322d30858e9e36a468f9a897
[INJECT-SYMS]   Breakpad GUID: E06F37A5634CFA56322D30858E9E36A40
[INJECT-SYMS] Downloaded 8.7M
[INJECT-SYMS] Decompressed 89M
[INJECT-SYMS] libxul.so.sym: 2160101 lines, 0 FUNC + 8622 PUBLIC records
[INJECT-SYMS]   Pre  .text SHA256: 08fb1caea7a84684e2af2c7f43f2ed297f5b55d9a02ded0b6d62eeb19674b665
      Parsed FUNC=0  PUBLIC=8,622
      .symtab: 8,623 entries (0.2 MiB)
      Patched .symtab[31]: sh_link=32, sh_info=8623, sh_entsize=24, sh_addralign=8
[OK] nm returned 8622 defined symbols.
[OK] Build ID unchanged (executable code not modified).
[INJECT-SYMS]   Post .text SHA256: 08fb1caea7a84684e2af2c7f43f2ed297f5b55d9a02ded0b6d62eeb19674b665
```

K2b's 32 captured DR-watchpoint RIPs: 17/32 in libxul (10 within 4 KiB of a
named PUBLIC; 7 within an unnamed-but-bounded function), 15/32 in ld-musl
(handled by the existing `install-firefox-musl-debug.sh` companion).

## Test plan

- [x] `bash -n` syntax check on `inject-libxul-symbols.sh` and `create-data-disk.sh`
- [x] End-to-end run on a real Alpine libxul (BuildID `a5376fe…`) — HIT, 8,622 PUBLIC, .text byte-identical
- [x] Idempotency: re-run skips when `.symtab` already present
- [x] Unknown-arg rejection (`--bogus` → rc=2)
- [x] Default (glibc) mode preserves identical pre-existing behaviour (target path, hardcoded ZIP byte offsets, raw-DEFLATE decompression all unchanged); only refactored under a `MODE=glibc` branch
- [x] `--help` prints the new dual-mode docstring
- [x] `parse_sym` unit-tested on mock FUNC/PUBLIC/FUNC-with-m/PUBLIC-with-m inputs
- [x] `parse_sym` still parses the existing Alpine .sym to 8,622 entries
- [ ] Build a fresh `data.img` with `ASTRYXOS_FIREFOX_VARIANT=musl ASTRYXOS_FIREFOX_DEBUG=musl bash scripts/create-data-disk.sh --force` (requires the apk-static dep chain — reviewer or coordinator-side check)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)