### PR TITLE
kernel: bundled nit cleanup PRs #371/#372/#373 (10 LOW non-blocking)

### DIFF
--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -182,21 +182,27 @@ pub fn is_kernel_static_phys(phys: u64) -> bool {
     base != 0 && end != 0 && phys >= base && phys < end
 }
 
-/// Compute the inclusive [first_page, last_page] PMM page indices that
-/// back the BootInfo struct at `BOOT_INFO_PHYS_BASE`, given the compile-
-/// time `size_of::<BootInfo>()`.
+/// Compute the inclusive `[first_page, last_page]` PMM page indices and
+/// total byte size of the BootInfo struct at `BOOT_INFO_PHYS_BASE`, given
+/// the compile-time `size_of::<BootInfo>()`.
 ///
-/// Exposed for tests verifying the CWE-787 fix (Test 267): the helper
-/// returns the same span used by `init` to reserve BootInfo pages.  A
-/// caller may check `last >= first + 1` to assert that BootInfo spans
-/// more than one page (the structural condition that motivated the
-/// fix).
-pub fn boot_info_phys_page_span() -> (usize, usize) {
+/// Returns `(first_page, last_page, bytes)`.  Exposed for tests verifying
+/// the CWE-787 fix (Test 267): the helper returns the same span used by
+/// `init` to reserve BootInfo pages, plus the byte count so callers do not
+/// duplicate the `size_of::<BootInfo>()` call site.  A caller may check
+/// `last >= first + 1` to assert that BootInfo spans more than one page
+/// (the structural condition that motivated the fix).
+///
+/// Uses `saturating_sub(1)` defensively: a zero-byte BootInfo is
+/// structurally impossible (the struct has named fields), but the
+/// arithmetic is hardened so a compiler bug or `#[repr(packed)]`
+/// regression cannot produce a wrap to `u64::MAX` here.
+pub fn boot_info_phys_page_span() -> (usize, usize, u64) {
     let bytes = core::mem::size_of::<BootInfo>() as u64;
     let first = (astryx_shared::BOOT_INFO_PHYS_BASE / PAGE_SIZE as u64) as usize;
-    let last = ((astryx_shared::BOOT_INFO_PHYS_BASE + bytes - 1)
+    let last = ((astryx_shared::BOOT_INFO_PHYS_BASE + bytes.saturating_sub(1))
         / PAGE_SIZE as u64) as usize;
-    (first, last)
+    (first, last, bytes)
 }
 
 /// True if the page index is currently marked used in the PMM bitmap.
@@ -328,13 +334,11 @@ pub fn init(boot_info: &BootInfo) {
     //       clamp in `kernel/src/main.rs` (PR #371), retained as defence
     //       in depth: after this fix it is a no-op in practice but stays
     //       to bound the blast radius of any future similar oversight.
-    const BOOT_INFO_BYTES: u64 = core::mem::size_of::<BootInfo>() as u64;
-    let boot_info_first_page =
-        (astryx_shared::BOOT_INFO_PHYS_BASE / PAGE_SIZE as u64) as usize;
-    let boot_info_last_page = ((astryx_shared::BOOT_INFO_PHYS_BASE
-        + BOOT_INFO_BYTES
-        - 1)
-        / PAGE_SIZE as u64) as usize;
+    // Single source-of-truth for the BootInfo phys span — `boot_info_phys_page_span`
+    // owns the `size_of::<BootInfo>()` computation so call sites cannot
+    // drift out of sync.
+    let (boot_info_first_page, boot_info_last_page, boot_info_bytes) =
+        boot_info_phys_page_span();
     let mut boot_info_reserved_pages = 0u64;
     for page in boot_info_first_page..=boot_info_last_page {
         if page < MAX_PAGES {
@@ -345,6 +349,11 @@ pub fn init(boot_info: &BootInfo) {
             // kernel-image reservation above is harmless to re-mark.  We
             // still decrement `total_available` only for pages that were
             // previously free.
+            //
+            // The `is_page_used_locked == true` branch is silently no-op
+            // (the bit is already set, idempotent OR); we just don't bump
+            // `boot_info_reserved_pages` because that counter is "newly
+            // reserved by this block" for the diagnostic line below.
             unsafe {
                 if !is_page_used_locked(page) {
                     mark_page_used(page);
@@ -352,9 +361,6 @@ pub fn init(boot_info: &BootInfo) {
                         total_available -= 1;
                     }
                     boot_info_reserved_pages += 1;
-                } else {
-                    // Already reserved by an earlier block (e.g. kernel
-                    // image + 256-page slack); nothing to do.
                 }
             }
         }
@@ -363,8 +369,8 @@ pub fn init(boot_info: &BootInfo) {
         "[PMM] BootInfo reservation: phys=[{:#x}..{:#x}) size={} B \
          pages={}..={} newly_reserved={} (CWE-787 fix)",
         astryx_shared::BOOT_INFO_PHYS_BASE,
-        astryx_shared::BOOT_INFO_PHYS_BASE + BOOT_INFO_BYTES,
-        BOOT_INFO_BYTES,
+        astryx_shared::BOOT_INFO_PHYS_BASE + boot_info_bytes,
+        boot_info_bytes,
         boot_info_first_page,
         boot_info_last_page,
         boot_info_reserved_pages,

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -33,7 +33,7 @@ pub const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
 /// (e.g. 0x400000).  Any physical address that falls within a region the ELF
 /// occupies can no longer be reached via `phys as *mut u64` while the user
 /// CR3 is active.  Using `PHYS_OFF + phys` avoids this problem entirely.
-const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+pub(crate) const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
 
 /// Convert a physical page-table address to a kernel-accessible virtual pointer.
 #[inline(always)]

--- a/kernel/src/subsys/linux/d7_bss_watch.rs
+++ b/kernel/src/subsys/linux/d7_bss_watch.rs
@@ -74,7 +74,6 @@
 //!   * transitions FS.base from zero to a non-zero value, AND
 //!   * is performed for `pid == 1` `tid == 1` (firefox-bin init thread —
 //!     pid=1 is firefox-bin under the Linux personality, per
-//!     `[[project_sc1171_litmus_test_worked_2026_05_21]]` and
 //!     [PSE Phase 1](docs/SC1171_PSE_END_TO_END_2026-05-22.md)), AND
 //!   * the new fs_base value is at least `0x18` (so `fs_base - 0x18`
 //!     does not underflow).
@@ -86,11 +85,10 @@
 //!
 //! ## No-fix discipline
 //!
-//! Per the saga-discipline rules ([[feedback_saga_diagnostic_discipline_2026_05_20]],
-//! Rule 1 phys-provenance FIRST), this module emits diagnostic data
-//! only.  It does NOT mutate page tables, allocate frames, change any
-//! lock order, or run any logic outside the WRMSR-precondition path
-//! when `D7_ARM_COUNT == 0`.  Captured fires identify the writer; a
+//! Per saga-discipline Rule 1 (phys-provenance FIRST), this module emits
+//! diagnostic data only.  It does NOT mutate page tables, allocate frames,
+//! change any lock order, or run any logic outside the WRMSR-precondition
+//! path when `D7_ARM_COUNT == 0`.  Captured fires identify the writer; a
 //! *separate* coordinator-dispatched fix uses that identification to
 //! target the exact path.
 //!

--- a/kernel/src/subsys/linux/d8_fault_tls_dump.rs
+++ b/kernel/src/subsys/linux/d8_fault_tls_dump.rs
@@ -119,13 +119,12 @@ const D8_TLS_SLOT_OFFSET: u64 = 0x18;
 /// Vol. 3A §4.6, an 8-byte access straddles only when
 /// `(addr & 0xFFF) > 0x1000 - 8`; in that case `None` is returned.
 fn read_user_qword(addr: u64) -> Option<(u64, u64)> {
-    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
     if !crate::syscall::validate_user_ptr(addr, 8) { return None; }
     if (addr & 0xFFF) > 0x1000 - 8 { return None; }
     let cr3 = crate::mm::vmm::get_cr3();
     let phys = crate::mm::vmm::virt_to_phys_in(cr3, addr)?;
     let val = unsafe {
-        core::ptr::read_volatile((PHYS_OFF + phys) as *const u64)
+        core::ptr::read_volatile((crate::mm::vmm::PHYS_OFF + phys) as *const u64)
     };
     Some((val, phys))
 }
@@ -223,9 +222,16 @@ pub fn try_dump_at_fault(
     // this is the value that turned the early-return into the slow
     // path.  Zero ⇒ Z1 falsified.  Non-zero ⇒ Z1 candidate.
     if fs_base < D8_TLS_SLOT_OFFSET {
+        // Emit shadow totals before bailing so a post-processor sees how
+        // many free/alloc events were recorded prior to the fault; helps
+        // disambiguate "no provenance because rings were empty" from
+        // "no provenance because we returned early before lookup".
+        let fr = crate::mm::w215_diag::free_shadow_recorded_count();
+        let ar = crate::mm::w215_diag::alloc_shadow_recorded_count();
         crate::serial_println!(
-            "[D8/FAULT-DUMP] tls_slot fs_base_too_small fs_base={:#x}",
-            fs_base,
+            "[D8/FAULT-DUMP] tls_slot fs_base_too_small fs_base={:#x} \
+             free_recorded={} alloc_recorded={}",
+            fs_base, fr, ar,
         );
         return;
     }
@@ -253,19 +259,63 @@ pub fn try_dump_at_fault(
     // recycled heap arena (non-zero pointer-shaped values) vs a
     // freshly-zeroed page (all zeros).  Per ELF gABI §5.2 the entire
     // PT_TLS BSS tail should read zero on first access.
-    for q in (-8i64)..8i64 {
+    //
+    // Emitted as a single multi-line `serial_println!` so the 16 rows
+    // cannot be interleaved with output from a concurrent CPU's serial
+    // writer (the underlying serial layer serialises per-call but does
+    // not lock across separate `serial_println!` invocations).
+    //
+    // `Some(0)` is encoded as `0x0000000000000000`; `None` (read failed
+    // — page not mapped under the current CR3) is encoded as `?` so the
+    // post-processor can distinguish "zero value" from "unreadable".
+    let mut vals: [Option<u64>; 16] = [None; 16];
+    for (idx, q) in (-8i64..8i64).enumerate() {
         let va = (fs_base as i64 + q * 8) as u64;
-        match read_user_qword(va) {
-            Some((v, _)) => crate::serial_println!(
-                "[D8/FAULT-DUMP] tls_dump fs_base{}{:#x}: {:#018x}",
-                if q < 0 { "-" } else { "+" }, (q * 8).unsigned_abs(), v,
-            ),
-            None => crate::serial_println!(
-                "[D8/FAULT-DUMP] tls_dump fs_base{}{:#x}: ?",
-                if q < 0 { "-" } else { "+" }, (q * 8).unsigned_abs(),
-            ),
-        }
+        vals[idx] = read_user_qword(va).map(|(v, _)| v);
     }
+    let fmt = |o: Option<u64>| -> [u8; 18] {
+        // 18 chars: "0x" + 16 hex digits, or "?" right-padded.  Returned
+        // as a stack array so the closure has no allocation footprint.
+        let mut buf = [b' '; 18];
+        match o {
+            Some(v) => {
+                buf[0] = b'0'; buf[1] = b'x';
+                for i in 0..16 {
+                    let nyb = ((v >> (60 - i * 4)) & 0xf) as u8;
+                    buf[2 + i] = if nyb < 10 { b'0' + nyb } else { b'a' + nyb - 10 };
+                }
+            }
+            None => { buf[0] = b'?'; }
+        }
+        buf
+    };
+    // Convert to &str via from_utf8_unchecked: all bytes above are ASCII
+    // hex / space / '?' / 'x' so UTF-8-validity holds by construction.
+    let s: [[u8; 18]; 16] = core::array::from_fn(|i| fmt(vals[i]));
+    let r: [&str; 16] = core::array::from_fn(|i| {
+        // SAFETY: `fmt` only writes ASCII bytes.
+        unsafe { core::str::from_utf8_unchecked(&s[i]) }
+    });
+    crate::serial_println!(
+        "[D8/FAULT-DUMP] tls_dump fs_base-0x40: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x38: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x30: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x28: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x20: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x18: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x10: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base-0x8:  {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x0:  {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x8:  {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x10: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x18: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x20: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x28: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x30: {}\n\
+         [D8/FAULT-DUMP] tls_dump fs_base+0x38: {}",
+        r[0], r[1], r[2],  r[3],  r[4],  r[5],  r[6],  r[7],
+        r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15],
+    );
 
     // ── Phys-frame provenance: FREE_SHADOW + ALLOC_SHADOW ──
     // Both rings are direct-addressed by `pfn & (SIZE-1)`, so a hit

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -36265,8 +36265,10 @@ fn test_267_pmm_reserves_full_bootinfo_span() -> bool {
 
     use astryx_shared::{BootInfo, BOOT_INFO_PHYS_BASE};
 
-    let size = core::mem::size_of::<BootInfo>();
-    let (first, last) = crate::mm::pmm::boot_info_phys_page_span();
+    let (first, last, bytes) = crate::mm::pmm::boot_info_phys_page_span();
+    let size = bytes as usize;
+    debug_assert_eq!(size, core::mem::size_of::<BootInfo>(),
+        "boot_info_phys_page_span bytes must equal size_of::<BootInfo>()");
     let page_size = crate::mm::pmm::PAGE_SIZE;
 
     test_println!(


### PR DESCRIPTION
## Scope

Bundled cosmetic and defensive cleanup of 10 LOW-severity nits flagged by review of three diagnostic / security PRs landed earlier today:

- **PR #371** — D7 PT_TLS BSS DR-watchpoint
- **PR #372** — D8 fault-time TLS slot dump + phys-frame provenance
- **PR #373** — BootInfo CWE-787 reservation fix

All 10 nits are cosmetic, documentation, or defence-in-depth. **Zero behavioural changes**: diagnostic-only paths, helper-signature additivity (one breaking call-site updated in-PR), and a private-const visibility raise.

## Per-nit rationale

### PR #371 — `subsys/linux/d7_bss_watch.rs`

| Nit | Rationale |
|-----|-----------|
| N1  | Module doc-comment contained internal memory-slug links (`[[project_*]]`, `[[feedback_*]]`) that don't render anywhere public. Replaced with the existing `docs/SC1171_PSE_END_TO_END_2026-05-22.md` public reference and inlined-prose for the saga-discipline rule. |

### PR #372 — `subsys/linux/d8_fault_tls_dump.rs` + `mm/vmm.rs`

| Nit | Rationale |
|-----|-----------|
| N1  | `read_user_qword` defined a file-local `const PHYS_OFF` duplicating `mm/vmm.rs:36`. Raised `vmm::PHYS_OFF` to `pub(crate)` and used the canonical value. Other in-crate sibling files (`mm/heap.rs`, `mm/stack_prov.rs`) already comment "matches `vmm::PHYS_OFF`"; the duplication had been deferred there too but is now fixable in d8 without touching them. |
| N3  | The `fs_base_too_small` early-return bailed without emitting the `free_recorded`/`alloc_recorded` totals that the success path emits. A post-processor watching for D8 output now sees the same shadow-totals fields regardless of which exit path fires, distinguishing "ring empty" from "we returned early before lookup". |
| N4  | The 16-row fs_base TLS-region dump used 16 separate `serial_println!` invocations. Under concurrent serial layer writes the rows could interleave with another CPU's output. Coalesced into a single multi-line invocation using a no-alloc stack-array formatter; one row per logical fs_base offset, encoded `Some(0)`→`0x0000…0000` and `None`→`?`. |

(N2 was acceptable as-is per the brief — `virt_to_phys_in(cr3, tls_va)` is only called twice in the immediate region and inlining helps readability; left untouched.)

### PR #373 — `mm/pmm.rs` + `test_runner.rs`

| Nit | Rationale |
|-----|-----------|
| N1  | `boot_info_phys_page_span()` and the inline `BOOT_INFO_BYTES` const in `init` independently computed `size_of::<BootInfo>()`. Helper signature widened from `(usize, usize)` to `(usize, usize, u64)` so `init` and Test 267 both reuse the helper's bytes — single source-of-truth. |
| N2  | Span arithmetic was `+ bytes - 1` raw; replaced with `bytes.saturating_sub(1)` so a structurally-impossible zero-byte BootInfo cannot wrap `last` to `u64::MAX`. CWE-191 defence-in-depth at zero cost. |
| N3  | The reservation loop had `if !is_page_used_locked(page) { ... } else { /* comment-only */ }`. Empty `else` blocks are a code-smell; dropped and moved the rationale into the loop-body comment immediately above the `if`. |

## Validation

Build verified clean on:

```
qemu-harness.py check                                                 → ok
qemu-harness.py check --features test-mode                            → ok
qemu-harness.py check --features firefox-test                         → ok
qemu-harness.py check --features test-mode,d7-bss-watch,d8-tls-fault-dump → ok
```

Test 267 (`pmm_reserves_full_bootinfo_span`) updated to consume the new 3-tuple signature; assertion content unchanged. A `debug_assert_eq!` cross-checks the returned bytes against `size_of::<BootInfo>()` at the call site so a future signature drift fails loud in test builds.

## Test plan

- [x] Default-features build clean
- [x] `test-mode` build clean
- [x] `firefox-test` build clean
- [x] `test-mode,d7-bss-watch,d8-tls-fault-dump` build clean
- [ ] Existing tests 107c, 107d, 265, 266, 267 still pass (deferred to CI — no behavioural change to test-paths)

## Refs

- Intel SDM Vol. 3A §3.4.4 (IA32_FS_BASE)
- Intel SDM Vol. 3A §4.10.5 (paging-structure coherence)
- Intel SDM Vol. 3A §8.1.1 (atomic-write granularity)
- ELF gABI §5.2 (PT_TLS zero-fill)
- UEFI Specification §7.2 (GetMemoryMap / EfiBootServicesData)
- CWE-191 (Integer Underflow)
- CWE-787 (Out-of-bounds Write)
- CWE-908 (Use of Uninitialized Resource)

## Diff size

5 files, +103 / -47 (net +56). Within the 50-100 LOC soft budget when measured as net additions; within the 150 LOC burst when measured as total churn.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>