### PR TITLE
kernel: D10 — dump heap-object phys-frame shadows on sc=1171 fault (Phase-2-E closer)

### DIFF
--- a/kernel/src/subsys/linux/d8_fault_tls_dump.rs
+++ b/kernel/src/subsys/linux/d8_fault_tls_dump.rs
@@ -342,5 +342,54 @@ pub fn try_dump_at_fault(
         );
     }
 
+    // ── D10: HEAP-OBJECT phys-provenance (Phase-2-E closer) ──
+    //
+    // The TLS slot at `[fs:-0x18]` holds a pointer to a heap-resident
+    // `RegisteredThread` object; Mozilla's `GetThreadRegistrationTime`
+    // loads that pointer into `r14` and then derefs `0x20(%r14)` (the
+    // `mThreadInfo` field).  Phase 2-A/B/C/D cleanly excluded heap-alloc
+    // zero-fill, ctor codegen elision, signal preemption, and
+    // unregistered-caller framings.  The one residual is whether the
+    // heap *page* itself (not the TLS slot's page) was the target of a
+    // recent `pmm::free_page` / `pmm::alloc_page` recycle that left the
+    // outer object with a partial-zero `+0x38` field.
+    //
+    // Block above dumped `FREE_SHADOW` / `ALLOC_SHADOW` on `tls_phys`
+    // — the page backing the TLS slot itself.  Block below resolves the
+    // *value* of the TLS slot as a user VA (the heap-object pointer) and
+    // dumps the same shadows on that page's phys, naming the most recent
+    // free/alloc caller RIPs for the heap frame.  Per saga-discipline
+    // Rule 1 (phys-provenance first), this completes the W215/W216
+    // aliasing-class falsification surface for the sc=1171 fingerprint.
+    //
+    // Refs: Intel SDM Vol. 3A §4.6 (paging address translation);
+    // POSIX `mmap(2)` (anonymous-mapping zero-fill); CWE-908
+    // (Use of Uninitialized Resource).
+    if let Some(v) = tls_val {
+        if v != 0 {
+            if let Some(heap_phys) = crate::mm::vmm::virt_to_phys_in(cr3, v) {
+                crate::serial_println!(
+                    "[D10/HEAP-OBJ-PROV] tls_val={:#018x} heap_phys={:#x}",
+                    v, heap_phys,
+                );
+                crate::mm::w215_diag::dump_free_shadow_for_phys(heap_phys);
+                crate::mm::w215_diag::dump_alloc_shadow_for_phys(heap_phys);
+            } else {
+                crate::serial_println!(
+                    "[D10/HEAP-OBJ-PROV] tls_val={:#018x} heap_phys=? (unmapped under cr3={:#x})",
+                    v, cr3,
+                );
+            }
+        } else {
+            crate::serial_println!(
+                "[D10/HEAP-OBJ-PROV] tls_val=0 — no heap pointer to resolve",
+            );
+        }
+    } else {
+        crate::serial_println!(
+            "[D10/HEAP-OBJ-PROV] tls_val=? (slot unreadable, see earlier dump)",
+        );
+    }
+
     crate::serial_println!("[D8/FAULT-DUMP] end pid={} tid={}", pid, tid);
 }


### PR DESCRIPTION
## Summary

Phase 2 sub-path scans for the sc=1171 fingerprint gave **4 CLEAN + 1 INCONCLUSIVE** (`docs/SC1171_PHASE2_E_HEAP_REUSE_2026-05-22.md`):

- **A-CLEAN** (heap-alloc) — musl mallocng + anon-mmap zero-fill match POSIX mmap(2) + ELF gABI §5.2.
- **B-CLEAN** (ctor codegen) — `const RefPtr<ThreadInfo>` at +0x38 cannot be elided per Itanium C++ ABI §2.5.
- **C-CLEAN** (signal window) — no preemption window between ctor and TLS publish per Intel SDM Vol. 3 §6.15.
- **D-MAIN** (caller identity) — TID=1 byte-identical, mandatory main-thread profiler_init registration confirmed.
- **E-INCONCLUSIVE** — D8 dumps `FREE_SHADOW` + `ALLOC_SHADOW` for the **TLS-slot phys**, NOT for the **heap-object phys** at `0x7eff8d681d50`.

This PR is the **Phase-2-E closer**: extends `d8_fault_tls_dump.rs` by ~49 LOC of additive read-only diagnostic to resolve `virt_to_phys_in(cr3, tls_val)` for `tls_val = *(fs:-0x18)` and invoke `dump_free_shadow_for_phys` + `dump_alloc_shadow_for_phys` on that heap-object phys (the page backing the `RegisteredThread*` payload, not the page backing the TLS slot itself).

Verdict shapes:

- both shadows MISS on `heap_phys` → **E-CLEAN**; heap page not recently freed/reused; aliasing exonerated.
- either shadow HITS → **E-CONFIRMED** with named writer/freer `(rip, tick)`.
- `tls_val=0` or unmapped → **D10-DEGENERATE**; would re-frame.

No production-path edits; same one-shot fingerprint gating as the D8 parent dump (`D8_FIRE_MAX = 1`). Feature gate unchanged (`d8-tls-fault-dump`). 49 LOC additive (soft budget 30, within 1.5× burst per `feedback_loc_caps_burst_budget`; the extra is comment block explaining the saga context).

## Single-trial KVM verdict

Single KVM trial with `--features firefox-test,ssp-canary-diag,fs-base-trace,firefox-trace-verbose,d8-tls-fault-dump`. Session `b48bfaa58ffc`.

**The sc=1171 fingerprint did not reproduce in this trial** — pid=1 firefox-bin terminated by `exit_group(-11)` at a strictly **earlier** fault:

- RIP = `0x7effd9fba8bc` (NOT firefox+0x207dc per the sc=1171 fingerprint)
- Opcode bytes = `4c 8b 47 08 84 c0 0f 85 ...` (`mov 0x8(%rdi), %r8` — NOT `49 8b 5e 20`)
- CR2 (inferred) = 0x8 (rdi was NULL)
- Final sc = 201 plateau (rather than sc=1171 cliff)

D8's content-gate (CR2=0x20 ∧ opcode prefix `49 8b 5e 20` ∧ pid=1) correctly rejected this fault — fingerprints differ — so neither D8 nor D10 emitted any dump. **D10 itself is therefore untriggered in this trial**, not falsified.

The interesting collateral signal in the same log: the kernel emitted `[FAULT/CACHE-KEY] bucket=A (same-key in-place corruption) rip_phys=0xa340000 key=(mount=4,inode=0xc7,off=0x9c000)` and a separate `[W215/CRC-MISMATCH] phys=0x363e0000 …` — i.e. the W215 Bucket-A aliasing-class fingerprint actually IS firing in this build, just on a *different* RIP than the D9-named sc=1171 instruction. That is a substantive datum for the post-PR-#368 / post-#374 demo-track surface but is outside this dispatch's scope.

## Status & hand-back

Per the PM verdict in `docs/PM_VERDICT_SC1171_PHASE3_2026-05-22.md`: stop after the single trial, do not pivot, do not implement a fix, hand back to user for live judgement. **Doing exactly that.**

What this PR delivers regardless of run outcome: the kernel now has the dispositive diagnostic wired in. Any future trial that hits the sc=1171 fingerprint will emit `[D10/HEAP-OBJ-PROV]` + the two shadow dumps for the heap-object phys, closing E one way or the other.

User decision points hand-back below.

## Test plan

- [x] D10 extension lands in the existing `d8_fault_tls_dump.rs` module (no new file, no new feature)
- [x] Build clean under `--features firefox-test,ssp-canary-diag,fs-base-trace,firefox-trace-verbose,d8-tls-fault-dump` (kernel binary built)
- [x] Single KVM trial executed; no kernel panic; harness session stopped cleanly
- [x] D8/D10 fingerprint-gate behaviour confirmed (no spurious emission on non-matching faults)
- [ ] sc=1171 fingerprint reproduction (out of scope for this PR — would require fingerprint re-elicitation; coordinator's call)

Citations: Intel SDM Vol. 3A §4.6 (paging address translation); POSIX mmap(2) (anonymous-mapping zero-fill on first access); CWE-908 (Use of Uninitialized Resource).

🤖 Generated with [Claude Code](https://claude.com/claude-code)