### PR TITLE
kernel/syscall + docs: document FUTEX_SHARED latent gap (Wave 2)

### DIFF
--- a/docs/LINUX_SYSCALL_COVERAGE.md
+++ b/docs/LINUX_SYSCALL_COVERAGE.md
@@ -207,7 +207,7 @@ Ranked by frequency in real program traces. Syscalls that would most unblock rea
 | 166 | `umount` | Full; delegates to vfs::sys_umount (flags=0) |
 | 169 | `umount2` | Full; delegates to vfs::sys_umount with flags |
 | 186 | `gettid` | Full |
-| 202 | `futex` | Full; WAIT, WAKE, REQUEUE, CMP_REQUEUE, WAIT_BITSET, WAKE_BITSET; under `firefox-test` / `test-mode` features a bounded broadcast-within-cluster wake compensation runs when `FUTEX_WAKE` finds 0 waiters (glibc BZ 25847 mitigation, runtime-gated via `kdb futex-set-cluster-wake`) |
+| 202 | `futex` | WAIT, WAKE, REQUEUE, CMP_REQUEUE, WAIT_BITSET, WAKE_BITSET, FUTEX_CLOCK_REALTIME (absolute deadline). WAKE_OP returns ENOSYS — glibc/musl fall back. Key shape is `(pid, uaddr)` — FUTEX_PRIVATE per `futex(2)`; FUTEX_PRIVATE_FLAG is treated as a hint (no separate key space). FUTEX_SHARED (`pthread_mutexattr_setpshared`, `pshared` semaphores, MAP_SHARED condvars) is NOT distinguished — same `(pid, uaddr)` key applies, which is correct only when both processes happen to map the shared region at the same VA. Cross-process MAP_SHARED futex synchronisation at differing VAs would miss; no upstream binary on the current demo path uses it (strace differential 2026-05-20: musl-FF uses FUTEX_PRIVATE only). Under `firefox-test` / `test-mode` a bounded broadcast-within-cluster wake compensation runs when `FUTEX_WAKE` finds 0 waiters (glibc BZ 25847 mitigation, runtime-gated via `kdb futex-set-cluster-wake`). |
 | 204 | `sched_getaffinity` | Full; writes per-CPU bitmask |
 | 213 | `epoll_create` | Full |
 | 217 | `getdents64` | Full |

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -234,10 +234,48 @@ pub(crate) unsafe fn user_read_timespec(addr: u64) -> Option<(u64, u64)> {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Futex wait queue — keyed by virtual address
+// Futex wait queue — keyed by (pid, uaddr)
 // ═══════════════════════════════════════════════════════════════════════════════
-
-/// Futex wait queue: maps (pid, uaddr) -> list of waiting TIDs.
+//
+// Key shape: `(pid, uaddr)` — the FUTEX_PRIVATE key per `futex(2)`.
+//
+// Per `futex(2)` (Linux man-pages, "FUTEX_PRIVATE_FLAG" and "Priority-inheritance
+// futexes"):
+//
+//   * FUTEX_PRIVATE futexes are scoped to a single process and identified by
+//     the tuple `(mm_struct, virtual address)`.  We approximate `mm_struct`
+//     with `pid` — correct because every process has its own page tables and
+//     no two processes share the `mm` of a Linux task on AstryxOS.
+//
+//   * FUTEX_SHARED futexes are scoped to a backing object and identified by
+//     the tuple `(inode, page offset within file)` for file-backed mappings
+//     or by an anonymous-mapping anchor for `MAP_SHARED|MAP_ANONYMOUS`.
+//     Two processes that map the same shared region at different virtual
+//     addresses must still hash to the same key, otherwise a
+//     `pthread_mutex_lock` in process A and the matching wake in process B
+//     will miss.
+//
+// This implementation uses the FUTEX_PRIVATE key shape for ALL futex
+// operations, including those with the FUTEX_PRIVATE_FLAG clear.  This is
+// correct in practice when:
+//
+//   (a) The futex is FUTEX_PRIVATE (FUTEX_PRIVATE_FLAG set, or implied by
+//       the caller's intent — `pthread_mutexattr_setpshared(_, PROCESS_PRIVATE)`
+//       and similar default to FUTEX_PRIVATE).
+//   (b) The futex is FUTEX_SHARED AND both processes have mapped the shared
+//       region at the same `uaddr` (common when a parent forks and the child
+//       inherits identical mappings, or when both ends explicitly request
+//       MAP_FIXED at the same VA).
+//
+// Cross-process FUTEX_SHARED synchronisation across DIFFERENT virtual
+// addresses is NOT supported.  No upstream binary on the current demo path
+// (musl-FF strace differential 2026-05-20) uses it.  When a use case
+// emerges, change `(u64, u64)` to a `FutexKey` enum with `Private(pid, va)`
+// and `Shared(mount_idx, inode, page_off)` variants, derive the shared
+// variant from `vma::lookup(pid, uaddr)` on every WAIT/WAKE/REQUEUE entry,
+// and back-fill tests with a two-process MAP_SHARED+pthread_mutex case.
+//
+// Refs: `futex(2)` Linux man-pages; POSIX.1-2017 §pthread_mutexattr_getpshared.
 pub(crate) static FUTEX_WAITERS: Mutex<BTreeMap<(u64, u64), Vec<u64>>> = Mutex::new(BTreeMap::new());
 
 /// Outcome of `futex_wait_check_and_enqueue`.


### PR DESCRIPTION
## Summary

Wave 2 ABI audit closing two FUTEX items.  The disposition is documentation-only: REQUEUE/CMP_REQUEUE is already correct (verified end-to-end against `futex(2)`); FUTEX_SHARED is a documented latent gap with no current demo-path user.

- **FUTEX_REQUEUE / FUTEX_CMP_REQUEUE (#238)** — already implemented at `sys_futex_linux` op 3|4.  Drains source `(pid, uaddr)` queue, wakes up to `val`, re-queues up to `val2` to `(pid, uaddr2)`, honours `val3` for op 4 (returns `-EAGAIN` on mismatch), returns woken count only.  Test 52 in `test_runner.rs` covers all four sub-cases.  No code change.
- **FUTEX_SHARED key distinction (#235)** — `FUTEX_WAITERS` is keyed by `(pid, uaddr)`, the FUTEX_PRIVATE shape per `futex(2)`.  FUTEX_SHARED with different virtual addresses across processes is NOT supported.  The musl-FF strace differential (2026-05-20) shows the demo path uses FUTEX_PRIVATE only (509 WAKE_PRIVATE + 5 WAIT_PRIVATE, zero SHARED), so converting the key type would buy unvalidated complexity.  Document the gap precisely with a migration sketch for when a FUTEX_SHARED user emerges.

Diff: 2 files, +42 / -4 lines.  Comment-only in `kernel/src/syscall/mod.rs`; one-row update in `docs/LINUX_SYSCALL_COVERAGE.md`.

Refs: `futex(2)` Linux man-pages (FUTEX_PRIVATE_FLAG, Priority-inheritance futexes); POSIX.1-2017 §pthread_mutexattr_getpshared.

## Test plan

- [x] `cargo check --release -p astryx-kernel` clean (default + `firefox-test,kdb,test-mode,syscall-trace`)
- [x] Pre-existing Test 52 (`test_futex_requeue`) covers REQUEUE / CMP_REQUEUE match + mismatch / WAKE_OP ENOSYS / WAIT_BITSET with relative + CLOCK_REALTIME absolute deadlines
- [x] No behavioural change — diff is comment + doc only