### PR TITLE
scripts+kernel+docs: ASTRYXOS_FIREFOX_PACKAGE axis for Alpine firefox-132

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -459,29 +459,71 @@ python3 scripts/qemu-harness.py resume abc123def456
 ## Data image — Firefox variant selection
 
 The test data disk (`build/data.img`, 2 GiB FAT32) is built by
-`scripts/create-data-disk.sh`. The script's `FIREFOX_VARIANT` env var
-controls which Firefox build is staged:
+`scripts/create-data-disk.sh`. Two orthogonal env vars control which Firefox
+build is staged:
 
-- `glibc` (default) — populates `/disk/opt/firefox/firefox-bin` from a glibc-linked
-  Firefox. The kernel test runner falls back here when the musl variant is
-  absent.
-- `musl` — additionally populates `/disk/usr/lib/firefox-esr/firefox-bin` from an
-  Alpine musl-linked Firefox. The kernel test runner *prefers* this path
-  when present (selection via `vfs::stat` in `kernel/src/main.rs`).
+| Env var | Values | Purpose |
+|---|---|---|
+| `ASTRYXOS_FIREFOX_VARIANT` | `glibc` (default), `musl` | C library + binary source |
+| `ASTRYXOS_FIREFOX_PACKAGE` | `firefox-esr` (default), `firefox` | Alpine package, musl variant only |
+
+`ASTRYXOS_FIREFOX_PACKAGE` is silently ignored under
+`ASTRYXOS_FIREFOX_VARIANT=glibc` — the glibc track always uses the
+Mozilla-official ESR 115 tarball staged at `/disk/opt/firefox/firefox-bin`.
+
+### Variants
+
+- `glibc` (default) — populates `/disk/opt/firefox/firefox-bin` from a
+  glibc-linked Firefox. The kernel test runner falls back here when no
+  musl variant is staged.
+- `musl` — populates `/disk/usr/lib/<install-dir>/firefox-bin` from an
+  Alpine musl-linked Firefox. `<install-dir>` is `firefox-esr` for the ESR
+  package and `firefox` for the current package; both directories match
+  the DT_RUNPATH baked into the corresponding Mozilla DSOs per ELF gABI
+  §5.4. The kernel test runner *prefers* the musl path when present
+  (selection via `vfs::stat` in `kernel/src/main.rs`).
+
+### Packages (musl variant)
+
+- `firefox-esr` (default) — Alpine community/firefox-esr 115.x. Mature ESR
+  binary; the historical reproducer for the F3-saga gate at sc=1233. Alpine
+  does **not** ship a `-dbg` subpackage for ESR; libxul attribution flows
+  through Mozilla tecken's PUBLIC-symbol corpus (~8,600 entries, no FUNC).
+- `firefox` — Alpine community/firefox 132.x. Current stable release;
+  carries the `firefox-dbg` companion with a real `.debug` file
+  (~46 MiB `libxul.so.debug`, ~420k symbols including FUNC + minimal
+  DWARF). `addr2line`, `nm`, and `gdb` resolve C++ function names natively
+  via the binary's `.gnu_debuglink` section — no Mozilla tecken
+  indirection. Use when an investigation needs to *name* the libxul
+  function at a captured RIP.
+
+> Switching `ASTRYXOS_FIREFOX_PACKAGE` changes the reproducer identity:
+> firefox-132 metrics will NOT match the firefox-esr sc=1233 plateau. The
+> staging pipeline detects package-switch automatically via the
+> `/disk/opt/firefox/.variant` sentinel and re-stages cleanly without
+> requiring `--force`.
+
+### Examples
 
 ```bash
-# Glibc variant (default)
+# Glibc variant (default — Mozilla-official ESR 115)
 bash scripts/create-data-disk.sh --force
 
-# Musl variant — required for the F3/SSP demo gate investigation track
+# Musl variant, firefox-esr 115.x (historical F3-saga reproducer)
 ASTRYXOS_FIREFOX_VARIANT=musl bash scripts/create-data-disk.sh --force
+
+# Musl variant, firefox 132.x — required for libxul C++ name attribution
+ASTRYXOS_FIREFOX_VARIANT=musl \
+  ASTRYXOS_FIREFOX_PACKAGE=firefox \
+    bash scripts/create-data-disk.sh --force
 ```
 
 Verify staging by inspecting the FAT image:
 
 ```bash
-mdir -i build/data.img '::/usr/lib/firefox-esr/firefox-bin'  # musl
-mdir -i build/data.img '::/opt/firefox/firefox-bin'          # glibc
+mdir -i build/data.img '::/usr/lib/firefox-esr/firefox-bin'  # musl + firefox-esr
+mdir -i build/data.img '::/usr/lib/firefox/firefox-bin'      # musl + firefox-132
+mdir -i build/data.img '::/opt/firefox/firefox-bin'          # glibc, OR musl mirror
 ```
 
 The musl path is required for any investigation that exercises the musl
@@ -519,25 +561,37 @@ ASTRYXOS_FIREFOX_VARIANT=musl bash scripts/create-data-disk.sh --force
 
 Coverage matrix (Alpine v3.20, x86_64):
 
-| `ASTRYXOS_FIREFOX_DEBUG` | data.img Δ | Covers |
-|---|---|---|
-| unset / `0` (off, default) | 0 | — |
-| `musl` | ~2.8 MiB | `ld-musl-x86_64.so.1`, `libc.musl-x86_64.so.1` (musl-dbg) |
-| `1` / `full` | ~54 MiB | + libglib/gobject/gio, libgdk_pixbuf, libcairo, libgtk-3/libgdk-3 |
+| `ASTRYXOS_FIREFOX_DEBUG` | `ASTRYXOS_FIREFOX_PACKAGE` | data.img Δ | Covers |
+|---|---|---|---|
+| unset / `0` (off, default) | (any) | 0 | — |
+| `musl` | `firefox-esr` (default) | ~2.8 MiB | `ld-musl-x86_64.so.1`, `libc.musl-x86_64.so.1` (musl-dbg) |
+| `1` / `full` | `firefox-esr` (default) | ~54 MiB | + libglib/gobject/gio, libgdk_pixbuf, libcairo, libgtk-3/libgdk-3 |
+| `1` / `full` | `firefox` | ~100 MiB | as above, + `libxul.so.debug` (~46 MiB, real FUNC + minimal DWARF) |
 
-`libxul.so` is **not** covered by Alpine's `-dbg` packages — Alpine's
-`firefox-esr` does not ship a `-dbg` subpackage (verified against Alpine v3.20
-community APKBUILD). It is instead handled by
-`scripts/inject-libxul-symbols.sh --musl`, which `create-data-disk.sh` invokes
-automatically whenever `ASTRYXOS_FIREFOX_DEBUG` is set in the musl variant.
-The script derives a Breakpad GUID from the libxul `NT_GNU_BUILD_ID` note and
-fetches the matching `.sym.gz` from Mozilla's tecken symbol server (Alpine
-uploads symbols there), so VMAs match the staged Alpine libxul byte-for-byte.
-Coverage is PUBLIC-only (Alpine builds without DWARF): ~8,600 entry-point
-names with the same VMAs `nm`/`addr2line` would read from a hypothetical
-`.dynsym` lookup, sufficient to attribute a sampled RIP to the nearest
-exported function. File and line numbers are **not** recoverable — that
-requires option 2 (Alpine source build with `--disable-strip`).
+### libxul attribution paths
+
+`libxul.so` is the load-bearing Mozilla DSO; attributing a captured RIP back
+to a function name requires per-package handling:
+
+- **firefox-esr (default)** — Alpine does not ship a `-dbg` subpackage for
+  firefox-esr. Coverage is provided by
+  `scripts/inject-libxul-symbols.sh --musl`, which `create-data-disk.sh`
+  invokes automatically when `ASTRYXOS_FIREFOX_DEBUG` is set in this mode.
+  The script derives a Breakpad GUID from the libxul `NT_GNU_BUILD_ID` note
+  and fetches the matching `.sym.gz` from Mozilla's tecken symbol server
+  (Alpine uploads symbols there), so VMAs match the staged Alpine libxul
+  byte-for-byte. Coverage is PUBLIC-only (Alpine builds without DWARF):
+  ~8,600 entry-point names sufficient to attribute a sampled RIP to the
+  nearest exported function. File and line numbers are NOT recoverable.
+
+- **firefox (132.x)** — Alpine *does* ship `firefox-dbg`, so
+  `install-firefox-musl-debug.sh` stages the real `.debug` companion at
+  `/disk/usr/lib/debug/usr/lib/firefox/libxul.so.debug` (~46 MiB,
+  containing full `.symtab` with FUNC records and minimal DWARF, ~420k
+  symbols). `addr2line` / `nm` / `gdb` resolve C++ names natively via the
+  binary's `.gnu_debuglink` section — no Mozilla tecken indirection.
+  `create-data-disk.sh` SKIPS the tecken injection in this mode (it would
+  be a no-op anyway; the firefox-dbg `.symtab` is strictly superior).
 
 The companion files land at `/usr/lib/debug/<path>` on the guest filesystem.
 For host-side resolution use a temporary verification root (the install

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -445,17 +445,21 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // later mmap()s these files, demand-paging hits the cache
             // (instant) instead of reading from disk (5+ minutes on WSL2/KVM).
             serial_println!("[FFTEST] Pre-populating page cache from disk (slow ATA PIO)...");
-            // We list both glibc and musl interpreter / libc paths plus both
+            // We list both glibc and musl interpreter / libc paths plus all
             // possible libxul.so locations.  Whichever variant is staged on
-            // the data disk resolves; the other returns 0 pages benignly
+            // the data disk resolves; the others return 0 pages benignly
             // (prepopulate_file → resolve_path Err → 0).
             //
-            // libxul.so location by variant:
-            //   - glibc: /opt/firefox/libxul.so (kernel-internal staging path)
-            //   - musl : /usr/lib/firefox-esr/libxul.so (the DT_RUNPATH baked
-            //            into firefox-bin per readelf -d; ELF gABI §5.4)
-            // /opt/firefox/firefox-bin is mirrored for both variants so the
-            // kernel launch path stays stable.
+            // libxul.so location by variant + package:
+            //   - glibc:                /opt/firefox/libxul.so
+            //                             (kernel-internal staging path)
+            //   - musl + firefox-esr:   /usr/lib/firefox-esr/libxul.so
+            //                             (DT_RUNPATH for Alpine 115.x ESR;
+            //                              ELF gABI §5.4)
+            //   - musl + firefox-132:   /usr/lib/firefox/libxul.so
+            //                             (DT_RUNPATH for Alpine 132.x current)
+            // /opt/firefox/firefox-bin is mirrored for both musl variants so
+            // the kernel launch path stays stable; only the runpath tree changes.
             for path in &[
                 "/disk/lib64/ld-linux-x86-64.so.2",         // glibc — 236 KB
                 "/disk/lib/ld-musl-x86_64.so.1",            // musl  — 650 KB
@@ -463,7 +467,8 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 "/disk/lib/x86_64-linux-gnu/libc.so.6",     // glibc — 2.0 MB
                 "/disk/lib/libc.musl-x86_64.so.1",          // musl  — symlink to ld-musl
                 "/disk/opt/firefox/libxul.so",              // 157 MB — glibc variant
-                "/disk/usr/lib/firefox-esr/libxul.so",      // 130 MB — musl variant (DT_RUNPATH)
+                "/disk/usr/lib/firefox-esr/libxul.so",      // 130 MB — musl variant (firefox-esr 115.x)
+                "/disk/usr/lib/firefox/libxul.so",          // 130 MB — musl variant (firefox 132.x)
             ] {
                 let t0 = arch::x86_64::irq::get_ticks();
                 let pages = mm::cache::prepopulate_file(path);
@@ -501,20 +506,23 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // relative to that resolved directory.  We therefore launch from
             // wherever the FULL Mozilla tree is staged.
             //
-            //   musl variant:  /disk/usr/lib/firefox-esr/firefox-bin
-            //                  (Alpine's package layout; DT_RUNPATH target;
-            //                   contains dependentlibs.list, application.ini,
-            //                   omni.ja, every Mozilla .so file)
-            //   glibc variant: /disk/opt/firefox/firefox-bin
-            //                  (in-tree convention; install-firefox.sh stages
-            //                   the tarball there directly)
+            //   musl + firefox-esr (115.x):  /disk/usr/lib/firefox-esr/firefox-bin
+            //                                  (Alpine package layout for ESR;
+            //                                   DT_RUNPATH target)
+            //   musl + firefox     (132.x):  /disk/usr/lib/firefox/firefox-bin
+            //                                  (Alpine package layout for current)
+            //   glibc:                       /disk/opt/firefox/firefox-bin
+            //                                  (in-tree convention; install-firefox.sh
+            //                                   stages the Mozilla tarball there)
             //
-            // Prefer the musl path when present so readlink-relative file
-            // opens (notably dependentlibs.list — ENOENT here aborts the
-            // process at sc≈73) land in the right tree.  Both fall through
-            // to firefox-test's --headless --screenshot pipeline.
-            const CMDLINE_MUSL:  &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
-            const CMDLINE_GLIBC: &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            // Prefer firefox-132 → firefox-esr → glibc.  firefox-132 is
+            // preferred when present because its bundled firefox-dbg lets
+            // addr2line / gdb resolve C++ names natively (no Mozilla tecken
+            // dependency).  All three fall through to the same --headless
+            // --screenshot pipeline.
+            const CMDLINE_MUSL_132: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            const CMDLINE_MUSL_ESR: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            const CMDLINE_GLIBC:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
             // Use stat() (resolve_path + FileSystemOps::stat) for the existence
             // probe instead of read_file().  read_file() allocates a Vec sized
             // to the full file (~795 KB for firefox-bin), reads every byte, and
@@ -522,17 +530,21 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // pipeline (short read, allocator pressure, cache lock contention)
             // reports Err here even though the file is reachable.  POSIX
             // stat(2) semantics: success iff the named file is reachable; no
-            // content is read.  Emit both probe results so future qa runs can
-            // see at a glance which build was chosen.
-            let musl_stat  = crate::vfs::stat("/disk/usr/lib/firefox-esr/firefox-bin");
-            let glibc_stat = crate::vfs::stat("/disk/opt/firefox/firefox-bin");
+            // content is read.  Emit all three probe results so future qa
+            // runs can see at a glance which build was chosen.
+            let musl_132_stat = crate::vfs::stat("/disk/usr/lib/firefox/firefox-bin");
+            let musl_esr_stat = crate::vfs::stat("/disk/usr/lib/firefox-esr/firefox-bin");
+            let glibc_stat    = crate::vfs::stat("/disk/opt/firefox/firefox-bin");
             serial_println!(
-                "[FFTEST] FF binary probe: musl={:?} glibc={:?}",
-                musl_stat.as_ref().map(|s| s.size).map_err(|e| *e),
+                "[FFTEST] FF binary probe: musl-132={:?} musl-esr={:?} glibc={:?}",
+                musl_132_stat.as_ref().map(|s| s.size).map_err(|e| *e),
+                musl_esr_stat.as_ref().map(|s| s.size).map_err(|e| *e),
                 glibc_stat.as_ref().map(|s| s.size).map_err(|e| *e),
             );
-            let cmdline = if musl_stat.is_ok() {
-                CMDLINE_MUSL
+            let cmdline = if musl_132_stat.is_ok() {
+                CMDLINE_MUSL_132
+            } else if musl_esr_stat.is_ok() {
+                CMDLINE_MUSL_ESR
             } else {
                 CMDLINE_GLIBC
             };

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -22198,16 +22198,22 @@ fn test_x11_hello_runs() -> bool {
 fn test_firefox_launch_progress() -> bool {
     test_header!("Firefox ESR launch oracle (progress probe)");
 
-    // ── 1. Pick Firefox binary: prefer musl, fall back to glibc ──────────────
+    // ── 1. Pick Firefox binary: prefer musl-132 → musl-esr → glibc ───────────
     //
-    // The musl wrapper at /disk/usr/lib/firefox-esr/firefox is Alpine's
-    // firefox-esr ELF (interpreter /lib/ld-musl-x86_64.so.1).  The glibc
-    // fallback at /disk/opt/firefox/firefox is the Mozilla official build
-    // (interpreter /lib64/ld-linux-x86-64.so.2).  exe_path is set to whichever
-    // path actually loaded, so readlink("/proc/self/exe") + append "-bin"
-    // resolves to the matching firefox-bin sibling.
+    // Three candidate paths are probed in order:
+    //   /disk/usr/lib/firefox/firefox      — Alpine musl firefox 132.x (preferred
+    //                                         when present; bundled firefox-dbg
+    //                                         enables native addr2line / gdb).
+    //   /disk/usr/lib/firefox-esr/firefox  — Alpine musl firefox-esr 115.x
+    //                                         (historical reproducer; no -dbg).
+    //   /disk/opt/firefox/firefox          — Mozilla official glibc build
+    //                                         (fallback).
+    //
+    // exe_path is set to whichever path actually loaded, so readlink("/proc/
+    // self/exe") + append "-bin" resolves to the matching firefox-bin sibling.
     const FF_CANDIDATES: &[&str] = &[
-        "/disk/usr/lib/firefox-esr/firefox",   // Alpine musl build (preferred)
+        "/disk/usr/lib/firefox/firefox",       // Alpine musl 132.x (preferred)
+        "/disk/usr/lib/firefox-esr/firefox",   // Alpine musl 115.x ESR
         "/disk/opt/firefox/firefox",           // Mozilla glibc build (fallback)
     ];
 
@@ -22249,7 +22255,17 @@ fn test_firefox_launch_progress() -> bool {
         return true;
     }
 
-    let is_musl = chosen_path.starts_with("/disk/usr/lib/firefox-esr/");
+    let is_musl = chosen_path.starts_with("/disk/usr/lib/firefox-esr/")
+        || chosen_path.starts_with("/disk/usr/lib/firefox/");
+    // Per-package install dir for PATH / LD_LIBRARY_PATH; both Alpine packages
+    // bake DT_RUNPATH=/usr/lib/<pkg> so we mirror that here.
+    let ff_install_dir: &str = if chosen_path.starts_with("/disk/usr/lib/firefox/") {
+        "/usr/lib/firefox"
+    } else if chosen_path.starts_with("/disk/usr/lib/firefox-esr/") {
+        "/usr/lib/firefox-esr"
+    } else {
+        "/opt/firefox"   // unused for is_musl == false but keeps the let well-typed
+    };
 
     // ── Basic ELF sanity ──────────────────────────────────────────────────────
     if !crate::proc::elf::is_elf(&ff_bin) {
@@ -22296,47 +22312,51 @@ fn test_firefox_launch_progress() -> bool {
     ];
     //
     // PATH / LD_LIBRARY_PATH tuned to whichever build we picked.  For musl,
-    // ld-musl reads DT_RUNPATH=/usr/lib/firefox-esr (per System V gABI §5.4)
-    // so transitive deps (libxul.so, libmozsandbox.so, ...) resolve from the
+    // ld-musl reads DT_RUNPATH=/usr/lib/<package> (per System V gABI §5.4) so
+    // transitive deps (libxul.so, libmozsandbox.so, ...) resolve from the
     // canonical tree without any extra LD_LIBRARY_PATH hint, but we still
     // include it for fallback search order (per ld-musl(8) and ld.so(8)).
-    //
-    let envp: alloc::vec::Vec<&str> = if is_musl {
+    // ff_install_dir was set above based on chosen_path so a 132 install
+    // picks /usr/lib/firefox, an ESR install picks /usr/lib/firefox-esr.
+    let path_env  = alloc::format!("PATH={}:/bin:/disk/bin", ff_install_dir);
+    let ld_env    = alloc::format!("LD_LIBRARY_PATH={}:/lib:/usr/lib", ff_install_dir);
+    let envp_owned: alloc::vec::Vec<alloc::string::String> = if is_musl {
         alloc::vec![
-            "HOME=/tmp",
-            "PATH=/usr/lib/firefox-esr:/bin:/disk/bin",
-            "LD_LIBRARY_PATH=/usr/lib/firefox-esr:/lib:/usr/lib",
-            "MOZ_HEADLESS=1",
-            "MOZ_LOG=all:5",
-            "MOZ_LOG_FILE=/tmp/firefox.log",
-            "DISPLAY=:0",
-            "XAUTHORITY=/tmp/.Xauthority",
-            "XDG_RUNTIME_DIR=/tmp",
-            "XDG_DATA_DIRS=/tmp",
-            "XDG_CONFIG_HOME=/tmp",
-            "XDG_CACHE_HOME=/tmp/cache",
-            "DBUS_SESSION_BUS_ADDRESS=",
-            "FONTCONFIG_FILE=/tmp",
+            alloc::string::String::from("HOME=/tmp"),
+            path_env,
+            ld_env,
+            alloc::string::String::from("MOZ_HEADLESS=1"),
+            alloc::string::String::from("MOZ_LOG=all:5"),
+            alloc::string::String::from("MOZ_LOG_FILE=/tmp/firefox.log"),
+            alloc::string::String::from("DISPLAY=:0"),
+            alloc::string::String::from("XAUTHORITY=/tmp/.Xauthority"),
+            alloc::string::String::from("XDG_RUNTIME_DIR=/tmp"),
+            alloc::string::String::from("XDG_DATA_DIRS=/tmp"),
+            alloc::string::String::from("XDG_CONFIG_HOME=/tmp"),
+            alloc::string::String::from("XDG_CACHE_HOME=/tmp/cache"),
+            alloc::string::String::from("DBUS_SESSION_BUS_ADDRESS="),
+            alloc::string::String::from("FONTCONFIG_FILE=/tmp"),
         ]
     } else {
         alloc::vec![
-            "HOME=/tmp",
-            "PATH=/opt/firefox:/bin:/disk/bin",
-            "LD_LIBRARY_PATH=/opt/firefox:/lib64:/lib/x86_64-linux-gnu",
-            "MOZ_HEADLESS=1",
-            "MOZ_LOG=all:5",
-            "MOZ_LOG_FILE=/tmp/firefox.log",
-            "DISPLAY=:0",
-            "XAUTHORITY=/tmp/.Xauthority",
-            "XDG_RUNTIME_DIR=/tmp",
-            "XDG_DATA_DIRS=/tmp",
-            "XDG_CONFIG_HOME=/tmp",
-            "XDG_CACHE_HOME=/tmp/cache",
-            "DBUS_SESSION_BUS_ADDRESS=",
-            "FONTCONFIG_FILE=/tmp",
+            alloc::string::String::from("HOME=/tmp"),
+            alloc::string::String::from("PATH=/opt/firefox:/bin:/disk/bin"),
+            alloc::string::String::from("LD_LIBRARY_PATH=/opt/firefox:/lib64:/lib/x86_64-linux-gnu"),
+            alloc::string::String::from("MOZ_HEADLESS=1"),
+            alloc::string::String::from("MOZ_LOG=all:5"),
+            alloc::string::String::from("MOZ_LOG_FILE=/tmp/firefox.log"),
+            alloc::string::String::from("DISPLAY=:0"),
+            alloc::string::String::from("XAUTHORITY=/tmp/.Xauthority"),
+            alloc::string::String::from("XDG_RUNTIME_DIR=/tmp"),
+            alloc::string::String::from("XDG_DATA_DIRS=/tmp"),
+            alloc::string::String::from("XDG_CONFIG_HOME=/tmp"),
+            alloc::string::String::from("XDG_CACHE_HOME=/tmp/cache"),
+            alloc::string::String::from("DBUS_SESSION_BUS_ADDRESS="),
+            alloc::string::String::from("FONTCONFIG_FILE=/tmp"),
         ]
     };
-    let envp: &[&str] = &envp;
+    let envp_refs: alloc::vec::Vec<&str> = envp_owned.iter().map(|s| s.as_str()).collect();
+    let envp: &[&str] = &envp_refs;
 
     // Use the *blocked* variant so we can set exe_path BEFORE the thread
     // is scheduled.  The Firefox launcher calls readlink("/proc/self/exe"),

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -40,6 +40,33 @@ FIREFOX=false
 # Selectable via CLI arg or env var; env var loses to explicit CLI arg.
 FIREFOX_VARIANT="${ASTRYXOS_FIREFOX_VARIANT:-glibc}"
 
+# Firefox package selector (musl variant only).  Picks which Alpine package
+# install-firefox-musl.sh + install-firefox-musl-debug.sh pull:
+#
+#   firefox-esr (default) — Alpine community/firefox-esr 115.x.  Mature ESR
+#                           binary; no -dbg subpackage in Alpine v3.20.
+#                           libxul attribution falls back to Mozilla tecken
+#                           (PUBLIC-only; ~8,600 symbols, no FUNC).  This is
+#                           the historical reproducer for the F3-saga gate at
+#                           sc=1233.
+#
+#   firefox               — Alpine community/firefox 132.x.  Current stable
+#                           release; carries firefox-dbg with a real .debug
+#                           companion (~46 MiB libxul.so.debug containing
+#                           ~420k symbols incl. FUNC + minimal DWARF — full
+#                           C++ name attribution via .gnu_debuglink without
+#                           Mozilla tecken).  Use when you need to NAME the
+#                           libxul function at a captured RIP.  Note that
+#                           switching the binary changes the reproducer
+#                           identity — new firefox-132 plateau metrics will
+#                           NOT match the firefox-esr sc=1233 plateau.
+#
+# Constraints:
+#   - Only meaningful when FIREFOX_VARIANT=musl.  Setting under glibc is
+#     silently ignored; glibc uses the Mozilla-official ESR 115 tarball
+#     unconditionally (install-firefox.sh path).
+FIREFOX_PACKAGE="${ASTRYXOS_FIREFOX_PACKAGE:-firefox-esr}"
+
 # Firefox debug-symbols opt-in.  When set, stages Alpine -dbg debug companion
 # files (musl-dbg + optionally glib/gdk-pixbuf/cairo/gtk+3.0-dbg) into
 # build/disk/usr/lib/debug/ and into data.img so that addr2line / objdump
@@ -72,6 +99,7 @@ for arg in "$@"; do
         --firefox-variant) :;;   # next arg consumed by trailing path
         --firefox-debug=*) FIREFOX_DEBUG="${arg#--firefox-debug=}" ;;
         --firefox-debug)   FIREFOX_DEBUG=1 ;;
+        --firefox-package=*) FIREFOX_PACKAGE="${arg#--firefox-package=}" ;;
         [0-9]*) SIZE_MB="$arg" ;;
     esac
 done
@@ -84,6 +112,27 @@ case "${FIREFOX_VARIANT}" in
         ;;
 esac
 echo "[DATA-DISK] Firefox variant: ${FIREFOX_VARIANT}"
+
+case "${FIREFOX_PACKAGE}" in
+    firefox-esr|firefox) ;;
+    *)
+        echo "[DATA-DISK] ERROR: unknown FIREFOX_PACKAGE='${FIREFOX_PACKAGE}' (expected firefox-esr|firefox)"
+        exit 1
+        ;;
+esac
+if [ "${FIREFOX_PACKAGE}" != "firefox-esr" ] && [ "${FIREFOX_VARIANT}" != "musl" ]; then
+    echo "[DATA-DISK] NOTE: ASTRYXOS_FIREFOX_PACKAGE=${FIREFOX_PACKAGE} ignored — only applies to FIREFOX_VARIANT=musl"
+    FIREFOX_PACKAGE=firefox-esr
+fi
+echo "[DATA-DISK] Firefox package: ${FIREFOX_PACKAGE}"
+
+# Compute the on-disk install-dir for the musl variant.  Mirrors
+# install-firefox-musl.sh's FF_INSTALL_DIR_NAME logic.  Used by the
+# /usr/lib/<pkg>/ copy below and the inject-libxul-symbols.sh trigger guard.
+case "${FIREFOX_PACKAGE}" in
+    firefox-esr) FIREFOX_INSTALL_DIRNAME=firefox-esr ;;
+    firefox)     FIREFOX_INSTALL_DIRNAME=firefox     ;;
+esac
 
 case "${FIREFOX_DEBUG}" in
     ''|0)        FIREFOX_DEBUG_MODE=off ;;
@@ -279,7 +328,10 @@ fi
 if [ -f "${ROOT_DIR}/scripts/install-firefox-musl.sh" ]; then
     MUSL_FLAGS=""
     [ "${FORCE}" = true ] && MUSL_FLAGS="--force"
-    bash "${ROOT_DIR}/scripts/install-firefox-musl.sh" ${MUSL_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+    # ASTRYXOS_FIREFOX_PACKAGE forwarded via env so install-firefox-musl.sh
+    # picks firefox-esr vs firefox-132 layout uniformly across the pipeline.
+    ASTRYXOS_FIREFOX_PACKAGE="${FIREFOX_PACKAGE}" \
+        bash "${ROOT_DIR}/scripts/install-firefox-musl.sh" ${MUSL_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
         { echo "[DATA-DISK] FATAL: install-firefox-musl.sh failed"; exit 1; }
 fi
 
@@ -296,30 +348,51 @@ if [ "${FIREFOX_DEBUG_MODE}" != off ] && \
     if [ "${FIREFOX_DEBUG_MODE}" = musl ]; then
         DBG_FLAGS="${DBG_FLAGS} --musl-only"
     fi
-    bash "${ROOT_DIR}/scripts/install-firefox-musl-debug.sh" ${DBG_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+    # Forward ASTRYXOS_FIREFOX_PACKAGE so the dbg installer adds firefox-dbg
+    # (only meaningful when FIREFOX_PACKAGE=firefox; firefox-esr has no -dbg).
+    ASTRYXOS_FIREFOX_PACKAGE="${FIREFOX_PACKAGE}" \
+        bash "${ROOT_DIR}/scripts/install-firefox-musl-debug.sh" ${DBG_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
         echo "[DATA-DISK] WARNING: install-firefox-musl-debug.sh failed — /usr/lib/debug not staged"
 fi
 
 # ── Optional: inject .symtab into the musl libxul.so ─────────────────────────
-# Alpine's firefox-esr does NOT ship a -dbg subpackage (verified vs
-# community/firefox 132.x which DOES; see scripts/install-firefox-musl-debug.sh
-# "Implication for libxul.so attribution").  Instead, Mozilla's symbol server
-# (tecken) indexes the exact Alpine BuildID and serves a gzipped Breakpad
-# .sym (~9 MiB compressed) that lists every .dynsym entry as a PUBLIC record.
-# scripts/inject-libxul-symbols.sh --musl downloads the .sym, derives the
-# Breakpad GUID from the libxul BuildID, and splices an Elf64_Sym .symtab
-# into libxul.so.  The .text section is byte-identical pre/post (verified
-# by SHA256 inside the script) — no upstream-binary edit.
+# Two cases, selected by ASTRYXOS_FIREFOX_PACKAGE:
+#
+#   firefox-esr (115.x) — Alpine does NOT ship a -dbg subpackage.  Mozilla's
+#       symbol server (tecken) indexes the exact Alpine BuildID and serves a
+#       gzipped Breakpad .sym (~9 MiB compressed) that lists every .dynsym
+#       entry as a PUBLIC record.  scripts/inject-libxul-symbols.sh --musl
+#       downloads the .sym, derives the Breakpad GUID from the libxul BuildID,
+#       and splices an Elf64_Sym .symtab into libxul.so.  The .text section
+#       is byte-identical pre/post (verified by SHA256 inside the script) —
+#       no upstream-binary edit.
+#
+#   firefox (132.x)     — Alpine DOES ship firefox-dbg with a real .debug
+#       companion at /usr/lib/debug/usr/lib/firefox/libxul.so.debug carrying
+#       full .symtab (~420k entries with FUNC records and minimal DWARF).
+#       install-firefox-musl-debug.sh stages it; the binary's .gnu_debuglink
+#       section already points there.  addr2line / nm / gdb resolve C++ names
+#       natively — no Mozilla tecken indirection required.  We SKIP the inject
+#       step in this mode (it would be a no-op anyway: tecken's libxul-132 GUID
+#       coverage is incomplete and the .symtab would be inferior to the
+#       firefox-dbg one).
 #
 # Triggered together with the -dbg companion stage so a single
 # ASTRYXOS_FIREFOX_DEBUG=musl|1|full request gets all attribution avenues.
+LIBXUL_STAGED="${BUILD_DIR}/disk/usr/lib/${FIREFOX_INSTALL_DIRNAME}/libxul.so"
 if [ "${FIREFOX_DEBUG_MODE}" != off ] && \
+   [ "${FIREFOX_PACKAGE}" = "firefox-esr" ] && \
    [ -f "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ] && \
-   [ -f "${BUILD_DIR}/disk/usr/lib/firefox-esr/libxul.so" ]; then
+   [ -f "${LIBXUL_STAGED}" ]; then
     MUSL_SYM_FLAGS="--musl"
     [ "${FORCE}" = true ] && MUSL_SYM_FLAGS="${MUSL_SYM_FLAGS} --force"
-    bash "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ${MUSL_SYM_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+    if bash "${ROOT_DIR}/scripts/inject-libxul-symbols.sh" ${MUSL_SYM_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' ; then
+        :
+    else
         echo "[DATA-DISK] WARNING: inject-libxul-symbols.sh --musl failed — libxul.so will lack .symtab"
+    fi
+elif [ "${FIREFOX_DEBUG_MODE}" != off ] && [ "${FIREFOX_PACKAGE}" = "firefox" ]; then
+    echo "[DATA-DISK] Skipping Mozilla tecken libxul .symtab injection — firefox-dbg companion covers libxul attribution natively via .gnu_debuglink."
 fi
 
 # Stage a /tmp/hello.html for the headless oracle test — install-firefox.sh
@@ -556,28 +629,30 @@ EOF
         done
         echo "[DATA-DISK] Copied ${local_count} musl support libs to /usr/lib/ (Alpine deps)"
 
-        # The canonical Mozilla tree must land at /usr/lib/firefox-esr/ on the
+        # The canonical Mozilla tree must land at /usr/lib/${dirname}/ on the
         # FAT32 image — that is the DT_RUNPATH baked into firefox-bin,
         # libxul.so, libmozsandbox.so, etc. (readelf -d shows
-        # RUNPATH=[/usr/lib/firefox-esr]).  Per the ELF gABI (System V ABI
-        # §5.4) and ld-musl(8), DT_RUNPATH is the third entry in the dynamic
-        # linker search order; without the tree at this path, libxul's
-        # transitive dlopen calls (e.g. libmozsandbox.so) fail with ENOENT
-        # and ld-musl exit_group()s at startup.
-        MUSL_FF_ESR="${BUILD_DIR}/disk/usr/lib/firefox-esr"
-        if [ -d "${MUSL_FF_ESR}" ]; then
-            echo "[DATA-DISK] Copying /usr/lib/firefox-esr (~206 MiB) to data image — this takes a moment..."
-            mmd -i "${DATA_IMG}" "::usr/lib/firefox-esr" 2>/dev/null || true
+        # RUNPATH=[/usr/lib/firefox-esr] for the 115.x package or
+        # RUNPATH=[/usr/lib/firefox] for the 132.x package).  Per the ELF gABI
+        # (System V ABI §5.4) and ld-musl(8), DT_RUNPATH is the third entry
+        # in the dynamic linker search order; without the tree at this path,
+        # libxul's transitive dlopen calls (e.g. libmozsandbox.so) fail with
+        # ENOENT and ld-musl exit_group()s at startup.
+        MUSL_FF_TREE="${BUILD_DIR}/disk/usr/lib/${FIREFOX_INSTALL_DIRNAME}"
+        if [ -d "${MUSL_FF_TREE}" ]; then
+            FF_TREE_SIZE="$(du -sh "${MUSL_FF_TREE}" | cut -f1)"
+            echo "[DATA-DISK] Copying /usr/lib/${FIREFOX_INSTALL_DIRNAME} (${FF_TREE_SIZE}) to data image — this takes a moment..."
+            mmd -i "${DATA_IMG}" "::usr/lib/${FIREFOX_INSTALL_DIRNAME}" 2>/dev/null || true
             # mcopy -s walks the full tree (omni.ja, browser/, defaults/,
             # fonts/, gmp-clearkey/, every .so file).  Tolerate failures for
             # any deep symlink chains (none expected — install-firefox-musl.sh
             # dereferences with cp -L during staging).
-            mcopy -s -o -i "${DATA_IMG}" "${MUSL_FF_ESR}/." \
-                "::usr/lib/firefox-esr/" 2>&1 | \
+            mcopy -s -o -i "${DATA_IMG}" "${MUSL_FF_TREE}/." \
+                "::usr/lib/${FIREFOX_INSTALL_DIRNAME}/" 2>&1 | \
                 grep -v "^$" | grep -iv "^skipping" | head -20 || true
-            echo "[DATA-DISK] Copied /usr/lib/firefox-esr/ to data image (DT_RUNPATH target)"
+            echo "[DATA-DISK] Copied /usr/lib/${FIREFOX_INSTALL_DIRNAME}/ to data image (DT_RUNPATH target)"
         else
-            echo "[DATA-DISK] WARNING: ${MUSL_FF_ESR} missing — musl FF DT_RUNPATH lookup will fail"
+            echo "[DATA-DISK] WARNING: ${MUSL_FF_TREE} missing — musl FF DT_RUNPATH lookup will fail"
         fi
 
         # ── Optional: /usr/lib/debug/ debug-info companion tree ─────────────

--- a/scripts/install-firefox-musl-debug.sh
+++ b/scripts/install-firefox-musl-debug.sh
@@ -36,30 +36,42 @@
 #                                          subpackages="$pkgname-intl" only.
 #                                          (Compare community/firefox/ which DOES
 #                                          ship firefox-dbg.)
+#   firefox  (132.x)        YES          /usr/lib/debug/usr/lib/firefox/libxul.so.debug
+#                                          (~46 MiB libxul.so.debug carrying full
+#                                          .symtab ~420k symbols incl. FUNC plus
+#                                          minimal DWARF; addr2line / nm / gdb
+#                                          resolve C++ names automatically via
+#                                          the binary's .gnu_debuglink section).
+#                                          Pulled iff ASTRYXOS_FIREFOX_PACKAGE=firefox.
 #
 # Implication for libxul.so attribution
 # -------------------------------------
 #
-# Because Alpine does not ship debug symbols for firefox-esr, addr2line cannot
-# resolve RIPs inside libxul.so by .gnu_debuglink alone.  Three options exist:
+# Two attribution flows are wired, selected by ASTRYXOS_FIREFOX_PACKAGE:
 #
-#   1. Coarse function-level names via Mozilla's tecken symbol server.  Alpine
-#      uploads to tecken keyed by its exact ELF BuildID, so the .sym matches
-#      the Alpine libxul byte-for-byte (no VMA drift).  The .sym contains
-#      PUBLIC-only records (Alpine builds without DWARF), so coverage is
-#      .dynsym names plus their entry-point VMAs — ~8,600 symbols, enough to
-#      attribute K-class RIP fires to within a function (file/line not
-#      recoverable).  scripts/inject-libxul-symbols.sh --musl handles this
-#      automatically; create-data-disk.sh wires it whenever
-#      ASTRYXOS_FIREFOX_DEBUG is set with FIREFOX_VARIANT=musl.
+#   firefox-esr — Alpine does not ship debug symbols for firefox-esr, so the
+#                 attribution flow uses Mozilla's tecken symbol server.  Alpine
+#                 uploads to tecken keyed by its exact ELF BuildID, so the .sym
+#                 matches the Alpine libxul byte-for-byte (no VMA drift).  The
+#                 .sym contains PUBLIC-only records (Alpine builds firefox-esr
+#                 without DWARF), so coverage is .dynsym names plus their
+#                 entry-point VMAs — ~8,600 symbols, enough to attribute
+#                 K-class RIP fires to within a function (file/line not
+#                 recoverable).  scripts/inject-libxul-symbols.sh --musl handles
+#                 this automatically; create-data-disk.sh wires it whenever
+#                 ASTRYXOS_FIREFOX_DEBUG is set with FIREFOX_VARIANT=musl and
+#                 ASTRYXOS_FIREFOX_PACKAGE=firefox-esr.
 #
-#   2. Build firefox-esr from source inside an Alpine builder with
-#      --disable-strip and --disable-install-strip.  Multi-hour, multi-GiB.
-#      Out of scope for this script.
+#   firefox     — Alpine ships firefox-dbg with a full /usr/lib/debug/usr/lib/
+#                 firefox/libxul.so.debug, so this script stages it alongside
+#                 the GTK-stack -dbg files.  No Mozilla tecken indirection is
+#                 needed — addr2line resolves C++ names (e.g. mozilla::widget::
+#                 GfxInfo::FireGLXTestProcess()) automatically.  create-data-disk.sh
+#                 SKIPS the tecken injection in this mode.
 #
-#   3. Switch the data-disk from firefox-esr-115.x to firefox-132.x and use
-#      Alpine's firefox-dbg (47.9 MiB installed).  Changes the reproducer.
-#      Coordinator-level decision; not done by this script.
+# Escalation if Alpine ever stops shipping firefox-dbg: build firefox from
+# source inside an Alpine builder with --disable-strip and --disable-install-
+# strip.  Multi-hour, multi-GiB.  Out of scope for this script.
 #
 # Layout written to build/disk/
 # -----------------------------
@@ -133,8 +145,17 @@ ROOTFS="${CACHE_DIR}/rootfs"
 # Pinned set of -dbg packages we know Alpine v3.20 ships for the FF stack.
 # Adding a package here is a deliberate act; the script verifies each one
 # landed under ${ROOTFS}/usr/lib/debug/ after `apk add`.
+#
+# firefox-dbg is conditionally appended below for ASTRYXOS_FIREFOX_PACKAGE=
+# firefox (it has no analogue when the staged binary is firefox-esr).
 ALL_DBG_PKGS=(musl-dbg glib-dbg gdk-pixbuf-dbg cairo-dbg gtk+3.0-dbg)
 MUSL_ONLY_DBG_PKGS=(musl-dbg)
+
+# Package selection mirrors install-firefox-musl.sh.  Default firefox-esr to
+# preserve existing caller behaviour.  When firefox is selected and the user
+# does NOT also pass --musl-only, we stage firefox-dbg so libxul.so attribution
+# works via .gnu_debuglink (no Mozilla tecken indirection needed).
+FIREFOX_PKG="${ASTRYXOS_FIREFOX_PACKAGE:-firefox-esr}"
 
 FORCE=false
 MUSL_ONLY=false
@@ -142,8 +163,9 @@ for arg in "$@"; do
     case "${arg}" in
         --force) FORCE=true ;;
         --musl-only) MUSL_ONLY=true ;;
+        --package=*) FIREFOX_PKG="${arg#--package=}" ;;
         -h|--help)
-            sed -n '2,90p' "$0"
+            sed -n '2,100p' "$0"
             exit 0
             ;;
         *)
@@ -153,9 +175,24 @@ for arg in "$@"; do
     esac
 done
 
+case "${FIREFOX_PKG}" in
+    firefox-esr|firefox) ;;
+    *)
+        echo "[FF-MUSL-DBG] ERROR: unknown FIREFOX_PKG='${FIREFOX_PKG}' (expected firefox-esr|firefox)" >&2
+        exit 2
+        ;;
+esac
+
 DBG_PKGS=("${ALL_DBG_PKGS[@]}")
 if [ "${MUSL_ONLY}" = true ]; then
     DBG_PKGS=("${MUSL_ONLY_DBG_PKGS[@]}")
+fi
+
+# Append firefox-dbg when staging the firefox-132 package; --musl-only callers
+# intentionally skip it (they only want musl-dbg for ld-musl SSP attribution
+# and don't care about libxul symbol resolution).
+if [ "${FIREFOX_PKG}" = "firefox" ] && [ "${MUSL_ONLY}" = false ]; then
+    DBG_PKGS+=(firefox-dbg)
 fi
 
 # ── Preconditions ────────────────────────────────────────────────────────────

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# install-firefox-musl.sh — Stage Alpine Linux's musl-linked Firefox ESR
-# into the AstryxOS data-disk staging tree.
+# install-firefox-musl.sh — Stage Alpine Linux's musl-linked Firefox
+# (firefox-esr 115.x OR firefox 132.x) into the AstryxOS data-disk staging tree.
 #
 # Why musl?  The glibc Firefox plateau (sc=2902 frozen for 28+ min, TID 2 in
 # NS_ProcessNextEvent) is hypothesised to be glibc-specific — glibc's
@@ -9,6 +9,37 @@
 # fundamentally different futex / mutex traffic than musl's single-slot
 # cond_var and simpler allocator.  Swapping the libc tests whether the
 # kernel publication paths intersect those primitives.
+#
+# Package selection via ASTRYXOS_FIREFOX_PACKAGE
+# ----------------------------------------------
+#
+# Two Alpine community packages are supported:
+#
+#   firefox-esr (default; 115.24.0-r0 on v3.20) — Extended Support Release.
+#     Mature, slow-moving binary; Mozilla tecken indexes its BuildID.  Alpine
+#     does NOT ship firefox-esr-dbg, so libxul attribution falls back to
+#     Mozilla Breakpad PUBLIC symbols (~8,600 entries; PUBLIC-only).
+#
+#   firefox (current; 132.0.2-r0 on v3.20) — Latest stable.  Alpine DOES ship
+#     firefox-dbg (~47 MiB on data.img) carrying a real .debug companion with
+#     full .symtab (~420k symbols incl. FUNC) and minimal DWARF — addr2line /
+#     gdb / nm resolve C++ names via the .gnu_debuglink chain.  Chosen for any
+#     investigation that needs to NAME the libxul function at a captured RIP.
+#
+# Layout-significant differences
+# ------------------------------
+#
+#   Item                          firefox-esr (115.x)          firefox (132.x)
+#   ─────────────────────────     ─────────────────────────    ─────────────────────────
+#   Binary install dir            /usr/lib/firefox-esr         /usr/lib/firefox
+#   DT_RUNPATH in Mozilla DSOs    /usr/lib/firefox-esr         /usr/lib/firefox
+#   Alpine subpackage layout      -intl                        -intl, -dbg
+#   Apk-tools-static name         "firefox-esr"                "firefox"
+#   Sentinel binary on guest      firefox-esr                  firefox
+#
+# The path of the canonical Mozilla tree on the staged data-disk MUST match
+# the DT_RUNPATH baked into each variant's DSOs (per ELF gABI §5.4); we honour
+# that here by computing FF_INSTALL_DIR and FF_SENTINEL_BIN per package.
 #
 # What this script does
 # ----------------------
@@ -60,15 +91,6 @@ DISK_DIR="${BUILD_DIR}/disk"
 DISK_OPT="${DISK_DIR}/opt/firefox"
 DISK_LIB="${DISK_DIR}/lib"
 DISK_USR_LIB="${DISK_DIR}/usr/lib"
-# Mozilla artefacts ship with DT_RUNPATH=/usr/lib/firefox-esr baked into the
-# ELF .dynamic section.  Per the ELF gABI (System V ABI §5.4 "Dynamic Linking
-# — Shared Object Dependencies"), DT_RUNPATH is consulted when resolving
-# DT_NEEDED entries.  FAT32 has no symlinks, so the canonical Mozilla tree
-# (libxul.so, libmozsandbox.so, liblgpllibs.so, … and the browser/, defaults/,
-# fonts/, gmp-clearkey/ subdirs) MUST be staged at this absolute path on disk
-# for the dynamic linker to find them.
-DISK_FF_ESR="${DISK_DIR}/usr/lib/firefox-esr"
-FIREFOX_BIN="${DISK_OPT}/firefox-bin"
 
 CACHE_DIR="${HOME}/.cache/astryxos-firefox-musl"
 APK_STATIC_DIR="${CACHE_DIR}/apk-tools"
@@ -81,35 +103,88 @@ APK_TOOLS_VERSION="2.14.4-r1"
 ALPINE_KEY="alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub"
 ALPINE_KEY_URL="https://alpinelinux.org/keys/${ALPINE_KEY}"
 APK_STATIC_URL="https://dl-cdn.alpinelinux.org/alpine/${ALPINE_VERSION}/main/x86_64/apk-tools-static-${APK_TOOLS_VERSION}.apk"
-FIREFOX_PKG="firefox-esr"   # 115.x ESR — mirrors the glibc build (115.15.0 ESR)
+
+# Package selection (env var + CLI override).  Default firefox-esr to preserve
+# every existing caller's behaviour.
+FIREFOX_PKG="${ASTRYXOS_FIREFOX_PACKAGE:-firefox-esr}"
 
 FORCE=false
 for arg in "$@"; do
     case "${arg}" in
         --force) FORCE=true ;;
+        --package=*) FIREFOX_PKG="${arg#--package=}" ;;
         -h|--help)
-            sed -n '2,40p' "$0"
+            sed -n '2,60p' "$0"
             exit 0
             ;;
     esac
 done
 
+case "${FIREFOX_PKG}" in
+    firefox-esr)
+        # 115.x ESR — mirrors the glibc build (115.15.0 ESR).  Alpine layout:
+        # /usr/lib/firefox-esr/{firefox-esr,libxul.so,...}.  No -dbg subpackage
+        # — libxul attribution flows through Mozilla tecken (see
+        # scripts/inject-libxul-symbols.sh --musl).
+        FF_INSTALL_DIR_NAME="firefox-esr"
+        FF_SENTINEL_BIN_NAME="firefox-esr"
+        ;;
+    firefox)
+        # 132.x current — Alpine community/firefox at v3.20 ships 132.0.2-r0
+        # with subpackages firefox-intl and firefox-dbg.  Alpine layout:
+        # /usr/lib/firefox/{firefox,firefox-bin,libxul.so,...}.  -dbg companion
+        # ships full .debug files with .symtab (~420k symbols including FUNC
+        # records and minimal DWARF), so addr2line / nm / gdb resolve C++
+        # function names automatically via the binary's .gnu_debuglink section
+        # without any Mozilla tecken indirection.
+        FF_INSTALL_DIR_NAME="firefox"
+        FF_SENTINEL_BIN_NAME="firefox"
+        ;;
+    *)
+        echo "[FF-MUSL] ERROR: unknown FIREFOX_PKG='${FIREFOX_PKG}' (expected firefox-esr|firefox)"
+        echo "[FF-MUSL]        Set ASTRYXOS_FIREFOX_PACKAGE=firefox-esr|firefox or pass --package=..."
+        exit 2
+        ;;
+esac
+
+# Mozilla artefacts ship with DT_RUNPATH=/usr/lib/<package> baked into the
+# ELF .dynamic section (where <package> is either "firefox-esr" or "firefox"
+# depending on the build).  Per the ELF gABI (System V ABI §5.4 "Dynamic
+# Linking — Shared Object Dependencies"), DT_RUNPATH is consulted when
+# resolving DT_NEEDED entries.  FAT32 has no symlinks, so the canonical
+# Mozilla tree (libxul.so, libmozsandbox.so, liblgpllibs.so, … and the
+# browser/, defaults/, fonts/, gmp-clearkey/ subdirs) MUST be staged at this
+# absolute path on disk for the dynamic linker to find them.
+DISK_FF_TREE="${DISK_DIR}/usr/lib/${FF_INSTALL_DIR_NAME}"
+FIREFOX_BIN="${DISK_OPT}/firefox-bin"
+
+# Variant sentinel file lives at $DISK_OPT/.variant; we read it during the
+# idempotency check so that switching packages forces a re-stage even when the
+# raw files all exist (otherwise a prior firefox-esr stage would be reported
+# "up-to-date" under a firefox-132 invocation that uses a different tree).
+VARIANT_SENTINEL="${DISK_OPT}/.variant"
+EXISTING_PKG=""
+if [ -f "${VARIANT_SENTINEL}" ]; then
+    EXISTING_PKG="$(grep -m1 '^package=' "${VARIANT_SENTINEL}" 2>/dev/null | cut -d= -f2 || true)"
+fi
+
 # ── Idempotency check ─────────────────────────────────────────────────────────
 # We consider the install up-to-date if firefox-bin exists, is musl-linked
 # (PT_INTERP = /lib/ld-musl-x86_64.so.1), the base shared libraries we stage
-# from ${ROOTFS}/lib/ are present in ${DISK_LIB}, AND the canonical Mozilla
-# tree is present at ${DISK_FF_ESR} (DT_RUNPATH).  The libxul.so sentinel under
-# /usr/lib/firefox-esr covers older partial installs that staged Mozilla under
-# /opt/firefox/ only — those need a restage so DT_RUNPATH lookups succeed.
+# from ${ROOTFS}/lib/ are present in ${DISK_LIB}, the canonical Mozilla tree
+# is present at ${DISK_FF_TREE} (DT_RUNPATH), AND the variant sentinel reports
+# the same package we are being asked to install (so a firefox-esr → firefox-132
+# switch invalidates the cache automatically).
 if [ "${FORCE}" = false ] && [ -f "${FIREFOX_BIN}" ] && \
    file "${FIREFOX_BIN}" 2>/dev/null | grep -q 'ld-musl' && \
    [ -e "${DISK_LIB}/libz.so.1" ] && \
-   [ -e "${DISK_FF_ESR}/libxul.so" ]; then
-    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base + runpath staged — skipping (use --force to reinstall)"
+   [ -e "${DISK_FF_TREE}/libxul.so" ] && \
+   [ "${EXISTING_PKG}" = "${FIREFOX_PKG}" ]; then
+    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base + runpath staged for ${FIREFOX_PKG} — skipping (use --force to reinstall)"
     exit 0
 fi
 
-echo "[FF-MUSL] Installing Alpine ${ALPINE_VERSION} musl Firefox ESR"
+echo "[FF-MUSL] Installing Alpine ${ALPINE_VERSION} musl ${FIREFOX_PKG}"
 
 # ── Step 1: Fetch apk-tools-static + Alpine signing key (cached) ─────────────
 mkdir -p "${APK_STATIC_DIR}" "${CACHE_DIR}"
@@ -128,11 +203,24 @@ if [ ! -x "${APK_BIN}" ] || [ "${FORCE}" = true ]; then
 fi
 
 # ── Step 2: Bootstrap Alpine rootfs ──────────────────────────────────────────
-if [ "${FORCE}" = true ]; then
+# When switching packages we need a fresh rootfs (apk's solver can leave a
+# hybrid state if we just `add firefox` over a `firefox-esr` rootfs).  Detect
+# via the on-disk presence of the OTHER package's main install dir; if found,
+# wipe so step 2 below installs cleanly.  Caller's explicit --force always wipes.
+ALT_INSTALL_DIR=""
+case "${FIREFOX_PKG}" in
+    firefox-esr) ALT_INSTALL_DIR="${ROOTFS}/usr/lib/firefox" ;;
+    firefox)     ALT_INSTALL_DIR="${ROOTFS}/usr/lib/firefox-esr" ;;
+esac
+if [ "${FORCE}" = true ] || \
+   ( [ -n "${ALT_INSTALL_DIR}" ] && [ -d "${ALT_INSTALL_DIR}" ] ); then
     rm -rf "${ROOTFS}"
 fi
 
-if [ ! -f "${ROOTFS}/usr/lib/firefox-esr/firefox-esr" ]; then
+# Sentinel for "package already installed in rootfs": the canonical binary file
+# the package owns (firefox-esr's own ELF for ESR; "firefox-bin" for 132).
+ROOTFS_FF_SENTINEL="${ROOTFS}/usr/lib/${FF_INSTALL_DIR_NAME}/${FF_SENTINEL_BIN_NAME}"
+if [ ! -f "${ROOTFS_FF_SENTINEL}" ]; then
     echo "[FF-MUSL] Bootstrapping Alpine rootfs at ${ROOTFS}"
     mkdir -p "${ROOTFS}/etc/apk/keys" "${ROOTFS}/var/cache/apk"
 
@@ -159,15 +247,16 @@ EOF
         | sed 's/^/[FF-MUSL apk] /' \
         | tail -40 || true
 
-    if [ ! -f "${ROOTFS}/usr/lib/firefox-esr/firefox-esr" ]; then
-        echo "[FF-MUSL] ERROR: firefox-esr not present in rootfs after apk add"
+    if [ ! -f "${ROOTFS_FF_SENTINEL}" ]; then
+        echo "[FF-MUSL] ERROR: ${FIREFOX_PKG} not present in rootfs after apk add"
+        echo "[FF-MUSL]        Expected file: ${ROOTFS_FF_SENTINEL}"
         exit 1
     fi
 fi
 
-INSTALLED_VERSION="$(grep -m1 '^P:firefox-esr$' -A1 "${ROOTFS}/lib/apk/db/installed" 2>/dev/null | \
+INSTALLED_VERSION="$(grep -m1 "^P:${FIREFOX_PKG}\$" -A1 "${ROOTFS}/lib/apk/db/installed" 2>/dev/null | \
                      grep '^V:' | cut -d: -f2 || echo unknown)"
-echo "[FF-MUSL] Alpine rootfs contains firefox-esr ${INSTALLED_VERSION}"
+echo "[FF-MUSL] Alpine rootfs contains ${FIREFOX_PKG} ${INSTALLED_VERSION}"
 echo "[FF-MUSL]   rootfs size: $(du -sh "${ROOTFS}" | cut -f1)"
 
 # ── Step 3: Stage rootfs into build/disk/ ────────────────────────────────────
@@ -231,25 +320,28 @@ for f in "${ROOTFS}"/lib/*; do
     fi
 done
 
-# (b) Wipe prior /opt/firefox/ and /usr/lib/firefox-esr/ staging so we cannot
-# end up with a hybrid (e.g. glibc firefox-bin + musl libxul.so).  Step (c)
-# below will repopulate /usr/lib/firefox-esr/ from the rootfs.
+# (b) Wipe prior /opt/firefox/ and BOTH possible /usr/lib/<pkg>/ trees so we
+# cannot end up with a hybrid (e.g. glibc firefox-bin + musl libxul.so, or
+# firefox-esr libxul.so left over from a prior run + firefox-132 firefox-bin).
+# Step (c) below will repopulate /usr/lib/${FF_INSTALL_DIR_NAME}/ from the
+# rootfs.
 #
 # DT_RUNPATH context: every Mozilla ELF (firefox-bin, libxul.so,
-# libmozsandbox.so, ...) carries DT_RUNPATH=/usr/lib/firefox-esr per
-# readelf -d.  Per the ELF gABI (System V ABI §5.4 "Shared Object
+# libmozsandbox.so, ...) carries DT_RUNPATH=/usr/lib/<package-name> per
+# readelf -d (where <package-name> is "firefox-esr" for 115.x or "firefox"
+# for 132.x).  Per the ELF gABI (System V ABI §5.4 "Shared Object
 # Dependencies") and ld-musl(8), DT_RUNPATH is consulted after
 # LD_LIBRARY_PATH for DT_NEEDED resolution.  Placing the Mozilla tree
 # anywhere else means libxul's dlopen for its sibling .so files fails with
 # ENOENT and ld-musl exit_group()s.  The canonical tree must live at
-# /disk/usr/lib/firefox-esr/ (mapped to guest /usr/lib/firefox-esr by the
-# kernel's /usr → /disk/usr VFS symlink).
+# /disk/usr/lib/${FF_INSTALL_DIR_NAME}/ (mapped to guest path by the kernel's
+# /usr → /disk/usr VFS symlink).
 #
 # We keep a minimal /opt/firefox/ duplicate consisting of firefox-bin alone
 # (~795 KiB) so the kernel's launch path (kernel/src/main.rs:508) and
 # pre-cache loader (kernel/src/main.rs:455) remain stable.  The launched
 # ELF's DT_RUNPATH is absolute, not relative to its on-disk location.
-rm -rf "${DISK_OPT}" "${DISK_FF_ESR}"
+rm -rf "${DISK_OPT}" "${DISK_DIR}/usr/lib/firefox-esr" "${DISK_DIR}/usr/lib/firefox"
 mkdir -p "${DISK_OPT}"
 
 # (c) Support libraries from Alpine's /usr/lib/.  Strip Alpine-specific
@@ -269,24 +361,52 @@ cp -aL "${ROOTFS}/usr/lib/." "${DISK_USR_LIB}/" 2>/dev/null || true
 # Drop apk's bookkeeping; not useful at runtime.
 rm -rf "${DISK_USR_LIB}/apk" 2>/dev/null || true
 
-# Within ${DISK_FF_ESR}: rename Alpine's "firefox-esr" → "firefox-bin" so
-# callers that follow the launcher's readlink("/proc/self/exe") + "-bin"
-# convention resolve there.  Keep the original "firefox-esr" name as an
-# alias for any caller using Alpine's name.  firefox-esr-bin is an Alpine
-# internal symlink to /usr/bin/firefox-esr (a shell wrapper); strip it —
-# we are using the resolved ELF directly.
-if [ -f "${DISK_FF_ESR}/firefox-esr" ]; then
-    cp -f "${DISK_FF_ESR}/firefox-esr" "${DISK_FF_ESR}/firefox-bin"
-    cp -f "${DISK_FF_ESR}/firefox-esr" "${DISK_FF_ESR}/firefox"
-fi
-rm -f "${DISK_FF_ESR}/firefox-esr-bin"
+# Within ${DISK_FF_TREE}: ensure both "firefox-bin" and "firefox" sentinel
+# names exist so callers that follow the launcher's readlink("/proc/self/exe")
+# + "-bin" convention (or its plain-name fallback) resolve there.
+#
+# Per-package starting point:
+#   firefox-esr (115.x): Alpine ships the ELF as "firefox-esr".  We copy it
+#                        as "firefox-bin" and "firefox" for caller convenience.
+#                        Strip the Alpine-internal "firefox-esr-bin" symlink
+#                        to /usr/bin/firefox-esr — we use the ELF directly.
+#   firefox (132.x):     Alpine already ships both "firefox" and "firefox-bin"
+#                        (firefox-bin is the real ELF; firefox is a small shell
+#                        wrapper).  Nothing to rename.
+case "${FIREFOX_PKG}" in
+    firefox-esr)
+        if [ -f "${DISK_FF_TREE}/firefox-esr" ]; then
+            cp -f "${DISK_FF_TREE}/firefox-esr" "${DISK_FF_TREE}/firefox-bin"
+            cp -f "${DISK_FF_TREE}/firefox-esr" "${DISK_FF_TREE}/firefox"
+        fi
+        rm -f "${DISK_FF_TREE}/firefox-esr-bin"
+        ;;
+    firefox)
+        # Alpine community/firefox 132.x layout (verified via apk extract):
+        #   /usr/lib/firefox/firefox      → real ELF (musl interp), what we run.
+        #   /usr/lib/firefox/firefox-bin  → symlink to /usr/bin/firefox
+        #                                    (the wrapper); cp -L resolves this
+        #                                    to the wrapper script during staging,
+        #                                    which is NOT the ELF we want.
+        #   /usr/bin/firefox              → POSIX-sh wrapper "exec
+        #                                    /usr/lib/firefox/firefox \"$@\"".
+        #
+        # We use the real ELF directly to bypass the wrapper.  Replace the
+        # bogus firefox-bin (resolved from the symlink) with a copy of the
+        # actual ELF so every caller — kernel pre-cache, kernel launch path,
+        # test_runner — sees the same musl-PIE binary at "firefox-bin".
+        if [ -f "${DISK_FF_TREE}/firefox" ]; then
+            cp -f "${DISK_FF_TREE}/firefox" "${DISK_FF_TREE}/firefox-bin"
+        fi
+        ;;
+esac
 
 # Mirror firefox-bin into /disk/opt/firefox/ (kernel launch + pre-cache path
-# stability).  Do NOT mirror the .so files — DT_RUNPATH is /usr/lib/firefox-esr,
-# so a duplicate libxul at /opt/firefox/ would never be loaded and would waste
-# ~160 MiB of FAT32 capacity.
-cp -f "${DISK_FF_ESR}/firefox-bin" "${DISK_OPT}/firefox-bin"
-cp -f "${DISK_FF_ESR}/firefox-bin" "${DISK_OPT}/firefox"
+# stability).  Do NOT mirror the .so files — DT_RUNPATH is
+# /usr/lib/${FF_INSTALL_DIR_NAME}/, so a duplicate libxul at /opt/firefox/
+# would never be loaded and would waste ~160 MiB of FAT32 capacity.
+cp -f "${DISK_FF_TREE}/firefox-bin" "${DISK_OPT}/firefox-bin"
+cp -f "${DISK_FF_TREE}/firefox-bin" "${DISK_OPT}/firefox"
 
 # (d) Etc — fontconfig / nss / dbus config that musl Firefox reads at runtime.
 mkdir -p "${DISK_DIR}/etc"
@@ -297,9 +417,13 @@ for sub in fonts ssl nsswitch.conf hosts; do
 done
 
 # (e) Drop a sentinel file so the kernel / scripts can detect which variant
-# was installed without binary-probing /opt/firefox/firefox-bin.
+# was installed without binary-probing /opt/firefox/firefox-bin.  The
+# `package=` field is consumed by the idempotency check at the top of this
+# script so an ESR→132 (or vice-versa) switch triggers a full re-stage.
 cat > "${DISK_OPT}/.variant" <<EOF
 variant=musl
+package=${FIREFOX_PKG}
+install_dir=/usr/lib/${FF_INSTALL_DIR_NAME}
 alpine_version=${ALPINE_VERSION}
 firefox_version=${INSTALLED_VERSION}
 apk_tools_version=${APK_TOOLS_VERSION}
@@ -321,16 +445,16 @@ if [ ! -f "${DISK_LIB}/ld-musl-x86_64.so.1" ]; then
     exit 1
 fi
 # Verify the canonical Mozilla tree landed at DT_RUNPATH.  libxul.so under
-# /usr/lib/firefox-esr/ is the single most load-bearing file — every Mozilla
-# DSO dlopen indirects through DT_RUNPATH to that directory.  See readelf -d
-# output: firefox-bin, libxul.so, libmozsandbox.so all have
-# DT_RUNPATH=/usr/lib/firefox-esr per ELF gABI §5.4.
-if [ ! -f "${DISK_FF_ESR}/libxul.so" ]; then
-    echo "[FF-MUSL] ERROR: ${DISK_FF_ESR}/libxul.so missing — DT_RUNPATH lookup will fail"
+# /usr/lib/${FF_INSTALL_DIR_NAME}/ is the single most load-bearing file —
+# every Mozilla DSO dlopen indirects through DT_RUNPATH to that directory.
+# See readelf -d output: firefox-bin, libxul.so, libmozsandbox.so all have
+# DT_RUNPATH=/usr/lib/<package> per ELF gABI §5.4.
+if [ ! -f "${DISK_FF_TREE}/libxul.so" ]; then
+    echo "[FF-MUSL] ERROR: ${DISK_FF_TREE}/libxul.so missing — DT_RUNPATH lookup will fail"
     exit 1
 fi
-if [ ! -f "${DISK_FF_ESR}/libmozsandbox.so" ]; then
-    echo "[FF-MUSL] ERROR: ${DISK_FF_ESR}/libmozsandbox.so missing — first DT_NEEDED of libxul will fail"
+if [ ! -f "${DISK_FF_TREE}/libmozsandbox.so" ]; then
+    echo "[FF-MUSL] ERROR: ${DISK_FF_TREE}/libmozsandbox.so missing — first DT_NEEDED of libxul will fail"
     exit 1
 fi
 # Verify the base shared libs landed.  libz in particular is mandatory —
@@ -349,15 +473,15 @@ if [ -n "${MISSING_BASE_LIBS}" ]; then
     exit 1
 fi
 
-echo "[FF-MUSL] Staged:"
-echo "[FF-MUSL]   firefox-bin (launcher):  $(stat -c%s "${FIREFOX_BIN}") bytes, musl PT_INTERP"
-echo "[FF-MUSL]   firefox-bin (runpath):   $(stat -c%s "${DISK_FF_ESR}/firefox-bin") bytes"
-echo "[FF-MUSL]   libxul.so (runpath):     $(stat -c%s "${DISK_FF_ESR}/libxul.so") bytes"
-echo "[FF-MUSL]   libmozsandbox (runpath): $(stat -c%s "${DISK_FF_ESR}/libmozsandbox.so") bytes"
-echo "[FF-MUSL]   ld-musl:                 $(stat -c%s "${DISK_LIB}/ld-musl-x86_64.so.1") bytes"
-echo "[FF-MUSL]   libz.so.1:               $(stat -c%s "${DISK_LIB}/libz.so.1") bytes"
-echo "[FF-MUSL]   /lib:                    $(du -sh "${DISK_LIB}" | cut -f1)"
-echo "[FF-MUSL]   /opt/firefox (launcher): $(du -sh "${DISK_OPT}" | cut -f1)"
-echo "[FF-MUSL]   /usr/lib/firefox-esr:    $(du -sh "${DISK_FF_ESR}" | cut -f1)"
-echo "[FF-MUSL]   /usr/lib (total):        $(du -sh "${DISK_USR_LIB}" | cut -f1)"
+echo "[FF-MUSL] Staged (${FIREFOX_PKG} ${INSTALLED_VERSION}):"
+echo "[FF-MUSL]   firefox-bin (launcher):       $(stat -c%s "${FIREFOX_BIN}") bytes, musl PT_INTERP"
+echo "[FF-MUSL]   firefox-bin (runpath):        $(stat -c%s "${DISK_FF_TREE}/firefox-bin") bytes"
+echo "[FF-MUSL]   libxul.so (runpath):          $(stat -c%s "${DISK_FF_TREE}/libxul.so") bytes"
+echo "[FF-MUSL]   libmozsandbox (runpath):      $(stat -c%s "${DISK_FF_TREE}/libmozsandbox.so") bytes"
+echo "[FF-MUSL]   ld-musl:                      $(stat -c%s "${DISK_LIB}/ld-musl-x86_64.so.1") bytes"
+echo "[FF-MUSL]   libz.so.1:                    $(stat -c%s "${DISK_LIB}/libz.so.1") bytes"
+echo "[FF-MUSL]   /lib:                         $(du -sh "${DISK_LIB}" | cut -f1)"
+echo "[FF-MUSL]   /opt/firefox (launcher):      $(du -sh "${DISK_OPT}" | cut -f1)"
+echo "[FF-MUSL]   /usr/lib/${FF_INSTALL_DIR_NAME} (runpath): $(du -sh "${DISK_FF_TREE}" | cut -f1)"
+echo "[FF-MUSL]   /usr/lib (total):             $(du -sh "${DISK_USR_LIB}" | cut -f1)"
 echo "[FF-MUSL] Done."


### PR DESCRIPTION
## Summary

- Adds opt-in `ASTRYXOS_FIREFOX_PACKAGE=firefox-esr|firefox` env-var axis so the data-disk pipeline can stage Alpine community/firefox 132.x alongside (not replacing) the existing community/firefox-esr 115.x track.
- Wires the new axis through `install-firefox-musl.sh`, `install-firefox-musl-debug.sh`, `create-data-disk.sh`, the kernel pre-cache + FF binary probe, and the `test_runner` Firefox launch oracle.
- firefox-132 ships Alpine's `firefox-dbg` subpackage (a real 46 MiB `libxul.so.debug` with full `.symtab` ~420k FUNC + minimal DWARF), so `addr2line`/`nm`/`gdb` resolve C++ function names natively via `.gnu_debuglink` — verified end-to-end against the staged Alpine apk on this PR. Mozilla tecken injection is skipped for firefox-132 because the firefox-dbg `.symtab` is strictly superior.

## Why

Phase 1.5 (PR #360 Mozilla tecken Breakpad injection) hit a corpus ceiling: tecken's PUBLIC-only symbol set for the Alpine ESR 115 libxul has no name within 175 KiB of the F3-saga's `trap_ra = libxul + 0x466F670`. The actual Mozilla C++ code is stripped from tecken's public corpus; only STL templates remain. Alpine's `firefox-dbg` for the 132.x package fills exactly this gap with ~420,000 demangled FUNC entries.

## Verified

- `bash -n` clean on all 3 modified shell scripts
- `cargo +nightly check --target x86_64-astryx.json --features firefox-test` clean (and without the feature)
- `ASTRYXOS_FIREFOX_PACKAGE=firefox bash scripts/install-firefox-musl.sh --force` end-to-end: staged firefox-bin = 397,544 bytes (musl PT_INTERP), libxul.so = 128,300,232 bytes, `/usr/lib/firefox/` = 218M tree
- `readelf -d build/disk/usr/lib/firefox/firefox-bin` shows `RUNPATH=[/usr/lib/firefox]` (matches our staging path; ELF gABI §5.4)
- `.variant` sentinel switching firefox-esr ↔ firefox triggers a clean rootfs wipe + restage automatically (no `--force` needed)
- addr2line against the staged libxul.so + extracted firefox-dbg companion resolves:
  - `0x466F670` → `mozilla::detail::RunnableFunction<...>::Run()`
  - `0x6139780` → `JS::ToInt32(double)`
  - nm finds `mozilla::widget::GfxInfo::FireGLXTestProcess()` and `nsAppShell::Init()`

## Default unchanged

Every caller that does NOT set `ASTRYXOS_FIREFOX_PACKAGE` continues to get firefox-esr 115.x — the historical F3-saga reproducer. firefox-132 is opt-in for investigations that need to *name* the libxul function at a captured RIP.

## Note for downstream

Switching `ASTRYXOS_FIREFOX_PACKAGE` changes the reproducer identity — firefox-132 plateau metrics will NOT match the firefox-esr `sc=1233` plateau. The new field `[FFTEST] FF binary probe: musl-132=<sz> musl-esr=<sz> glibc=<sz>` is **additive** (harness-invariant safe) so existing log-parsers continue to work.

## Test plan

- [x] bash -n on all 3 modified shell scripts
- [x] cargo +nightly check kernel (with and without firefox-test feature)
- [x] install-firefox-musl.sh end-to-end staging for ASTRYXOS_FIREFOX_PACKAGE=firefox
- [x] readelf -d confirms DT_RUNPATH on staged firefox-bin
- [x] .variant sentinel package-switch handling (esr→132→esr→132 cycle)
- [x] addr2line + nm resolution against firefox-dbg libxul.so.debug
- [ ] (downstream qa dispatch) Boot KVM with ASTRYXOS_FIREFOX_PACKAGE=firefox + ASTRYXOS_FIREFOX_DEBUG=1, confirm test-runner picks musl-132 path, confirm kdb `rip-trace-resolve` (or any addr2line-based attribution) produces named C++ functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)