### PR TITLE
kernel/mm: dynamic HEAP_START from __kernel_end (fixes heavy-diag boot-OOM)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1168,19 +1168,25 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
     // CPU's ring-level check (GP fault) before reaching here; guard detection
     // is purely a defence-in-depth for buggy kernel allocations.
     {
-        use crate::mm::heap::{HEAP_GUARD_BELOW_VA, HEAP_GUARD_ABOVE_VA, HEAP_START, HEAP_SIZE};
-        let is_below_guard = faulting_addr >= HEAP_GUARD_BELOW_VA
-                          && faulting_addr <  HEAP_GUARD_BELOW_VA + 0x1000;
-        let is_above_guard = faulting_addr >= HEAP_GUARD_ABOVE_VA
-                          && faulting_addr <  HEAP_GUARD_ABOVE_VA + 0x1000;
-        if is_below_guard || is_above_guard {
-            // Do not hold any lock — panic is unrecoverable.
-            panic!(
-                "[KERNEL HEAP GUARD] overflow at {:#x} (heap range: {:#x}..{:#x})",
-                faulting_addr,
-                HEAP_START as u64,
-                (HEAP_START + HEAP_SIZE) as u64,
-            );
+        use crate::mm::heap::{heap_guard_below_va, heap_guard_above_va, heap_start, HEAP_SIZE};
+        let below = heap_guard_below_va();
+        let above = heap_guard_above_va();
+        // `heap_start() == 0` means `heap::init()` has not run yet — no
+        // guard is installed, so skip the check entirely (the early-boot
+        // page-fault path can still fire for legitimate PT-building work).
+        let base = heap_start();
+        if base != 0 {
+            let is_below_guard = faulting_addr >= below && faulting_addr < below + 0x1000;
+            let is_above_guard = faulting_addr >= above && faulting_addr < above + 0x1000;
+            if is_below_guard || is_above_guard {
+                // Do not hold any lock — panic is unrecoverable.
+                panic!(
+                    "[KERNEL HEAP GUARD] overflow at {:#x} (heap range: {:#x}..{:#x})",
+                    faulting_addr,
+                    base as u64,
+                    (base + HEAP_SIZE) as u64,
+                );
+            }
         }
     }
 

--- a/kernel/src/mm/heap.rs
+++ b/kernel/src/mm/heap.rs
@@ -2,37 +2,133 @@
 //!
 //! Linked-list free-list allocator for the kernel heap.
 //! Supports proper allocation and deallocation with coalescing of adjacent free blocks.
+//!
+//! ## Heap base placement
+//!
+//! The heap virtual base is computed at runtime in `init()` from the
+//! `__kernel_end` linker symbol so the heap always sits above whatever the
+//! linker actually placed BSS at.  Default builds (where BSS fits under
+//! 8 MiB) keep the historical layout — `HEAP_START_MIN_VA = 0xFFFF_8000_0080_0000`
+//! — for byte-identical behaviour.  Heavy diagnostic feature combinations
+//! (`firefox-test,w215-diag,f3-watch,file-buf-witness`) grow BSS past
+//! 8 MiB; in those builds the heap follows BSS rather than overlapping it,
+//! avoiding the silent free-list corruption that first surfaced in Phase 2
+//! QA on 2026-05-21.
+//!
+//! `vmm::init()` calls `compute_heap_layout()` to reserve the backing
+//! frames in the PMM before any `pmm::alloc_page()` runs; `init()` here
+//! latches the same layout and wires the global allocator.  Both call
+//! sites get identical answers because `__kernel_end` is a link-time
+//! constant.  See Intel SDM Vol. 3A §4.3 (IA-32e 2 MiB paging) for the
+//! 2 MiB-aligned base rationale.
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Mutex;
 
-/// Kernel heap start address.
-///
-/// Placed in the higher-half mapping (PML4 entry 256) at the virtual address
-/// corresponding to physical 8 MiB.  Starting above 8 MiB ensures no overlap
-/// with the kernel image (text + data + bss < 6 MiB) while leaving the 0–8 MiB
-/// identity-mapped range free for user ELF segment mappings and the kernel image
-/// itself.  This keeps the heap accessible even when CR3 points to a user-process
-/// page table (which clones PML4 entries 256-511 from the kernel).
-pub const HEAP_START: usize = 0xFFFF_8000_0080_0000;
 /// Kernel heap size: 128 MiB (sufficient for 1920×1080 GUI with multiple window surfaces).
 pub const HEAP_SIZE: usize = 128 * 1024 * 1024;
 
-/// Guard page immediately below the heap (one 4 KiB page, not-present).
+/// Minimum heap base virtual address — phys 8 MiB in the higher-half map.
 ///
-/// Virtual address `HEAP_START - 4096`.  Faults into the kernel guard handler.
-/// Physical frame `HEAP_GUARD_BELOW_PHYS` is reserved in the PMM so the
-/// allocator never hands it out — preventing a direct-map alias via
-/// `PHYS_OFF + phys` from silently corrupting the guard.
-pub const HEAP_GUARD_BELOW_VA: u64   = HEAP_START as u64 - 0x1000;
-pub const HEAP_GUARD_BELOW_PHYS: u64 = HEAP_GUARD_BELOW_VA - 0xFFFF_8000_0000_0000;
+/// Preserves the historical layout for small kernel builds.  When BSS fits
+/// below 8 MiB (default `firefox-test`) the computed layout pins the heap
+/// here and the build is byte-identical to pre-dynamic-heap kernels.
+const HEAP_START_MIN_VA: usize = 0xFFFF_8000_0080_0000;
 
-/// Guard page immediately above the heap (one 4 KiB page, not-present).
+/// One 2 MiB huge page.  Heap base is rounded up to this alignment so it
+/// always falls on a 2 MiB boundary matching the bootloader's higher-half
+/// huge-page map.  See Intel SDM Vol. 3A §4.3.
+const HUGE_PAGE_SIZE: usize = 2 * 1024 * 1024;
+
+/// Physical-to-virtual offset for the kernel's higher-half map (PML4[256-511]).
+/// Matches `shared::KERNEL_VIRT_BASE` and `vmm::PHYS_OFF`.
+const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+
+extern "C" {
+    /// 4 KiB-aligned symbol emitted by `kernel/linker.ld` immediately after
+    /// `.bss` (see `__kernel_end = .;`).  Used to position the heap above
+    /// whatever the linker actually placed BSS at, so feature-gated
+    /// diagnostic statics that inflate BSS (e.g. `w215_diag` shadow tables
+    /// at ~1.65 MiB) do not silently overlap the heap.
+    static __kernel_end: u8;
+}
+
+/// Runtime-latched heap virtual base, computed in `heap::init()` from the
+/// `__kernel_end` linker symbol.  `0` until `heap::init()` runs.  All
+/// external callers (idt page-fault guard, test_runner) must read through
+/// `heap_start()` / `heap_guard_*_va()` so the "not yet initialised"
+/// sentinel is honoured.
+static HEAP_START_VA: AtomicUsize = AtomicUsize::new(0);
+
+/// Returns the kernel heap base virtual address, or `0` if `heap::init()`
+/// has not yet executed.
+#[inline]
+pub fn heap_start() -> usize {
+    HEAP_START_VA.load(Ordering::Relaxed)
+}
+
+/// Returns the not-present guard page VA immediately below the heap base,
+/// or `0` if `heap::init()` has not yet executed.
+#[inline]
+pub fn heap_guard_below_va() -> u64 {
+    let base = HEAP_START_VA.load(Ordering::Relaxed);
+    if base == 0 { 0 } else { base as u64 - 0x1000 }
+}
+
+/// Returns the not-present guard page VA immediately above the heap, or
+/// `0` if `heap::init()` has not yet executed.
+#[inline]
+pub fn heap_guard_above_va() -> u64 {
+    let base = HEAP_START_VA.load(Ordering::Relaxed);
+    if base == 0 { 0 } else { (base + HEAP_SIZE) as u64 }
+}
+
+/// Compute the kernel heap layout — virtual base, physical base, physical
+/// end-exclusive — by aligning past the linker's `__kernel_end` symbol.
 ///
-/// Virtual address `HEAP_START + HEAP_SIZE`.  Same PMM reservation rationale.
-pub const HEAP_GUARD_ABOVE_VA: u64   = (HEAP_START + HEAP_SIZE) as u64;
-pub const HEAP_GUARD_ABOVE_PHYS: u64 = HEAP_GUARD_ABOVE_VA - 0xFFFF_8000_0000_0000;
+/// Called twice during early boot: once from `vmm::init()` to reserve the
+/// backing frames in the PMM before any `pmm::alloc_page()` can hand them
+/// out, and once from `heap::init()` to wire the allocator.  Both calls
+/// agree because `__kernel_end` is a link-time constant.
+///
+/// Returns `(va_start, phys_start, phys_end_exclusive)`.
+pub fn compute_heap_layout() -> (usize, u64, u64) {
+    // SAFETY: `__kernel_end` is a linker-defined symbol; taking its
+    // address is always safe.  Its higher-half VA translates back to a
+    // physical address via `va - PHYS_OFF`.
+    let kernel_end_va: u64 = unsafe { &__kernel_end as *const u8 as u64 };
+    let kernel_end_phys: u64 = kernel_end_va.saturating_sub(PHYS_OFF);
+
+    // Round up past kernel_end by ≥1 page (so there is always a strictly
+    // non-present byte between BSS and the below-guard PTE), then to the
+    // next 2 MiB huge-page boundary so the heap base aligns with the
+    // bootloader's higher-half huge-page map.
+    let candidate_phys = (kernel_end_phys + 0x1000 + HUGE_PAGE_SIZE as u64 - 1)
+        & !(HUGE_PAGE_SIZE as u64 - 1);
+
+    // Honour the historical lower bound (HEAP_START_MIN_VA, phys 0x80_0000)
+    // so default builds with BSS < 8 MiB get byte-identical layout.
+    let min_phys = (HEAP_START_MIN_VA as u64).saturating_sub(PHYS_OFF);
+    let phys_start = core::cmp::max(candidate_phys, min_phys);
+    let phys_end = phys_start + HEAP_SIZE as u64;
+    let va_start = (phys_start + PHYS_OFF) as usize;
+
+    (va_start, phys_start, phys_end)
+}
+
+/// Physical frame backing the below-guard VA, for PMM reservation.
+#[inline]
+fn heap_guard_below_phys() -> u64 {
+    heap_guard_below_va().saturating_sub(PHYS_OFF)
+}
+
+/// Physical frame backing the above-guard VA, for PMM reservation.
+#[inline]
+fn heap_guard_above_phys() -> u64 {
+    heap_guard_above_va().saturating_sub(PHYS_OFF)
+}
 
 /// Minimum block size — must be large enough to hold a FreeBlock header.
 const MIN_BLOCK_SIZE: usize = core::mem::size_of::<FreeBlock>();
@@ -257,12 +353,35 @@ pub fn stats() -> (usize, usize, usize) {
 }
 
 /// Initialize the kernel heap.
+///
+/// Computes the heap base from the linker's `__kernel_end` symbol so the
+/// heap follows BSS dynamically (see module docs).  Panics if the heap
+/// would extend past 1 GiB phys (outside the bootloader's huge-page map)
+/// — this is a build-misconfiguration assertion that catches kernels
+/// grown so large they would extend the heap into MMIO territory.
 pub fn init() {
-    ALLOCATOR.0.lock().init(HEAP_START, HEAP_SIZE);
+    let (va_start, phys_start, phys_end) = compute_heap_layout();
+
+    // Sanity: the bootloader maps phys 0..1 GiB into PML4[256] via 2 MiB
+    // huge pages; `vmm::extend_higher_half_to_4gib` later covers 1..4 GiB
+    // but that path is for MMIO, not RAM-backed heap.  A heap extending
+    // past 1 GiB phys means the kernel image+BSS is multiple-hundred-MiB
+    // — investigate before papering over.
+    assert!(
+        phys_end <= 0x4000_0000,
+        "[HEAP] heap layout phys_end={:#x} exceeds 1 GiB — kernel image too large?",
+        phys_end,
+    );
+
+    HEAP_START_VA.store(va_start, Ordering::Relaxed);
+    ALLOCATOR.0.lock().init(va_start, HEAP_SIZE);
+
     crate::serial_println!(
-        "[HEAP] Initialized at 0x{:x}-0x{:x} ({} KiB) — linked-list allocator",
-        HEAP_START,
-        HEAP_START + HEAP_SIZE,
+        "[HEAP] Initialized at {:#x}-{:#x} (phys {:#x}-{:#x}, {} KiB) — linked-list allocator",
+        va_start,
+        va_start + HEAP_SIZE,
+        phys_start,
+        phys_end,
         HEAP_SIZE / 1024
     );
 }
@@ -271,9 +390,9 @@ pub fn init() {
 ///
 /// # Guard layout
 /// ```
-/// HEAP_GUARD_BELOW_VA  (not-present PTE)  ← underflow trap
-/// HEAP_START           (heap, 128 MiB)
-/// HEAP_START + HEAP_SIZE (= HEAP_GUARD_ABOVE_VA, not-present PTE) ← overflow trap
+/// heap_guard_below_va()         (not-present PTE)  ← underflow trap
+/// heap_start()                  (heap, 128 MiB)
+/// heap_start() + HEAP_SIZE  (= heap_guard_above_va(), not-present PTE) ← overflow trap
 /// ```
 ///
 /// # Physical-alias prevention
@@ -291,26 +410,34 @@ pub fn init() {
 pub fn init_guard_pages() {
     use crate::mm::{pmm, vmm};
 
+    let below_va    = heap_guard_below_va();
+    let above_va    = heap_guard_above_va();
+    let below_phys  = heap_guard_below_phys();
+    let above_phys  = heap_guard_above_phys();
+    let base        = heap_start() as u64;
+
+    debug_assert!(base != 0, "init_guard_pages called before heap::init");
+
     // Reserve the physical frames for both guard pages.
     // This must happen before installing PTEs so that no racing allocation can
     // grab those frames in the window between the PMM free-mark and the PTE write.
-    pmm::reserve_range(HEAP_GUARD_BELOW_PHYS, HEAP_GUARD_BELOW_PHYS + 0x1000);
-    pmm::reserve_range(HEAP_GUARD_ABOVE_PHYS, HEAP_GUARD_ABOVE_PHYS + 0x1000);
+    pmm::reserve_range(below_phys, below_phys + 0x1000);
+    pmm::reserve_range(above_phys, above_phys + 0x1000);
 
     // Install not-present PTEs (creates PT hierarchy, writes PTE = 0).
-    if !vmm::install_not_present_guard(HEAP_GUARD_BELOW_VA) {
-        crate::serial_println!("[HEAP GUARD] WARN: failed to install below-guard at {:#x}", HEAP_GUARD_BELOW_VA);
+    if !vmm::install_not_present_guard(below_va) {
+        crate::serial_println!("[HEAP GUARD] WARN: failed to install below-guard at {:#x}", below_va);
     }
-    if !vmm::install_not_present_guard(HEAP_GUARD_ABOVE_VA) {
-        crate::serial_println!("[HEAP GUARD] WARN: failed to install above-guard at {:#x}", HEAP_GUARD_ABOVE_VA);
+    if !vmm::install_not_present_guard(above_va) {
+        crate::serial_println!("[HEAP GUARD] WARN: failed to install above-guard at {:#x}", above_va);
     }
 
     crate::serial_println!(
         "[HEAP GUARD] Guard pages installed: below={:#x} above={:#x} (heap {:#x}..{:#x})",
-        HEAP_GUARD_BELOW_VA,
-        HEAP_GUARD_ABOVE_VA,
-        HEAP_START as u64,
-        (HEAP_START + HEAP_SIZE) as u64,
+        below_va,
+        above_va,
+        base,
+        base + HEAP_SIZE as u64,
     );
 }
 

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -106,11 +106,19 @@ pub fn get_kernel_cr3() -> u64 {
 ///    heap mapping.
 pub fn init() {
     // Reserve physical pages that back the higher-half kernel heap.
-    // HEAP_START 0xFFFF_8000_0080_0000 → physical 0x0080_0000 (8 MiB).
-    // Starting at 8 MiB avoids overlap with the kernel image (ends < 6 MiB).
-    // Heap size is 128 MiB.
-    let heap_phys_start = 0x0080_0000u64;
-    let heap_phys_end = heap_phys_start + (128 * 1024 * 1024) as u64;
+    //
+    // The heap layout (virtual base + phys range) is computed from the
+    // linker's `__kernel_end` symbol so it always sits above BSS — see
+    // `mm/heap.rs::compute_heap_layout()` for the alignment rules.  Default
+    // builds (BSS < 8 MiB) get phys_start = 0x80_0000 / VA 0xFFFF_8000_0080_0000
+    // for byte-identical behaviour; heavy-diagnostic builds (e.g.
+    // `firefox-test,w215-diag,f3-watch`) push the heap above the inflated
+    // BSS, preventing the silent free-list overlap surfaced by Phase 2 QA
+    // on 2026-05-21.
+    //
+    // This reservation MUST run before any `pmm::alloc_page()` below so
+    // PD copies and the 1..4 GiB extension cannot land in the heap region.
+    let (_heap_va, heap_phys_start, heap_phys_end) = super::heap::compute_heap_layout();
     pmm::reserve_range(heap_phys_start, heap_phys_end);
 
     // Separate the PD pages between the identity map (PML4[0]) and the

--- a/kernel/src/mm/w215_diag.rs
+++ b/kernel/src/mm/w215_diag.rs
@@ -1087,12 +1087,13 @@ pub fn pte_change_displaced_count() -> u64 {
 // frame backing the canary slot at fault time.
 //
 // 4 Ki entries × 24 B = 96 KiB BSS, gated on `firefox-test` (the module).
-// The kernel-image bss_end must stay below the heap start at
-// `phys 0x80_0000` (8 MiB) — see `mm/heap.rs::HEAP_START` and the
-// `pmm::reserve_range` call in `mm/vmm.rs::init`.  Phase D's FREE_SHADOW
-// (1.5 MiB) consumed most of the headroom that remained after the kernel
-// .text/.data sections, so ALLOC_SHADOW is intentionally sized at 1/16th
-// of FREE_SHADOW.  A 4 Ki direct-mapped table hashes 64 frames per slot
+// Before the 2026-05-21 dynamic-heap fix the kernel-image bss_end had to
+// stay below the heap base at `phys 0x80_0000` (8 MiB) or the heap would
+// silently overlap BSS; the heap base is now computed past `__kernel_end`
+// in `mm/heap.rs::compute_heap_layout()` so heavy diagnostic feature
+// combinations no longer corrupt the free list.  Phase D's FREE_SHADOW
+// (1.5 MiB) is the largest contributor to BSS in this module; ALLOC_SHADOW
+// is intentionally sized at 1/16th of FREE_SHADOW.  A 4 Ki direct-mapped table hashes 64 frames per slot
 // in a 1 GiB QEMU configuration; the typical *most-recent* alloc working
 // set in the firefox-test sc≈1233 window is well under 4 Ki frames, so
 // per-slot collisions are exceptional.  When a collision occurs,

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -19783,10 +19783,7 @@ fn test_execve_no_pmm_leak() -> bool {
 fn test_heap_guard_pte() -> bool {
     test_header!("Heap guard pages — PTE present-bit verification");
 
-    use crate::mm::heap::{
-        HEAP_GUARD_BELOW_VA, HEAP_GUARD_ABOVE_VA,
-        HEAP_START, HEAP_SIZE,
-    };
+    use crate::mm::heap::{heap_guard_below_va, heap_guard_above_va, heap_start, HEAP_SIZE};
     use crate::mm::vmm;
 
     let kernel_cr3 = vmm::get_kernel_cr3();
@@ -19796,24 +19793,32 @@ fn test_heap_guard_pte() -> bool {
     }
     test_println!("  kernel CR3 = {:#x} ✓", kernel_cr3);
 
+    let below_va = heap_guard_below_va();
+    let above_va = heap_guard_above_va();
+    let heap_va  = heap_start() as u64;
+    if heap_va == 0 {
+        test_fail!("heap_guard", "heap_start() == 0 — heap::init not run");
+        return false;
+    }
+
     // 1. Guard below: PTE must NOT be present (bit 0 = 0).
-    let pte_below = vmm::read_pte(kernel_cr3, HEAP_GUARD_BELOW_VA);
-    test_println!("  Below-guard VA={:#x}  PTE={:#x}", HEAP_GUARD_BELOW_VA, pte_below);
+    let pte_below = vmm::read_pte(kernel_cr3, below_va);
+    test_println!("  Below-guard VA={:#x}  PTE={:#x}", below_va, pte_below);
     if pte_below & 1 != 0 {
         test_fail!("heap_guard",
             "Below-guard PTE at {:#x} has PRESENT set (PTE={:#x}) — guard not installed",
-            HEAP_GUARD_BELOW_VA, pte_below);
+            below_va, pte_below);
         return false;
     }
     test_println!("  Below-guard PTE present=0 (not-present) ✓");
 
     // 2. Guard above: PTE must NOT be present (bit 0 = 0).
-    let pte_above = vmm::read_pte(kernel_cr3, HEAP_GUARD_ABOVE_VA);
-    test_println!("  Above-guard VA={:#x}  PTE={:#x}", HEAP_GUARD_ABOVE_VA, pte_above);
+    let pte_above = vmm::read_pte(kernel_cr3, above_va);
+    test_println!("  Above-guard VA={:#x}  PTE={:#x}", above_va, pte_above);
     if pte_above & 1 != 0 {
         test_fail!("heap_guard",
             "Above-guard PTE at {:#x} has PRESENT set (PTE={:#x}) — guard not installed",
-            HEAP_GUARD_ABOVE_VA, pte_above);
+            above_va, pte_above);
         return false;
     }
     test_println!("  Above-guard PTE present=0 (not-present) ✓");
@@ -19823,19 +19828,18 @@ fn test_heap_guard_pte() -> bool {
     //    The heap is backed by 2 MiB huge pages from the bootloader so the
     //    higher-half PD entry will be a huge-page entry (bit 7 = 1, bit 0 = 1).
     //    read_pte returns the huge-page PD entry in that case; present=1 is enough.
-    let heap_first_page = HEAP_START as u64;
-    let pte_heap = vmm::read_pte(kernel_cr3, heap_first_page);
-    test_println!("  Heap first page VA={:#x}  PTE={:#x}", heap_first_page, pte_heap);
+    let pte_heap = vmm::read_pte(kernel_cr3, heap_va);
+    test_println!("  Heap first page VA={:#x}  PTE={:#x}", heap_va, pte_heap);
     if pte_heap & 1 == 0 {
         test_fail!("heap_guard",
             "Heap first page PTE at {:#x} is not present (PTE={:#x}) — unexpected",
-            heap_first_page, pte_heap);
+            heap_va, pte_heap);
         return false;
     }
     test_println!("  Heap first page PTE present=1 ✓");
 
-    // 4. Last heap page (HEAP_START + HEAP_SIZE - 4096): also present.
-    let heap_last_page = (HEAP_START + HEAP_SIZE) as u64 - 0x1000;
+    // 4. Last heap page (heap_va + HEAP_SIZE - 4096): also present.
+    let heap_last_page = heap_va + HEAP_SIZE as u64 - 0x1000;
     let pte_heap_last = vmm::read_pte(kernel_cr3, heap_last_page);
     test_println!("  Heap last page  VA={:#x}  PTE={:#x}", heap_last_page, pte_heap_last);
     if pte_heap_last & 1 == 0 {
@@ -19847,8 +19851,8 @@ fn test_heap_guard_pte() -> bool {
     test_println!("  Heap last page PTE present=1 ✓");
 
     test_println!("  Guard below={:#x} above={:#x} heap={:#x}..{:#x}",
-        HEAP_GUARD_BELOW_VA, HEAP_GUARD_ABOVE_VA,
-        HEAP_START as u64, (HEAP_START + HEAP_SIZE) as u64);
+        below_va, above_va,
+        heap_va, heap_va + HEAP_SIZE as u64);
     test_pass!("Heap guard pages — PTE present-bit verification");
     true
 }


### PR DESCRIPTION
## Summary

- Hardcoded `HEAP_START = 0xFFFF_8000_0080_0000` (phys 8 MiB) in `kernel/src/mm/heap.rs` overlapped `.bss` when heavy diagnostic features (`firefox-test + w215-diag + f3-watch + file-buf-witness`) inflated BSS past 0x800000 — the heap allocator init was writing its free-list head into live `w215_diag::FREE_SHADOW / ALLOC_SHADOW / PTE_CHANGE_RING` tables (~1.65 MiB combined), silently corrupting the list. First subsequent allocation walked a garbage `next` pointer and aborted as `memory allocation of 224 bytes failed` at ATA init in QA Phase 2 (2026-05-21).
- Heap base is now computed at boot in `compute_heap_layout()` from the `__kernel_end` linker symbol (already exported by `kernel/linker.ld`). Result is rounded up to the next 2 MiB huge-page boundary at least one page past `__kernel_end`, clamped by the historical phys 8 MiB lower bound so default builds (`bss_end < 0x800000`) get byte-identical layout. Both `vmm::init()` (PMM `reserve_range`) and `heap::init()` (allocator wire-up) call this helper; the link-time `__kernel_end` constant guarantees they agree.
- `HEAP_START / HEAP_GUARD_BELOW_VA / HEAP_GUARD_ABOVE_VA` move from `pub const` to accessor functions backed by an `AtomicUsize` latched at heap init. `idt.rs` (heap-guard page-fault path) and `test_runner.rs` (`test_heap_guard_pte`) updated. The IDT path tolerates the pre-init sentinel (`heap_start() == 0`).

## Test plan

- [x] Builds clean for `default` features.
- [x] Builds clean for `firefox-test`.
- [x] Builds clean for the heavy combo: `firefox-test,w215-diag,f3-watch,file-buf-witness,ssp-canary-diag,syscall-trace,pf-trace,vma-dump-on-gp,kernel-gp-trap-diag,elf-init-array-diag`.
- [x] KVM boot under `firefox-test`: heap at phys 0x80_0000 (byte-identical), reaches sc=71 heartbeat same as baseline.
- [x] KVM boot under heavy combo: heap at phys 0xa00000 (pushed past `bss_end=0x88b000`), boots through ATA / VFS / IPC / IO / Network / NT Exec / Power / Phase 10a — i.e. the 224-byte-alloc gate is closed.
- [ ] CI test_runner pass.

## Out-of-scope follow-up

The heavy-combo build now reaches a separate pre-existing bug at Phase 10b: `BOOT_INFO_PHYS_BASE = 0x100_0000` (16 MiB) lives inside the 128 MiB heap range, so allocations crossing 8 MiB into the heap can clobber the framebuffer descriptor read at Phase 10. That overlap exists on `master` too — it manifests as `[Aether] Display: 0x0 fb=0x0 stride=0` in default builds (no GUI), and only becomes visible when something forces enough allocations to actually reach phys 16 MiB. Recommend follow-up to either move `BOOT_INFO_PHYS_BASE` outside the heap range or copy `BootInfo` into a kernel static during `_start` (before any heap activity).

References: Intel SDM Vol. 3A §4.3 (IA-32e 2 MiB paging) for the 2 MiB heap-base alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)