### PR TITLE
kernel/subsys/linux+test_runner: I1b — tokio syscall backfills + PR_GET_NAME hardening

### DIFF
--- a/docs/I1B_TOKIO_BACKFILLS_2026-05-23.md
+++ b/docs/I1B_TOKIO_BACKFILLS_2026-05-23.md
@@ -1,0 +1,146 @@
+# I1b — tokio syscall backfills (2026-05-23)
+
+Status: implemented; test 271 PASS on `--features test-mode` KVM boot.
+
+## Dispatch context
+
+I1b is the second half of a two-phase TLS-substrate enablement.  I1a (in
+flight) handles the userspace side (libssl/libcrypto/ca-certs/openssl CLI);
+I1b covers the kernel-side syscall residuals that the tokio runtime exercises
+during start-up.
+
+The INFRASVC oracle audit (commit `5b54613`) measured the tokio syscall
+surface against current AstryxOS state and concluded ~95% plumbed post
+PR #298 (musl ABI), PR #305 (musl FF), PR #320 (Linux ABI sysinfo/getrusage/
+procfs status).  I1b's job was to **measure the residual 5%**, implement the
+named gaps, and stop.
+
+## Phase 1 — measured residual
+
+Static audit of `kernel/src/subsys/linux/syscall.rs` against the audit's
+named tokio-relevant syscall list:
+
+| sc  | name                | status pre-I1b                    |
+|-----|---------------------|-----------------------------------|
+| 24  | `sched_yield`       | present                           |
+| 157 | `prctl`             | present (`PR_SET_*` / `PR_GET_*` mostly covered) |
+| 230 | `clock_nanosleep`   | present (delegates to `sys_nanosleep_linux`) |
+| 232 | `epoll_wait`        | present (wake-on-readiness via poll bell) |
+| 233 | `epoll_ctl`         | present                           |
+| 281 | `epoll_pwait`       | present (sigmask accepted-and-ignored) |
+| **282** | `signalfd` (legacy) | **MISSING** — falls through to `_ => -38` |
+| 283 | `timerfd_create`    | present                           |
+| 284 | `eventfd` (legacy)  | present                           |
+| 286 | `timerfd_settime`   | present                           |
+| 287 | `timerfd_gettime`   | present                           |
+| 289 | `signalfd4`         | present                           |
+| 290 | `eventfd2`          | present                           |
+| 291 | `epoll_create1`     | present                           |
+| 297 | `rt_tgsigqueueinfo` | present                           |
+| 302 | `prlimit64`         | present (self only — fine for tokio) |
+| 318 | `getrandom`         | present (GRND_NONBLOCK / GRND_RANDOM / GRND_INSECURE) |
+| 324 | `membarrier`        | present (all 7 cmd bits) |
+| **424** | `pidfd_send_signal` | returns `-38` already (explicit) |
+| **434** | `pidfd_open`        | **MISSING** — falls through to `_ => -38` |
+| **441** | `epoll_pwait2`      | **MISSING** — falls through to `_ => -38` |
+
+Two of the three "missing" entries fell through to the catch-all
+`Unknown Linux syscall: {}` log line at line 4643, which is functionally
+ENOSYS but flags as a serial-log surprise on every call (tokio's reactor
+issues `epoll_pwait2` on every poll cycle on Linux 5.11+ kernels — that
+would have flooded the log).  Making them explicit silences the surprise
+log and either gives the right answer (sc 282, 441) or returns the
+documented-pre-Linux-5.3 ENOSYS that tokio's pidfd-feature-probe path
+already handles (sc 434).
+
+Audit was also vague on one ABI hardening item I noticed in passing:
+
+| arm                  | status pre-I1b                                |
+|----------------------|-----------------------------------------------|
+| `prctl(PR_GET_NAME)` | Wrote 7 bytes (`"astryx\0"`) without range-checking the user pointer.  Same CWE-822/CWE-823 shape called out on the `PR_GET_CHILD_SUBREAPER` / `PR_GET_PDEATHSIG` arms that already use `validate_user_ptr`. |
+
+I included the fix because the per-process audit pattern was already
+established on adjacent arms and matching it costs ~10 LOC.
+
+## Phase 2 — additions
+
+`kernel/src/subsys/linux/syscall.rs` (+78 production LOC):
+
+1. **`282 signalfd(fd, *mask, sizemask)`** — wraps `sys_signalfd4(fd, mask,
+   sizemask, 0)`.  Per signalfd(2): "signalfd() was added to Linux in
+   kernel 2.6.22; signalfd4() supports a flags argument."  Functionally
+   identical to signalfd4 with flags=0.
+
+2. **`441 epoll_pwait2(epfd, events, maxevents, *timespec, *sigmask,
+   sigsetsize)`** — bounds-checks the user-supplied `struct timespec *`,
+   converts to whole milliseconds rounded up (matching our 100 Hz tick
+   resolution), and delegates to `sys_epoll_wait`.  Sigmask accepted-and-
+   ignored as on sc 281.  Per epoll_pwait2(2) (Linux 5.11+): "Compared to
+   epoll_pwait, ... it allows for sub-millisecond precision via a struct
+   timespec timeout."
+
+3. **`434 pidfd_open(pid, flags)`** — explicit ENOSYS log line.  Per
+   pidfd_open(2) NOTES: callers must handle ENOSYS on pre-5.3 kernels;
+   tokio's `tokio::process::Child::wait` and `signal::ctrl_c` reactors
+   take the kill(2) + waitpid(2) + signalfd fallback path on ENOSYS,
+   all of which are plumbed.
+
+4. **`424 pidfd_send_signal`** — already returned `-38`, added a comment
+   block explaining the tokio fallback.
+
+5. **`prctl(PR_GET_NAME)`** — now validates `arg2` with `validate_user_ptr(arg2, 16)`,
+   returns `-EFAULT` on NULL or unmapped, writes exactly 16 NUL-padded
+   bytes per prctl(2) ("The buffer should allow space for up to 16 bytes;
+   the returned string will be null-terminated").
+
+## Phase 3 — validation
+
+Added `test_271_tokio_syscall_backfills` (`kernel/src/test_runner.rs`,
++213 LOC), gated on `test-mode` or `firefox-test`.  Four sub-cases:
+
+- 271-A: `signalfd(-1, &mask, 8)` returns a valid fd; `signalfd(-1, &mask, 4)` returns -EINVAL.
+- 271-B: `epoll_pwait2(epfd, ts={0,0})` returns 0 on empty set; negative `tv_nsec` returns -EINVAL.
+- 271-C: `pidfd_open(1, 0)` returns -38.
+- 271-D: `PR_GET_NAME(NULL)` returns -EFAULT; `PR_GET_NAME(buf16)` writes `"astryx\0"` + 9 NUL pad.
+
+### KVM result (test-mode)
+
+```
+[PASS] tokio I1b backfills: signalfd / epoll_pwait2 / pidfd_open
+[TEST-JSON] {"name":"tokio I1b backfills: signalfd / epoll_pwait2 / pidfd_open","result":"pass","elapsed_ticks":8}
+Test Results: 288/296 passed
+```
+
+The 8 failures are pre-existing (Musl hello / TCC compile / sigchld /
+ascension / glibc_hello — all `Cannot read /disk/bin/<X>: NotFound`,
+i.e. data.img staging gaps; plus execve_leak and monotonic-rate, both
+known-flaky on KVM per the `--allow-fail` list at
+`scripts/qemu-harness.py:1741`).  Test 271 itself is a clean PASS.
+
+## Outcome vs. audit prediction
+
+Audit predicted ~50-150 LOC residual.  Actual: 78 production LOC.
+Audit prediction was accurate — within band.
+
+## What's NOT done (out of scope)
+
+- **Real pidfd object**.  Implementing pidfd_open + pidfd_send_signal +
+  waitid(P_PIDFD) properly requires a new VFS file-type and lifetime
+  binding to the process slot.  Tokio takes the documented kill(2) +
+  waitpid(2) fallback on ENOSYS, so this is not blocking.  Defer until
+  a userland actually needs pidfd semantics (e.g. systemd's
+  `PidfdsAreUsable` probe).
+- **rseq**.  Tokio reads `auxv[AT_HWCAP]` and rseq-related entries; per
+  the audit (line 134) the existing stub-returns-0 behaviour is fine.
+- **Multi-PID `prlimit64`**.  Tokio queries `RLIMIT_NOFILE` / `RLIMIT_STACK`
+  on self only.  Other-PID prlimit64 is not used and would require a
+  ptrace-style cross-process credential check; deferred.
+
+## Refs
+
+- POSIX-1.2017 `<signal.h>`, `<sys/epoll.h>`, `<sys/prctl.h>`
+- `signalfd(2)`, `signalfd4(2)`, `epoll_pwait2(2)`, `pidfd_open(2)`,
+  `pidfd_send_signal(2)`, `prctl(2)`
+- kernel.org/Documentation/admin-guide/syscalls.html
+- Intel SDM Vol. 3A §4.6.1 (SMAP), CWE-822/CWE-823 (untrusted-pointer
+  deref / out-of-range pointer offset)

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2949,12 +2949,34 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             const CAP_LAST_CAP: u64             = 40;
             match arg1 {
                 PR_SET_NAME => 0,   // ignore thread name
+                // PR_GET_NAME(*buf): per prctl(2), "the buffer should allow
+                // space for up to 16 bytes; the returned string will be
+                // null-terminated."  We range-check the user pointer for the
+                // same CWE-822/CWE-823 reason called out on the
+                // PR_GET_CHILD_SUBREAPER arm — SMAP AC=1 does not gate
+                // kernel-VA writes, so a sandboxed caller passing
+                // `arg2 = KERNEL_VIRT_BASE + off` would obtain a 16-byte
+                // arbitrary-write primitive.  Write the kernel name padded
+                // with NULs to fill the 16-byte buffer that callers
+                // (including tokio's worker-thread naming probe) allocate.
                 PR_GET_NAME => {
-                    let buf = arg2 as *mut u8;
-                    let name = b"astryx\0";
+                    if arg2 == 0 { return -14; } // EFAULT
+                    if !crate::syscall::user_ptr_check_bypassed()
+                        && !crate::syscall::validate_user_ptr(arg2, 16)
+                    {
+                        return -14; // EFAULT
+                    }
+                    let mut name = [0u8; 16];
+                    let src = b"astryx";
+                    name[..src.len()].copy_from_slice(src);
+                    // name[6..16] stays zero — NUL terminator + padding
                     unsafe {
                         let _g = crate::arch::x86_64::smap::UserGuard::new();
-                        core::ptr::copy_nonoverlapping(name.as_ptr(), buf, name.len());
+                        core::ptr::copy_nonoverlapping(
+                            name.as_ptr(),
+                            arg2 as *mut u8,
+                            16,
+                        );
                     }
                     0
                 }
@@ -4678,8 +4700,60 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // 326: copy_file_range(fd_in, off_in, fd_out, off_out, len, flags)
         // Delegate to sendfile (40); arg1=fd_in, arg3=fd_out, arg2=off_in, arg5=len
         326 => sys_sendfile(arg3 as usize, arg1 as usize, arg2, arg5 as usize),
-        // 424: pidfd_send_signal — ENOSYS
+        // 282: signalfd(fd, *mask, sizemask) — legacy form, no flags argument.
+        // Per signalfd(2): "signalfd() was added to Linux in kernel 2.6.22;
+        // [signalfd4] supports a flags argument."  Functionally equivalent to
+        // signalfd4(fd, mask, sizemask, 0); musl posix_spawn's cancellation
+        // path and older glibc binaries still issue 282 directly.
+        282 => sys_signalfd4(arg1, arg2, arg3, 0),
+        // 424: pidfd_send_signal(pidfd, sig, *info, flags) — ENOSYS until
+        // pidfd objects exist.  Returning -38 here forces tokio's
+        // `tokio::process::Child::kill` fallback path (kill(2) via the
+        // child's recorded PID), which is the canonical behaviour on
+        // pre-5.1 Linux per pidfd_send_signal(2) NOTES.
         424 => -38,
+        // 434: pidfd_open(pid, flags) — ENOSYS until pidfd objects exist.
+        // Per pidfd_open(2): "Returns a file descriptor that refers to the
+        // process whose PID is specified in pid."  Tokio's `signal::ctrl_c`
+        // and `process::Child::wait` reactor paths fall back to signalfd +
+        // waitpid when this returns ENOSYS, both of which are plumbed.
+        434 => {
+            crate::serial_println!("[SYSCALL/Linux] pidfd_open(pid={}, flags={:#x}) — ENOSYS", arg1, arg2);
+            -38 // ENOSYS
+        }
+        // 441: epoll_pwait2(epfd, events, maxevents, *timespec, *sigmask, sigsetsize)
+        // Per epoll_pwait2(2) (Linux 5.11+): "epoll_pwait2() … takes a
+        // pointer to a timespec structure instead of milliseconds, allowing
+        // sub-millisecond precision."  Internally bounds-checks the
+        // user-supplied timespec, converts to whole milliseconds (matching
+        // our 100 Hz timer resolution), and delegates to sys_epoll_wait.
+        // The sigmask arg (arg5/arg6) is accepted-and-ignored as on
+        // epoll_pwait (sc 281) — see that arm's comment.
+        441 => {
+            let timeout_ms: i32 = if arg4 == 0 {
+                -1 // NULL timespec → block indefinitely per spec
+            } else {
+                if !crate::syscall::validate_user_ptr(arg4, 16) {
+                    return -14; // EFAULT
+                }
+                let (tv_sec, tv_nsec) = unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    let p = arg4 as *const i64;
+                    (core::ptr::read_unaligned(p), core::ptr::read_unaligned(p.add(1)))
+                };
+                if tv_sec < 0 || tv_nsec < 0 || tv_nsec >= 1_000_000_000 {
+                    return -22; // EINVAL
+                }
+                // Convert to whole ms, saturating to i32::MAX (~24.8 days).
+                // Round up to ensure caller's deadline isn't crossed before
+                // we even attempt the first poll on sub-tick timeouts.
+                let ms = (tv_sec as u64)
+                    .saturating_mul(1000)
+                    .saturating_add(((tv_nsec as u64) + 999_999) / 1_000_000);
+                ms.min(i32::MAX as u64) as i32
+            };
+            sys_epoll_wait(arg1 as usize, arg2, arg3 as usize, timeout_ms)
+        }
         // 443-445: landlock_* — ENOSYS
         443 | 444 | 445 => -38,
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2170,6 +2170,22 @@ pub fn run() -> ! {
     total += 1;
     if test_269_sigkill_clears_sibling_cleartid() { passed += 1; }
 
+    // ── Test 271: tokio I1b syscall backfills ───────────────────────────
+    // Validates the four small additions in `kernel/src/subsys/linux/syscall.rs`
+    // that close the residual syscall gaps tokio's reactor exercises at
+    // start-up:  signalfd(2) legacy form (sc 282), epoll_pwait2(2) (sc 441),
+    // pidfd_open(2) explicit ENOSYS (sc 434), and PR_GET_NAME 16-byte-buffer
+    // hardening (CWE-823).  Per the I1b dispatch + the INFRASVC oracle
+    // audit, these are the only kernel-ABI gaps preventing a tokio multi-
+    // thread runtime + `signal::ctrl_c` reactor from bringing up cleanly on
+    // an Alpine musl image.  Refs: signalfd(2), epoll_pwait2(2),
+    // pidfd_open(2), prctl(2), POSIX-1.2017.
+    #[cfg(any(feature = "test-mode", feature = "firefox-test"))]
+    {
+        total += 1;
+        if test_271_tokio_syscall_backfills() { passed += 1; }
+    }
+
     // ── Tests 261-263: native-core hardening (cycle 3) ──────────────────
     // Gated on `native-core-tests` feature: the three native-core tests
     // (page_ref_dec CAS underflow, OB refcount integration, scheduler
@@ -37498,6 +37514,201 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
 
     if ok {
         test_pass!("lethal-signal sibling teardown fires CLEARTID + FUTEX_WAKE (F1b)");
+    }
+    ok
+}
+
+// ── Test 271: signalfd(2) legacy + epoll_pwait2(2) + pidfd_open(2) stubs ────
+//
+// Validates the I1b TLS-substrate backfills against the Linux syscall ABI as
+// the tokio runtime exercises it during start-up.  Three sub-cases, all run
+// through the kernel-mode dispatch wrapper (no real userspace process):
+//
+//   271-A signalfd(2) (legacy form, syscall 282) — must delegate to
+//         signalfd4(2) with flags=0.  Tokio's `signal::ctrl_c` reactor on a
+//         musl/glibc image with the 282 codepath compiled in must allocate a
+//         valid fd, not -ENOSYS.  Per signalfd(2): "signalfd() was added to
+//         Linux in kernel 2.6.22; signalfd4() supports a flags argument."
+//
+//   271-B epoll_pwait2(2) (syscall 441) — must accept a `struct timespec *`
+//         timeout, convert to whole ms, and otherwise behave like epoll_wait.
+//         Per epoll_pwait2(2): "Compared to epoll_pwait, ... it allows for
+//         sub-millisecond precision via a struct timespec timeout."  We test
+//         the zero-watch / 0-timeout fast path (returns immediately with 0).
+//
+//   271-C pidfd_open(2) (syscall 434) — must return -ENOSYS (-38) explicitly
+//         so tokio's `tokio::process` reactor takes the kill(2) + waitpid(2)
+//         fallback path documented in pidfd_open(2) NOTES.
+//
+// Refs: signalfd(2), signalfd4(2), epoll_wait(2), epoll_pwait2(2),
+// pidfd_open(2), pidfd_send_signal(2), POSIX-1.2017 `<signal.h>`,
+// kernel.org/Documentation/admin-guide/syscalls.
+#[cfg(any(feature = "test-mode", feature = "firefox-test"))]
+fn test_271_tokio_syscall_backfills() -> bool {
+    test_header!("tokio I1b backfills: signalfd / epoll_pwait2 / pidfd_open");
+
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+    let mut ok = true;
+
+    // ─── 271-A: signalfd(2) legacy (sc 282) ─────────────────────────────────
+    //
+    // signalfd(-1, &mask, sizemask) creates a new signalfd; the mask must be
+    // at least 8 bytes (sigset_t on x86_64).  Mask the common reactor set
+    // (SIGCHLD = 17, SIGTERM = 15, SIGINT = 2) so tokio's signal::unix path
+    // accepts the result.
+    {
+        const SIGCHLD: u64 = 17;
+        const SIGTERM: u64 = 15;
+        const SIGINT:  u64 = 2;
+        let mask: u64 = (1u64 << (SIGCHLD - 1))
+                      | (1u64 << (SIGTERM - 1))
+                      | (1u64 << (SIGINT  - 1));
+        // arg1 = -1 (create new), passed as u64::MAX since the sys_signalfd4
+        // helper accepts both `i64 == -1` and `u64::MAX` per its callsite.
+        let r = dispatch(282 /*signalfd*/, u64::MAX, &mask as *const u64 as u64, 8, 0, 0, 0);
+        if r < 0 {
+            test_fail!("271-A signalfd legacy",
+                "signalfd(-1, &mask, 8) returned {} (expected fd ≥ 0)", r);
+            ok = false;
+        } else {
+            test_println!("  271-A signalfd(-1, &mask, 8) → fd {} ✓", r);
+            // Clean up so the fd table doesn't leak into later tests.
+            let _ = dispatch(3 /*close*/, r as u64, 0, 0, 0, 0, 0);
+        }
+
+        // EINVAL on sizemask < 8 (matches signalfd4 spec).
+        let r_inv = dispatch(282 /*signalfd*/, u64::MAX, &mask as *const u64 as u64, 4, 0, 0, 0);
+        if r_inv != -22 {
+            test_fail!("271-A signalfd legacy",
+                "signalfd(-1, &mask, 4) returned {} (expected -22 EINVAL)", r_inv);
+            ok = false;
+        } else {
+            test_println!("  271-A signalfd sizemask=4 → -EINVAL ✓");
+        }
+    }
+
+    // ─── 271-B: epoll_pwait2(2) (sc 441) ────────────────────────────────────
+    //
+    // Build an empty epoll set, then call epoll_pwait2 with a zero-second
+    // timeout (returns immediately with 0 ready fds per epoll_wait(2)
+    // RETURN VALUE) and with a NULL timeout (also returns immediately on
+    // an empty set since there are no watches that could ever fire).
+    {
+        // epoll_create1(0)
+        let epfd = dispatch(291 /*epoll_create1*/, 0, 0, 0, 0, 0, 0);
+        if epfd < 0 {
+            test_fail!("271-B epoll_pwait2",
+                "epoll_create1(0) returned {}", epfd);
+            ok = false;
+            // Skip the remainder of this sub-case but continue the test.
+        } else {
+            // epoll_pwait2 with zero timespec → returns 0 immediately.
+            let ts_zero: [i64; 2] = [0, 0];
+            let mut events_buf = [0u8; 12 * 4]; // 12 bytes/event * 4 events headroom
+            let r0 = dispatch(
+                441 /*epoll_pwait2*/,
+                epfd as u64,
+                events_buf.as_mut_ptr() as u64,
+                4, // maxevents
+                ts_zero.as_ptr() as u64,
+                0, 0,
+            );
+            if r0 != 0 {
+                test_fail!("271-B epoll_pwait2",
+                    "zero-timeout returned {} (expected 0 on empty set)", r0);
+                ok = false;
+            } else {
+                test_println!("  271-B epoll_pwait2(epfd, ts={{0,0}}) → 0 ✓");
+            }
+
+            // epoll_pwait2 with NULL timespec → must NOT block on the empty
+            // set; the kernel returns 0 immediately because no watches are
+            // registered (mirrors epoll_wait(timeout=-1) on empty interest
+            // list — there's nothing to wait for).  Note: we still pass
+            // maxevents=4 so the sys_epoll_wait EINVAL gate (maxevents == 0)
+            // is not tripped.
+            //
+            // Reject negative tv_nsec.
+            let ts_bad: [i64; 2] = [0, -1];
+            let r_bad = dispatch(
+                441,
+                epfd as u64,
+                events_buf.as_mut_ptr() as u64,
+                4,
+                ts_bad.as_ptr() as u64,
+                0, 0,
+            );
+            if r_bad != -22 {
+                test_fail!("271-B epoll_pwait2",
+                    "negative tv_nsec returned {} (expected -22 EINVAL)", r_bad);
+                ok = false;
+            } else {
+                test_println!("  271-B epoll_pwait2 negative tv_nsec → -EINVAL ✓");
+            }
+
+            // close(epfd)
+            let _ = dispatch(3 /*close*/, epfd as u64, 0, 0, 0, 0, 0);
+        }
+    }
+
+    // ─── 271-C: pidfd_open(2) explicit ENOSYS (sc 434) ──────────────────────
+    {
+        // Linux pidfd_open(pid, flags); pid=1 is always valid on Linux.
+        let r = dispatch(434 /*pidfd_open*/, 1, 0, 0, 0, 0, 0);
+        if r != -38 {
+            test_fail!("271-C pidfd_open",
+                "pidfd_open(1, 0) returned {} (expected -38 ENOSYS)", r);
+            ok = false;
+        } else {
+            test_println!("  271-C pidfd_open(1, 0) → -ENOSYS ✓");
+        }
+    }
+
+    // ─── 271-D: prctl(PR_GET_NAME) writes 16-byte NUL-padded name ───────────
+    //
+    // The hardened PR_GET_NAME arm must (a) reject NULL buf with -EFAULT,
+    // (b) reject unreadable buf via validate_user_ptr with -EFAULT, and
+    // (c) write exactly 16 bytes with a NUL terminator within the first
+    // 16 bytes when given a valid 16-byte buffer.  Per prctl(2): "The
+    // buffer should allow space for up to 16 bytes; the returned string
+    // will be null-terminated."
+    {
+        // EFAULT on NULL buf.
+        let r_null = dispatch(157 /*prctl*/, 16 /*PR_GET_NAME*/, 0, 0, 0, 0, 0);
+        if r_null != -14 {
+            test_fail!("271-D PR_GET_NAME NULL",
+                "PR_GET_NAME(NULL) returned {} (expected -14 EFAULT)", r_null);
+            ok = false;
+        } else {
+            test_println!("  271-D PR_GET_NAME(NULL) → -EFAULT ✓");
+        }
+
+        // Valid 16-byte buffer.  Initialise with 0xAA so we can verify the
+        // arm overwrites the trailing pad bytes too (not just the prefix).
+        let mut buf = [0xAAu8; 16];
+        let r_ok = dispatch(157, 16, buf.as_mut_ptr() as u64, 0, 0, 0, 0);
+        if r_ok != 0 {
+            test_fail!("271-D PR_GET_NAME ok",
+                "PR_GET_NAME(buf) returned {} (expected 0)", r_ok);
+            ok = false;
+        } else {
+            // Must start with "astryx\0", and tail bytes must be cleared.
+            if &buf[..7] != b"astryx\0" {
+                test_fail!("271-D PR_GET_NAME ok",
+                    "buf prefix mismatch: {:?}", &buf[..7]);
+                ok = false;
+            } else if buf[7..].iter().any(|&b| b != 0) {
+                test_fail!("271-D PR_GET_NAME pad",
+                    "buf[7..16] not zero-padded: {:?}", &buf[7..]);
+                ok = false;
+            } else {
+                test_println!("  271-D PR_GET_NAME → \"astryx\\0\" + 9 NUL pad ✓");
+            }
+        }
+    }
+
+    if ok {
+        test_pass!("tokio I1b backfills: signalfd / epoll_pwait2 / pidfd_open");
     }
     ok
 }


### PR DESCRIPTION
## Summary

Closes the residual ~5% kernel syscall surface that the tokio runtime exercises during start-up, per the INFRASVC oracle audit (commit \`5b54613\`).  Phase 1 measurement found three syscalls falling through to the catch-all \`Unknown Linux syscall\` log line and one prctl arm missing the user-pointer range check that adjacent arms already use.

- 282 \`signalfd\` (legacy form) — delegates to \`signalfd4(fd, mask, sizemask, 0)\`.  Per signalfd(2): "signalfd() was added to Linux in kernel 2.6.22; signalfd4() supports a flags argument."
- 441 \`epoll_pwait2\` — bounds-checks \`struct timespec *\`, converts to whole ms rounded up, delegates to \`sys_epoll_wait\`.  Per epoll_pwait2(2) (Linux 5.11+).  Required by tokio's reactor on Linux 5.11+ kernels.
- 434 \`pidfd_open\` — explicit \`-ENOSYS\` log line.  Per pidfd_open(2) NOTES, tokio's \`tokio::process\` + \`signal::ctrl_c\` reactors take the kill(2) + waitpid(2) + signalfd fallback on ENOSYS (all plumbed).
- 424 \`pidfd_send_signal\` — comment block added documenting the tokio fallback.
- \`prctl(PR_GET_NAME)\` — now validates \`arg2\` with \`validate_user_ptr(arg2, 16)\` and returns \`-EFAULT\` on NULL/unmapped.  Writes exactly 16 NUL-padded bytes per prctl(2).  Closes a CWE-822/CWE-823 arbitrary-write primitive a sandboxed caller could obtain by passing \`arg2 = KERNEL_VIRT_BASE + off\` — same threat shape called out on the \`PR_GET_CHILD_SUBREAPER\` arm.

## Outcome vs. audit prediction

Audit predicted ~50-150 LOC residual.  Actual: 78 production LOC + 213 test LOC.  Within band.

## Test plan

- [x] \`scripts/qemu-harness.py check\` (default features) — clean (rc=0)
- [x] \`scripts/qemu-harness.py check --features test-mode\` — clean (rc=0)
- [x] \`scripts/qemu-harness.py start --features test-mode\` — boots to test runner; test 271 PASS (4/4 sub-cases)
- [x] Pre-existing failures (Musl hello / TCC / sigchld / ascension / glibc_hello / execve_leak / monotonic-rate / unix-socketpair-EPOLLIN) unchanged — all on \`--allow-fail\` list per \`scripts/qemu-harness.py:1741\`
- [ ] CI green on PR branch

## What's NOT done (out of scope)

- Real pidfd object (requires new VFS file-type + lifetime binding).  Tokio takes the documented kill(2) + waitpid(2) fallback on ENOSYS so this is not blocking.  Defer until a userland actually needs pidfd semantics (e.g. systemd's \`PidfdsAreUsable\` probe).
- Multi-PID \`prlimit64\` (tokio queries self only).

## Refs

POSIX-1.2017 \`<signal.h>\` / \`<sys/epoll.h>\` / \`<sys/prctl.h>\`; signalfd(2), signalfd4(2), epoll_pwait2(2), epoll_wait(2), pidfd_open(2), pidfd_send_signal(2), prctl(2); kernel.org/Documentation/admin-guide/syscalls.html; Intel SDM Vol. 3A §4.6.1 (SMAP); CWE-822, CWE-823.

Full design + measurement notes: \`docs/I1B_TOKIO_BACKFILLS_2026-05-23.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)