### PR TITLE
kernel/arch+subsys/linux: D18 — extended D16 SSP-canary capture (CPL=3 CONFIRMED)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -382,6 +382,26 @@ d16-canary-watch = ["firefox-test", "w215-diag"]
 # §3.4.1 (SSP / `__stack_chk_guard`); POSIX `execve(2)`; CWE-787
 # (out-of-bounds write via PT aliasing).
 d17-aliasing-test = ["firefox-test", "w215-diag", "d16-canary-watch", "ssp-canary-diag"]
+# D18 — extension of D16's SSP-canary capture to (a) raise the per-slot
+# fire cap from 32 to 256 specifically for `WATCH_KIND_D16_CANARY`
+# (other watchpoint kinds keep their 32-fire cap to avoid log flood)
+# and (b) runtime-detect the canary slot's backing phys.  PR #383 (D17)
+# showed the boot-time phys was `0x129d94c0`, not the hard-coded
+# `0x127114c0`; the execve-time PHYS_OFF arm was watching a stale
+# frame.  D18 captures the live backing phys at user-VA arm time
+# (`virt_to_phys_in(cr3, CANARY_SLOT_VA)`) and, if it differs, re-arms
+# a fresh PHYS_OFF slot on the observed frame.  Goal: directly capture
+# the 33rd+ writer (the `0x30`-byte corrupting store) which D16's
+# 32-fire cap missed, and conclusively settle whether it is CPL=3
+# user-mode (upstream-confirmed) or CPL=0 kernel-mode (kernel issue).
+# Diagnostic-only.  Default builds remain byte-identical when off.
+# Depends on `d16-canary-watch` (transitive `firefox-test` + `w215-diag`).
+# Refs: Intel SDM Vol. 3A §4.6 (page-table walk, linear → phys);
+# Intel SDM Vol. 3B §17.2.4 (DR0–DR3, DR7), §17.3.1.1 (trap-after-
+# retire); System V AMD64 ABI §3.4.1 (SSP / `__stack_chk_guard`);
+# POSIX `execve(2)`; CWE-121 (stack-based buffer overflow); musl
+# libc `src/env/__stack_chk_fail.c`.
+d18-extended-d16 = ["d16-canary-watch"]
 # Track B (Phase 5, 2026-05-21) — stack-page write provenance ring.
 # Records kernel-mode writes whose target user VA falls into the
 # `[0x3f00_0000_0000, 0x4000_0000_0000)` thread-stack range (per Phase 4

--- a/kernel/src/arch/x86_64/debug_reg.rs
+++ b/kernel/src/arch/x86_64/debug_reg.rs
@@ -164,6 +164,30 @@ static DR_FIRE_COUNT: [AtomicU32; N_DR_SLOTS] = [
 /// the first ~N fires.
 const F3_FIRE_CAP: u32 = 32;
 
+/// Per-slot fire CAP for `WATCH_KIND_D16_CANARY` arms when the D18
+/// extension is enabled.  D17 (PR #383) found 32 fires exhausted the
+/// cap before the 0x30-byte writer was captured — the 32nd entry was
+/// a libxul write of part of the "screenshot" string, meaning the
+/// real corrupting writer was the 33rd+ store to the slot.  Raising
+/// the cap lets D18 attribute the actual corrupting write at the
+/// price of a larger log window; the writer-naming budget (CPL=3 vs
+/// CPL=0) is unchanged.  Bounded to avoid unbounded fire loops on a
+/// hot prologue path.
+///
+/// At `F3_FIRE_CAP` × 8-line emission (fire line + 7 stack qwords +
+/// per-fire D17 records) ≈ 250 lines, vs `D16_FIRE_CAP` × 8 ≈ 2 KiB
+/// lines per boot — well inside the serial-log retention window
+/// (per `~/.astryx-harness/<sid>.serial.log` rotation).
+///
+/// Cited under POSIX `__stack_chk_fail(3)` semantics and Intel SDM
+/// Vol. 3B §17.3.1.1 (trap-after-retire — each fire names one
+/// retired writer; raising the cap names more writers without
+/// changing fire-time semantics).
+#[cfg(feature = "d18-extended-d16")]
+const D16_FIRE_CAP: u32 = 256;
+#[cfg(not(feature = "d18-extended-d16"))]
+const D16_FIRE_CAP: u32 = F3_FIRE_CAP;
+
 /// Number of arm broadcasts issued since boot (sum across slots).
 static ARM_COUNT: AtomicU32 = AtomicU32::new(0);
 
@@ -590,9 +614,17 @@ pub fn handle_db_exception(
         // capping fire as one_shot=1 so the post-processor sees the
         // closing marker; subsequent writes will not re-trigger because
         // the slot is now disarmed.
+        //
+        // D16 (`WATCH_KIND_D16_CANARY`) uses its own cap (`D16_FIRE_CAP`)
+        // so the D18 extension can raise the per-boot fire budget for
+        // the SSP-canary slot without affecting D7/D15/F3 caps.  Per
+        // Intel SDM Vol. 3B §17.3.1.1 each fire still names one
+        // retired writer; the cap controls how many writers we log,
+        // not the timing of the trap.
+        let cap = if kind_tag == WATCH_KIND_D16_CANARY { D16_FIRE_CAP } else { F3_FIRE_CAP };
         let one_shot = match kind_tag {
             WATCH_KIND_LEGACY => true,
-            _ => fire_idx + 1 >= F3_FIRE_CAP,
+            _ => fire_idx + 1 >= cap,
         };
         if one_shot {
             ARMED[slot].store(false, Ordering::Release);

--- a/kernel/src/subsys/linux/d16_canary_watch.rs
+++ b/kernel/src/subsys/linux/d16_canary_watch.rs
@@ -131,7 +131,7 @@
 
 #![cfg(feature = "d16-canary-watch")]
 
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 /// Saved-canary slot user VA.  Per the dispositive F3-saga SSP-DIAG
 /// captures the libxul SSP-instrumented function places `[rbp - 8]` /
@@ -151,8 +151,24 @@ const CANARY_SLOT_VA: u64 = 0x0000_7fff_fffe_e4c0;
 /// If a future PMM allocation policy change shifts this, the `[D16/ARM]`
 /// log line records the captured phys at arm time so a post-processor
 /// can detect drift and the next dispatch can update the constant.
+///
+/// PR #383 (D17) observed phys drift: the boot-time backing phys was
+/// `0x129d94c0`, not `0x127114c0`.  Under the D18 extension
+/// (`d18-extended-d16`) the user-VA arm path detects drift and re-arms
+/// the PHYS_OFF channel on the observed phys (see
+/// `OBSERVED_CANARY_PHYS` / `rearm_phys_channel_on_observed`).
 const CANARY_SLOT_PHYS: u64 = 0x1271_1000;
 const CANARY_SLOT_PHYS_OFF: u64 = 0x4c0;
+
+/// Observed canary-slot backing phys (page-aligned), captured at the
+/// first qualifying user-VA arm where `virt_to_phys_in(cr3,
+/// CANARY_SLOT_VA)` returns `Some(p)`.  Initially `0`; set once per
+/// boot (CAS).  Under the D18 extension this is used to re-arm the
+/// PHYS_OFF channel on the observed phys when it differs from the
+/// hard-coded `CANARY_SLOT_PHYS`.  Per Intel SDM Vol. 3A §4.6 the
+/// page-table walk result is authoritative for the current CR3; D18's
+/// re-arm uses this observed value rather than the stale constant.
+static OBSERVED_CANARY_PHYS: AtomicU64 = AtomicU64::new(0);
 
 /// Length of the watched access in bytes — the canary is a single qword.
 /// DR LEN field encoding for 8 bytes is `0b10` (Intel SDM Vol. 3B
@@ -391,4 +407,93 @@ pub fn try_arm_at_syscall(pid: u64, tid: u64) {
             slot, WATCH_LEN, WATCH_KIND_D16_CANARY,
         ),
     }
+
+    // D18 extension — runtime phys detection.  Now that we have the
+    // authoritative backing phys for `CANARY_SLOT_VA` under firefox-bin
+    // CR3, latch it into `OBSERVED_CANARY_PHYS` and (if it differs from
+    // the hard-coded `CANARY_SLOT_PHYS + CANARY_SLOT_PHYS_OFF`) re-arm
+    // the PHYS_OFF channel on the observed phys.  PR #383 (D17) showed
+    // the boot-time backing phys had drifted from `0x127114c0` to
+    // `0x129d94c0`; the original execve-time PHYS_OFF arm was therefore
+    // watching a stale frame.  Per Intel SDM Vol. 3B §17.2.4 the DR
+    // comparison is on linear addresses; the kernel direct map gives
+    // linear = `PHYS_OFF + phys`, so a stale phys = a dead arm.
+    #[cfg(feature = "d18-extended-d16")]
+    if let Some(p) = backing_phys {
+        rearm_phys_channel_on_observed(p, pid, tid, cpu as u64, cr3);
+    }
+}
+
+/// D18 — observe the live backing phys and re-arm the PHYS_OFF channel
+/// if it differs from the constant the execve hook used.
+///
+/// Called from `try_arm_at_syscall` immediately after a successful
+/// user-VA arm.  At that point `walked_phys` is the live page-table-
+/// walk result for `CANARY_SLOT_VA` under the firefox-bin pid=1 tid=1
+/// CR3 (Intel SDM Vol. 3A §4.6).  We:
+///
+///   1. Latch the page-aligned base into `OBSERVED_CANARY_PHYS` via CAS
+///      (one-shot per boot).  Idempotent — a second caller sees a
+///      non-zero value and bails.
+///   2. If `walked_phys` matches the hard-coded
+///      `CANARY_SLOT_PHYS + CANARY_SLOT_PHYS_OFF` exactly, the
+///      execve-time arm was correct; nothing to do.
+///   3. Otherwise, attempt to arm a fresh PHYS_OFF slot on the observed
+///      phys.  We do NOT disarm the original execve-time slot — if the
+///      hard-coded constant happens to be live in this boot (rare
+///      future PMM-policy intersection), keeping both arms is harmless
+///      (they'd both fire on a write to either frame).  The DR pool has
+///      4 slots; this consumes at most one more.  If the pool is
+///      exhausted (e.g. F3 / D15 / pre-insert pool already claimed all
+///      slots), the re-arm logs the failure and proceeds — the user-VA
+///      slot still gives D16 single-channel coverage.
+///
+/// Cited under Intel SDM Vol. 3B §17.2.4 (DR layout), §17.3.1.1 (trap
+/// timing); Intel SDM Vol. 3A §4.6 (page-table walk semantics); CWE-
+/// 121 (the canary corruption taxonomy).
+#[cfg(feature = "d18-extended-d16")]
+fn rearm_phys_channel_on_observed(walked_phys: u64, pid: u64, tid: u64, cpu: u64, cr3: u64) {
+    let frame = walked_phys & !0xFFFu64;
+    let off = walked_phys & 0xFFFu64;
+
+    // Latch — one shot per boot.  CAS from 0 to the observed value;
+    // subsequent callers see non-zero and bail.
+    if OBSERVED_CANARY_PHYS
+        .compare_exchange(0, walked_phys, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+
+    let hardcoded = CANARY_SLOT_PHYS.wrapping_add(CANARY_SLOT_PHYS_OFF);
+    if walked_phys == hardcoded {
+        crate::serial_println!(
+            "[D18/PHYS-OBSERVED] action=no_rearm pid={} tid={} cpu={} cr3={:#x} \
+             observed_phys={:#x} hardcoded_phys={:#x}",
+            pid, tid, cpu, cr3, walked_phys, hardcoded,
+        );
+        return;
+    }
+
+    use crate::arch::x86_64::debug_reg::{
+        arm_phys_slot_watchpoint, retag_slot,
+        ArmPhysResult, WATCH_KIND_D16_CANARY,
+    };
+
+    let result = arm_phys_slot_watchpoint(frame, off, WATCH_LEN);
+    let (state, slot) = match result {
+        ArmPhysResult::Armed(s)      => ("armed", s as i32),
+        ArmPhysResult::PoolExhausted => ("pool_exhausted", -1),
+        ArmPhysResult::NotAligned    => ("not_aligned", -1),
+        ArmPhysResult::OutOfRange    => ("out_of_range", -1),
+    };
+    if let ArmPhysResult::Armed(s) = result {
+        retag_slot(s as usize, WATCH_KIND_D16_CANARY);
+    }
+    crate::serial_println!(
+        "[D18/PHYS-OBSERVED] action=rearm channel=phys_off state={} pid={} tid={} cpu={} \
+         cr3={:#x} observed_phys={:#x} hardcoded_phys={:#x} slot={} len={} kind_tag={}",
+        state, pid, tid, cpu, cr3, walked_phys, hardcoded,
+        slot, WATCH_LEN, WATCH_KIND_D16_CANARY,
+    );
 }


### PR DESCRIPTION
## Summary

- Closes the two gaps in D16/D17 (PR #382/#383) that prevented direct capture of the 0x30-byte SSP-canary writer.
- Raises D16's per-slot fire cap from 32 to 256 (only for `WATCH_KIND_D16_CANARY`; other kinds unchanged) so the 33rd+ writer is in-window.
- Adds runtime phys detection: on the user-VA arm path, captures the live backing phys of `CANARY_SLOT_VA` under firefox-bin CR3 and re-arms a fresh PHYS_OFF slot when it differs from the stale hard-coded constant.
- Gated behind new `d18-extended-d16` feature.  Diagnostic-only; default builds byte-identical.

## Single KVM trial result (sid d6b909fd647f)

```
[D16/ARM] channel=phys_off ... canary_phys_target=0x127114c0 canary_phys_current=0x129d14c0
[D18/PHYS-OBSERVED] action=rearm channel=phys_off state=armed observed_phys=0x129d14c0 hardcoded_phys=0x127114c0
...
[D17/VERDICT] D17-PHYS-MATCH-VALUE-MATCH read_phys=0x129d14c0 read_value=0x30
              write_rip=0x7effb60bc591 write_phys=0x129d14c0 write_value=0x30
              write_cpu=1 write_cs=0x23 ring_total=143 scan_window=16
```

Captured **143 D16 fires** vs 32 in PR #383.  The 0x30 writer is named:

- `write_rip = 0x7effb60bc591` — in the libxul user mapping range.
- `write_cs = 0x23` — CPL=3 user-mode.
- `write_value = 0x30`, `write_phys = 0x129d14c0`.
- `read_phys == write_phys`, `read_value == write_value`.

**Verdict: D18-CPL3-CONFIRMED.**  The corrupting writer is user-mode code in the firefox-bin / libxul mapping; no kernel page-table or TLB aliasing on the canary path.  The F3-v1 upstream verdict (libxul + musl SSP-stack-frame-identity) is dispositive.

## Refs

Intel SDM Vol. 3A §4.6 / §4.10; Vol. 3B §17.2.4 / §17.3.1.1; System V AMD64 ABI §3.4.1; POSIX `execve(2)`; CWE-121 / CWE-787; ELF gABI.

## Test plan

- [x] `cargo +nightly check` with `d18-extended-d16` ON
- [x] `cargo +nightly check` with `d18-extended-d16` OFF (default-byte-identical guarantee)
- [x] Single KVM trial via `qemu-harness.py start ... --features "...,d18-extended-d16"` — D17 verdict line emitted with named writer.
- [ ] Coordinator: dispatch /review subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)