### PR TITLE
scripts: qemu-harness preserves --oracle/--sshd/--tls across variant-pin restage

### DIFF
--- a/docs/HARNESS_FLAG_PRESERVATION_2026-05-23.md
+++ b/docs/HARNESS_FLAG_PRESERVATION_2026-05-23.md
@@ -1,0 +1,179 @@
+# Harness variant-pin restage drops user demo-binary flags (2026-05-23)
+
+## The wart
+
+The Firefox variant-pin guard added in PR #378 auto-invokes
+`scripts/create-data-disk.sh --force` when the data disk's staged Firefox
+layout (musl vs glibc) does not match the variant requested by the
+harness `--firefox-variant` option.  The auto-invocation only forwards
+the `ASTRYXOS_FIREFOX_VARIANT` environment variable; it does not
+forward any other staging opt-in.
+
+PR #439 (oracle staging) introduced the first such opt-in that bites:
+`--oracle` / `ASTRYXOS_ORACLE=1`.  When the agent ran:
+
+```
+ASTRYXOS_ORACLE=1 bash scripts/create-data-disk.sh --oracle --force   # baseline
+python3 scripts/qemu-harness.py start --features oracle-test \
+    --firefox-variant glibc
+```
+
+…the harness detected a variant mismatch (existing data.img was musl),
+spawned `ASTRYXOS_FIREFOX_VARIANT=glibc bash scripts/create-data-disk.sh
+--force`, and the data-disk builder re-created the image **without** the
+`--oracle` opt-in.  Oracle and its glibc-linked TLS libs vanished, and
+the kernel's `oracle-test` first-boot path reported
+
+```
+[ORACLE] FATAL: cannot read /disk/usr/bin/oracle: NotFound
+```
+
+on the next boot — a staging failure mis-attributed to a kernel bug.
+
+The same gap exists for `--sshd` / `ASTRYXOS_SSHD=1` (PR #434) and
+`--tls` / `ASTRYXOS_TLS=1` (PR #438).  Without this fix, any future
+opt-in repeats the wart.
+
+## The fix
+
+### `scripts/qemu-harness.py`
+
+1. `_regen_data_img` accepts two new optional parameters,
+   `extra_flags: list[str]` and `extra_env: dict[str, str]`, appended
+   to the create-data-disk.sh argv (after `--force`) and layered onto
+   the child env respectively.  The function also returns `argv` and
+   `env_overrides` in its result dict for debuggability.
+
+2. A new helper, `_resolve_demo_binary_flags(features, env)`, derives
+   the (--flag, ENV=1) set from two additive sources:
+
+   | Source | Precedence | Example |
+   |---|---|---|
+   | `ASTRYXOS_ORACLE` / `_SSHD` / `_TLS` env vars | 1 (winning) | `ASTRYXOS_ORACLE=1` → `--oracle` |
+   | Cargo features `oracle-test` / `sshd-test` / `tls-test` | 2 (fallback) | `--features oracle-test` → `--oracle` |
+
+   Truthy env values are `1`, `true`, `yes`, `on` (case-insensitive).
+   Per-flag source (`"env"` / `"feature"` / `None`) is recorded so the
+   resolution is auditable from `events <sid>` JSON.
+
+3. `cmd_start` computes the resolved flag set once via
+   `_resolve_demo_binary_flags(feats)` and passes the result into both
+   `_regen_data_img` call sites (staleness-driven regen + variant-
+   mismatch regen) so neither path can silently drop staging intent.
+
+4. The pre-restage banner now shows `preserved demo flags: <list>` so
+   the propagation is visible in stderr; the result is also recorded
+   in `firefox_variant_info.restage_extra_flags`,
+   `.restage_extra_env`, and `.restage_flag_sources`, and folded into
+   the `firefox_variant_requested` event.
+
+All harness output changes are **additive** — new keys appear on
+existing JSON objects; no field renames; no semantic shifts in
+existing keys.  Downstream agents tolerating extra keys (the harness
+contract) continue to work unchanged.
+
+### `scripts/create-data-disk.sh`
+
+Independently caught while reproducing the oracle staging failure:
+the `openssl.cnf` mtools copy at the TLS-stack staging step did not
+ensure its parent FAT32 directory existed before `mcopy`.  When a
+preceding step (the CA-bundle copy) did not run — for instance when
+the bundle was not staged or when the staged bundles took different
+paths — `mcopy ... ::etc/ssl/openssl.cnf` failed with
+`no match for target`.
+
+Fixed by adding idempotent `mmd -i "${DATA_IMG}" "::etc"` and
+`mmd -i "${DATA_IMG}" "::etc/ssl"` calls (each with the standard
+`2>/dev/null || true` guard for the "already exists" case) before the
+`mcopy` line.  An audit of every other `mcopy` call writing to a
+multi-level FAT32 path showed all other sites already had matching
+`mmd` guards.
+
+Reference: mtools(1) `mcopy` does NOT auto-create parent directories
+(unlike GNU `cp --parents`), and `mmd -p` is not portable across
+mtools versions; explicit chained `mmd` calls are the documented
+pattern (see `mtools(1)` and `mtools.conf(5)`).
+
+## Verification
+
+End-to-end run against the worktree's harness with oracle pre-staged:
+
+```
+ASTRYXOS_ORACLE=1 bash scripts/create-data-disk.sh --oracle --force
+ASTRYXOS_ORACLE=1 python3 scripts/qemu-harness.py start \
+    --features oracle-test --firefox-variant glibc
+```
+
+Harness output (stderr) excerpt:
+
+```
+║  Firefox variant mismatch — re-staging data.img              ║
+║  staged: musl       requested: glibc                       ║
+║  Running scripts/create-data-disk.sh --force with            ║
+║  ASTRYXOS_FIREFOX_VARIANT=glibc                              ║
+║  preserved demo flags:    --oracle                           ║
+╚══════════════════════════════════════════════════════════════╝
+║  variant re-stage OK in 51.0s (now musl-esr).
+[VARIANT-PIN] requested=glibc staged=musl action=restaged-ok
+```
+
+Post-restage data.img audit (`mdir -i build/data.img ::/usr/bin |
+grep oracle`):
+
+```
+oracle         5042136 2026-05-23  22:08
+```
+
+Oracle SURVIVED the auto-restage.
+
+Kernel first-boot oracle-test serial excerpt:
+
+```
+[ORACLE] oracle-test starting (PIVOT-I2, 2026-05-23)
+[ORACLE] Loaded /disk/usr/bin/oracle (5042136 bytes)
+[ORACLE] Spawning oracle with argv=["oracle", "--mode", "console",
+         "--once", "--log-level", "debug", "--config",
+         "/etc/oracle/config.toml"]
+[ORACLE] oracle spawned: pid=1
+[ORACLE] oracle | oracle: error while loading shared libraries:
+         libzstd.so.1: cannot open shared object file:
+         No such file or directory
+[ORACLE] === SUMMARY === banner=0 collector_init=0 observation=0 ...
+         exit=127 state=Zombie captured_bytes=118 timed_out=0
+[ORACLE] === ORACLE-TEST: PARTIAL (some stdout but no banner;
+         exit=127; first bytes may name the loader gate) ===
+[ORACLE] DONE
+```
+
+## New oracle first-gate
+
+The previous failure (`FATAL: cannot read /disk/usr/bin/oracle:
+NotFound`) is no longer observed — the harness-side flag-preservation
+fix removes it.  The new first-gate, surfaced now that oracle can
+actually load, is:
+
+> **`libzstd.so.1: cannot open shared object file`** — exit 127 from
+> the glibc ELF loader.
+
+This is a staging gap in `scripts/install-oracle.sh` /
+`scripts/install-glibc.sh`: the oracle binary's `DT_NEEDED`
+transitively pulls in `libzstd.so.1` (via `libssl3` or `libcrypto3`
+on some host-glibc distributions), but neither installer copies the
+host's `/lib/x86_64-linux-gnu/libzstd.so.1` into
+`build/disk/lib/x86_64-linux-gnu/`.
+
+Fixing it is the next dispatch — out of scope for this harness fix.
+
+## Suggested next work
+
+- Stage `libzstd.so.1` (and any other oracle DT_NEEDED transitives
+  the host's glibc-linked oracle expects) into the data disk via
+  `scripts/install-oracle.sh` or a new helper.  Re-run the soak —
+  the kernel-side `oracle-test` path should then either reach
+  `[ORACLE] === ORACLE-TEST: PASS ===` or surface the next legitimate
+  runtime gate (sysfs probe failure, /proc not yet mounted, etc.).
+
+## References
+
+- Public spec: mtools(1) — mcopy parent-directory semantics
+- Public spec: ELF gABI (System V ABI §5.4) — DT_NEEDED resolution

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -1092,6 +1092,15 @@ EOF
         echo "[DATA-DISK] Copied /etc/pki/tls/certs/ca-bundle.crt (RHEL)"
     fi
     if [ -f "${BUILD_DIR}/disk/etc/ssl/openssl.cnf" ]; then
+        # mtools(1) mcopy does NOT create parent directories implicitly; when
+        # neither cert.pem nor ca-certificates.crt was staged (--tls without
+        # the bundle present, or a freshly created data.img reached this
+        # block before the cert-bundle block), ::etc/ssl does not yet exist
+        # and `mcopy ::etc/ssl/openssl.cnf` fails with "no match for target".
+        # `mmd -p`-style chained parents are not portable across mtools
+        # versions, so create both levels idempotently.
+        mmd -i "${DATA_IMG}" "::etc"     2>/dev/null || true
+        mmd -i "${DATA_IMG}" "::etc/ssl" 2>/dev/null || true
         mcopy -o -i "${DATA_IMG}" \
             "${BUILD_DIR}/disk/etc/ssl/openssl.cnf" "::etc/ssl/openssl.cnf"
         echo "[DATA-DISK] Copied /etc/ssl/openssl.cnf"

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -1321,7 +1321,9 @@ def _data_img_staleness(data_img: Path, disk_dir: Path,
 
 
 def _regen_data_img(root_dir: Path,
-                    firefox_variant: "str | None" = None) -> dict:
+                    firefox_variant: "str | None" = None,
+                    extra_flags: "list[str] | None" = None,
+                    extra_env: "dict[str, str] | None" = None) -> dict:
     """
     Invoke `scripts/create-data-disk.sh --force` and capture its outcome.
 
@@ -1330,6 +1332,8 @@ def _regen_data_img(root_dir: Path,
       rc: int
       duration_s: float
       tail: str       — last ~1500 chars of stderr (so a failure surfaces)
+      argv: list[str] — full argv handed to the child (for debuggability)
+      env_overrides: dict[str, str] — env vars layered on top of os.environ
 
     `firefox_variant`, when set, is exported to the child shell as
     ASTRYXOS_FIREFOX_VARIANT so the data-disk builder stages the requested
@@ -1337,22 +1341,40 @@ def _regen_data_img(root_dir: Path,
     None, the script's default applies (currently glibc; controlled by the
     script, not the harness).
 
+    `extra_flags` are appended verbatim to the create-data-disk.sh argv
+    after `--force`.  Used to forward demo-binary opt-ins
+    (e.g. `--oracle`, `--sshd`, `--tls`) so an auto-restage triggered by
+    the variant-pin guard does not silently drop staging the user
+    previously opted into.
+
+    `extra_env` is layered on top of os.environ (and after the
+    ASTRYXOS_FIREFOX_VARIANT injection).  Mirrors the env-var equivalents
+    of the demo-binary flags (ASTRYXOS_ORACLE, ASTRYXOS_SSHD, ASTRYXOS_TLS)
+    for callers that prefer env to argv.
+
     The script logs to stdout (mixed with stderr by some sub-scripts); we
     fold both streams together and keep the tail for diagnostics.
     """
     script = root_dir / "scripts" / "create-data-disk.sh"
+    flags = list(extra_flags or [])
+    env_overrides = dict(extra_env or {})
+    argv = ["bash", str(script), "--force", *flags]
     out = {"ok": False, "rc": -1, "duration_s": 0.0, "tail": "",
-           "firefox_variant": firefox_variant}
+           "firefox_variant": firefox_variant,
+           "argv": argv,
+           "env_overrides": env_overrides}
     if not script.exists():
         out["tail"] = f"create-data-disk.sh not found at {script}"
         return out
     env = os.environ.copy()
     if firefox_variant:
         env["ASTRYXOS_FIREFOX_VARIANT"] = firefox_variant
+    for k, v in env_overrides.items():
+        env[k] = v
     t0 = time.monotonic()
     try:
         proc = subprocess.run(
-            ["bash", str(script), "--force"],
+            argv,
             cwd=str(root_dir),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -1371,6 +1393,83 @@ def _regen_data_img(root_dir: Path,
         out["tail"] = f"{type(e).__name__}: {e}"
     out["duration_s"] = time.monotonic() - t0
     return out
+
+
+# ── Demo-binary flag preservation (auto-restage path) ─────────────────────────
+#
+# When the variant-pin guard re-invokes scripts/create-data-disk.sh to swap
+# between the musl and glibc Firefox layouts, the auto-restage runs with a
+# bare `--force` — none of the user's prior demo-binary opt-ins (--oracle,
+# --sshd, --tls / ASTRYXOS_ORACLE=1, ASTRYXOS_SSHD=1, ASTRYXOS_TLS=1) carry
+# across.  Result: the previously-staged demo binaries vanish from data.img
+# and the kernel fails at first-boot probe with `[ORACLE] FATAL: cannot
+# read /disk/usr/bin/oracle: NotFound` (or the SSHD / TLS equivalents).
+#
+# `_resolve_demo_binary_flags` reconstructs the user's intent from two
+# additive sources and folds them into one (flags, env) pair that the
+# restage call can replay verbatim:
+#
+#   1. Explicit env vars in os.environ (ASTRYXOS_ORACLE / _SSHD / _TLS) —
+#      the canonical way users opt in to demo binaries from the shell.
+#      Truthy when the value is one of "1" / "true" / "yes" / "on" (case
+#      insensitive).  These take precedence: if the env says ORACLE=1 we
+#      stage oracle even when the cargo feature list does not include
+#      oracle-test (e.g. an investigation where oracle is staged on disk
+#      but the kernel is built without the runtime-launch hook).
+#
+#   2. Cargo feature names in the harness's `--features` comma list:
+#      `oracle-test` → ORACLE=1, `sshd-test` → SSHD=1, `tls-test` → TLS=1.
+#      This catches the common case where the user passed
+#      `--features oracle-test` and expects the staging to follow without
+#      having to also export ASTRYXOS_ORACLE=1.
+#
+# Both flag and env forms are emitted: create-data-disk.sh accepts either,
+# but emitting both is harmless (the script ORs them) and means a future
+# refactor in either layer keeps working.  Additive output — agents
+# parsing `firefox_variant_info.restage_extra_flags` see the resolved
+# argv tail and can audit it.
+_DEMO_BIN_SPEC = [
+    # (cargo-feature, create-data-disk-flag, env-var-name)
+    ("oracle-test", "--oracle", "ASTRYXOS_ORACLE"),
+    ("sshd-test",   "--sshd",   "ASTRYXOS_SSHD"),
+    ("tls-test",    "--tls",    "ASTRYXOS_TLS"),
+]
+
+
+def _resolve_demo_binary_flags(features: "list[str]",
+                                env: "dict[str, str] | None" = None
+                                ) -> dict:
+    """
+    Compute the (--flag, ENV=1) set to forward into an auto-restage call.
+
+    `features` — comma-split harness `--features` list (already trimmed).
+    `env`      — env mapping to inspect (defaults to os.environ).
+
+    Returns a dict:
+      flags:        list[str]  — argv-tail e.g. ["--oracle", "--tls"]
+      env:          dict[str,str]  — env additions e.g. {"ASTRYXOS_ORACLE":"1"}
+      sources:      dict[str,str]  — per-flag, "env" | "feature" | None,
+                                     for debuggability
+    """
+    if env is None:
+        env = os.environ
+    truthy = {"1", "true", "yes", "on"}
+    flags: list = []
+    env_out: dict = {}
+    sources: dict = {}
+    for feat_name, flag, env_var in _DEMO_BIN_SPEC:
+        env_val = (env.get(env_var) or "").strip().lower()
+        if env_val in truthy:
+            flags.append(flag)
+            env_out[env_var] = "1"
+            sources[flag] = "env"
+        elif feat_name in features:
+            flags.append(flag)
+            env_out[env_var] = "1"
+            sources[flag] = "feature"
+        else:
+            sources[flag] = None
+    return {"flags": flags, "env": env_out, "sources": sources}
 
 
 # ── Firefox variant pin (D10 staging-gap guard) ───────────────────────────────
@@ -2593,6 +2692,14 @@ def cmd_start(args):
     # staged in build/disk/ we trigger an `ASTRYXOS_FIREFOX_VARIANT=<v>
     # scripts/create-data-disk.sh --force` to re-stage the disk before boot.
     _requested_variant = getattr(args, "firefox_variant", None) or "musl"
+    # Resolve the demo-binary flag set ONCE so both regen sites (staleness
+    # and variant mismatch) forward the same staging intent.  Without this,
+    # an auto-restage runs `create-data-disk.sh --force` bare and silently
+    # drops the user's prior `--oracle` / `--sshd` / `--tls` opt-ins,
+    # producing `[ORACLE] FATAL: cannot read /disk/usr/bin/oracle: NotFound`
+    # (or the SSHD/TLS analogue) on the next boot.  See
+    # `_resolve_demo_binary_flags` for the env-vs-feature precedence rule.
+    _demo_bin = _resolve_demo_binary_flags(feats)
     _ff_variant_info: dict = {
         "requested": _requested_variant,
         "staged_predicted": None,   # filled in after probe
@@ -2609,6 +2716,14 @@ def cmd_start(args):
         "data_img_symlink": None,   # populated below when relevant
         "kernel_chosen": None,      # filled in by post-boot probe verifier
         "match": None,              # final verdict, when known
+        # Demo-binary flag preservation (2026-05-23): the resolved
+        # (--oracle / --sshd / --tls) tail that the auto-restage path will
+        # forward into create-data-disk.sh, plus the per-flag source
+        # ("env" | "feature" | None) for debuggability.  Additive — never
+        # rename without updating downstream agents.
+        "restage_extra_flags": list(_demo_bin["flags"]),
+        "restage_extra_env":   dict(_demo_bin["env"]),
+        "restage_flag_sources": dict(_demo_bin["sources"]),
     }
     # D10 fix-it: in worktrees the local build/disk/ is typically absent;
     # if build/data.img is a symlink into the canonical tree, inspect that
@@ -2667,7 +2782,9 @@ def cmd_start(args):
                 file=sys.stderr,
             )
             _data_img_regen_info = _regen_data_img(
-                Path(wt.ROOT), firefox_variant=_requested_variant)
+                Path(wt.ROOT), firefox_variant=_requested_variant,
+                extra_flags=_demo_bin["flags"],
+                extra_env=_demo_bin["env"])
             _data_img_regenerated = bool(_data_img_regen_info.get("ok"))
             if _data_img_regenerated:
                 # Re-scan; the regen should have updated data.img mtime so the
@@ -2771,17 +2888,28 @@ def cmd_start(args):
                 file=sys.stderr,
             )
         else:
+            # 2026-05-23: surface the demo-binary flag preservation in the
+            # re-stage banner so it is obvious in stderr that the auto-
+            # restage is honouring the user's prior `--oracle` / `--sshd` /
+            # `--tls` opt-ins (the missing-flag bug that produced
+            # "[ORACLE] FATAL: cannot read /disk/usr/bin/oracle: NotFound"
+            # on first-boot verification of the oracle-test track).
+            _df_disp = (" ".join(_demo_bin["flags"])
+                        if _demo_bin["flags"] else "<none>")
             print(
                 "╔══════════════════════════════════════════════════════════════╗\n"
                 "║  Firefox variant mismatch — re-staging data.img              ║\n"
                 f"║  staged: {_staged_family:<10} requested: {_requested_variant:<28}║\n"
                 "║  Running scripts/create-data-disk.sh --force with            ║\n"
                 f"║  ASTRYXOS_FIREFOX_VARIANT={_requested_variant:<35} ║\n"
+                f"║  preserved demo flags:    {_df_disp:<35} ║\n"
                 "╚══════════════════════════════════════════════════════════════╝",
                 file=sys.stderr,
             )
             _variant_regen = _regen_data_img(
-                Path(wt.ROOT), firefox_variant=_requested_variant)
+                Path(wt.ROOT), firefox_variant=_requested_variant,
+                extra_flags=_demo_bin["flags"],
+                extra_env=_demo_bin["env"])
             _ff_variant_info["regen_triggered"] = True
             _ff_variant_info["regen_ok"] = bool(_variant_regen.get("ok"))
             # Fold into the existing regen-info slot so a single field carries
@@ -2993,6 +3121,13 @@ def cmd_start(args):
         # D10 fix-it (additive): None on the success path, populated when
         # variant-pin refused to clobber a shared data.img symlink target.
         "regen_refused_reason": _ff_variant_info.get("regen_refused_reason"),
+        # 2026-05-23 demo-binary flag preservation: the (--oracle / --sshd /
+        # --tls) tail the auto-restage forwarded into create-data-disk.sh
+        # plus the per-flag source so a single `events <sid>` answers
+        # "why did oracle disappear after my variant swap?".
+        "restage_extra_flags":  _ff_variant_info.get("restage_extra_flags"),
+        "restage_extra_env":    _ff_variant_info.get("restage_extra_env"),
+        "restage_flag_sources": _ff_variant_info.get("restage_flag_sources"),
     })
     # Spawn a detached verifier that tails the serial log for the kernel's
     # "[FFTEST] FF binary probe:" line, parses the chosen variant, updates


### PR DESCRIPTION
## Summary

- `scripts/qemu-harness.py` variant-pin auto-restage now forwards
  every demo-binary opt-in (`--oracle`, `--sshd`, `--tls`) along with
  the matching `ASTRYXOS_*` env var. Previously the auto-invoked
  `create-data-disk.sh --force` ran bare and silently dropped staging
  intent — surfacing as `[ORACLE] FATAL: cannot read /disk/usr/bin/oracle:
  NotFound` on the first oracle-test soak after a variant swap.
- New helper `_resolve_demo_binary_flags(features, env)` derives the
  flag set from env vars (winning) + cargo `--features` (fallback).
- `_regen_data_img` gained optional `extra_flags` / `extra_env`
  kwargs (signature additive — existing callers unchanged).
- `firefox_variant_info` gains three additive JSON fields
  (`restage_extra_flags` / `restage_extra_env` / `restage_flag_sources`)
  so a single `status <sid>` / `events <sid>` answers "why did the
  staging disappear?".
- Secondary fix: `scripts/create-data-disk.sh` openssl.cnf step now
  `mmd`'s `::etc/ssl` before `mcopy` (mtools(1) does not auto-create
  parents; failure mode was `no match for target` on freshly created
  data.img).

## Verification

End-to-end with oracle pre-staged + intentional variant mismatch to
trigger the auto-restage path:

```
ASTRYXOS_ORACLE=1 bash scripts/create-data-disk.sh --oracle --force
ASTRYXOS_ORACLE=1 python3 scripts/qemu-harness.py start \
    --features oracle-test --firefox-variant glibc
```

Harness banner now shows `preserved demo flags: --oracle`. Post-restage
data.img audit confirms `oracle 5042136` bytes survived. Kernel boots:

```
[ORACLE] oracle-test starting (PIVOT-I2, 2026-05-23)
[ORACLE] Loaded /disk/usr/bin/oracle (5042136 bytes)
[ORACLE] oracle spawned: pid=1
[ORACLE] oracle | oracle: error while loading shared libraries:
         libzstd.so.1: cannot open shared object file: ...
```

The previous misleading `NotFound` first-gate is gone; the new
legitimate gate is `libzstd.so.1` (a DT_NEEDED transitive not yet
staged by install-oracle.sh / install-glibc.sh). Out of scope for
this PR — next dispatch.

## Test plan

- [x] `python3 scripts/qemu-harness-smoke.py` — still passes, the
  new `restage_extra_*` fields appear in `firefox_variant_info`.
- [x] Unit-level resolver tests across env-only, feature-only, both,
  truthy variants (1/true/yes/on), explicit-false, empty.
- [x] `_regen_data_img` monkeypatched to capture argv+env — both
  `--oracle/--tls` flags and `ASTRYXOS_*` env appear.
- [x] Backward-compat: `_regen_data_img(..., firefox_variant="musl")`
  with no extras still produces bare `--force` argv (no breaking
  change for any other caller).
- [x] End-to-end firefox-test soak with intentional variant mismatch:
  oracle survives auto-restage, kernel launches oracle, new
  legitimate first-gate captured.
- [x] Harness output changes are additive — every existing JSON key
  retains its prior semantics; only new keys appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)