### PR TITLE
kernel/syscall: don't drag mmap_hint on MAP_FIXED placements (F3 axis closer)

### DIFF
--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -915,6 +915,23 @@ impl VmSpace {
         self.areas.iter_mut().find(|vma| vma.contains(addr))
     }
 
+    /// Lower `mmap_hint` to `base` only when this placement participates in
+    /// the NULL-hint downward-walk regime — i.e. neither MAP_FIXED nor a
+    /// MAP_STACK kernel-chosen allocation.  Skipping MAP_FIXED preserves the
+    /// per-process entropy seeded by `randomised_mmap_hint()`: a dynamic
+    /// linker that MAP_FIXED-loads shared libraries at a PIE-biased base
+    /// would otherwise drag the hint down to that base, destroying entropy
+    /// before any later NULL-hint allocation (notably `pthread_create`'s
+    /// stack fallback path) is ever issued.
+    ///
+    /// References: POSIX mmap(2), pthread_create(3), CWE-330.
+    #[inline]
+    pub fn note_mmap_placement(&mut self, base: u64, is_fixed: bool, is_stack_alloc: bool) {
+        if !is_fixed && !is_stack_alloc && base < self.mmap_hint {
+            self.mmap_hint = base;
+        }
+    }
+
     /// Insert a new VMA, maintaining sorted order by base address.
     /// Returns an error if the new VMA overlaps with any existing one.
     pub fn insert_vma(&mut self, vma: VmArea) -> Result<(), VmaError> {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2477,17 +2477,23 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
 
     match space.insert_vma(vma) {
         Ok(()) => {
-            // MAP_STACK allocations live in the stack-ASLR window (above
-            // `MMAP_BASE`); they must NOT lower `mmap_hint` because doing so
-            // would have no effect on the general allocator's downward walk
-            // (which is already below `MMAP_BASE`) and would needlessly
-            // perturb invariants tested by mm::vma::find_free_range callers
-            // that assume `mmap_hint <= MMAP_BASE`.  Likewise MAP_FIXED
-            // allocations at user-chosen addresses inside the stack window
-            // should not perturb the hint.
-            if !is_stack_alloc && base < space.mmap_hint {
-                space.mmap_hint = base;
-            }
+            // Lower `mmap_hint` only when this allocation participates in the
+            // NULL-hint downward-walk regime — i.e. neither MAP_FIXED nor a
+            // MAP_STACK kernel-chosen allocation.  See
+            // `VmSpace::note_mmap_placement` for the full rationale; the
+            // critical case is MAP_FIXED at a PIE-biased shared-library load
+            // base, which would otherwise destroy the per-process entropy
+            // seeded by `randomised_mmap_hint()` before any NULL-hint
+            // allocation is ever issued (POSIX mmap(2), CWE-330).
+            let hint_before = space.mmap_hint;
+            space.note_mmap_placement(base, is_fixed, is_stack_alloc);
+            let hint_after = space.mmap_hint;
+            #[cfg(all(feature = "firefox-test", feature = "firefox-trace-verbose"))]
+            crate::serial_println!(
+                "[MMAP-HINT] pid={} base={:#x} hint_before={:#x} hint_after={:#x} is_fixed={} is_stack_alloc={}",
+                pid, base, hint_before, hint_after, is_fixed as u8, is_stack_alloc as u8
+            );
+            let _ = (hint_before, hint_after);
             base as i64
         }
         Err(_) => {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -984,6 +984,11 @@ pub fn run() -> ! {
     total += 1;
     if test_aslr_shared_lib() { passed += 1; }
 
+    // ── Test 107c: mmap_hint not dragged downward by MAP_FIXED placements ─
+
+    total += 1;
+    if test_mmap_hint_not_dragged_by_fixed() { passed += 1; }
+
     // ── Test 108: ASLR — ET_EXEC load base is stable (never randomised) ───
 
     total += 1;
@@ -20467,6 +20472,70 @@ fn test_aslr_shared_lib() -> bool {
     drop(vm_stack);
 
     test_pass!("ASLR — shared-library VA jitter (interpreter + mmap hint)");
+    true
+}
+
+// ── Test 107c: mmap_hint not dragged downward by MAP_FIXED placements ────────
+//
+// PR #365 seeds each VmSpace with a randomised `mmap_hint` so NULL-hint mmaps
+// (per POSIX mmap(2) when `addr == NULL`) land at a per-process randomised
+// upper bound.  A dynamic linker that MAP_FIXED-loads shared libraries at a
+// PIE-biased load base must NOT drag this hint down, because doing so
+// destroys the per-process entropy before any later NULL-hint allocation
+// (notably pthread_create(3)'s stack fallback path) is ever issued.
+//
+// References: POSIX mmap(2), pthread_create(3), CWE-330.
+
+fn test_mmap_hint_not_dragged_by_fixed() -> bool {
+    test_header!("mmap_hint not dragged downward by MAP_FIXED placements");
+
+    let mut vm = match crate::mm::vma::VmSpace::new_user() {
+        Some(v) => v,
+        None => { test_fail!("mmap_hint_fixed", "VmSpace::new_user() failed"); return false; }
+    };
+    let hint_initial = vm.mmap_hint;
+    test_println!("  hint_initial: {:#x}", hint_initial);
+
+    // Step 1: NULL-hint anonymous mmap lowers the hint (downward walk).
+    const ALLOC_LEN: u64 = 0x10_0000; // 1 MiB
+    let va_a = hint_initial - ALLOC_LEN;
+    vm.note_mmap_placement(va_a, /*is_fixed=*/false, /*is_stack_alloc=*/false);
+    test_println!("  after NULL-hint base={:#x}: hint={:#x}", va_a, vm.mmap_hint);
+    if vm.mmap_hint != va_a {
+        test_fail!("mmap_hint_fixed",
+                   "NULL-hint should lower hint to {:#x}, got {:#x}", va_a, vm.mmap_hint);
+        return false;
+    }
+
+    // Step 2: MAP_FIXED at PIE-biased base must NOT drag the hint
+    // (the libxul-via-ld-musl pattern at ~0x3F_xxxx_xxxx).
+    const FIXED_VA: u64 = 0x0000_003F_5E7C_0000;
+    let hint_before_fixed = vm.mmap_hint;
+    vm.note_mmap_placement(FIXED_VA, /*is_fixed=*/true, /*is_stack_alloc=*/false);
+    test_println!("  after MAP_FIXED base={:#x}: hint={:#x} (must equal {:#x})",
+                  FIXED_VA, vm.mmap_hint, hint_before_fixed);
+    if vm.mmap_hint != hint_before_fixed {
+        test_fail!("mmap_hint_fixed",
+                   "MAP_FIXED at {:#x} dragged hint {:#x} -> {:#x} (PR #365 entropy lost)",
+                   FIXED_VA, hint_before_fixed, vm.mmap_hint);
+        return false;
+    }
+
+    // Step 3: a follow-up NULL-hint allocation still walks downward from the
+    // high jittered region, not from FIXED_VA.  Exit criterion: the next
+    // placement lies well above FIXED_VA.
+    let va_b_predicted = vm.mmap_hint - ALLOC_LEN;
+    test_println!("  next NULL-hint would land at {:#x} (must be > {:#x})",
+                  va_b_predicted, FIXED_VA + ALLOC_LEN);
+    if va_b_predicted <= FIXED_VA + ALLOC_LEN {
+        test_fail!("mmap_hint_fixed",
+                   "next NULL-hint {:#x} too close to FIXED base {:#x} — hint dragged",
+                   va_b_predicted, FIXED_VA);
+        return false;
+    }
+
+    drop(vm);
+    test_pass!("mmap_hint not dragged downward by MAP_FIXED placements");
     true
 }
 


### PR DESCRIPTION
## Problem

PR #365 jitters `VmSpace::mmap_hint` by 20 bits at process construction so that NULL-hint anonymous mmap allocations (per POSIX `mmap(2)` when `addr == NULL`) land at a per-process randomised upper bound. However, `sys_mmap` unconditionally lowered `mmap_hint` after every successful `insert_vma` — including MAP_FIXED placements at caller-chosen addresses.

ld-musl MAP_FIXED-loads libxul + its dependent shared objects at a PIE-biased range (~`0x3F_xxxx_xxxx`). Each such MAP_FIXED insert dragged `mmap_hint` from the per-process jittered ceiling (~`0x7EFF_xxxx`, set by PR #365's `randomised_mmap_hint`) all the way down past `0x3F`. From that point onward, every NULL-hint allocation walked downward from the dragged hint, landing in a deterministic region across boots — exactly the gap PR #365's entropy was supposed to close. PR #367's MAP_STACK helper sits *above* `MMAP_BASE` in a disjoint window, so it doesn't help anonymous mmap allocations that take the general `find_free_range` path (notably `pthread_create`'s stack fallback when `MAP_STACK` is not set — the workload Phase 4 qa observed).

Phase 4 qa observed F3 BUCKET signatures (`saved_slot=0x3f5e7c5850`, `caller_rsp=0x3f5e7c5800`, `fs_base=0x3f5e7ccb00`, `trap_ra=0x3feee75567`) byte-identical across 4 boots despite interpreter ASLR being active — because the per-process entropy was destroyed by MAP_FIXED hint-drag *before any thread was created*.

## Fix

Gate the post-insert hint-update on `!is_fixed && !is_stack_alloc`, encapsulated in a new helper `VmSpace::note_mmap_placement` so the policy is unit-testable. MAP_FIXED placements no longer perturb the hint, so a follow-up NULL-hint mmap still walks downward from the high jittered region instead of from the PIE-biased load base.

`sys_mmap` also gains a new `[MMAP-HINT]` verbose-trace line (gated behind `firefox-test + firefox-trace-verbose`) that prints `hint_before`, `hint_after`, `is_fixed`, `is_stack_alloc` per call so Phase 5 qa can verify the hint trajectory directly from serial.

## Threat model

CWE-330 (use of insufficiently random values). PR #365's per-process entropy was being clobbered before any consumer benefited from it; this PR preserves the entropy through process lifetime.

## Test plan

- [x] Build clean: `qemu-harness.py check` passes for `""`, `firefox-test`, and `firefox-test,firefox-trace-verbose` feature sets.
- [x] Test 107c `test_mmap_hint_not_dragged_by_fixed` added in `kernel/src/test_runner.rs` — exercises the helper directly. Sample values from the test:
  - `hint_initial ≈ 0x7EFF_xxxx_x000` (PR #365 jittered)
  - `hint_after NULL-hint base=0x7EFF_xxxx_x000 - 1 MiB`: lowered to `va_a`
  - `hint_after MAP_FIXED base=0x0000_003F_5E7C_0000`: unchanged (must equal pre-FIXED hint)
  - next NULL-hint placement remains in the `[~0x7EFF, ~0x7F00)` window, well above `0x3F_5E7D`.
- [ ] Phase 5 qa: 3-trial KVM soak; exit criterion is `saved_slot` VA distinct across 3 boots and within the jittered `[0x7EFF, 0x7F00)` mmap-hint window (not the `0x3F` PIE-bias band).

## Scope

Completes the F3 axis kernel-side closure paired with PR #367. PR #367's commit message correctly identified the residual gap ("musl pthread_create does not set MAP_STACK, so its thread stacks continue to go through `find_free_range` with mmap_hint-based variance"); this PR ensures that variance is no longer destroyed by MAP_FIXED placements.

LOC: +103 / -11 across 3 files (mm/vma.rs +17, syscall/mod.rs net +17, test_runner.rs +69). Above the soft 15-LOC fix budget because the fix is encapsulated into a unit-testable helper with a meaningful docstring, and the test exercises three steps (NULL-hint → MAP_FIXED → follow-up NULL-hint) per the dispatch's exit criterion.

## References

- POSIX `mmap(2)` — kernel chooses VA only when `addr == NULL` or `MAP_FIXED` is unset
- POSIX `pthread_create(3)` — typical NULL-hint caller of `mmap` for thread stacks
- System V AMD64 ABI §3.3.3 — Address Space Layout
- CWE-330 — Use of Insufficiently Random Values

🤖 Generated with [Claude Code](https://claude.com/claude-code)