### PR TITLE
gui/compositor: fix firefox-test build — rename tick_and_compose → compose

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -531,8 +531,8 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 crate::gui::terminal::poll_output();
                 // Drive the compositor at ~50 Hz via the ISR-set tick flag.
                 // timer ISR sets COMPOSITOR_TICK_DUE every 2 ticks;
-                // tick_and_compose() atomically drains it and renders a frame.
-                gui::compositor::tick_and_compose();
+                // compose() drains the tick flag and renders a frame.
+                gui::compositor::compose();
 
                 let now = arch::x86_64::irq::get_ticks();
                 let elapsed = now.wrapping_sub(t_launch);
@@ -1318,10 +1318,9 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 crate::gui::terminal::poll_output();
                 // Drive the compositor via the ISR-set tick flag (≈50 Hz).
                 // The timer ISR sets COMPOSITOR_TICK_DUE every 2 published
-                // ticks; tick_and_compose() atomically drains it and renders
-                // a frame.  Replaces the unreliable `ticks % 3` check (see
-                // gui/compositor.rs for rationale).
-                gui::compositor::tick_and_compose();
+                // ticks; compose() drains it and renders a frame.  Replaces
+                // the unreliable `ticks % 3` check (see gui/compositor.rs).
+                gui::compositor::compose();
 
                 let now = arch::x86_64::irq::get_ticks();
                 let elapsed = now.wrapping_sub(t_launch);


### PR DESCRIPTION
## Summary

Two call sites in `kernel/src/main.rs` (both inside `#[cfg(feature = "firefox-test")]` GUI loop bodies) still referenced `gui::compositor::tick_and_compose`, which was removed when the compositor was consolidated to a single `compose()` entry point.  This produced E0425 ("cannot find function \`tick_and_compose\` in module \`gui::compositor\`") and blocked the `firefox-test` feature build entirely.

The fix updates both call sites to `gui::compositor::compose()`.  There is no behavioural change: `compose()` subsumes the tick-drain logic directly and has the same no-argument void signature.

**FF soak baseline** (KVM, ext2-mounted data.img, post-fix):
- sc plateau: **~822** (pid=1 `/disk/usr/lib/firefox-esr/firefox-bin`)
- Gate signatures observed:
  1. `FUTEX-WAKE-EMPTY` on uaddr `0x7eff85ee8e58` — bucket_present=0, same-PID wakers=0 (pre-existing ghost-wake pattern, not a regression)
  2. Demand-paging still active at plateau (pf climbing, disk reads ~13 MB) — libxul page-faults continuing after sc frozen
  3. sc sub-breakdown: vm=368, file=427, sync=4, proc=7 — no faults or crashes observed, clean exit path not reached
- No W215/aliasing markers, no SIGSEGV, no MOZ_CRASH in full soak log.

## Test plan

- [x] `cargo +nightly build --features firefox-test` — no E0425, no E-code errors
- [x] KVM firefox-test soak — boots, reaches sc=822 plateau, no new crash signatures
- [ ] Verify baseline holds across 3 trials (coordinator scope — this PR is fix-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)