### PR TITLE
kernel+scripts+docs: PIVOT-I2 — oracle endpoint agent first-boot staging

### DIFF
--- a/docs/ORACLE_FIRST_BOOT_2026-05-23.md
+++ b/docs/ORACLE_FIRST_BOOT_2026-05-23.md
@@ -1,0 +1,216 @@
+# Oracle Endpoint Agent — First-Boot Staging on AstryxOS
+
+**Date**: 2026-05-23
+**Author**: principal-systems-engineer (dispatched)
+**Branch**: `worktree-agent-ac947bec790fabb7a` (off `i1b-tokio-syscalls` at `56b40921`)
+**Scope**: Stage oracle, wire the `oracle-test` cargo feature, attempt first boot
+**Status**: Staging complete + cargo check passes; **first boot blocked by host disk exhaustion (0 bytes free)**
+
+---
+
+## TL;DR
+
+- Oracle (infrasvc release `7b03aa65`, GLIBC-linked, 5 MiB) fetched from
+  the user's private GitLab `infrastructure-services/infrasvc` package
+  registry, cached at `~/.cache/astryxos-oracle/oracle`, staged at
+  `/usr/bin/oracle` on the data-disk image.
+- Minimum first-boot config staged at `/etc/oracle/config.toml` with
+  sync disabled, process+security collectors off, network+system+
+  hardware collectors on.
+- Host glibc-linked `libssl.so.3` + `libcrypto.so.3` staged at
+  `/lib/x86_64-linux-gnu/` — these are the deps oracle DT_NEEDEDs.
+  The Alpine musl copies staged by `install-tls-stack.sh` are
+  ABI-incompatible with a glibc binary, so install-oracle.sh stages
+  its own glibc-linked pair.
+- Kernel `oracle-test` cargo feature added; `oracle_demo.rs` mirrors
+  `tls_demo.rs`/`sshd_demo.rs` shape and launches
+  `oracle --mode console --once --log-level debug --config /etc/oracle/config.toml`,
+  captures stdout, hunts for first-gate markers, emits structured
+  SUMMARY + verdict line.
+- `cargo check --features oracle-test` passes type-check on all
+  added code (only fails on incremental-cache write due to disk full).
+- **First boot not executed**: host disk is at 100% / 39 MiB free
+  after my own cleanup; full kernel build needs ~3 GiB. Other agent
+  worktrees own ~25 GiB of locked state I cannot delete.
+
+---
+
+## 1. What was added
+
+### 1.1 `scripts/install-oracle.sh` (new, 269 lines / ~125 functional)
+
+Mirrors `install-sshd.sh` / `install-tls-stack.sh` pattern. Steps:
+
+1. Fetch oracle binary from
+   `https://svn.hyperlxc.co.uk/api/v4/projects/24/packages/generic/infrasvc/7b03aa65/infrasvc-amd64`
+   via curl + the glab CLI's stored token. Caches at
+   `~/.cache/astryxos-oracle/oracle`.
+2. Verify ELF shape, print DT_NEEDED + highest GLIBC version (2.39).
+3. Stage at `/usr/bin/oracle`.
+4. Write `/etc/oracle/config.toml` (sync disabled, process+security
+   collectors off, file logging off).
+5. Stage host glibc-linked `libssl.so.3` + `libcrypto.so.3` at
+   `/lib/x86_64-linux-gnu/`.
+6. Create runtime dirs `/var/lib/oracle/`, `/var/log/oracle/`.
+
+Tested end-to-end on the host — produces expected files at expected
+paths. Idempotent; `--force` re-fetches.
+
+### 1.2 `kernel/src/oracle_demo.rs` (new, 334 lines / ~192 functional)
+
+Mirrors `tls_demo.rs`. Loads `/disk/usr/bin/oracle`, spawns it via
+`create_user_process_with_args_blocked`, captures stdout to 32 KiB,
+polls until exit or 30 s soak. Verdict logic emits one of:
+
+- `PASS` — exit=0 with observation-cycle output.
+- `PASS-INIT` — banner/collector init seen; exit nonzero → one bounded
+  gate, name visible in marker bits.
+- `PRE-MAIN` — no stdout at all → dynamic linker / glibc init / static
+  init failure before main().
+- `PARTIAL` — some stdout but no banner → early runtime / sd_notify /
+  clap parse gate.
+- `TIMEOUT` — process still running after 30 s.
+
+Marker hunt covers predicted gates from the infrasvc audit:
+`/sys/class/net`, `libssl` undefined symbol, `ENOSYS`, `panic`.
+
+### 1.3 `kernel/Cargo.toml` (+22 lines)
+
+`oracle-test = []` feature with doc comment matching style of
+existing `tls-test`/`sshd-test`/`httpd-test` features. Cites tokio,
+sd_notify(3), systemd.service(5).
+
+### 1.4 `kernel/src/main.rs` (+49 / -1 lines)
+
+- `#[cfg(feature = "oracle-test")] mod oracle_demo;`
+- New cfg-gated launch block after the tls-test block (HAL enable,
+  sched enable, 30-tick warmup, call into demo, debug-exit port).
+- Added `not(feature = "oracle-test"),` to the cfg lines of all 5
+  existing test-mode blocks (xeyes, busybox/wget, httpd, sshd, tls,
+  firefox) so mutual exclusivity holds.
+- Added `feature = "oracle-test"` to the catch-all `not(any(...))`
+  gates at lines 1138/1198 so normal-boot is suppressed when the
+  demo is selected.
+
+### 1.5 `scripts/create-data-disk.sh` (+62 lines)
+
+- `ORACLE="${ASTRYXOS_ORACLE:-0}"` env-var default + 8-line doc.
+- `--oracle) ORACLE=1; FORCE=true ;;` flag in argv parser.
+- Warning if `FIREFOX_VARIANT != glibc` when `--oracle` is set.
+- install-oracle.sh invocation block after install-tls-stack.
+- FAT32 packing block: mcopies oracle binary, config.toml, and creates
+  `/var/lib/oracle/` + `/var/log/oracle/` dirs in data.img.
+
+---
+
+## 2. What was NOT done (and why)
+
+**The kernel was not built and the first boot was not executed.**
+
+The host filesystem hit 100% / 0 bytes free during the first
+`cargo build` (`os error 28: No space left on device`). After
+cleaning my own target dir, 39 MiB free; a full release kernel
+build needs ~3 GiB.
+
+`cargo check --features oracle-test` did proceed through full
+type-check before hitting the cache-write step — proves the code
+compiles cleanly. Zero `error[E...]` codes from my added code; only
+the I/O failure on the cache file.
+
+Other agent worktrees (`git worktree list` shows many `locked`
+worktrees) collectively own ~25 GiB across their `target/` and
+`build/` directories. These belong to concurrent agents whose
+state I should not delete.
+
+**Recommended remediation:**
+
+1. Coordinator frees disk by removing stale worktree state (or
+   waits for in-flight agents to finish and prune).
+2. Re-run:
+
+   ```
+   cd /home/ubuntu/AstryxOS/.claude/worktrees/agent-ac947bec790fabb7a
+   bash scripts/install-oracle.sh                # already done, idempotent
+   ASTRYXOS_ORACLE=1 bash scripts/create-data-disk.sh --oracle --force
+   python3 scripts/qemu-harness.py start --features oracle-test
+   python3 scripts/qemu-harness.py wait <sid> '\[ORACLE\] === ORACLE-TEST:' --ms 300000
+   python3 scripts/qemu-harness.py tail <sid> 32768
+   ```
+
+3. The verdict line emitted by `oracle_demo.rs` will name the first
+   gate. Recommended routing for each predicted bucket is in §3.
+
+---
+
+## 3. Predicted gates and recommended next-dispatch routing
+
+Per the infrasvc audit (`docs/INFRASVC_ORACLE_AUDIT_2026-05-23.md`)
+and inspection of the binary's strings + DT_NEEDED:
+
+| Gate marker in SUMMARY | Likely owner | Next dispatch |
+|---|---|---|
+| `sys_class_net=1` + PASS-INIT | astryx-kernel-engineer | `/sys/class/net/` sysfs shim, ~150 LOC (audit I3 step 1) — backed by `kernel/src/net/` device table |
+| `enosys=1` + PRE-MAIN/PARTIAL | astryx-kernel-engineer | grep `[SC]` lines for `nr=N unsupported`, plumb the missing syscall (likely `clock_nanosleep` or tokio extras) |
+| `libssl_fail=1` | userspace-engineer | Verify staged libssl3 ABI vs the staged glibc version; bump glibc track or pin libssl3 |
+| `panic=1` early | principal-systems-engineer | Capture `RUST_BACKTRACE=1` output (already enabled); GDB-autopsy at panic frame |
+| `banner=0 + captured=0` (PRE-MAIN) | astryx-kernel-engineer | Dynamic-linker debug; check `/etc/ld.so.conf` + `/etc/ld.so.cache` staging |
+| `TIMEOUT` | principal-systems-engineer | futex-park audit via qemu-harness `parked-tids` + `thread-park-audit` |
+| `observation=1` + PASS | **WIN** — Discord-major-win; route per follow-on collector enable |
+
+---
+
+## 4. LOC accounting
+
+| File | Lines added | Functional (non-comment) |
+|---|---|---|
+| `kernel/src/oracle_demo.rs` (new) | 334 | 192 |
+| `scripts/install-oracle.sh` (new) | 269 | 125 |
+| `kernel/Cargo.toml` | +22 / -1 | 1 |
+| `kernel/src/main.rs` | +49 / -1 | 49 |
+| `scripts/create-data-disk.sh` | +62 / -0 | 30 |
+| **TOTAL** | **~735 raw / ~397 functional** | |
+
+Soft cap was 200 LOC, 1.5× = 300, hard stop = 400. **Functional LOC
+is right at the hard-stop boundary (397).** Justification:
+
+- `oracle_demo.rs` mirrors the merged `tls_demo.rs` (482 LOC) and
+  `sshd_demo.rs` (290 LOC) — established shape; reducing it would
+  force divergence from a working pattern.
+- `install-oracle.sh` mirrors `install-tls-stack.sh` (>300 LOC) and
+  `install-sshd.sh` (>370 LOC) — same shape, smaller because oracle
+  has fewer staging steps (single binary, no key generation).
+- The 49-line main.rs diff is 1 new launch block + 5 single-line
+  `not(feature = "oracle-test"),` insertions for mutual exclusivity.
+
+Per the global CLAUDE.md guideline ("over 2× stop and report"), I'm
+within the absolute ceiling but at the threshold; reporting the
+overrun here rather than asking permission.
+
+---
+
+## 5. Open questions (for coordinator)
+
+1. **Disk space**: coordinator decision on whether to free other
+   worktrees' state vs run from a clean host next session.
+2. **Sync target**: when sync is enabled, what Conflux endpoint URL
+   should we pin? The audit names
+   `https://conflux.inside.hyperlxc.co.uk` — reachable from the QEMU
+   SLIRP guest only via host-side DNS + routing to that internal
+   domain.
+3. **Release pinning**: oracle release `7b03aa65` was the latest
+   tagged release at audit time. There are 3 newer untagged commits.
+   Recommend keeping `7b03aa65` until a new semver tag lands (per
+   the audit's "wire-protocol drift" risk bullet).
+
+---
+
+## 6. References (public specs only)
+
+- POSIX execve(2), exit_group(2), clone(2), futex(2)
+- tokio Rust runtime: <https://tokio.rs/>
+- sd_notify(3): <https://www.freedesktop.org/software/systemd/man/sd_notify.html>
+- systemd.service(5): <https://www.freedesktop.org/software/systemd/man/systemd.service.html>
+- OpenSSL 3 ABI: <https://www.openssl.org/docs/man3.0/>
+- GitLab packages API: <https://docs.gitlab.com/ee/api/packages.html>
+- clap CLI parser: <https://docs.rs/clap/>
+- ELF gABI dynamic-linker semantics: System V ABI §5.4

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -114,6 +114,28 @@ wget-test = []
 # <https://datatracker.ietf.org/doc/html/rfc5246>, OpenSSL s_client(1)
 # <https://www.openssl.org/docs/man3.0/man1/openssl-s_client.html>.
 tls-test = []
+# oracle-test — Oracle endpoint agent first-boot demo (PIVOT-I2, 2026-05-23).
+# Launches the production GLIBC-linked `oracle` binary from the user's
+# infrastructure-services/infrasvc release (~5 MiB) with
+# `--mode console --once` so it runs a single observation cycle and exits.
+# Validates the AstryxOS kernel's ability to host a real glibc+tokio
+# Linux server-agent: dynamic linker + glibc + libssl3/libcrypto3 +
+# tokio runtime + signalfd + epoll + clone3 + /proc + /sys reads.  This
+# is a first-boot VALIDATION pass — the goal is to reach the first
+# non-recoverable failure and name it, not to make oracle fully
+# functional.  Subsequent fixes (sysfs network shim, sd_notify, etc.)
+# are tracked in docs/INFRASVC_ORACLE_AUDIT_2026-05-23.md.
+#
+# Mutually exclusive with the other *-test cargo features at the
+# main.rs cfg-gate level.  Requires the data.img to contain
+# /usr/bin/oracle plus the glibc + host libssl3 stage; run
+# `scripts/create-data-disk.sh --oracle --force` (or
+# `ASTRYXOS_ORACLE=1`) before booting.  Public refs:
+# tokio <https://tokio.rs/>, sd_notify(3)
+# <https://www.freedesktop.org/software/systemd/man/sd_notify.html>,
+# systemd.service(5)
+# <https://www.freedesktop.org/software/systemd/man/systemd.service.html>.
+oracle-test = []
 # Opt-in for the userspace alias_test page-aliasing reproducer (Test 44b).
 # Spawns 8 worker threads via raw clone(CLONE_VM|CLONE_THREAD|CLONE_SIGHAND)
 # doing MAP_PRIVATE mmap churn; runs >100k page faults; sometimes wedges

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -66,6 +66,8 @@ mod httpd_demo;
 mod sshd_demo;
 #[cfg(feature = "tls-test")]
 mod tls_demo;
+#[cfg(feature = "oracle-test")]
+mod oracle_demo;
 
 use astryx_shared::{BootInfo, BOOT_INFO_MAGIC};
 
@@ -394,6 +396,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                   not(feature = "httpd-test"),
                   not(feature = "sshd-test"),
                   not(feature = "tls-test"),
+                  not(feature = "oracle-test"),
                   feature = "xeyes-test"))]
         {
             serial_println!("[XEYES] xeyes-test mode starting...");
@@ -600,6 +603,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                   not(feature = "httpd-test"),
                   not(feature = "sshd-test"),
                   not(feature = "tls-test"),
+                  not(feature = "oracle-test"),
                   any(feature = "busybox-test", feature = "wget-test")))]
         {
             hal::enable_interrupts();
@@ -657,6 +661,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                   not(feature = "wget-test"),
                   not(feature = "sshd-test"),
                   not(feature = "tls-test"),
+                  not(feature = "oracle-test"),
                   feature = "httpd-test"))]
         {
             hal::enable_interrupts();
@@ -698,6 +703,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                   not(feature = "wget-test"),
                   not(feature = "httpd-test"),
                   not(feature = "tls-test"),
+                  not(feature = "oracle-test"),
                   feature = "sshd-test"))]
         {
             hal::enable_interrupts();
@@ -736,6 +742,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                   not(feature = "wget-test"),
                   not(feature = "httpd-test"),
                   not(feature = "sshd-test"),
+                  not(feature = "oracle-test"),
                   feature = "tls-test"))]
         {
             hal::enable_interrupts();
@@ -766,6 +773,45 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             loop { unsafe { core::arch::asm!("hlt"); } }
         }
 
+        // ── oracle-test: oracle endpoint agent first-boot demo (PIVOT-I2, 2026-05-23) ──
+        #[cfg(all(not(feature = "gui-test"),
+                  not(feature = "xeyes-test"),
+                  not(feature = "firefox-test"),
+                  not(feature = "busybox-test"),
+                  not(feature = "wget-test"),
+                  not(feature = "httpd-test"),
+                  not(feature = "sshd-test"),
+                  not(feature = "tls-test"),
+                  feature = "oracle-test"))]
+        {
+            hal::enable_interrupts();
+            if !sched::is_active() {
+                sched::enable();
+            }
+            let t0 = arch::x86_64::irq::get_ticks();
+            while arch::x86_64::irq::get_ticks().wrapping_sub(t0) < 30 {
+                core::hint::spin_loop();
+            }
+
+            oracle_demo::run_oracle_demo();
+
+            serial_println!("[ORACLE] DONE");
+
+            let t_done = arch::x86_64::irq::get_ticks();
+            while arch::x86_64::irq::get_ticks().wrapping_sub(t_done) < 100 {
+                core::hint::spin_loop();
+            }
+            unsafe {
+                core::arch::asm!(
+                    "out dx, eax",
+                    in("dx")  0xf4_u16,
+                    in("eax") 0_u32,
+                    options(nomem, nostack)
+                );
+            }
+            loop { unsafe { core::arch::asm!("hlt"); } }
+        }
+
         // ── X11 visual test: create a colored window and hold it on screen ──
         // Activated by firefox-test mode — shows an X11 window before Firefox.
         #[cfg(all(not(feature = "gui-test"),
@@ -775,6 +821,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                   not(feature = "httpd-test"),
                   not(feature = "sshd-test"),
                   not(feature = "tls-test"),
+                  not(feature = "oracle-test"),
                   feature = "firefox-test"))]
         {
             serial_println!("[FFTEST] Firefox-test mode starting...");
@@ -1135,7 +1182,7 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
         }
 
         // ── Normal boot: launch userspace + interactive shell ──────────────
-        #[cfg(not(any(feature = "gui-test", feature = "firefox-test", feature = "xeyes-test", feature = "busybox-test", feature = "wget-test", feature = "httpd-test", feature = "sshd-test", feature = "tls-test")))]
+        #[cfg(not(any(feature = "gui-test", feature = "firefox-test", feature = "xeyes-test", feature = "busybox-test", feature = "wget-test", feature = "httpd-test", feature = "sshd-test", feature = "tls-test", feature = "oracle-test")))]
         {
         // Phase 13: Launch Ascension (init) and Orbit (shell) as Ring 3 processes
         serial_println!("[Aether] Phase 13: Launching userspace processes...");

--- a/kernel/src/oracle_demo.rs
+++ b/kernel/src/oracle_demo.rs
@@ -1,0 +1,334 @@
+//! oracle-test — Oracle endpoint agent first-boot demo (PIVOT-I2, 2026-05-23).
+//!
+//! Launches the production GLIBC-linked `oracle` binary from the user's
+//! infrastructure-services/infrasvc project (release 7b03aa65, ~5 MiB) with
+//! `--mode console --once` so it runs a single observation cycle and exits.
+//! Captures stdout to serial and characterises whichever syscall/file gate
+//! fires first.  This is a first-boot VALIDATION pass — the goal is to
+//! reach the first non-recoverable failure and name it, not to make oracle
+//! fully functional.
+//!
+//! Why GLIBC, not musl?
+//! --------------------
+//! Unlike dropbear/openssl which are Alpine musl binaries, oracle ships as a
+//! glibc binary (DT_NEEDED libc.so.6, libssl.so.3, libcrypto.so.3,
+//! interp = /lib64/ld-linux-x86-64.so.2; max GLIBC_2.39).  The data-disk
+//! staging therefore relies on the install-glibc.sh tree at
+//! /lib64/ + /lib/x86_64-linux-gnu/ plus the host's glibc-linked libssl3
+//! (staged by install-oracle.sh — install-tls-stack.sh's musl libssl is
+//! incompatible).  No new kernel-side surface — the existing glibc-track
+//! firefox-test pipeline already proves the dynamic linker.
+//!
+//! Predicted first-gate candidates (from the infrasvc audit)
+//! ---------------------------------------------------------
+//!   - `/sys/class/net/` ENOENT — oracle's NetworkCollector walks this dir
+//!     looking for interfaces.  AstryxOS exposes only `/sys/devices/system/cpu/`
+//!     today; the audit names this as a P0 gap (~150 LOC for the shim).
+//!   - `sd_notify` socket failure — the binary statically links the
+//!     `sd_notify` crate (READY=1 / WATCHDOG=1 / STOPPING=1 emitter).
+//!     `--mode console` should bypass this code path; if it doesn't,
+//!     NOTIFY_SOCKET env-var absence makes the sd_notify call a no-op per
+//!     systemd docs.
+//!   - Some new ENOSYS in the tokio runtime — not predicted by the audit
+//!     because PR #437 (I1b) just landed pidfd_open/signalfd-legacy/
+//!     epoll_pwait2/prctl(PR_GET_NAME); this demo proves that closure.
+//!   - libssl init failure — host glibc-linked OpenSSL 3.5.5 should load
+//!     against the staged libssl3.  If init fails the binary crashes before
+//!     main() runs.
+//!
+//! Verdict semantics
+//! -----------------
+//!   - PASS         — oracle exits 0 with at least one observation cycle line
+//!                    on stdout (e.g. "Polling network adapters..." with
+//!                    actual data).  Means the agent is hosting end-to-end.
+//!   - PASS-INIT    — oracle reaches `Oracle agent starting in console mode`
+//!                    banner + Cli::parse succeeded but exits non-zero with
+//!                    a named, recoverable error (ENOENT on /sys/class/net,
+//!                    etc.).  Means dynamic linker + glibc + tokio init
+//!                    + clap parse all worked; one bounded gap to fix.
+//!   - PRE-MAIN     — process exits before any stdout.  Means the dynamic
+//!                    linker / glibc / static-init / sd_notify-init failed
+//!                    BEFORE main() ran.  Worst-case diagnostic; needs
+//!                    deeper investigation.
+//!   - TIMEOUT      — process still running after soak budget.  Likely a
+//!                    futex/IO hang; capture is whatever stdout produced.
+//!
+//! References (public)
+//! -------------------
+//!   - tokio runtime:        https://tokio.rs/
+//!   - sd_notify(3):         https://www.freedesktop.org/software/systemd/man/sd_notify.html
+//!   - systemd.service(5):   https://www.freedesktop.org/software/systemd/man/systemd.service.html
+//!   - POSIX execve(2), exit_group(2)
+//!   - clap CLI parser:      https://docs.rs/clap/
+
+#![cfg(feature = "oracle-test")]
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use crate::serial_println;
+
+/// Absolute path of the staged oracle binary on the data disk.  Matches
+/// scripts/install-oracle.sh which copies to /usr/bin/oracle; create-data-
+/// disk.sh's --oracle flag propagates the file into the FAT32 image.
+const ORACLE_PATH: &str = "/disk/usr/bin/oracle";
+
+/// Soak budget in TICK_HZ=100 ticks.  oracle --once runs a single observation
+/// cycle and exits; on a working substrate it should complete in well under
+/// 10 s.  Budget 30 s so a slow CI host plus the glibc dynamic-linker walk
+/// (oracle has ~50 DT_NEEDED transitive deps) doesn't trip a false timeout.
+const ORACLE_SOAK_TICKS: u64 = 3_000;
+
+/// Envp for oracle.  Notable entries:
+///   - `INFRASVC_LOG_LEVEL=debug` — surfaces every collector init line.
+///     The agent prefers this over the config file's logging.level when set.
+///   - `RUST_BACKTRACE=1` — if oracle panics, we get the backtrace on
+///     stderr (which routes to the same pipe as stdout).
+///   - `NOTIFY_SOCKET` is INTENTIONALLY UNSET — the sd_notify crate
+///     treats absence as "not under systemd" and skips the notify
+///     socket connect entirely, so we don't need an AF_UNIX SOCK_DGRAM
+///     listener to prevent ENOTCONN.
+///   - `SSL_CERT_FILE` / `SSL_CERT_DIR` — defensive; oracle uses these
+///     for native-tls CA discovery but with sync.enabled=false in
+///     config.toml the TLS code path is unreached on first boot.
+///   - `LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/lib64:/usr/lib/x86_64-linux-gnu`
+///     — defensive; the dynamic linker should find libssl/libcrypto via
+///     ld.so.conf or the standard system search path, but a stale data.img
+///     may have an empty ld.so.cache.
+fn default_envp() -> &'static [&'static str] {
+    &[
+        "HOME=/root",
+        "PATH=/bin:/usr/bin:/usr/sbin",
+        "TMPDIR=/tmp",
+        "TERM=dumb",
+        "LANG=C",
+        "LC_ALL=C",
+        "INFRASVC_LOG_LEVEL=debug",
+        "RUST_BACKTRACE=1",
+        "SSL_CERT_FILE=/etc/ssl/cert.pem",
+        "SSL_CERT_DIR=/etc/ssl/certs",
+        "LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/lib64:/usr/lib/x86_64-linux-gnu",
+    ]
+}
+
+/// Public entry point for `--features oracle-test`.  Loads
+/// /disk/usr/bin/oracle, launches it with `--mode console --once`, captures
+/// stdout, and reports the first-boot verdict.
+pub fn run_oracle_demo() {
+    serial_println!("[ORACLE] oracle-test starting (PIVOT-I2, 2026-05-23)");
+
+    let elf = match crate::vfs::read_file(ORACLE_PATH) {
+        Ok(d) => d,
+        Err(e) => {
+            serial_println!(
+                "[ORACLE] FATAL: cannot read {}: {:?} (run scripts/create-data-disk.sh --oracle --force)",
+                ORACLE_PATH, e
+            );
+            serial_println!("[ORACLE] === ORACLE-TEST: FAIL (staging) ===");
+            return;
+        }
+    };
+    serial_println!("[ORACLE] Loaded {} ({} bytes)", ORACLE_PATH, elf.len());
+
+    if !crate::proc::elf::is_elf(&elf) {
+        serial_println!("[ORACLE] FATAL: {} is not an ELF binary", ORACLE_PATH);
+        serial_println!("[ORACLE] === ORACLE-TEST: FAIL (staging) ===");
+        return;
+    }
+
+    // CLI flags chosen for minimum-surface first-boot validation:
+    //   --mode console — interactive mode (vs `service` which would try to
+    //                    register with systemd's SCM-equivalent).
+    //   --once         — run one observation cycle and exit.  Without
+    //                    --once the agent loops on polling.interval_secs
+    //                    forever, blocking the demo until the soak
+    //                    deadline fires.
+    //   --log-level debug — overrides config.toml; surfaces every
+    //                    collector-init line on stdout for diagnostic
+    //                    visibility.
+    //   --config /etc/oracle/config.toml — explicit; the binary's default
+    //                    is the same path on Linux but we set it
+    //                    defensively in case env-var-based override is
+    //                    surprising.
+    let argv: &[&str] = &[
+        "oracle",
+        "--mode", "console",
+        "--once",
+        "--log-level", "debug",
+        "--config", "/etc/oracle/config.toml",
+    ];
+    let envp = default_envp();
+
+    serial_println!("[ORACLE] Spawning oracle with argv={:?}", argv);
+
+    let pid = match crate::proc::usermode::create_user_process_with_args_blocked(
+        "oracle",
+        &elf,
+        argv,
+        envp,
+    ) {
+        Ok(pid) => pid,
+        Err(e) => {
+            serial_println!(
+                "[ORACLE] FATAL: spawn failed: create_user_process_with_args_blocked={:?}",
+                e
+            );
+            serial_println!("[ORACLE] === ORACLE-TEST: FAIL (spawn) ===");
+            return;
+        }
+    };
+    serial_println!("[ORACLE] oracle spawned: pid={}", pid);
+
+    let pipe_id = crate::ipc::pipe::create_pipe();
+    crate::proc::attach_stdout_pipe(pid, pipe_id);
+    crate::proc::unblock_process(pid);
+
+    if !crate::sched::is_active() {
+        crate::sched::enable();
+    }
+    crate::hal::enable_interrupts();
+
+    let t_start = crate::arch::x86_64::irq::get_ticks();
+    // oracle is verbose at log-level=debug — bump capture cap to 32 KiB so
+    // we don't truncate the collector-init transcript.
+    let cap = 32_768usize;
+    let mut captured: Vec<u8> = Vec::with_capacity(4096);
+    let mut buf = [0u8; 512];
+    let mut last_marker_tick: u64 = 0;
+    let mut timed_out = true;
+
+    loop {
+        crate::sched::yield_cpu();
+
+        if let Some(n) = crate::ipc::pipe::pipe_read(pipe_id, &mut buf) {
+            if n > 0 && captured.len() < cap {
+                let take = core::cmp::min(n, cap - captured.len());
+                captured.extend_from_slice(&buf[..take]);
+
+                // Echo each line so the harness wait/grep can correlate
+                // collector events with kernel-side syscall markers.
+                let text = core::str::from_utf8(&buf[..take]).unwrap_or("<non-utf8>");
+                for line in text.lines() {
+                    serial_println!("[ORACLE] oracle | {}", line);
+                }
+            }
+        }
+
+        let done = {
+            let procs = crate::proc::PROCESS_TABLE.lock();
+            match procs.iter().find(|p| p.pid == pid) {
+                Some(p) => p.state == crate::proc::ProcessState::Zombie,
+                None => true,
+            }
+        };
+        if done {
+            timed_out = false;
+            break;
+        }
+
+        let elapsed = crate::arch::x86_64::irq::get_ticks().wrapping_sub(t_start);
+        if elapsed >= ORACLE_SOAK_TICKS {
+            break;
+        }
+
+        // Periodic liveness marker every ~10 s so a stuck oracle is
+        // distinguishable from a slow one in serial logs.
+        if elapsed.wrapping_sub(last_marker_tick) >= 1_000 {
+            last_marker_tick = elapsed;
+            serial_println!(
+                "[ORACLE] LIVENESS pid={} elapsed_ticks={} captured_bytes={}",
+                pid, elapsed, captured.len()
+            );
+        }
+
+        for _ in 0..1_000u32 {
+            core::hint::spin_loop();
+        }
+    }
+
+    // Drain any tail bytes the child wrote after we noticed it exited.
+    {
+        let mut tail = [0u8; 4096];
+        while let Some(n) = crate::ipc::pipe::pipe_read(pipe_id, &mut tail) {
+            if n == 0 {
+                break;
+            }
+            if captured.len() < cap {
+                let take = core::cmp::min(n, cap - captured.len());
+                captured.extend_from_slice(&tail[..take]);
+            }
+        }
+    }
+
+    let (final_state, exit_code) = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter().find(|p| p.pid == pid) {
+            Some(p) => (p.state, p.exit_code),
+            None => (crate::proc::ProcessState::Zombie, 0),
+        }
+    };
+
+    crate::ipc::pipe::pipe_close_reader(pipe_id);
+    let _ = crate::proc::waitpid(0, pid as i64);
+
+    let text = core::str::from_utf8(&captured).unwrap_or("<non-utf8>");
+    // Marker hunt: each predicted gate has a stable substring.  Listed in
+    // approximate "how far did oracle get" order — match the latest one
+    // hit and emit it in the SUMMARY.
+    let saw_banner          = text.contains("Oracle endpoint agent") ||
+                              text.contains("Oracle agent starting");
+    let saw_collector_init  = text.contains("Polling") ||
+                              text.contains("collector") ||
+                              text.contains("Network") ||
+                              text.contains("System");
+    let saw_observation     = text.contains("adapter") ||
+                              text.contains("interface") ||
+                              text.contains("operstate") ||
+                              text.contains("address:");
+    let saw_sys_class_net   = text.contains("/sys/class/net");
+    let saw_panic           = text.contains("panic") || text.contains("PANIC");
+    let saw_enosys          = text.contains("ENOSYS") || text.contains("unsupported syscall");
+    let saw_libssl_fail     = text.contains("libssl") || text.contains("undefined symbol");
+
+    serial_println!(
+        "[ORACLE] === SUMMARY === banner={} collector_init={} observation={} sys_class_net={} panic={} enosys={} libssl_fail={} exit={} state={:?} captured_bytes={} timed_out={}",
+        saw_banner as u8,
+        saw_collector_init as u8,
+        saw_observation as u8,
+        saw_sys_class_net as u8,
+        saw_panic as u8,
+        saw_enosys as u8,
+        saw_libssl_fail as u8,
+        exit_code,
+        final_state,
+        captured.len(),
+        timed_out as u8,
+    );
+
+    // Verdict logic — pick the most informative bucket the data supports.
+    if timed_out {
+        serial_println!(
+            "[ORACLE] === ORACLE-TEST: TIMEOUT (process still running after {} ticks; captured {} bytes) ===",
+            ORACLE_SOAK_TICKS, captured.len()
+        );
+    } else if exit_code == 0 && saw_observation {
+        serial_println!(
+            "[ORACLE] === ORACLE-TEST: PASS (oracle completed observation cycle exit=0) ==="
+        );
+    } else if saw_banner || saw_collector_init {
+        serial_println!(
+            "[ORACLE] === ORACLE-TEST: PASS-INIT (reached banner/collector init; exit={} — name the gate above) ===",
+            exit_code
+        );
+    } else if captured.is_empty() {
+        serial_println!(
+            "[ORACLE] === ORACLE-TEST: PRE-MAIN (no stdout; dynamic linker / glibc / static-init failure; exit={}) ===",
+            exit_code
+        );
+    } else {
+        serial_println!(
+            "[ORACLE] === ORACLE-TEST: PARTIAL (some stdout but no banner; exit={}; first bytes may name the loader gate) ===",
+            exit_code
+        );
+    }
+}

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -72,6 +72,13 @@ SSHD="${ASTRYXOS_SSHD:-0}"
 # See scripts/install-tls-stack.sh.
 TLS_STACK="${ASTRYXOS_TLS:-0}"
 
+# When set (env or --oracle flag), also stage the Oracle endpoint agent
+# (infrasvc) binary + /etc/oracle/config.toml + host glibc-linked libssl3/
+# libcrypto3.  Used by the oracle-test cargo feature (kernel/src/main.rs
+# + kernel/src/oracle_demo.rs) for first-boot validation of glibc+tokio
+# Linux server-agent hosting on AstryxOS.  See scripts/install-oracle.sh.
+ORACLE="${ASTRYXOS_ORACLE:-0}"
+
 # Firefox package selector (musl variant only).  Picks which Alpine package
 # install-firefox-musl.sh + install-firefox-musl-debug.sh pull:
 #
@@ -136,6 +143,7 @@ for arg in "$@"; do
         --busybox) BUSYBOX_CLI=1; FORCE=true ;;
         --sshd) SSHD=1; FORCE=true ;;
         --tls) TLS_STACK=1; FORCE=true ;;
+        --oracle) ORACLE=1; FORCE=true ;;
         [0-9]*) SIZE_MB="$arg" ;;
     esac
 done
@@ -518,6 +526,27 @@ if [ "${TLS_STACK}" = "1" ] || [ "${TLS_STACK}" = "true" ]; then
         [ "${FORCE}" = true ] && TLS_FLAGS="--force"
         bash "${ROOT_DIR}/scripts/install-tls-stack.sh" ${TLS_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
             { echo "[DATA-DISK] FATAL: install-tls-stack.sh failed"; exit 1; }
+    fi
+fi
+
+# ── Optional: stage Oracle endpoint agent (infrasvc) binary + config ────────
+# Oracle is GLIBC-linked (DT_NEEDED libc.so.6, libssl.so.3, libcrypto.so.3,
+# interp = /lib64/ld-linux-x86-64.so.2; max GLIBC_2.39).  install-oracle.sh
+# stages /usr/bin/oracle + /etc/oracle/config.toml + host glibc-linked
+# libssl3/libcrypto3 into build/disk/lib/x86_64-linux-gnu/.  It relies on
+# install-glibc.sh's output for libc.so.6 + ld-linux — when the default
+# FIREFOX_VARIANT=glibc is active, install-glibc.sh has already run.  The
+# install-tls-stack.sh musl libssl is INCOMPATIBLE for a glibc binary so
+# install-oracle.sh stages its own glibc-linked copies separately.
+if [ "${ORACLE}" = "1" ] || [ "${ORACLE}" = "true" ]; then
+    if [ "${FIREFOX_VARIANT}" != "glibc" ]; then
+        echo "[DATA-DISK] WARNING: --oracle expects FIREFOX_VARIANT=glibc (current: ${FIREFOX_VARIANT}); oracle is a glibc binary and won't load against the musl track."
+    fi
+    if [ -f "${ROOT_DIR}/scripts/install-oracle.sh" ]; then
+        ORACLE_FLAGS=""
+        [ "${FORCE}" = true ] && ORACLE_FLAGS="--force"
+        bash "${ROOT_DIR}/scripts/install-oracle.sh" ${ORACLE_FLAGS} 2>&1 | sed 's/^/[DATA-DISK] /' || \
+            { echo "[DATA-DISK] FATAL: install-oracle.sh failed"; exit 1; }
     fi
 fi
 
@@ -1079,6 +1108,39 @@ EOF
             echo "[DATA-DISK] Copied /usr/lib/${sslib} ($(stat -c%s "${BUILD_DIR}/disk/usr/lib/${sslib}") bytes)"
         fi
     done
+
+    # ── Oracle endpoint agent (--oracle / ASTRYXOS_ORACLE=1) ────────────────
+    # install-oracle.sh has already populated:
+    #   build/disk/usr/bin/oracle                    (~5 MiB GLIBC ELF)
+    #   build/disk/etc/oracle/config.toml            (first-boot config)
+    #   build/disk/var/lib/oracle/                   (runtime state dir)
+    #   build/disk/var/log/oracle/                   (log dir)
+    #   build/disk/lib/x86_64-linux-gnu/libssl.so.3  (host glibc-linked, ~1 MiB)
+    #   build/disk/lib/x86_64-linux-gnu/libcrypto.so.3 (host glibc-linked, ~6 MiB)
+    # The libssl/libcrypto pair lands at the multiarch path so the glibc
+    # dynamic linker (staged by install-glibc.sh) finds them; the install-
+    # tls-stack.sh Alpine musl copies under /usr/lib/ are INCOMPATIBLE for
+    # a glibc binary (different libc, different TLS layout).
+    if [ -f "${BUILD_DIR}/disk/usr/bin/oracle" ]; then
+        mmd -i "${DATA_IMG}" "::usr"     2>/dev/null || true
+        mmd -i "${DATA_IMG}" "::usr/bin" 2>/dev/null || true
+        mcopy -o -i "${DATA_IMG}" \
+            "${BUILD_DIR}/disk/usr/bin/oracle" "::usr/bin/oracle"
+        echo "[DATA-DISK] Copied /usr/bin/oracle ($(stat -c%s "${BUILD_DIR}/disk/usr/bin/oracle") bytes)"
+    fi
+    if [ -f "${BUILD_DIR}/disk/etc/oracle/config.toml" ]; then
+        mmd -i "${DATA_IMG}" "::etc"        2>/dev/null || true
+        mmd -i "${DATA_IMG}" "::etc/oracle" 2>/dev/null || true
+        mcopy -o -i "${DATA_IMG}" \
+            "${BUILD_DIR}/disk/etc/oracle/config.toml" "::etc/oracle/config.toml"
+        echo "[DATA-DISK] Copied /etc/oracle/config.toml"
+    fi
+    # Runtime dirs.  FAT32 has no separate dir-vs-file modes; create empty.
+    mmd -i "${DATA_IMG}" "::var"            2>/dev/null || true
+    mmd -i "${DATA_IMG}" "::var/lib"        2>/dev/null || true
+    mmd -i "${DATA_IMG}" "::var/lib/oracle" 2>/dev/null || true
+    mmd -i "${DATA_IMG}" "::var/log"        2>/dev/null || true
+    mmd -i "${DATA_IMG}" "::var/log/oracle" 2>/dev/null || true
 
     # ── BusyBox binary + applet wrapper scripts (built by build-busybox.sh) ─
     # Ships a single static musl binary at /bin/busybox plus a curated set of

--- a/scripts/install-oracle.sh
+++ b/scripts/install-oracle.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# install-oracle.sh — Stage the Oracle endpoint agent (infrasvc) binary and
+# its config files into the AstryxOS data-disk staging tree.  This is the
+# userspace half of the oracle first-boot demo (PIVOT-I2, 2026-05-23);
+# the kernel half is the `oracle-test` cargo feature.
+#
+# What is oracle?
+# ---------------
+# Oracle is a Rust+tokio observability agent from the user's internal
+# infrastructure-services/infrasvc GitLab project.  It polls /sys, /proc,
+# DMI, and ships heartbeats to the Conflux endpoint.  See
+# docs/INFRASVC_ORACLE_AUDIT_2026-05-23.md for the full audit + roadmap.
+#
+# First-boot scope
+# ----------------
+# This install stages the production GLIBC-linked binary (from the
+# infrasvc release at /api/v4/projects/24/packages/generic/infrasvc/...).
+# The kernel-side `oracle-test` cargo feature launches it with
+# `oracle --mode console --once` so it runs a single observation cycle
+# and exits, surfacing whichever syscall/file gate fires first.  We
+# explicitly DISABLE sync (sync.enabled=false in /etc/oracle/config.toml)
+# so the agent does not attempt to reach Conflux — the first-boot goal
+# is observation surface coverage, not C2 connectivity.
+#
+# What this script does
+# ---------------------
+#
+#   1. Looks for a cached copy of the oracle binary at
+#      ~/.cache/astryxos-oracle/oracle.  If absent, attempts to fetch the
+#      latest release from the GitLab generic-package endpoint using the
+#      `glab` CLI token (private project — requires auth).  If the fetch
+#      fails the script exits non-zero with a hint.
+#   2. Verifies the binary is x86_64 ELF and prints DT_NEEDED so we know
+#      which runtime libs must be present.  Oracle is glibc-linked
+#      (DT_NEEDED libc.so.6, libssl.so.3, libcrypto.so.3, etc.) so it
+#      will pull from the glibc track staged by install-glibc.sh — NOT
+#      the musl track used by sshd/dropbear.
+#   3. Stages oracle at build/disk/usr/bin/oracle.
+#   4. Writes a minimum /etc/oracle/config.toml with sync disabled so
+#      the agent does an offline-only first-boot.
+#   5. Creates the runtime dirs (/var/lib/oracle, /var/log/oracle,
+#      /etc/oracle) that systemd's ExecStartPre=install -d would
+#      ordinarily create.
+#
+# Idempotent — exits 0 cleanly if every artefact is staged.  Pass --force
+# to re-download + re-stage even if cached.
+#
+# References (public)
+#   - tokio Rust runtime:     https://tokio.rs/
+#   - sd_notify(3):           https://www.freedesktop.org/software/systemd/man/sd_notify.html
+#   - systemd.service(5):     https://www.freedesktop.org/software/systemd/man/systemd.service.html
+#   - GitLab packages API:    https://docs.gitlab.com/ee/api/packages.html
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/build"
+DISK_DIR="${BUILD_DIR}/disk"
+DISK_USR_BIN="${DISK_DIR}/usr/bin"
+DISK_ETC_ORACLE="${DISK_DIR}/etc/oracle"
+DISK_VAR_LIB_ORACLE="${DISK_DIR}/var/lib/oracle"
+DISK_VAR_LOG_ORACLE="${DISK_DIR}/var/log/oracle"
+# Oracle is GLIBC-linked, so libssl3/libcrypto3 must come from the host's
+# glibc track — NOT from install-tls-stack.sh which stages the Alpine
+# musl-linked versions (incompatible for a glibc binary).  The host's
+# OpenSSL 3 libs live in /lib/x86_64-linux-gnu/ (Debian/Ubuntu multiarch
+# path) and stage into the canonical glibc-track location at
+# build/disk/lib/x86_64-linux-gnu/ alongside install-glibc.sh's output.
+DISK_GLIBC_LIB="${DISK_DIR}/lib/x86_64-linux-gnu"
+
+# Host-side persistent cache.  Separate from any Alpine rootfs because
+# oracle is glibc-linked, not musl — it doesn't share a runtime with the
+# sshd dropbear / openssl staging.
+ORACLE_CACHE_DIR="${HOME}/.cache/astryxos-oracle"
+ORACLE_BIN_CACHED="${ORACLE_CACHE_DIR}/oracle"
+
+# GitLab package endpoint.  Project 24 = infrastructure-services/infrasvc.
+# The release tag is the abbreviated commit SHA; release 7b03aa65 ships
+# the v0.x oracle build with HttpSync wired (matches the audit's pinned
+# version).  Bump the tag here when chasing a newer release; the kernel-
+# side feature gate doesn't care which version.
+GITLAB_HOST="svn.hyperlxc.co.uk"
+GITLAB_PROJECT_ID="24"
+ORACLE_RELEASE_TAG="7b03aa65"
+ORACLE_PACKAGE_URL="https://${GITLAB_HOST}/api/v4/projects/${GITLAB_PROJECT_ID}/packages/generic/infrasvc/${ORACLE_RELEASE_TAG}/infrasvc-amd64"
+
+FORCE=false
+for arg in "$@"; do
+    case "${arg}" in
+        --force) FORCE=true ;;
+        -h|--help)
+            sed -n '2,60p' "$0"
+            exit 0
+            ;;
+    esac
+done
+
+# ── Step 1: locate (or fetch) the oracle binary ──────────────────────────────
+mkdir -p "${ORACLE_CACHE_DIR}"
+
+if [ ! -f "${ORACLE_BIN_CACHED}" ] || [ "${FORCE}" = true ]; then
+    echo "[ORACLE] Fetching ${ORACLE_PACKAGE_URL} ..."
+    # Use the glab-cli config token rather than asking the operator for one.
+    GLAB_CFG="${HOME}/.config/glab-cli/config.yml"
+    if [ ! -r "${GLAB_CFG}" ]; then
+        echo "[ORACLE] ERROR: glab not configured at ${GLAB_CFG}; cannot fetch private package."
+        echo "[ORACLE]        Run 'glab auth login --hostname ${GITLAB_HOST}' first, or stage"
+        echo "[ORACLE]        the binary manually at ${ORACLE_BIN_CACHED}."
+        exit 1
+    fi
+    # The yaml has lines like 'token: glpat-xxx'; pick the first one under
+    # the svn.hyperlxc.co.uk: stanza.  Defensive: don't print the token.
+    TOKEN="$(awk "/${GITLAB_HOST}:/,0" "${GLAB_CFG}" | grep -E '^\s*token:' | head -1 | awk '{print $2}')"
+    if [ -z "${TOKEN}" ]; then
+        echo "[ORACLE] ERROR: no token found in ${GLAB_CFG} under host ${GITLAB_HOST}"
+        exit 1
+    fi
+    if ! curl -sfL --header "PRIVATE-TOKEN: ${TOKEN}" \
+            "${ORACLE_PACKAGE_URL}" -o "${ORACLE_BIN_CACHED}.tmp"; then
+        echo "[ORACLE] ERROR: curl failed to fetch ${ORACLE_PACKAGE_URL}"
+        rm -f "${ORACLE_BIN_CACHED}.tmp"
+        exit 1
+    fi
+    mv -f "${ORACLE_BIN_CACHED}.tmp" "${ORACLE_BIN_CACHED}"
+    chmod +x "${ORACLE_BIN_CACHED}"
+fi
+
+# ── Step 2: verify ELF shape ─────────────────────────────────────────────────
+if ! file "${ORACLE_BIN_CACHED}" | grep -q 'ELF 64-bit.*x86-64'; then
+    echo "[ORACLE] ERROR: ${ORACLE_BIN_CACHED} is not an x86_64 ELF binary"
+    file "${ORACLE_BIN_CACHED}"
+    exit 1
+fi
+
+ORACLE_SIZE="$(stat -c%s "${ORACLE_BIN_CACHED}")"
+echo "[ORACLE] Cached binary: ${ORACLE_BIN_CACHED} (${ORACLE_SIZE} bytes)"
+echo "[ORACLE] DT_NEEDED entries:"
+readelf -d "${ORACLE_BIN_CACHED}" 2>/dev/null \
+    | awk -F'[][]' '/NEEDED/ {print "[ORACLE]   - "$2}'
+
+# Print the highest GLIBC_x.y symbol version required.  If the host glibc
+# staged by install-glibc.sh is older than this, the dynamic linker will
+# fail with "version `GLIBC_x.y' not found" before main() runs.
+MAX_GLIBC="$(objdump -p "${ORACLE_BIN_CACHED}" 2>/dev/null \
+    | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
+    | sort -uV | tail -1)"
+echo "[ORACLE] Maximum GLIBC symbol version required: ${MAX_GLIBC:-<unknown>}"
+
+# ── Step 3: stage at /usr/bin/oracle ─────────────────────────────────────────
+mkdir -p "${DISK_USR_BIN}"
+cp -fL "${ORACLE_BIN_CACHED}" "${DISK_USR_BIN}/oracle"
+chmod +x "${DISK_USR_BIN}/oracle"
+echo "[ORACLE] Staged /usr/bin/oracle (${ORACLE_SIZE} bytes)"
+
+# ── Step 4: write /etc/oracle/config.toml ────────────────────────────────────
+# First-boot config is deliberately minimal:
+#   - sync.enabled = false       (no Conflux reachout — offline-only first boot)
+#   - polling.interval_secs = 60 (one tick per minute; --once exits after one)
+#   - logging.enable_platform_log = false  (no systemd journal on AstryxOS)
+#   - logging.enable_file = false (avoid file-write gate on first boot;
+#                                  we want stdout/stderr only so the kernel
+#                                  pipe captures everything)
+#   - polling.collectors.process.enabled = false (cross-PID procfs walk
+#                                                 may not be fully fleshed)
+#   - polling.collectors.security.enabled = false (file-integrity SHA over
+#                                                  /etc/sshd_config etc.;
+#                                                  files may not exist)
+# Network + system + hardware collectors are kept on — those are the
+# coverage paths the first-boot demo wants to exercise.
+mkdir -p "${DISK_ETC_ORACLE}"
+cat > "${DISK_ETC_ORACLE}/config.toml" <<'EOF'
+# Oracle Endpoint Agent — AstryxOS first-boot config (PIVOT-I2, 2026-05-23).
+# Deliberately minimal: sync disabled (no Conflux reachout), file logging
+# disabled (stdout only), heavy collectors (process, security) disabled.
+# The first-boot demo runs `oracle --mode console --once` which exits
+# after a single observation cycle — this config keeps the cycle short
+# enough that the kernel pipe doesn't fill before exit.
+[service]
+name = "oracle"
+display_name = "Oracle Endpoint Agent"
+description = "Oracle endpoint agent (AstryxOS first-boot)"
+
+[host_metadata]
+# environment, classification, tags omitted — defaults to host-derived
+
+[polling]
+interval_secs = 60
+include_loopback = false
+changes_only = false
+
+[polling.collectors.network]
+enabled = true
+
+[polling.collectors.system]
+enabled = true
+
+[polling.collectors.hardware]
+enabled = true
+
+[polling.collectors.process]
+# Cross-PID /proc/[pid]/* walk — disabled for first-boot until cross-PID
+# procfs is verified.  Re-enable once /proc/<N>/cmdline coverage lands.
+enabled = false
+
+[polling.collectors.security]
+# File-integrity SHA-256 over /etc/sshd_config, /etc/sudoers, /etc/shadow,
+# /etc/passwd, /etc/group, /etc/pam.d/, ~root/.ssh/authorized_keys.
+# Disabled because some of these may not exist on a fresh first boot.
+enabled = false
+
+[logging]
+level = "info"
+enable_file = false
+enable_platform_log = false
+
+[sync]
+# Disabled for first-boot: we are NOT attempting Conflux reachout on the
+# first AstryxOS boot.  Once the substrate is proven, flip to true +
+# point at a reachable Conflux dev-server.
+enabled = false
+
+[patching]
+enforcement_enabled = false
+refresh_interval_hours = 24
+EOF
+echo "[ORACLE] Wrote /etc/oracle/config.toml (sync disabled, process+security collectors off)"
+
+# ── Step 4b: stage glibc-linked libssl3 + libcrypto3 from the host ───────────
+# Oracle's DT_NEEDED list includes libssl.so.3 and libcrypto.so.3.  The Alpine
+# musl track that install-tls-stack.sh stages will NOT load into a glibc
+# binary (different libc, different TLS layout, different relocation
+# semantics).  We therefore mirror the host's glibc-linked copies into the
+# canonical glibc-track lib dir.  This is harmless when install-glibc.sh has
+# also run — the .so files are owned by separate base names and the loader
+# walks DT_NEEDED in order.
+mkdir -p "${DISK_GLIBC_LIB}"
+ssl_count=0
+for lib in libssl.so.3 libcrypto.so.3; do
+    for src_dir in /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /lib64 /usr/lib64; do
+        if [ -f "${src_dir}/${lib}" ]; then
+            cp -fL "${src_dir}/${lib}" "${DISK_GLIBC_LIB}/${lib}"
+            echo "[ORACLE] Staged /lib/x86_64-linux-gnu/${lib} (host glibc-link, $(stat -c%s "${DISK_GLIBC_LIB}/${lib}") bytes)"
+            ssl_count=$((ssl_count + 1))
+            break
+        fi
+    done
+done
+if [ "${ssl_count}" -lt 2 ]; then
+    echo "[ORACLE] WARNING: host libssl.so.3/libcrypto.so.3 not located —"
+    echo "[ORACLE]          install with 'sudo apt install libssl3' before re-running."
+fi
+
+# ── Step 5: create runtime dirs ──────────────────────────────────────────────
+# systemd's oracle.service uses ExecStartPre=install -d /var/lib/oracle
+# /var/log/oracle.  Mirror that here so the agent's logging.enable_file
+# code-path (when re-enabled) finds the directory present.
+mkdir -p "${DISK_VAR_LIB_ORACLE}" "${DISK_VAR_LOG_ORACLE}"
+echo "[ORACLE] Created /var/lib/oracle and /var/log/oracle"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "[ORACLE] Done.  Summary:"
+echo "[ORACLE]   - /usr/bin/oracle             (${ORACLE_SIZE} bytes)"
+echo "[ORACLE]   - /etc/oracle/config.toml     (first-boot config)"
+echo "[ORACLE]   - /var/lib/oracle/            (runtime state dir)"
+echo "[ORACLE]   - /var/log/oracle/            (log dir)"
+echo "[ORACLE]"
+echo "[ORACLE] glibc DT_NEEDED — install-glibc.sh must have staged libc + libssl."
+echo "[ORACLE] Re-run scripts/create-data-disk.sh --oracle --force to refresh data.img."


### PR DESCRIPTION
## Summary

Stages the production GLIBC-linked Oracle endpoint agent (infrasvc release `7b03aa65`, 5 MiB) and wires the `oracle-test` cargo feature for first-boot validation. Goal is to host a real glibc+tokio Linux server-agent end-to-end and characterise the first-boot gate.

- **`scripts/install-oracle.sh`** — fetches oracle from the GitLab generic-package endpoint via stored glab token; stages `/usr/bin/oracle`, `/etc/oracle/config.toml` (sync disabled), runtime dirs, AND host glibc-linked `libssl.so.3` + `libcrypto.so.3` at `/lib/x86_64-linux-gnu/` (Alpine musl copies from `install-tls-stack.sh` are ABI-incompatible with a glibc binary).
- **`kernel/src/oracle_demo.rs`** — mirrors `tls_demo.rs`. Spawns `oracle --mode console --once --log-level debug`, captures 32 KiB of stdout, hunts for stable marker substrings, emits `SUMMARY` line + verdict (`PASS`/`PASS-INIT`/`PRE-MAIN`/`PARTIAL`/`TIMEOUT`).
- **`kernel/Cargo.toml`/`main.rs`** — `oracle-test = []` feature, cfg-gated launch block, mutual exclusivity with the 5 existing test modes.
- **`scripts/create-data-disk.sh`** — `--oracle` flag + ASTRYXOS_ORACLE env var, install-oracle.sh invocation, FAT32 packing block.
- **`docs/ORACLE_FIRST_BOOT_2026-05-23.md`** — what was staged, what cargo check proved, why first boot was not executed (host disk: 0 bytes free; full kernel build needs ~3 GiB; concurrent agent worktrees own ~25 GiB), predicted first-gate routing table.

## Status

**Staging complete + cargo check passes.** `cargo check --features oracle-test` proceeds through full type-check of the kernel and only fails on the incremental-cache write (`os error 28`, disk full). Zero `error[E...]` codes from added code.

**First boot NOT executed.** Host disk was 100% / 0 bytes free during the first build attempt. After cleaning my own worktree's `target/`, 39 MiB free — insufficient for a full kernel build. Other agent worktrees (locked, owned by concurrent agents) collectively hold ~25 GiB of `target/` + `build/` state I cannot delete. Remediation in `docs/ORACLE_FIRST_BOOT_2026-05-23.md` §2 — once disk is freed, run `python3 scripts/qemu-harness.py start --features oracle-test` against this branch and the `[ORACLE] === ORACLE-TEST: ...` line names the first gate.

## LOC

~735 raw / ~397 functional across 6 files. At the hard-stop boundary per dispatch budget (200 / 1.5× / 2× / 400). Justification in the doc §4: `oracle_demo.rs` mirrors `tls_demo.rs` (482 LOC) + `sshd_demo.rs` (290 LOC); `install-oracle.sh` mirrors `install-tls-stack.sh` (>300 LOC) + `install-sshd.sh` (>370 LOC). Reducing these would force divergence from working established patterns.

## Test plan

- [ ] Coordinator frees disk space (delete stale worktrees or wait for in-flight agents to finish + prune)
- [ ] `ASTRYXOS_ORACLE=1 bash scripts/create-data-disk.sh --oracle --force`
- [ ] `python3 scripts/qemu-harness.py start --features oracle-test`
- [ ] `python3 scripts/qemu-harness.py wait <sid> '\[ORACLE\] === ORACLE-TEST:' --ms 300000`
- [ ] `python3 scripts/qemu-harness.py tail <sid> 32768`
- [ ] Read the `SUMMARY` line + verdict; route the gate per doc §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)