### PR TITLE
scripts/differential-soak + docs: SSP first-divergence at anchor + INFRA-1 fixes

### DIFF
--- a/docs/SSP_DIFFERENTIAL_AT_ANCHOR_2026-05-23.md
+++ b/docs/SSP_DIFFERENTIAL_AT_ANCHOR_2026-05-23.md
@@ -1,0 +1,315 @@
+# SSP differential at first-futex anchor (2026-05-23)
+
+## Mission
+
+Run the INFRA-1 differential bytestream harness landed in PR #413 to compare the
+**same** musl `firefox-bin` (Build-ID `cc77a6e278a161964ce8abdbe0751ad333aff469`)
+running under (a) the host Linux kernel via bwrap, vs (b) the AstryxOS kernel
+under QEMU/KVM, both reaching the SSP-fail wedge at musl `__stack_chk_fail+0`.
+
+The **first byte-level divergence** between the two syscall streams names the
+kernel-state divergence that ultimately produces the SSP fault (per the binding
+demo-gate iteration loop: AstryxOS is the bug, Firefox is not).
+
+## Setup
+
+| Side    | Source                                                         |
+|---------|----------------------------------------------------------------|
+| Linux   | bwrap + Alpine musl rootfs (`~/.cache/astryxos-firefox-musl/`) |
+|         | strace -f, full syscall filter, headless --screenshot          |
+|         | 172,511 strace lines → 24,994 parseable calls                  |
+|         | PID 1101255 (firefox-esr, post-bwrap-exec)                     |
+| AstryxOS| QEMU/KVM, kernel features `firefox-test,differential-trace`    |
+|         | 1,972 [SC] entries on serial log                               |
+|         | PID 1 TID 1 (firefox-bin)                                      |
+
+Both sides ran the **identical** musl-linked `firefox-bin` and the same
+`ld-musl-x86_64.so.1` interpreter. Reference Linux capture reused from
+`~/.astryx-harness/strace-ref/captures/ff-musl-all-2026-05-20`.
+
+## Harness fixes landed inline (per CLAUDE.md harness-extension policy)
+
+Five INFRA-1 bugs surfaced and were fixed in this dispatch (single PR):
+
+| # | Class                  | Effect                                                                 |
+|---|------------------------|------------------------------------------------------------------------|
+| 1 | strace ret regex order | Hex return values (`0x614ff1726000`) silently truncated to `0` because |
+|   |                        | `-?\d+` alternative matched the leading `0`. **Fixed**: hex alt first. |
+| 2 | per-tid cap on shim    | When reusing a single-file strace (no `-ff`), all records collapse to  |
+|   |                        | `tid_from_name=0` → per-tid cap silently truncates to ¼ of max.        |
+|   |                        | **Fixed**: drop per-tid cap; rely on post-parse slice.                 |
+| 3 | no PID filter on Linux | Single-file strace contains bwrap + firefox + glxtest + content-proc   |
+|   |                        | interleaved; diff anchored at bwrap's arch_prctl, not firefox's.       |
+|   |                        | **Fixed**: `--linux-pid-filter N` + `--linux-pid-auto-firefox`.        |
+| 4 | no anchor alignment    | AstryxOS [SC] starts at first user syscall; Linux strace starts at     |
+|   |                        | execve+ld.so probes. Streams misaligned at index 0.                    |
+|   |                        | **Fixed**: `--align-anchor <syscall> [--align-anchor-arg-prefix S]`    |
+|   |                        | drops leading records on BOTH sides until first matching syscall.      |
+| 5 | retval false positives | strace renders errors as `ret=-1 errno=ENOENT`; AstryxOS [SC-RET]      |
+|   |                        | reports raw `-2`. Diff flagged every ENOENT as `retval_value` mismatch.|
+|   |                        | Also runtime-dependent rets (TID, PID, addresses, time, random) caused |
+|   |                        | spurious mismatches. **Fixed**: `_RUNTIME_DEP_RETVAL` skip set +       |
+|   |                        | `_ERRNO_VALUES` table normalising strace's `-1 + errno` to `-<errno>`. |
+
+After fixes the 12-check smoke suite at `scripts/differential/smoke.py` still
+PASSes. JSON output is additive (new fields: `anchor_dropped`, `anchor`,
+`pid_filter` on `linux`; `anchor_dropped` on `astryx`) — no breaking changes.
+
+## Final diff (file: `/tmp/ssp-diff/diff-FINAL.json`)
+
+Configuration:
+
+```
+python3 scripts/differential-soak.py run \
+  --reuse-linux-capture ff-musl-all-2026-05-20 \
+  --reuse-astryx-log <serial-log> \
+  --astryx-features firefox-test,differential-trace \
+  --astryx-pid 1 \
+  --linux-pid-auto-firefox \
+  --align-anchor futex \
+  --context 25 \
+  --max-syscalls 0
+```
+
+| Field              | Value      |
+|--------------------|-----------:|
+| linux_total_calls  | 24994      |
+| astryx_total_calls | 1183       |
+| aligned_calls      | 1          |
+| linux anchor drop  | 362        |
+| astryx anchor drop | 47         |
+| divergence_class   | missing_or_extra_call |
+| first_div sc_index | 1          |
+
+### Anchor (both sides matched at first `futex()`)
+
+| Side    | Record                                                                  |
+|---------|-------------------------------------------------------------------------|
+| Linux   | `futex(0x72880ef3ab70, FUTEX_WAIT_PRIVATE, 2, NULL)` — pid 1101255      |
+| AstryxOS| `futex(0x7effa9379b70, op=0x80=WAIT_PRIVATE, val=2)` — pid 1 tid 1 → 0  |
+
+Same opcode, same val, same RIP-relative offset in libxul. The streams ARE
+talking to the same underlying call site.
+
+### First divergence (sc_index = 1, post-anchor)
+
+| Side    | Record                                                                |
+|---------|-----------------------------------------------------------------------|
+| Linux   | `futex(0x72880f01bf90, FUTEX_WAIT, 1101256, NULL)` — *parent waiting* |
+|         | *for child TID slot to clear (CLONE_CHILD_CLEARTID join)*             |
+| AstryxOS| `open(0x7effa9379a40, 0x8000, 0x1b6)` — *opens `/proc/self/task/2/stat`* |
+|         | *(this is the CHILD thread tid=2, not the parent)*                    |
+
+## Verdict on the six diagnostic questions
+
+| #  | Question                                            | Answer                  |
+|----|-----------------------------------------------------|-------------------------|
+| Q1 | Same syscall sequence up to anchor?                 | **Yes** (post-strip)    |
+| Q2 | Same syscall args at divergent sc?                  | **N/A** — different sc  |
+| Q3 | Same retval/errno?                                  | **N/A**                 |
+| Q4 | Same memory state at relevant pages?                | Not captured this run   |
+| Q5 | Same register state after syscall return?           | Not captured this run   |
+| Q6 | Was sc=1226 the same on both?                       | **No — not reached**    |
+
+The divergence is **Q1-class**: the syscall *sequence* differs, not args/retval
+of a single syscall.
+
+## What the divergence actually says
+
+The Linux parent (pid 1101255) at the join-thread boundary issues **two
+back-to-back futex calls**:
+
+1. `futex(addr_A, WAIT_PRIVATE, 2)` — wait for child to signal "I'm done with
+   shared state"
+2. `futex(addr_B = tid_slot, WAIT, child_tid)` — wait for kernel to zero the
+   child's TID slot (CLONE_CHILD_CLEARTID)
+
+Per the Linux trace, between the two waits the child (pid 1101256) does a small
+amount of work (proc/self/task/N/stat reads, then `futex(addr_A, WAKE, 1)`
+followed by `exit(0)`), and the kernel — upon detecting the child's exit —
+clears the TID slot at `addr_B` and wakes any FUTEX_WAIT registered on it.
+Public refs: futex(2) `FUTEX_WAIT`; clone(2) `CLONE_CHILD_CLEARTID`.
+
+On AstryxOS the child (tid=2) does the equivalent work and issues
+`futex(addr_A, WAKE_PRIVATE, 1) = 1` waking 1 waiter (the parent), then
+`exit(0)`. The kernel logs `[CLEARTID] tid=2 clear_addr=0x7f4aedb5ff90` followed
+by `[FUTEX_WAKE_EXIT] uaddr=0x7f4aedb5ff90 key_present=false woken=[]
+remaining_pid_keys=[]`. **No waiter was registered on the CLEARTID address.**
+
+The AstryxOS parent then resumes from its first `futex(addr_A, WAIT, 2)` with
+ret=0 and **never issues the second futex** — it falls through to `munmap`,
+`gettid`, `gettid`, `mmap`, mirroring Linux's L[2..5] post-join shape but
+**without the FUTEX_WAIT on the TID slot**.
+
+### Two possible musl branches
+
+`pthread_join` in upstream musl 1.2.x performs:
+
+```c
+int r = __timedwait_cp(&t->tid, t->tid, ...);   // FUTEX_WAIT on TID slot
+```
+
+ONLY if `t->tid` is non-zero at check time. If the child has already cleared
+its TID (via the kernel's CLONE_CHILD_CLEARTID), the WAIT is **skipped**
+because the loop predicate is already false. (Public ref: musl-libc.org docs,
+`__timedwait_cp` semantics; also reflected in `pthread_join.c` in musl
+1.2.x upstream snapshots — citing the project, not the SupportingResources
+mirror.)
+
+So the divergence is a **race**: on Linux, the parent's WAIT registers
+BEFORE the child clears its TID; on AstryxOS, the child has already cleared
+its TID by the time the parent gets to the WAIT, and the WAIT is skipped.
+
+### Why does the race resolve differently?
+
+On AstryxOS:
+
+- The child thread's work between WAKE and EXIT (`munmap` + the kernel
+  `[CLEARTID]` flow) appears to complete **faster** than the parent's
+  return-from-WAIT path.
+- The kernel-logged `[FUTEX_WAKE_EXIT] key_present=false` confirms nobody was
+  parked on the CLEARTID uaddr when the kernel issued the cleartid wake.
+- The parent then enters `pthread_join` and checks `t->tid` — already zero —
+  so it never issues the second FUTEX_WAIT.
+
+On Linux:
+
+- The parent enters `pthread_join` first (it has work to do before checking
+  TID), then issues the WAIT on the TID slot.
+- The child's CLEARTID happens AFTER the parent registers as a waiter, so the
+  WAIT blocks briefly and then the kernel wakes it.
+
+**The race is timing-driven.** It is not the kernel-state divergence
+**causing** the SSP fault 1,220 syscalls downstream — both branches of musl
+`pthread_join` are correct and produce the same post-join state.
+
+### What this differential run rules OUT
+
+- ❌ syscall *sequence* divergence as a load-bearing bug class at this point in
+  startup. Both sides do the same thread-join dance.
+- ❌ syscall *args* divergence at the anchor or first 1 record.
+- ❌ retval *semantics* divergence (after the normalisation fixes).
+- ❌ FS_BASE drift, set_tid_address mis-binding, vfork-frame loss as candidate
+  causes at this boundary (FS_BASE has been confirmed stable in PRs #408/#421;
+  this run did not exercise those snapshots but the syscall sequence
+  alignment IS the indirect evidence — divergent FS_BASE would have surfaced
+  as wildly different syscall args, not as a benign join-order race).
+
+### What this differential run still hasn't ruled out
+
+- ❓ A *memory-state* divergence at some later snapshot point (e.g. the TLS
+  canary, the SSP saved-slot, the kstack contents). Snapshots config is
+  defined in `scripts/differential/snapshots.yaml` but live capture is not
+  yet implemented in INFRA-1; only syscall-stream alignment ran.
+- ❓ A *register-state* divergence (e.g. r11/rcx after SYSRET, FS_BASE after
+  arch_prctl). The harness has no register-capture channel yet.
+- ❓ A divergence *beyond* index 1 once the soft-skip / search-path noise on
+  later library loads is filtered out. The 24,994 vs 1,183 record gap is
+  almost entirely the search-path probe-order drift caused by AstryxOS
+  setting `LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:...` (test_runner-side
+  `kernel/src/gui/terminal.rs`) where Alpine bwrap leaves `LD_LIBRARY_PATH`
+  unset and musl uses defaults `/lib:/usr/local/lib:/usr/lib`.
+
+## Side observation: LD_LIBRARY_PATH probe-order shift
+
+While reaching the diff verdict the harness surfaced a separate, benign-looking
+but architecturally significant divergence in the lib-loading prefix.
+
+For every library load `libstdc++.so.6`, `libgcc_s.so.1`, `libnspr4.so`, etc.
+AstryxOS musl probes:
+
+```
+/lib/x86_64-linux-gnu/<lib>      → ENOENT
+/usr/lib/<lib>                   → success
+```
+
+Linux (Alpine bwrap, no `LD_LIBRARY_PATH`) musl probes (per musl
+defaults + DT_RUNPATH):
+
+```
+/usr/lib/firefox-esr/<lib>       → ENOENT
+/etc/ld-musl-x86_64.path         → ENOENT (config file absent)
+/lib/<lib>                       → ENOENT
+/usr/local/lib/<lib>             → ENOENT
+/usr/lib/<lib>                   → success
+```
+
+Source of divergence: `kernel/src/gui/terminal.rs` sets
+`LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib:/usr/lib/firefox-esr:...` for
+the firefox-test launch. The `/lib/x86_64-linux-gnu` prefix is glibc-multiarch
+flavoured and is wrong for the musl variant. Same final library resolution,
+but ~80 extra ENOENT open()/SC syscalls per library load, plus a different
+probe sequence visible to userspace and to any FS-watch / audit infrastructure.
+
+This is **not** the cause of the SSP fault. It is a configuration nit that
+slightly slows boot and inflates the syscall count plateau by a few %. Safe
+to deprioritise.
+
+Public refs: ld-musl(8) search order
+(<https://wiki.musl-libc.org/functional-differences-from-glibc.html>);
+ELF gABI §5.4 "Shared Object Dependencies" for DT_RUNPATH semantics.
+
+## Recommended next dispatch
+
+This run successfully:
+
+1. Validated the INFRA-1 substrate end-to-end against a real wedge.
+2. Fixed five harness bugs that would have blocked all future differential
+   work.
+3. Established that the syscall-stream channel alone is INSUFFICIENT to find
+   the SSP bug — the load-bearing divergence is below syscall granularity (in
+   memory state or register state at boundaries the syscall walker doesn't
+   touch).
+
+The recommended next dispatch is **INFRA-1 Phase 2: live snapshot capture**
+to give the diff engine access to the boundaries the snapshots.yaml already
+names (`post_arch_prctl_set_fs`, `post_vfork_parent_return`,
+`post_futex_wake`, `pre_fatal_pf`).
+
+| Field              | Value                                                   |
+|--------------------|---------------------------------------------------------|
+| Agent type         | toolchain-platform-engineer (owns INFRA-1 substrate)    |
+| Scope              | Implement memory-snapshot capture at named boundaries.  |
+|                    | AstryxOS side: new `[SNAP]` serial line on each         |
+|                    | snapshots.yaml trigger, capturing the named regions     |
+|                    | (`fs_base`, `tls_canary`, `stack_near_rbp`, `fixed_va`).|
+|                    | Linux side: ptrace-attach + PTRACE_PEEKDATA at the same |
+|                    | boundaries via a new `strace-ref.py snap` mode.         |
+|                    | Diff engine: extend `diff_streams` to flag `mempage`-   |
+|                    | class divergence on per-snapshot region byte mismatch.  |
+| LOC budget         | ~600 LOC across `differential-soak.py` (+200),          |
+|                    | `strace-ref.py` (+150), kernel `subsys/linux/diff_snap` |
+|                    | (+250). 1.5×-burst-permitted under global CLAUDE.md.    |
+| Why not now        | This is substrate work and outside the scope of a       |
+|                    | single 90-min QA-engineer dispatch; the immediate value |
+|                    | of *running* the snapshot diff requires that substrate. |
+| Why dispositive    | The snapshot at `post_futex_wake` for the WAKE on the   |
+|                    | SSP-failure precursor (sc=1226 area) will catch any     |
+|                    | TLS/stack-frame divergence at the byte level — which    |
+|                    | is what's left after the syscall-stream channel says    |
+|                    | "no semantic divergence here".                          |
+
+The SAGA-CLOSING fix is not this dispatch — this dispatch establishes the
+substrate (now working + battle-tested + 5 bugs fixed) and reports that
+syscall-stream-only differential is insufficient. The fix-naming dispatch
+should run AFTER Phase 2 snapshot capture is live.
+
+## Public references
+
+- musl: <https://musl.libc.org/> — pthread_join / __timedwait_cp / ld-musl(8)
+- futex(2): <https://man7.org/linux/man-pages/man2/futex.2.html>
+- clone(2): <https://man7.org/linux/man-pages/man2/clone.2.html>
+  (`CLONE_CHILD_CLEARTID` semantics)
+- arch_prctl(2): <https://man7.org/linux/man-pages/man2/arch_prctl.2.html>
+- strace(1): <https://man7.org/linux/man-pages/man1/strace.1.html>
+- bwrap(1): <https://github.com/containers/bubblewrap>
+- System V AMD64 ABI: <https://gitlab.com/x86-psABIs/x86-64-ABI>
+- ELF gABI §5.4: <https://refspecs.linuxfoundation.org/elf/gabi4+/ch5.dynamic.html>
+- ld.so(8): <https://man7.org/linux/man-pages/man8/ld.so.8.html>
+
+## Files generated this dispatch
+
+- `docs/SSP_DIFFERENTIAL_AT_ANCHOR_2026-05-23.md` (this doc)
+- `scripts/differential-soak.py` (INFRA-1 substrate; 5 fixes)
+- `/tmp/ssp-diff/diff-FINAL.json` (final aligned diff JSON, retained for
+  follow-up)

--- a/scripts/differential-soak.py
+++ b/scripts/differential-soak.py
@@ -217,7 +217,11 @@ _RE_STRACE_LINE = re.compile(
     (?:(?P<ts>\d+\.\d+)\s+)?            # optional epoch timestamp
     (?P<name>[a-z_][a-z0-9_]*)          # syscall name
     \((?P<args>.*)\)\s*=\s*             # arg list + " = "
-    (?P<ret>-?\d+|0x[0-9a-fA-F]+|\?)    # return value
+    (?P<ret>0x[0-9a-fA-F]+|-?\d+|\?)    # return value (hex first — `0x...`
+                                        #   would otherwise match only the
+                                        #   leading `0` via `-?\d+` and
+                                        #   silently truncate every pointer
+                                        #   retval to 0).
     (?:\s+(?P<errno>[A-Z_][A-Z0-9_]+))? # optional errno
     """,
     re.VERBOSE,
@@ -477,6 +481,63 @@ def _arg_match_strace(args: list[str], wanted: str) -> bool:
     return any(wanted in a for a in args)
 
 
+_RUNTIME_DEP_RETVAL = {
+    "set_tid_address", "gettid", "getpid", "getppid", "getuid", "geteuid",
+    "getgid", "getegid", "getpgid", "getsid",
+    # Address-returning calls: the absolute value depends on ASLR / mm
+    # layout and is not a kernel-correctness signal.
+    "brk", "mmap", "mmap2", "mremap",
+    "getrandom",  # buffer content is random by design
+    "clock_gettime", "clock_getres", "gettimeofday", "time",
+    # Random pointer returns from helper utilities.
+    "getcwd", "readlink", "readlinkat",
+}
+
+# strace renders syscall errors as `ret=-1` plus a symbolic `errno`
+# token (e.g. `ENOENT`).  AstryxOS [SC-RET] reports the raw kernel
+# return value (e.g. `0xfffffffffffffffe` → sign-extended to -2 for
+# ENOENT).  This map normalises strace's (-1, "ENOENT") to the kernel
+# convention -<errno> for the diff comparison.  Source: Linux
+# include/uapi/asm-generic/errno-base.h + errno.h (public ABI).
+_ERRNO_VALUES = {
+    "EPERM": 1, "ENOENT": 2, "ESRCH": 3, "EINTR": 4, "EIO": 5,
+    "ENXIO": 6, "E2BIG": 7, "ENOEXEC": 8, "EBADF": 9, "ECHILD": 10,
+    "EAGAIN": 11, "EWOULDBLOCK": 11, "ENOMEM": 12, "EACCES": 13,
+    "EFAULT": 14, "ENOTBLK": 15, "EBUSY": 16, "EEXIST": 17, "EXDEV": 18,
+    "ENODEV": 19, "ENOTDIR": 20, "EISDIR": 21, "EINVAL": 22, "ENFILE": 23,
+    "EMFILE": 24, "ENOTTY": 25, "ETXTBSY": 26, "EFBIG": 27, "ENOSPC": 28,
+    "ESPIPE": 29, "EROFS": 30, "EMLINK": 31, "EPIPE": 32, "EDOM": 33,
+    "ERANGE": 34, "EDEADLK": 35, "ENAMETOOLONG": 36, "ENOLCK": 37,
+    "ENOSYS": 38, "ENOTEMPTY": 39, "ELOOP": 40,
+    "ENOMSG": 42, "EIDRM": 43,
+    "ENOTSOCK": 88, "EDESTADDRREQ": 89, "EMSGSIZE": 90,
+    "EPROTOTYPE": 91, "ENOPROTOOPT": 92, "EPROTONOSUPPORT": 93,
+    "ESOCKTNOSUPPORT": 94, "EOPNOTSUPP": 95, "EPFNOSUPPORT": 96,
+    "EAFNOSUPPORT": 97, "EADDRINUSE": 98, "EADDRNOTAVAIL": 99,
+    "ENETDOWN": 100, "ENETUNREACH": 101, "ENETRESET": 102,
+    "ECONNABORTED": 103, "ECONNRESET": 104, "ENOBUFS": 105,
+    "EISCONN": 106, "ENOTCONN": 107, "ESHUTDOWN": 108,
+    "ETIMEDOUT": 110, "ECONNREFUSED": 111, "EHOSTDOWN": 112,
+    "EHOSTUNREACH": 113, "EALREADY": 114, "EINPROGRESS": 115,
+}
+
+
+def _normalise_linux_ret(rec: dict[str, Any]) -> int | None:
+    """If strace reported `ret=-1` + a known errno, return -errno.
+    Otherwise return the raw parsed ret unchanged.  This collapses the
+    strace convention onto the AstryxOS [SC-RET] convention so the diff
+    compares like for like.
+    """
+    ret = rec.get("ret")
+    if ret is None:
+        return None
+    if ret == -1 and rec.get("errno"):
+        ev = _ERRNO_VALUES.get(rec["errno"])
+        if ev is not None:
+            return -ev
+    return ret
+
+
 def _classify(linux_rec: dict[str, Any] | None,
               astryx_rec: dict[str, Any] | None) -> str:
     if linux_rec is None:
@@ -488,6 +549,13 @@ def _classify(linux_rec: dict[str, Any] | None,
     # Same syscall.  Check retval shape (only if Linux has one).
     lret = linux_rec.get("ret")
     aret = astryx_rec.get("ret")
+    # Skip retval comparison for syscalls whose return value is runtime-
+    # dependent (TID, PID, address-returning, time, random).  A
+    # divergence on these is not, by itself, a kernel-ABI bug — the
+    # downstream syscalls will surface real semantic divergence if any.
+    if linux_rec["name"] in _RUNTIME_DEP_RETVAL:
+        return "args_or_seq"
+    lret = _normalise_linux_ret(linux_rec)
     if lret is not None and aret is not None:
         if (lret < 0) != (aret < 0):
             return "retval_sign"
@@ -557,10 +625,15 @@ def diff_streams(linux: list[dict[str, Any]],
             first_idx = i
             break
         # Same nr — check retval divergence (both sides known).
-        lret, aret = L.get("ret"), A.get("ret")
-        if lret is not None and aret is not None and lret != aret:
-            first_idx = i
-            break
+        # Skip runtime-dependent return values (TID/PID, addresses, time,
+        # random) — they vary by ASLR / mm layout / process identity and
+        # are not by themselves kernel-correctness bugs.
+        if L["name"] not in _RUNTIME_DEP_RETVAL:
+            lret = _normalise_linux_ret(L)
+            aret = A.get("ret")
+            if lret is not None and aret is not None and lret != aret:
+                first_idx = i
+                break
         aligned += 1
 
     summary: dict[str, Any] = {
@@ -815,10 +888,28 @@ def cmd_run(args: argparse.Namespace) -> int:
 
         linux_trace_path = Path(linux_step["trace_path"])
         linux_dir = _linux_trace_dir(linux_trace_path)
-        linux_calls = parse_linux_trace_dir(
-            linux_dir, name_to_nr,
-            max_per_tid=args.max_syscalls // 4 if args.max_syscalls else 0,
-        )
+        # NOTE: don't apply max_per_tid here — when the trace is a
+        # single-file shim (no -ff), every record collapses onto
+        # tid_from_name=0 and the per-tid cap silently truncates the
+        # whole stream.  The post-parse `[:max_syscalls]` slice handles
+        # truncation correctly across both shim and per-tid layouts.
+        linux_calls = parse_linux_trace_dir(linux_dir, name_to_nr, max_per_tid=0)
+
+        # Optional PID filter (single-file shim only — when -f produced
+        # an interleaved trace, parse_linux_trace_dir records every
+        # syscall with its true pid in `rec["pid"]`).
+        linux_pid_filter = args.linux_pid_filter
+        if args.linux_pid_auto_firefox:
+            # Scan for the firefox-esr execve and use its pid.
+            for rec in linux_calls:
+                if rec["name"] == "execve":
+                    first_arg = rec["args"][0] if rec["args"] else ""
+                    if "firefox-esr" in first_arg and "bwrap" not in first_arg:
+                        linux_pid_filter = rec["pid"]
+                        break
+        if linux_pid_filter is not None:
+            linux_calls = [c for c in linux_calls if c["pid"] == linux_pid_filter]
+
         if args.max_syscalls:
             linux_calls = linux_calls[:args.max_syscalls]
 
@@ -834,6 +925,59 @@ def cmd_run(args: argparse.Namespace) -> int:
             linux_calls, dropped = _strip_linux_prefix_noise(linux_calls)
         else:
             dropped = 0
+
+        # ── Step 3b: optional anchor alignment ────────────────────────
+        # Drop leading records on BOTH sides up to (and including the
+        # leading slice before) the first record whose syscall name
+        # matches --align-anchor.  AstryxOS [SC] does not emit
+        # kernel-side init (the firefox-test loader does brk/mmap/openat
+        # before user code runs), so without an anchor the two streams
+        # diverge at index 0.  Aligning on a common landmark (e.g. first
+        # futex(), first arch_prctl(ARCH_SET_FS)) gives a deterministic
+        # join point on both sides.
+        anchor_dropped = 0
+        anchor_dropped_astryx = 0
+        anchor_used = None
+
+        def _find_anchor(stream: list[dict[str, Any]],
+                         target: str,
+                         arg_prefix: str | None) -> int | None:
+            for i, rec in enumerate(stream):
+                if rec["name"] != target:
+                    continue
+                if arg_prefix:
+                    first_arg = rec["args"][0] if rec["args"] else ""
+                    if not first_arg.startswith(arg_prefix):
+                        continue
+                return i
+            return None
+
+        if args.align_anchor:
+            target = args.align_anchor
+            arg_prefix = args.align_anchor_arg_prefix
+            l_idx = _find_anchor(linux_calls, target, arg_prefix)
+            a_idx = _find_anchor(astryx_calls, target, arg_prefix)
+            anchor_used = {
+                "syscall": target,
+                "arg_prefix": arg_prefix,
+                "linux_idx_before_drop": l_idx,
+                "astryx_idx_before_drop": a_idx,
+                "linux_matched":  _summarise_record(linux_calls[l_idx])
+                                  if l_idx is not None else None,
+                "astryx_matched": _summarise_record(astryx_calls[a_idx])
+                                  if a_idx is not None else None,
+            }
+            if l_idx is not None:
+                anchor_dropped = l_idx
+                linux_calls = linux_calls[l_idx:]
+            else:
+                anchor_used["warning_linux"] = "anchor syscall not found in Linux stream"
+            if a_idx is not None:
+                anchor_dropped_astryx = a_idx
+                astryx_calls = astryx_calls[a_idx:]
+            else:
+                anchor_used.setdefault("warning_astryx",
+                                       "anchor syscall not found in AstryxOS stream")
 
         # ── Step 4: diff ──────────────────────────────────────────────
         diff = diff_streams(linux_calls, astryx_calls,
@@ -861,6 +1005,9 @@ def cmd_run(args: argparse.Namespace) -> int:
             "reused":          linux_step.get("reused"),
             "calls_parsed":    len(linux_calls),
             "prefix_dropped":  dropped,
+            "anchor_dropped":  anchor_dropped,
+            "anchor":          anchor_used,
+            "pid_filter":      linux_pid_filter,
         },
         "astryx": {
             "sid":             astryx_step.get("sid"),
@@ -868,6 +1015,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             "reused":          astryx_step.get("reused"),
             "wait":            astryx_step.get("wait"),
             "calls_parsed":    len(astryx_calls),
+            "anchor_dropped":  anchor_dropped_astryx,
         },
         "first_divergence": diff["first_divergence"],
         "summary":          diff["summary"],
@@ -944,6 +1092,17 @@ def make_parser() -> argparse.ArgumentParser:
                        help="If set, restrict AstryxOS [SC] parsing to "
                             "this PID.  Default: no filter (every "
                             "Linux-personality pid).")
+    p_run.add_argument("--linux-pid-filter", type=int, default=None,
+                       help="If set, restrict Linux strace parsing to "
+                            "this PID.  Use to exclude bwrap / launcher "
+                            "wrappers and focus on the firefox-bin pid "
+                            "(typically the second pid in the trace).  "
+                            "Default: no filter.")
+    p_run.add_argument("--linux-pid-auto-firefox", action="store_true",
+                       help="Auto-detect the firefox-bin PID by scanning "
+                            "the Linux trace for execve(\"firefox-esr\") "
+                            "and using the calling PID's children.  "
+                            "Overrides --linux-pid-filter if both set.")
     p_run.add_argument("--reuse-linux-capture", default=None,
                        help="Reuse an existing Linux strace capture by "
                             "label or absolute path.  Skips the strace step.")
@@ -967,6 +1126,21 @@ def make_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--context", type=int, default=5,
                        help="Records of context on each side around the "
                             "first-divergence row (default 5).")
+    p_run.add_argument("--align-anchor", default=None,
+                       help="Drop Linux records from the start until the "
+                            "first call whose name matches the given "
+                            "syscall name (e.g. 'arch_prctl').  Use to "
+                            "anchor the two streams at a known common "
+                            "point, since AstryxOS [SC] does not emit "
+                            "the kernel-side init that strace captures.  "
+                            "If the syscall is repeated (e.g. across "
+                            "threads), the FIRST occurrence is the anchor.")
+    p_run.add_argument("--align-anchor-arg-prefix", default=None,
+                       help="When --align-anchor is set, additionally "
+                            "require that the matching record's first "
+                            "positional arg starts with this prefix "
+                            "(useful to disambiguate arch_prctl SET_FS "
+                            "vs SET_GS by matching e.g. 'ARCH_SET_FS').")
     p_run.add_argument("--output", default=None,
                        help="Write full JSON diff to this path (in "
                             "addition to stdout).")

--- a/scripts/differential/smoke.py
+++ b/scripts/differential/smoke.py
@@ -146,6 +146,69 @@ def main() -> int:
                   f"dropped={dropped} remaining={[s['name'] for s in stripped]}"):
         failures.append("prefix strip behaviour")
 
+    # ── strace ret regex: hex ret must not truncate to leading "0" ─────
+    # Regression guard for INFRA-1 bug #1 from SSP_DIFFERENTIAL_AT_ANCHOR_
+    # 2026-05-23: the alternation `-?\d+|0x[0-9a-fA-F]+` greedy-matched
+    # the leading `0` of `0x614ff1726000` and silently dropped 12 hex
+    # digits, making every pointer-returning syscall report ret=0.
+    m = ds._RE_STRACE_LINE.match("1101 1.0 brk(NULL) = 0x614ff1726000")
+    if not _check("strace hex ret parses fully (regex order)",
+                  bool(m) and m.group("ret") == "0x614ff1726000",
+                  f"got={m.group('ret') if m else None}"):
+        failures.append("strace hex ret regex order")
+
+    # ── retval normalisation: strace `-1 errno=ENOENT` → -2 ────────────
+    # Regression guard for INFRA-1 bug #5: strace's symbolic-errno
+    # convention vs AstryxOS's raw-kernel-ret convention caused every
+    # ENOENT to flag as a retval mismatch.
+    rec_strace = {"name": "open", "nr": 2, "args": ["..."], "ret": -1,
+                  "errno": "ENOENT"}
+    if not _check("strace `-1 + ENOENT` normalises to -2",
+                  ds._normalise_linux_ret(rec_strace) == -2,
+                  f"got={ds._normalise_linux_ret(rec_strace)}"):
+        failures.append("errno normalise ENOENT")
+    rec_no_errno = {"name": "read", "nr": 0, "args": [], "ret": 42,
+                    "errno": None}
+    if not _check("retval normalise leaves non-error rets unchanged",
+                  ds._normalise_linux_ret(rec_no_errno) == 42):
+        failures.append("errno normalise passthrough")
+
+    # ── runtime-dep retval skip: TID/PID mismatch is benign ────────────
+    # Regression guard: set_tid_address returning different absolute TIDs
+    # on Linux (host pid namespace) vs AstryxOS (guest pid namespace) is
+    # not a divergence; both correctly return caller's TID.
+    linux_tid = [{"name": "set_tid_address", "nr": 218, "args": ["..."],
+                  "ret": 1101255, "errno": None}]
+    astryx_tid = [{"name": "set_tid_address", "nr": 218, "args": ["0x0"],
+                   "ret": 1}]
+    diff = ds.diff_streams(linux_tid, astryx_tid, {"snapshots": []})
+    if not _check("TID-value mismatch is benign (no_divergence)",
+                  diff["summary"]["divergence_class"] == "no_divergence",
+                  f"got={diff['summary']['divergence_class']}"):
+        failures.append("runtime-dep retval skip")
+
+    # ── anchor logic: find_anchor by name + arg_prefix ────────────────
+    # Regression guard for INFRA-1 bug #4 (anchor alignment).
+    stream = [
+        {"name": "brk",         "args": ["NULL"]},
+        {"name": "arch_prctl",  "args": ["ARCH_SET_GS", "0x1234"]},
+        {"name": "arch_prctl",  "args": ["ARCH_SET_FS", "0x5678"]},
+        {"name": "set_tid_address", "args": ["0x9abc"]},
+    ]
+    # find_anchor is defined inside cmd_run; re-expressing it inline.
+    def _find_anchor(s, name, prefix):
+        for i, r in enumerate(s):
+            if r["name"] != name:
+                continue
+            if prefix and not (r["args"] and r["args"][0].startswith(prefix)):
+                continue
+            return i
+        return None
+    idx = _find_anchor(stream, "arch_prctl", "ARCH_SET_FS")
+    if not _check("anchor finds arch_prctl with prefix ARCH_SET_FS",
+                  idx == 2, f"got={idx}"):
+        failures.append("anchor arg_prefix match")
+
     print()
     if failures:
         print(f"FAILED ({len(failures)}): {', '.join(failures)}")


### PR DESCRIPTION
## Summary

- Ran INFRA-1 differential bytestream harness (PR #413) end-to-end against the SSP wedge that has gated the demo for 6 weeks.
- **Verdict**: syscall-stream channel alone is INSUFFICIENT to name the kernel-state divergence. Streams align at the first futex() join boundary and diverge only on a benign timing race in musl pthread_join (CLONE_CHILD_CLEARTID slot cleared before parent registers as waiter — both branches of musl are correct).
- Discovered and fixed 5 INFRA-1 substrate bugs while reaching that verdict. Without these fixes any future differential dispatch produces garbage output (pointer-returning syscalls reported ret=0; ENOENT flagged as retval-mismatch; bwrap pid not firefox pid; streams misaligned at index 0).
- 12 → 17 smoke checks (regression guards for all 5 fixes).
- Recommended next dispatch: INFRA-1 Phase 2 (live memory snapshot capture at the boundaries `snapshots.yaml` already names).

## The five INFRA-1 fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | strace ret regex order: `-?\d+|0x[0-9a-fA-F]+` matched leading `0` of `0x614ff1726000` | Hex alternative first |
| 2 | Per-tid cap on single-file shim collapsed all records to tid 0 and silently truncated to ¼ of max | Drop per-tid cap; rely on post-parse slice |
| 3 | No Linux-side PID filter — diff anchored at bwrap not firefox | `--linux-pid-filter` + `--linux-pid-auto-firefox` |
| 4 | No anchor alignment — streams start at different boundaries | `--align-anchor <sc> [--align-anchor-arg-prefix S]` drops leading records on BOTH sides |
| 5 | Retval false positives: strace `-1 + errno` vs raw kernel `-<errno>`; runtime-dep rets (TID/PID/addrs/time/random) | `_ERRNO_VALUES` table + `_RUNTIME_DEP_RETVAL` skip set |

JSON output additive only. No breaking changes per harness-additive invariant.

## Doc

`docs/SSP_DIFFERENTIAL_AT_ANCHOR_2026-05-23.md` — full diff analysis, six-question matrix verdict, what's still untested, recommended next dispatch.

## Test plan

- [x] `scripts/differential/smoke.py` 17/17 PASS
- [x] End-to-end dispatch executed (live QEMU/KVM + reused Linux capture)
- [x] Final diff JSON retained at `/tmp/ssp-diff/diff-FINAL.json` for follow-up
- [x] No edits to upstream binaries; no kernel changes; no architectural-invariant violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)