### PR TITLE
kernel/mm+signal: D13 — phys-shadow on data fault + widened pte_ring window

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -777,6 +777,34 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
                 unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags)); }
                 let pid = crate::proc::current_pid_lockless();
                 crate::signal::emit_fault_phys_for_fatal(pid, frame.rip, cr2, cr3_now);
+                // D13 (2026-05-22): also dump per-phys provenance for the
+                // SysV AMD64 argument registers — the GPRs most likely to
+                // hold a user pointer at the moment of fault.  Reads from
+                // the ISR push frame (see push order in `isr_with_error!`
+                // — frame layout: rsp+128 = InterruptFrame, descending
+                // pushes below it).  Offsets below mirror the existing
+                // `rbp_at_fault` deref above (frame.sub(12)).
+                //
+                // SAFETY: the ISR stub guarantees the GPR pushes occupy
+                // the 16 u64 slots immediately below `frame` (see the
+                // `isr_with_error!` macro definition lower in this file).
+                // Reads are 8-byte aligned and within the kernel stack
+                // page we are executing on.
+                #[cfg(feature = "firefox-test")]
+                {
+                    let base = frame as *const InterruptFrame as *const u64;
+                    let rdx = unsafe { *base.sub(4) };
+                    let rsi = unsafe { *base.sub(5) };
+                    let rdi = unsafe { *base.sub(6) };
+                    let r8  = unsafe { *base.sub(7) };
+                    let r9  = unsafe { *base.sub(8) };
+                    let rcx = unsafe { *base.sub(3) };
+                    crate::signal::emit_fault_gpr_phys_for_fatal(
+                        pid, cr3_now,
+                        &[("rdi", rdi), ("rsi", rsi), ("rdx", rdx),
+                          ("rcx", rcx), ("r8", r8), ("r9", r9)],
+                    );
+                }
                 // PSE 2026-05-20: full VMA enumeration to anchor PIE-ASLR
                 // bases (libxul, ld-musl, anonymous JIT) at fatal-user-#PF
                 // time.  Bounded 4 dumps/boot; see `mm::vma_dump`.
@@ -1112,6 +1140,26 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags)); }
             let pid = crate::proc::current_pid_lockless();
             crate::signal::emit_fault_phys_for_fatal(pid, frame.rip, 0, cr3_now);
+            // D13 (2026-05-22): mirror the user-#PF site — dump per-phys
+            // provenance for the SysV AMD64 argument registers.  A #UD on
+            // a `call [rdi]` through a freed vtable is named by the
+            // FREE-shadow on `rdi`'s page just as well here as it would be
+            // at the corresponding #PF.  See SysV AMD64 ABI §3.2.3.
+            #[cfg(feature = "firefox-test")]
+            {
+                let base = frame as *const InterruptFrame as *const u64;
+                let rdx = unsafe { *base.sub(4) };
+                let rsi = unsafe { *base.sub(5) };
+                let rdi = unsafe { *base.sub(6) };
+                let r8  = unsafe { *base.sub(7) };
+                let r9  = unsafe { *base.sub(8) };
+                let rcx = unsafe { *base.sub(3) };
+                crate::signal::emit_fault_gpr_phys_for_fatal(
+                    pid, cr3_now,
+                    &[("rdi", rdi), ("rsi", rsi), ("rdx", rdx),
+                      ("rcx", rcx), ("r8", r8), ("r9", r9)],
+                );
+            }
             // PSE 2026-05-20: full VMA enumeration to anchor PIE-ASLR
             // bases (libxul, ld-musl, anonymous JIT) at fatal-user-#UD /
             // #GP / #AC time.  Bounded 4 dumps/boot; see `mm::vma_dump`.

--- a/kernel/src/mm/w215_diag.rs
+++ b/kernel/src/mm/w215_diag.rs
@@ -873,22 +873,39 @@ pub fn free_shadow_displaced_count() -> u64 {
 // All counters / rings are `firefox-test`-gated; default builds remain
 // byte-identical.
 
-/// Lower bound of the user-stack PTE-change ring window.  Covers the entire
-/// upper 2 MiB of canonical user space — generous enough to capture every
-/// known stack VMA the AstryxOS Linux personality produces (main thread
-/// initial stack, vfork helper stacks at `0x7fff_ffef_…`, clone-child
-/// thread stacks the syscalls assign in the same region).  See
-/// `proc/usermode.rs::map_initial_stack` for the main-thread VA.
-pub const USER_STACK_RING_LO: u64 = 0x0000_7fff_ffe0_0000;
+/// Lower bound of the PTE-change ring window (D13 widening, 2026-05-22).
+///
+/// Originally `0x0000_7fff_ffe0_0000` — the top 2 MiB of canonical user space,
+/// chosen to cover the main-thread initial stack + vfork helper stacks.  D12
+/// (sc=201 glibc FILE._lock NULL-deref, 2026-05-22) demonstrated the
+/// restriction was diagnostically fatal: the corrupted frame lived at
+/// `0x7effd9a21020` (a glibc malloc-arena heap page well below the stack
+/// window), so `pte_change_record` was a no-op for every PTE event on the
+/// faulting page and the ring could not name the writer.
+///
+/// D13 widens the filter to the full canonical user VA range (skipping the
+/// nullptr page at 0).  Per Intel SDM Vol. 3A §4.6 user VA covers
+/// `[0, 0x0000_8000_0000_0000)`; we admit any user-VA PTE change.  The ring
+/// SIZE is unchanged (1024 slots — see [`USER_STACK_PTE_RING_SIZE`] below)
+/// to keep BSS bounded, so collisions are now expected and observable via
+/// [`PTE_CHANGE_DISPLACED`].  Most-recent-write-wins per slot; for a saga
+/// in flight the dispatcher cross-checks the ring's `tick` field against
+/// the fault tick to confirm freshness.  This is a *diagnostic-only* tradeoff
+/// gated under `firefox-test`; default builds remain byte-identical.
+pub const USER_STACK_RING_LO: u64 = 0x0000_0000_0000_1000;
 
 /// Upper (exclusive) bound — top of canonical lower-half user address space.
 pub const USER_STACK_RING_HI: u64 = 0x0000_8000_0000_0000;
 
-/// Number of entries in the user-stack PTE-change ring.  Direct addressing
-/// over `(va >> 12)` means the window holds at most
-/// `(HI - LO) / 4 KiB = 0x200 == 512` distinct 4 KiB-aligned VAs; 1024
-/// gives 2× headroom for hash collisions to be effectively impossible
-/// without bloating BSS (1024 × 48 B = 48 KiB).
+/// Number of entries in the PTE-change ring.  Direct addressing over
+/// `(va >> 12)` mod the size.  Pre-D13 the window covered only 2 MiB (512
+/// 4 KiB pages, so 1024 slots gave 2× headroom and effectively zero
+/// collisions); post-D13 the window covers the full 128 TiB canonical user
+/// VA, so collisions are unavoidable at this size — the ring is a
+/// most-recent-write-wins cache rather than a complete record.  Bumping to
+/// e.g. 64 Ki slots (3 MiB BSS) would not eliminate aliasing either
+/// (`2^35 PFNs >> 2^16`), so we keep the small footprint and rely on the
+/// `tick` freshness cross-check at dump time.  See module banner.
 const USER_STACK_PTE_RING_SIZE: usize = 1024;
 
 /// PTE-change kind codes.

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1098,7 +1098,7 @@ pub unsafe fn deliver_sigsegv_from_isr(
     {
         let cr3_now: u64;
         core::arch::asm!("mov {}, cr3", out(reg) cr3_now, options(nomem, nostack, preserves_flags));
-        emit_fault_phys_diagnostic(pid, user_rip, cr3_now, &vma_snapshot);
+        emit_fault_phys_diagnostic(pid, user_rip, Some(cr2), cr3_now, &vma_snapshot);
     }
 
     // Bump the per-tid delivery counter (SSP-diag discriminator).  See
@@ -1418,7 +1418,73 @@ fn vma_file_key(vma: &VmaSnap, fault_va: u64) -> Option<(usize, u64, u64)> {
 /// `cr3` is the live CR3 read by the caller in ISR context (always equal
 /// to the faulting process's PML4 phys; we cannot derive it from the VmSpace
 /// here without re-acquiring locks already dropped).
+/// D13 (2026-05-22): dump per-phys provenance for likely user-pointer GPRs
+/// at fatal-#PF time.  Complements `[D13/CR2-PROV]` (which queries only the
+/// fault address `cr2`); a NULL-deref of `[rdi+8]` shows `cr2=8` but the
+/// real pointer of interest is in `rdi`.  Useful when the faulting
+/// instruction is a load through a register that should have held a heap
+/// pointer (e.g. `mov r8, [rdi+0x8]` with `rdi=0` after `rdi = *(fp+0x88)`,
+/// the D11/D12 `_IO_link_in` pattern).
+///
+/// Bounded: up to 6 candidate GPRs (rdi, rsi, rdx, rcx, r8, r9 — the SysV
+/// AMD64 ABI argument registers per §3.2.3) are queried.  Each emits at
+/// most one `[D13/GPR-PROV]` line plus shadow lookups; ring lookups are
+/// O(1).  Skips: kernel VAs, sub-page pointers, the nullptr page.
+///
+/// Cite: Intel SDM Vol. 3A §4.6 (paging walk); System V AMD64 ABI §3.2.3
+/// (argument-register conventions).
+pub fn emit_fault_gpr_phys_for_fatal(
+    pid: u64,
+    cr3: u64,
+    candidates: &[(&'static str, u64)],
+) {
+    #[cfg(feature = "firefox-test")]
+    {
+        const KERNEL_BASE: u64 = 0x0000_8000_0000_0000;
+        let tid = crate::proc::current_tid();
+        for (name, val) in candidates.iter() {
+            let v = *val;
+            // Skip kernel pointers and the nullptr page; we only care
+            // about pointers into the user heap / stack / code arenas.
+            if v < 0x1000 || v >= KERNEL_BASE {
+                continue;
+            }
+            let page = v & !0xFFFu64;
+            match crate::mm::vmm::virt_to_phys_in(cr3, page) {
+                Some(phys) => {
+                    crate::serial_println!(
+                        "[D13/GPR-PROV] pid={} tid={} reg={} val={:#x} \
+                         page={:#x} phys={:#x}",
+                        pid, tid, name, v, page, phys,
+                    );
+                    crate::mm::w215_diag::dump_free_shadow_for_phys(phys);
+                    crate::mm::w215_diag::dump_alloc_shadow_for_phys(phys);
+                }
+                None => {
+                    // Unmapped GPR pointer is itself informative — likely
+                    // the upstream that produced the NULL/garbage that
+                    // triggered the fault.
+                    crate::serial_println!(
+                        "[D13/GPR-PROV] pid={} tid={} reg={} val={:#x} \
+                         page={:#x} phys=UNMAPPED",
+                        pid, tid, name, v, page,
+                    );
+                }
+            }
+        }
+        // Silence unused-variable warning when no candidates pass the
+        // filter.
+        let _ = (pid, cr3, tid);
+    }
+    #[cfg(not(feature = "firefox-test"))]
+    let _ = (pid, cr3, candidates);
+}
+
 pub fn emit_fault_phys_for_fatal(pid: u64, user_rip: u64, cr2: u64, cr3: u64) {
+    // D13 (2026-05-22): cr2 was previously dropped at the call boundary;
+    // forward it through so `emit_fault_phys_diagnostic` can query
+    // phys-shadows on the DATA fault address (not just the instruction
+    // page).  See D12 sc=201 verdict and the [D13/CR2-PROV] line below.
     // Snapshot under the PROCESS_TABLE lock, then release before printing.
     //
     // For a CLONE_VM child (`vm_space == None`, shared CR3 with parent —
@@ -1446,7 +1512,7 @@ pub fn emit_fault_phys_for_fatal(pid: u64, user_rip: u64, cr2: u64, cr3: u64) {
             signal_vma_snapshot(None, user_rip, cr2)
         }
     };
-    emit_fault_phys_diagnostic(pid, user_rip, cr3, &snap);
+    emit_fault_phys_diagnostic(pid, user_rip, Some(cr2), cr3, &snap);
 }
 
 /// Emit `[FAULT/PHYS]` and `[FAULT/RIP-CONTENT]` diagnostic lines.
@@ -1476,9 +1542,15 @@ pub fn emit_fault_phys_for_fatal(pid: u64, user_rip: u64, cr2: u64, cr3: u64) {
 pub(crate) fn emit_fault_phys_diagnostic(
     pid: u64,
     user_rip: u64,
+    cr2: Option<u64>,
     cr3: u64,
     vma_snapshot: &[VmaSnap],
 ) {
+    // D13: `cr2` is consumed only by the firefox-test gated block below
+    // (see [D13/CR2-PROV]).  Silence the unused-variable warning when the
+    // feature is off — default builds stay byte-identical.
+    #[cfg(not(feature = "firefox-test"))]
+    let _ = cr2;
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
     const KERNEL_BASE: u64 = 0x0000_8000_0000_0000;
     let tid = crate::proc::current_tid();
@@ -1542,6 +1614,53 @@ pub(crate) fn emit_fault_phys_diagnostic(
     #[cfg(feature = "firefox-test")]
     if let Some(rp) = rip_phys {
         crate::mm::w215_diag::dump_free_shadow_for_phys(rp);
+    }
+
+    // ── [D13/CR2-PROV] phys-shadow lookup on the DATA fault address ─────────
+    // D12 (sc=201 glibc `_IO_link_in` NULL-deref of `fp->_lock`, 2026-05-22)
+    // identified that the existing `[FAULT/PHYS/FREESHADOW]` /
+    // `[FAULT/PHYS/ALLOCSHADOW]` / `[FAULT/PHYS/PROV]` dumps query only
+    // `rip_phys` (the instruction-page phys), never the data-page phys.
+    // For heap-class faults the corrupted byte lives in the data page, not
+    // the code page, so the only diagnostic available was a single
+    // `caller_rip=glibc.text` line — uselessly redundant with the RIP itself.
+    //
+    // D13 closes that gap: when `cr2` is known (always true for a #PF; see
+    // `emit_fault_phys_for_fatal` + `deliver_sigsegv_from_isr`), translate
+    // `cr2 & ~0xFFF` through the faulting CR3 and dump per-phys
+    // FREE/ALLOC/PROV provenance.  Per Intel SDM Vol. 3A §4.6 (paging walk)
+    // a successful `virt_to_phys_in` resolves the same physical frame the
+    // CPU's translation produced; per §4.10.5 the most-recent free + most-
+    // recent alloc together name the upstream of any use-after-recycle.
+    //
+    // Output format mirrors the existing `[FAULT/PHYS/…]` family so the
+    // qemu-harness grep pattern is invariant.  `cr2 < KERNEL_BASE` guards
+    // against kernel-mode CR2 (which would not have a user CR3 mapping
+    // anyway, but cheap to be explicit).
+    #[cfg(feature = "firefox-test")]
+    if let Some(cr2_va) = cr2 {
+        if cr2_va < KERNEL_BASE && cr2_va >= 0x1000 {
+            let cr2_page = cr2_va & !0xFFFu64;
+            match crate::mm::vmm::virt_to_phys_in(cr3, cr2_page) {
+                Some(data_phys) => {
+                    crate::serial_println!(
+                        "[D13/CR2-PROV] pid={} tid={} cr2={:#x} cr2_page={:#x} \
+                         data_phys={:#x}",
+                        pid, tid, cr2_va, cr2_page, data_phys,
+                    );
+                    crate::mm::w215_diag::dump_free_shadow_for_phys(data_phys);
+                    crate::mm::w215_diag::dump_alloc_shadow_for_phys(data_phys);
+                    crate::mm::w215_diag::dump_prov_for_phys(data_phys);
+                }
+                None => {
+                    crate::serial_println!(
+                        "[D13/CR2-PROV] pid={} tid={} cr2={:#x} cr2_page={:#x} \
+                         data_phys=UNMAPPED",
+                        pid, tid, cr2_va, cr2_page,
+                    );
+                }
+            }
+        }
     }
 
     // ── [FAULT/PHYS/PROV] unconditional dump (Phase D 2026-05-20) ──────────


### PR DESCRIPTION
## Problem

D12 (sc=201 glibc \`_IO_link_in\` NULL-deref of \`fp->_lock\`, FILE struct at user VA \`0x7effd9a21020\`, 2026-05-22) returned a **DIAGNOSTIC INSUFFICIENT** verdict per the saga-diagnostic-discipline rule (phys-provenance FIRST):

- The PF handler's existing `[FAULT/PHYS/FREESHADOW]` / `[FAULT/PHYS/ALLOCSHADOW]` / `[FAULT/PHYS/PROV]` dumps query only **`rip_phys`** (the instruction-page phys), never the **data-page phys**.
- For heap-class faults, the corrupted byte lives in the data page; the only diagnostic produced was a single `caller_rip=glibc.text` line — uselessly redundant with the RIP itself.
- The `PTE_CHANGE_RING` was bounded to `[USER_STACK_RING_LO=0x7fff_ffe0_0000, 0x8000_0000_0000)` — only the main-thread initial stack window. The fp at `0x7effd9a21020` is well below that window, so `pte_change_record` was a no-op for every PTE event on the faulting page.

Without phys-provenance for the data frame we cannot distinguish anon-heap W215 from PTE-swap from cross-thread cleanup from kernel write. Per the discipline rule, any fix attempt without that data is the saga anti-pattern.

## Fix

Three additive, diagnostic-only changes — all gated on `#[cfg(feature = "firefox-test")]`; default builds byte-identical.

### Part 1: forward `cr2` into the phys-diagnostic and dump CR2 data-page shadows

\`signal.rs::emit_fault_phys_diagnostic\` gains a \`cr2: Option<u64>\` parameter. When set and the user VA passes a sanity guard (\`cr2 < KERNEL_BASE && cr2 >= 0x1000\`), translate \`cr2 & ~0xFFF\` through the faulting CR3 and emit:

\`\`\`
[D13/CR2-PROV] pid=N tid=N cr2=0x... cr2_page=0x... data_phys=0x...
[FAULT/PHYS/FREESHADOW] phys=0x... hit={0,1} ...
[FAULT/PHYS/ALLOCSHADOW] phys=0x... hit={0,1} ...
[FAULT/PHYS/PROV] ... (per-phys ring)
\`\`\`

\`cr2\` is now forwarded by both call paths: \`emit_fault_phys_for_fatal\` (the fatal-PF site in \`idt.rs\`) and \`deliver_sigsegv_from_isr\` (the SIGSEGV-delivery path inside the in-process branch).

### Part 2: dump per-phys provenance for SysV AMD64 argument GPRs

New helper \`signal.rs::emit_fault_gpr_phys_for_fatal\` takes six candidate GPRs (rdi, rsi, rdx, rcx, r8, r9 — System V AMD64 ABI §3.2.3 argument registers) and emits one \`[D13/GPR-PROV]\` line + shadow lookups per canonical user pointer. Skips kernel VAs and the nullptr page.

A NULL-deref of \`[rdi+8]\` shows \`cr2=8\` but the *real* pointer of interest is in \`rdi\`. For the D12 fingerprint (\`mov r8,[rdi+0x8]\` with \`rdi=0\` after \`rdi=*(fp+0x88)\`) we expect:

\`\`\`
[D13/GPR-PROV] pid=N tid=N reg=rdi val=0x0 page=0x0 phys=UNMAPPED
\`\`\`

…which names the operand directly.

Called from both fatal-PF and fatal-#UD/#GP/#AC sites in \`arch/x86_64/idt.rs\`. Reads GPRs from the ISR push frame via the same \`frame.sub(N)\` pattern the existing \`rbp_at_fault\` stack walk already uses.

### Part 3: widen \`PTE_CHANGE_RING\` window to full user VA

\`mm/w215_diag.rs::USER_STACK_RING_LO\` widens from \`0x0000_7fff_ffe0_0000\` (top 2 MiB) to \`0x0000_0000_0000_1000\` (skip nullptr page; admit the entire canonical lower-half user VA, per Intel SDM Vol. 3A §4.6).

Ring SIZE stays at 1024 slots — BSS unchanged, collisions now expected and observable via \`PTE_CHANGE_DISPLACED\`. Most-recent-write-wins per slot; downstream dispatchers cross-check the ring's \`tick\` field against the fault tick for freshness. The constant name is preserved (kept exported under the same symbol for ABI continuity with stack_prov.rs's documentation reference).

## Threat model (CWE-908 — Use of Uninitialized Resource)

Diagnostic-only. No new write paths, no new locks, no new error paths.

The GPR helper reads at most six 8-byte-aligned GPRs from the ISR push frame (already a kernel stack page we are executing on) and performs at most one CR3 page-table walk per page. These are the same operations the existing \`[FAULT/PHYS]\` and \`[FAULT/PHYS/RAW16]\` dumps already perform. Output is bounded to a constant ~10 serial lines per fatal user-mode exception.

## Verification

\`qemu-harness.py check\` clean across:
- no features → \`ok=true rc=0\`
- \`--features firefox-test\` → \`ok=true rc=0\`
- \`--features firefox-test,w215-diag,vma-dump-on-gp\` → \`ok=true rc=0\`

Per dispatcher instructions: NO KVM trial run by this PR. Coordinator will dispatch /review + qa. Expected serial-log content on the sc=201 fp.lock fault:

- \`[D13/CR2-PROV] pid=... cr2=0x8 cr2_page=0x0 data_phys=UNMAPPED\` (since cr2=0x8 < 0x1000 it'll be skipped by the guard — good, no spurious dump for the obvious-NULL case).
- \`[D13/GPR-PROV] reg=rdi val=0x0 ... phys=UNMAPPED\` naming the NULL operand.
- \`[D13/GPR-PROV] reg=rsi val=<fp>\` etc. with shadow lookups for the rbx/rdx-class heap pointers that were on the SHADOWs' silent-list under D12.
- The most-recent FREE / ALLOC for fp's data frame, naming the writer.

Doc-only output \`docs/SC201_D13_DIAGNOSIS_2026-05-22.md\` produced by coordinator after merge + 1-trial KVM.

## Cite

Intel SDM Vol. 3A §4.6 (paging walk), §4.10.5 (TLB / cache coherence), §6.4 (interrupt RFLAGS preserve); System V AMD64 ABI §3.2.3 (argument-register conventions); POSIX \`fopen(3)\` (FILE-lock contract); CWE-908 (diagnostic threat-class).

## Test plan

- [ ] Coordinator dispatches /review subagent
- [ ] Coordinator dispatches qa subagent for 1-trial KVM with \`firefox-test\`
- [ ] On boot reaching sc=201 fp.lock fault, verify \`[D13/CR2-PROV]\` and \`[D13/GPR-PROV]\` lines appear
- [ ] Verify FREESHADOW/ALLOCSHADOW totals are non-zero (recording active under firefox-test)
- [ ] If shadows are hit, dispatcher's next step is to symbolise the caller_rip values

🤖 Generated with [Claude Code](https://claude.com/claude-code)