### PR TITLE
scripts: stage Alpine /usr/share/ runtime data trees for musl Firefox

### DIFF
--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -673,6 +673,35 @@ EOF
                 grep -v "^$" | grep -iv "^skipping" | head -20 || true
             echo "[DATA-DISK] Copied /usr/lib/debug/ to data image (${FIREFOX_DEBUG_MODE} coverage)"
         fi
+
+        # ── Runtime data trees under /usr/share/ ────────────────────────────
+        # Several Alpine packages split their runtime payload from the .so:
+        # libicudata.so is a 9 KiB stub, the real 2.7 MiB tables live at
+        # /usr/share/icu/<ver>/icudt<ver>l.dat.  Without these files the
+        # libraries fail at first use (ICU u_init -> U_FILE_ACCESS_ERROR,
+        # which aborts SpiderMonkey JS_Init inside NS_InitXPCOM).  Staged
+        # into build/disk/usr/share/ by install-firefox-musl.sh (allow-list
+        # of runtime-relevant subdirs); copied into the FAT32 image here.
+        MUSL_USR_SHARE="${BUILD_DIR}/disk/usr/share"
+        if [ -d "${MUSL_USR_SHARE}" ]; then
+            mmd -i "${DATA_IMG}" "::usr"       2>/dev/null || true
+            mmd -i "${DATA_IMG}" "::usr/share" 2>/dev/null || true
+            # Each subdir is copied independently so a single oversized or
+            # symlink-pathological subtree can't take down the whole step.
+            # Skip the "fonts" subdir — it is staged by the HOST_FONTS block
+            # below from the host DejaVu install, not from the Alpine rootfs.
+            for share_subdir in "${MUSL_USR_SHARE}"/*; do
+                [ -d "${share_subdir}" ] || continue
+                share_name="$(basename "${share_subdir}")"
+                [ "${share_name}" = "fonts" ] && continue
+                share_size="$(du -sh "${share_subdir}" | cut -f1)"
+                echo "[DATA-DISK] Copying /usr/share/${share_name} (${share_size}) to data image..."
+                mmd -i "${DATA_IMG}" "::usr/share/${share_name}" 2>/dev/null || true
+                mcopy -s -o -i "${DATA_IMG}" "${share_subdir}/." \
+                    "::usr/share/${share_name}/" 2>&1 | \
+                    grep -v "^$" | grep -iv "^skipping" | head -10 || true
+            done
+        fi
     fi
     HOST_FONTS="${BUILD_DIR}/disk/usr/share/fonts"
     if [ -d "${HOST_FONTS}/truetype/dejavu" ]; then

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -361,6 +361,49 @@ cp -aL "${ROOTFS}/usr/lib/." "${DISK_USR_LIB}/" 2>/dev/null || true
 # Drop apk's bookkeeping; not useful at runtime.
 rm -rf "${DISK_USR_LIB}/apk" 2>/dev/null || true
 
+# (c2) Auxiliary data trees under /usr/share/.  Several Alpine packages
+# split runtime data from the .so files: the dynamic loader resolves the
+# stub library by SONAME, but the library reads its real payload from a
+# fixed path under /usr/share/<pkg>/ at runtime.  Notable examples:
+#
+#   /usr/share/icu/<ver>/icudt<ver>l.dat     ← libicudata.so.<ver> is a
+#                                              9 KiB stub; the 2.7 MiB
+#                                              data file is here.  ICU
+#                                              u_init() returns
+#                                              U_FILE_ACCESS_ERROR
+#                                              without it, and SpiderMonkey
+#                                              JS_Init aborts inside
+#                                              NS_InitXPCOM.
+#   /usr/share/mime/                         ← shared-mime-info DB used
+#                                              by GIO/GTK file-type queries.
+#   /usr/share/X11/xkb/                      ← libxkbcommon keymap rules.
+#   /usr/share/glib-2.0/schemas/             ← compiled GSettings schemas
+#                                              looked up by GIO at startup.
+#   /usr/share/icons/, /usr/share/themes/    ← GTK icon/theme resolution.
+#   /usr/share/dbus-1/, applications/, etc.  ← misc runtime metadata.
+#
+# Total ~15 MiB across all subdirs — comfortably within the data.img
+# budget.  Skip Alpine build-time helpers (aclocal/, pkgconfig/, gettext/)
+# and human-only content (doc/, man/, info/, locale/) which contribute no
+# runtime behaviour.
+DISK_USR_SHARE="${DISK_DIR}/usr/share"
+if [ -d "${ROOTFS}/usr/share" ]; then
+    mkdir -p "${DISK_USR_SHARE}"
+    # Allow-list of runtime-relevant subdirs.  Anything not in this list is
+    # build-time helpers or human-readable docs; we drop it to keep the
+    # data image lean and to avoid surprising side-effects from copying
+    # everything Alpine happens to ship.
+    for share_subdir in icu mime X11 glib-2.0 icons themes dbus-1 applications \
+                        gtk-3.0 fontconfig drirc.d alsa libdrm hwdata defaults \
+                        metainfo thumbnailers xml; do
+        if [ -d "${ROOTFS}/usr/share/${share_subdir}" ]; then
+            mkdir -p "${DISK_USR_SHARE}/${share_subdir}"
+            cp -aL "${ROOTFS}/usr/share/${share_subdir}/." \
+                "${DISK_USR_SHARE}/${share_subdir}/" 2>/dev/null || true
+        fi
+    done
+fi
+
 # Within ${DISK_FF_TREE}: ensure both "firefox-bin" and "firefox" sentinel
 # names exist so callers that follow the launcher's readlink("/proc/self/exe")
 # + "-bin" convention (or its plain-name fallback) resolve there.


### PR DESCRIPTION
## Summary

- Stages Alpine `/usr/share/` runtime data trees (icu, mime, X11 xkb, glib-2.0 schemas, icons, themes, dbus-1, applications, gtk-3.0, fontconfig, drirc.d, alsa, libdrm, hwdata, defaults, metainfo, thumbnailers, xml) into `build/disk/usr/share/` from the Alpine rootfs cache, and copies them into the FAT32 data image. Closes the firefox-132 sc=1796 `NS_InitXPCOM` MOZ_CRASH `"ICU4CLibrary::Initialize() failed"`.
- Root cause is the Alpine packaging split: `libicudata.so.74.2` ships as a 9056-byte STUB whose `.rodata` literally contains `"stubdata"`; the real 2.7 MiB ICU tables live at `/usr/share/icu/74.2/icudt74l.dat`. The previous install-firefox-musl.sh only copied `/usr/lib/` from the rootfs, so the stub `.so` satisfied `NEEDED libicudata.so.74` but the data file was absent and `u_init()` returned `U_FILE_ACCESS_ERROR`.
- 72 LOC across two scripts. Allow-list of 18 runtime-relevant subdirs (~15 MiB total); excludes Alpine build helpers (aclocal/pkgconfig/gettext) and doc/man/info/locale. Per-subdir mcopy with its own log line so a single pathological subtree can't take down the whole step.

## Test plan

- [x] `bash scripts/install-firefox-musl.sh` (firefox-esr default): verified `build/disk/usr/share/icu/74.2/icudt74l.dat` = 2,799,392 bytes
- [x] `ASTRYXOS_FIREFOX_VARIANT=musl ASTRYXOS_FIREFOX_PACKAGE=firefox bash scripts/install-firefox-musl.sh`: verified all 18 share subdirs present in `build/disk/usr/share/`
- [x] `ASTRYXOS_FIREFOX_VARIANT=musl ASTRYXOS_FIREFOX_PACKAGE=firefox bash scripts/create-data-disk.sh 700`: verified 18 per-subdir log lines, `mdir -i build/data.img ::/usr/share/icu/74.2/` lists `icudt74l dat 2799392`, `mtype` extraction shows magic `9000 da27 1400 0000 0000 0200 436d 6e44` (CmnD UDataInfo header, real data — not "stubdata")
- [ ] Downstream qa Phase 3 trial: confirm `sc > 1796` and no fault at libxul VMA 0x19df035 (NS_InitXPCOM MOZ_CRASH path no longer taken)

## Notes

- Architectural invariant preserved: we ship Alpine's ICU data file byte-for-byte (no patching of upstream binaries).
- Fonts staging (`/usr/share/fonts/`) is intentionally skipped in the new loop and continues to land via the existing host-DejaVu pipeline.
- Size budget: full `/usr/share/` allow-list is ~15 MiB; data.img is 2 GiB FAT32 with plenty of headroom even at debug-symbols-full (~280-340 MiB total used post-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)