### PR TITLE
kernel/mm/vmm: shrink to_free BATCH from 1024->128 (primary STACK_CANARY_CORRUPT fix per PR #395 finding)

### DIFF
--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -678,10 +678,25 @@ pub fn unmap_page_in(pml4_phys: u64, virt_addr: u64) {
 /// Returns the number of frames actually freed (rc reached zero).  Pages
 /// that were never demand-paged are skipped.
 pub fn unmap_and_free_range_in(pml4_phys: u64, base: u64, length: u64) -> usize {
-    // Maximum physical addresses to defer per shootdown round.  1024 pages =
-    // 4 MiB.  Keeping the batch finite bounds stack-pressure (this runs on
-    // the kernel stack, not a heap-allocated buffer).
-    const BATCH: usize = 1024;
+    // Maximum physical addresses to defer per shootdown round.
+    //
+    // Sized to bound on-stack pressure on the brk-shrink / munmap path, which
+    // can be entered on the 4 KiB emergency-fallback kernel stack.  At
+    // `BATCH = 128`, `to_free = [0u64; BATCH]` consumes 1024 bytes — leaving
+    // headroom for the surrounding call chain (PTE walk, refcount dec, TLB
+    // shootdown, PMM free).  An earlier value of 1024 (8192 bytes) was the
+    // dominant source of STACK_CANARY_CORRUPT bugchecks under brk(2) shrink
+    // by glibc/musl when the emergency-fallback kstack was in use.
+    //
+    // Trade-off: shrinking the batch increases TLB-shootdown IPI rounds for
+    // very large `munmap` ranges (8× more IPIs per 1024 pages).  Typical
+    // brk-shrink and process-teardown ranges are small (≤16 pages), so the
+    // practical IPI cost is unchanged; only multi-MiB munmap calls see the
+    // extra rounds, and per Intel SDM Vol. 3A §4.10.4-5 each round is
+    // bounded by the per-CPU acknowledgement latency.
+    //
+    // Cite: brk(2) (POSIX 2017); Intel SDM Vol. 3A §4.10.4-5.
+    const BATCH: usize = 128;
 
     // W216 mm_sem read-lock: held across PTE clear → shootdown → free so a
     // sibling CPU executing `clone_for_fork` on the same address space (which


### PR DESCRIPTION
## Summary

`unmap_and_free_range_in` in `kernel/src/mm/vmm.rs` declares a stack-resident `to_free = [0u64; BATCH]` buffer to hold physical addresses scheduled for free after a deferred TLB shootdown. With `BATCH = 1024` the array alone consumed **8192 bytes** of kernel stack — comfortable within the typical 16 KiB kstack, but lethal on the **4 KiB emergency-fallback kstack** that is handed out under PMM fragmentation.

PR #395's stack-pressure comparison named `vmm.rs:712` as the dominant culprit: AstryxOS's brk-shrink / munmap path totals ~8.8 KiB on stack, with this single buffer accounting for ~93% of that pressure. A prior diagnostic trial confirmed dispositively (3/3) that brk-shrink invoked by glibc/musl `_int_free` running on the 4 KiB fallback kstack drove `to_free` over the canary and bugchecked with `0xdead0001 STACK_CANARY_CORRUPT`.

This PR shrinks `BATCH` from 1024 → 128:

- on-stack array: **8192 B → 1024 B**
- per-PR-#395 measurement of remaining call-chain overhead (~600 B base), the brk-shrink path now fits comfortably under 4 KiB with headroom for PTE walk + refcount dec + shootdown + PMM free
- the function's outer `while pg < end` loop already iterates across batches, so no caller observes the batch boundary and no correctness invariant depends on the 1024-page granularity

## Trade-off

Very large `munmap` ranges now issue 8× more TLB-shootdown IPI rounds per 1024 pages. Typical brk-shrink and process-teardown ranges are a handful of pages (≤16), so the practical IPI cost is unchanged. Multi-MiB `munmap` calls see modest additional shootdown latency, bounded per Intel SDM Vol. 3A §4.10.4-5 by per-CPU acknowledgement.

## Related code — left for follow-up

A near-identical batch-buffer pattern lives in the `MADV_DONTNEED` path at `kernel/src/subsys/linux/syscall.rs` (also `const BATCH: usize = 1024; let mut to_free = [0u64; BATCH];`). It is reachable from a different syscall and a different stack budget; per scope discipline (and PR #395's specific naming of vmm.rs as the primary site) it is left for a focused follow-up.

## Verification

Boot under KVM with `firefox-test,kdb,syscall-trace,--firefox-variant musl`; wait ≥4 minutes.

- `[FFTEST] X11 server ready` reached
- `[KSTACK/EMERGENCY] base=… size=4K (PMM fragmented)` still appears (allocator behaviour unchanged)
- `[KSTACK/EMERGENCY-THREAD] tid=2 pid=1` — the previously-bugchecking thread per PR #395 / qa evidence — still flagged
- `[KSTACK/EMERGENCY-THREAD] tid=3 pid=1` likewise flagged
- **`BUGCHECK 0xdead0001 STACK_CANARY_CORRUPT` did NOT fire**
- **`[KSTACK/CANARY-FAIL]` did NOT fire**
- pid=1 alive past tick=25000, sc=1114 still climbing, pf=3421 still advancing

## Test plan

- [x] `python3 scripts/qemu-harness.py check` → rc=0 (default features)
- [x] `python3 scripts/qemu-harness.py check --features "kdb,syscall-trace"` → rc=0
- [x] `python3 scripts/qemu-harness.py check --features "firefox-test,kdb,syscall-trace"` → rc=0
- [x] Boot trial: ≥4 min KVM, musl variant, no STACK_CANARY_CORRUPT, no CANARY-FAIL

## References

- `brk(2)` (POSIX.1-2017) — heap-shrink semantics
- Intel SDM Vol. 3A §4.10.4-5 — TLB management; INVLPG and IPI ordering invariants