### PR TITLE
kernel/subsys/linux: MADV_DONTNEED — lower to_free BATCH 1024 → 128 (twin of PR #397)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -5322,11 +5322,18 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     //   Pass 2 — synchronous shootdown (IPI + ack) across all CPUs.
     //   Pass 3 — return frames to the PMM (safe after pass 2 completes).
     //
-    // The batch buffer uses the same BATCH constant as unmap_and_free_range_in.
-    // For MADV_DONTNEED the typical range is a handful of pages (stack trim,
-    // arena shrink), so a single pass of 1024 is more than sufficient.
+    // The batch buffer mirrors the BATCH constant in unmap_and_free_range_in
+    // (mm/vmm.rs, PR #397).  At BATCH = 128, `to_free = [0u64; BATCH]`
+    // consumes 1024 bytes of kernel stack.  The previous value of 1024 (8192
+    // bytes) could overflow the 4 KiB emergency-fallback kstack when layered
+    // on top of the madvise(2) entry path plus PTE walk, refcount decrement,
+    // TLB shootdown, and PMM free.  The outer while-loop already handles
+    // continuation across multiple batches, so this is a tuning change only:
+    // no caller observes the batch boundary.
+    //
+    // Cite: madvise(2) (POSIX.1-2017); Intel SDM Vol. 3A §4.10.4-5.
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
-    const BATCH: usize = 1024;
+    const BATCH: usize = 128;
 
     let mut page = start;
     let mut any_unmap = false;


### PR DESCRIPTION
## Summary

- `sys_madvise` declares `to_free = [0u64; BATCH]` on the kernel stack; at `BATCH = 1024` this is 8192 bytes.
- The madvise(2) entry path can land on the 4 KiB emergency-fallback kstack under glibc/musl arena-shrink sequences, where 8192 bytes for the array overflows the budget and trips `STACK_CANARY_CORRUPT`.
- PR #397 fixed the structurally identical pattern in `unmap_and_free_range_in` (`mm/vmm.rs`) by lowering `BATCH` to 128 (1024-byte array). This commit applies the same change to the twin site in `sys_madvise`.
- The outer `while page < end` loop already handles continuation across multiple batches; no caller observes the batch boundary, making this a pure tuning change.
- Trade-off: large madvise(2) ranges issue up to 8× more TLB-shootdown IPI rounds per 1024 pages. Typical MADV_DONTNEED workloads (stack trim, arena shrink) advise a handful of pages per call, so the practical cost is unchanged.

## Verification

- `firefox-test` build: clean (0 errors, pre-existing warnings only).
- QEMU boot with `firefox-test` feature: Firefox reached GTK library loading phase (sc=145+, no BUGCHECK, no `STACK_CANARY_CORRUPT`).
- Test 94 (`test_madvise_dontneed`) exercises the handler; the batch-size change does not affect correctness.

## References

- Twin fix: PR #397 (`kernel/mm/vmm: shrink to_free BATCH from 1024 to 128`)
- Cite: madvise(2) (POSIX.1-2017); Intel SDM Vol. 3A §4.10.4-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)