### PR TITLE
kernel/syscall: reset clear_child_tid + robust_list on exec (sc=1171 closer candidate)

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1446,6 +1446,39 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
     //     new image — reaching this point in execve(2) is that moment.
     wake_vfork_parent();
 
+    // 5c. Reset the per-thread thread-exit protocol slots on the surviving
+    //     thread per `execve(2)` ABI.  The new image must start with a
+    //     clean `clear_child_tid` and `robust_list` slate — if it cares
+    //     about either, it will re-register via `set_tid_address(2)` and
+    //     `set_robust_list(2)` from its own startup code (glibc/musl
+    //     `__libc_setup_tls` and the pthread bootstrap).
+    //
+    //     Why this matters: the calling thread's `clear_child_tid` was
+    //     registered by the *previous* image against a user VA that is
+    //     about to be unmapped and replaced.  If the slot survives the
+    //     exec, the kernel's eventual `exit_thread` zero-store +
+    //     `FUTEX_WAKE` (the CLONE_CHILD_CLEARTID protocol per
+    //     `clone(2)`) would land on whatever VA the new image happens to
+    //     have at that offset — under firefox-bin the worst case is
+    //     BaseProfiler's `RegisteredThread::mThreadInfo` storage, where
+    //     a stale zero-store produces an unrelated NULL deref far away
+    //     from any exit path.  The same shape applies to
+    //     `robust_list_head` / `robust_list_len` per `set_robust_list(2)`
+    //     /`get_robust_list(2)`: the kernel would walk a head pointer
+    //     into the new image's memory at the next exit.
+    //
+    //     Threat-model: CWE-672 (Operation on Resource After Expiration
+    //     or Release).  Stale per-thread state surviving exec violates
+    //     the `execve(2)` process-image cleanslate guarantee.
+    //
+    //     `tls_base` (FS.MSR) is intentionally retained — the new ELF's
+    //     `_start` will issue `arch_prctl(ARCH_SET_FS, ...)` (or the
+    //     dynamic linker will, before any TLS access).  Resetting it
+    //     here would either be a no-op (overwritten before first use)
+    //     or actively wrong (some code paths observe FS.base in the
+    //     window between exec and `_start`).
+    exec_reset_thread_exit_slots(crate::proc::current_tid());
+
     // 6. Modify the syscall return frame on the kernel stack so that when
     //    we return through syscall_entry's epilogue, SYSRETQ jumps to the
     //    new entry point with the new stack.
@@ -1502,6 +1535,37 @@ pub fn wake_vfork_parent() {
                 p.state = crate::proc::ThreadState::Ready;
             }
         }
+    }
+}
+
+/// Reset the per-thread thread-exit protocol slots on `execve(2)`.
+///
+/// Per `execve(2)`, the new image starts with no `CLONE_CHILD_CLEARTID`
+/// address registered and no robust-futex list; if the new image cares
+/// about either it will re-register via `set_tid_address(2)` and
+/// `set_robust_list(2)` from its own startup code (glibc/musl pthread
+/// bootstrap).  Carrying the old image's values across exec would let a
+/// later `exit_thread` zero-store + `FUTEX_WAKE` (the
+/// `CLONE_CHILD_CLEARTID` protocol per `clone(2)`) land on whatever VA
+/// the new image happens to have at that offset — under firefox-bin the
+/// worst case is BaseProfiler's `RegisteredThread::mThreadInfo` storage,
+/// where a stale zero-store produces an unrelated NULL deref far away
+/// from any exit path.  The robust-list head/len fields have the same
+/// shape per `set_robust_list(2)`/`get_robust_list(2)`: the kernel would
+/// walk a stale head pointer at the next exit.
+///
+/// Threat-model: CWE-672 (Operation on Resource After Expiration or
+/// Release).  Stale per-thread state surviving exec violates the
+/// `execve(2)` process-image cleanslate guarantee.
+///
+/// Called by `sys_exec` (post-image-install, pre-SYSRET-frame-rewrite)
+/// and by the `execve(2)` ABI test in `test_runner.rs`.
+pub(crate) fn exec_reset_thread_exit_slots(tid: crate::proc::Tid) {
+    let mut threads = crate::proc::THREAD_TABLE.lock();
+    if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+        t.clear_child_tid  = 0;
+        t.robust_list_head = 0;
+        t.robust_list_len  = 0;
     }
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2041,6 +2041,16 @@ pub fn run() -> ! {
     total += 1;
     if test_264_vfork_child_tls_layout() { passed += 1; }
 
+    // ── Test 265: execve(2) resets clear_child_tid + robust_list ────────
+    // Verifies the `exec_reset_thread_exit_slots` helper that `sys_exec`
+    // calls between new-image install and SYSRET-frame rewrite zeroes
+    // `clear_child_tid`, `robust_list_head`, `robust_list_len` on the
+    // surviving thread per `execve(2)`/`clone(2)` (CLONE_CHILD_CLEARTID)
+    // and `set_robust_list(2)`/`get_robust_list(2)` ABI.  Threat-model:
+    // CWE-672 (Operation on Resource After Expiration or Release).
+    total += 1;
+    if test_265_exec_resets_cleartid_and_robust_list() { passed += 1; }
+
     // ── Tests 261-263: native-core hardening (cycle 3) ──────────────────
     // Gated on `native-core-tests` feature: the three native-core tests
     // (page_ref_dec CAS underflow, OB refcount integration, scheduler
@@ -35914,4 +35924,138 @@ fn test_264_vfork_child_tls_layout() -> bool {
 
     test_pass!("alloc_vfork_child_tls layout (musl posix_spawn unblocker)");
     true
+}
+
+// ── Test 265: execve(2) resets clear_child_tid + robust_list ─────────────────
+//
+// Per `execve(2)` and `clone(2)`, the new image starts with a fresh
+// thread-exit-protocol slate: the `CLONE_CHILD_CLEARTID` user-VA
+// registered by `set_tid_address(2)` and the robust-futex list head/length
+// registered by `set_robust_list(2)` are dropped on exec.  If the new
+// image cares about either, it re-registers from its own startup.
+// Carrying the old image's values across exec would let a later
+// `exit_thread` zero-store + `FUTEX_WAKE` (the `CLONE_CHILD_CLEARTID`
+// protocol) land on whatever VA the new image happens to have at that
+// offset, and would let the kernel walk a stale robust-list head into
+// unrelated memory at the next exit.
+//
+// This test exercises the `exec_reset_thread_exit_slots` helper that
+// `sys_exec` calls between the new-image install and the SYSRET-frame
+// rewrite.  The helper is testable in isolation; the full `sys_exec`
+// path requires a userspace VmSpace which the kernel-only test runner
+// doesn't have.
+//
+// References:
+//   * Linux `clone(2)` (CLONE_CHILD_CLEARTID semantics, set_child_tid)
+//   * Linux `execve(2)` (thread-state reset on image replacement)
+//   * Linux `set_tid_address(2)`
+//   * Linux `set_robust_list(2)` / `get_robust_list(2)`
+//   * Linux `futex(2)` (FUTEX_WAKE on task exit)
+//   * POSIX-1.2017 `execve(2)`
+fn test_265_exec_resets_cleartid_and_robust_list() -> bool {
+    test_header!("execve(2) resets clear_child_tid + robust_list");
+
+    let tid = crate::proc::current_tid();
+
+    // Stash whatever the kernel-test-runner thread already has registered
+    // so the assertion below is exclusively about the reset semantics,
+    // and so the test leaves THREAD_TABLE indistinguishable from how it
+    // found it (no leakage into subsequent tests).
+    let (saved_cct, saved_rlh, saved_rll) = {
+        let threads = crate::proc::THREAD_TABLE.lock();
+        match threads.iter().find(|t| t.tid == tid) {
+            Some(t) => (t.clear_child_tid, t.robust_list_head, t.robust_list_len),
+            None => {
+                test_fail!("test265",
+                    "current_tid={} not present in THREAD_TABLE — test \
+                     prerequisite broken", tid);
+                return false;
+            }
+        }
+    };
+
+    // Plant sentinel values that are obviously not zero, obviously not a
+    // plausible default, and obviously not derived from any current
+    // pointer the kernel might hand out.
+    const SENTINEL_CCT: u64    = 0x0123_4567_89ab_cdef;
+    const SENTINEL_RLH: u64    = 0xfedc_ba98_7654_3210;
+    const SENTINEL_RLL: usize  = 0xa5a5_a5a5;
+
+    {
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+            t.clear_child_tid  = SENTINEL_CCT;
+            t.robust_list_head = SENTINEL_RLH;
+            t.robust_list_len  = SENTINEL_RLL;
+        }
+    }
+
+    // Readback sanity — the plant landed.
+    {
+        let threads = crate::proc::THREAD_TABLE.lock();
+        let t = threads.iter().find(|t| t.tid == tid).unwrap();
+        if t.clear_child_tid  != SENTINEL_CCT
+        || t.robust_list_head != SENTINEL_RLH
+        || t.robust_list_len  != SENTINEL_RLL
+        {
+            test_fail!("test265",
+                "Pre-reset plant did not land: cct={:#x} rlh={:#x} rll={:#x}",
+                t.clear_child_tid, t.robust_list_head, t.robust_list_len);
+            return false;
+        }
+    }
+    test_println!("  Pre-reset plant: cct={:#x} rlh={:#x} rll={:#x} ✓",
+        SENTINEL_CCT, SENTINEL_RLH, SENTINEL_RLL);
+
+    // Exercise the helper that `sys_exec` calls.
+    crate::syscall::exec_reset_thread_exit_slots(tid);
+
+    // All three slots must now be zero.
+    let (post_cct, post_rlh, post_rll) = {
+        let threads = crate::proc::THREAD_TABLE.lock();
+        let t = threads.iter().find(|t| t.tid == tid).unwrap();
+        (t.clear_child_tid, t.robust_list_head, t.robust_list_len)
+    };
+
+    let mut ok = true;
+    if post_cct != 0 {
+        test_fail!("test265",
+            "clear_child_tid not reset: got {:#x}, expected 0 \
+             (execve(2)/clone(2) CLONE_CHILD_CLEARTID slate)", post_cct);
+        ok = false;
+    } else {
+        test_println!("  clear_child_tid reset to 0 ✓");
+    }
+    if post_rlh != 0 {
+        test_fail!("test265",
+            "robust_list_head not reset: got {:#x}, expected 0 \
+             (set_robust_list(2) slate)", post_rlh);
+        ok = false;
+    } else {
+        test_println!("  robust_list_head reset to 0 ✓");
+    }
+    if post_rll != 0 {
+        test_fail!("test265",
+            "robust_list_len not reset: got {:#x}, expected 0 \
+             (set_robust_list(2) slate)", post_rll);
+        ok = false;
+    } else {
+        test_println!("  robust_list_len reset to 0 ✓");
+    }
+
+    // Restore whatever was there before the test so the runner thread
+    // leaves the table in the state it found it.
+    {
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+            t.clear_child_tid  = saved_cct;
+            t.robust_list_head = saved_rlh;
+            t.robust_list_len  = saved_rll;
+        }
+    }
+
+    if ok {
+        test_pass!("execve(2) resets clear_child_tid + robust_list");
+    }
+    ok
 }


### PR DESCRIPTION
## Problem

Per `execve(2)`, the new process image starts with a fresh thread-exit protocol slate: the `CLONE_CHILD_CLEARTID` user-VA registered via `set_tid_address(2)` and the robust-futex list head/length registered via `set_robust_list(2)` are dropped on exec; if the new image cares about either, it re-registers from its own startup (glibc/musl pthread bootstrap).  AstryxOS's `sys_exec` modified CR3 and the SYSRET frame but never cleared the surviving thread's `clear_child_tid`, `robust_list_head`, or `robust_list_len` fields (declared in `proc/mod.rs`), so the slots carried into the new image — the next `exit_thread` on that thread would then zero-store + `FUTEX_WAKE` (per `clone(2)` CLONE_CHILD_CLEARTID) at a user VA registered by the *previous* image, which under the new image can be live unrelated data.  The qa-observed sc=1171 gate in firefox-bin (NULL deref at `mov rbx,[r14+0x20]` inside `mozilla::baseprofiler::detail::GetThreadRegistrationTime`) is consistent with this shape: BaseProfiler reads `RegisteredThread::mThreadInfo` from a TLS-resident pointer, and a stale CLEARTID zero-store at an address that under firefox-bin now backs that storage is precisely the observed fingerprint.  pid=1 is the firefox launcher then `firefox-bin` via exec, so launcher → firefox-bin is the very first exec the kernel ever services — the gap bites there before it bites anywhere else.

## Fix

In `sys_exec`, between the vfork-parent wake (step 5b) and the SYSRET-frame rewrite (step 6), call a new `exec_reset_thread_exit_slots(tid)` helper that takes `THREAD_TABLE.lock()` and zeroes `clear_child_tid`, `robust_list_head`, and `robust_list_len` on the surviving thread.  The helper is extracted so the test can exercise the reset logic without invoking the full `sys_exec` path (which requires a userspace VmSpace not present in the kernel test runner).  `tls_base` (FS.MSR) is intentionally retained — the new ELF's `_start` issues `arch_prctl(ARCH_SET_FS, ...)` before any TLS access; resetting it here would be either a no-op or actively wrong.

## Threat-model

**CWE-672 (Operation on Resource After Expiration or Release).**  Stale per-thread state surviving exec violates the `execve(2)` process-image cleanslate guarantee.  The same bug class as a use-after-free, but specialised to the thread-exit-protocol slots.

## Verification plan

- [x] Test 265 (new) — `test_265_exec_resets_cleartid_and_robust_list` plants sentinel values into the running thread's three fields, calls `exec_reset_thread_exit_slots`, asserts all three are zero post-reset, and restores prior values so the runner thread leaves THREAD_TABLE indistinguishable from how it found it.
- [x] Compile-clean under `cargo +nightly check --features test-mode,firefox-test` via `python3 scripts/qemu-harness.py check`.
- [ ] qa Phase 6 KVM 3-trial firefox-test soak — **exit criterion**: sc=1171 closes, either the plateau advances past sc=1171 or a different gate appears at a different RIP/opcode (a moved fingerprint confirms the stale-CLEARTID write site is no longer firing).  If the same `GetThreadRegistrationTime` RIP recurs after this fix, the upstream mozglue teardown-order verdict becomes load-bearing and `MOZ_DISABLE_BASE_PROFILER=1` is the right next step.

## Scope note

**F1 is a separate orthogonal gap, recommended as a follow-up PR.**  `exit_group_inner` in `proc/mod.rs` does NOT honour CLONE_CHILD_CLEARTID for either the calling thread or its siblings — the clear+wake is only performed on the explicit `exit_thread` path.  That gap manifests as joiner-side `pthread_join` hangs rather than reader-side NULL derefs, so it's orthogonal to sc=1171; closing F1 would extend `exit_group_inner` (~40 LOC) to iterate Dead-bound threads and run `write_u32_to_user_pub` + `futex_wake_for_exit` for each non-zero `clear_child_tid` before marking Dead.

## Refs

- Linux `clone(2)` — CLONE_CHILD_CLEARTID, set_child_tid, FUTEX_WAKE on task exit
- Linux `execve(2)` — process-image cleanslate guarantee
- Linux `set_tid_address(2)`, `set_robust_list(2)`, `get_robust_list(2)`
- Linux `futex(2)` — NOTES on task-exit semantics
- POSIX-1.2017 `execve(2)`, `pthread_create(3)`, `pthread_exit(3)`
- CWE-672 — Operation on Resource After Expiration or Release

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>