### PR TITLE
kernel/gui+elf: variant-aware LD_LIBRARY_PATH for the Firefox exec env

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -838,6 +838,38 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         crate::sched::enable();
     }
 
+    // Variant-aware library search scope.  The disk image is intentionally
+    // mixed-ABI: a glibc tree under /lib/x86_64-linux-gnu + /lib64, and a
+    // musl (Alpine) tree under /usr/lib — and each tree ships its OWN
+    // libstdc++.so.6 / libgcc_s.so.1.  A dynamic linker resolves a soname by
+    // scanning LD_LIBRARY_PATH left-to-right (ELF gABI §5.4; ld.so(8) /
+    // ld-musl(8)), binding the FIRST match.  So the path order must keep each
+    // libc's C++ runtime within that libc's tree:
+    //   * musl  binaries (PT_INTERP /lib/ld-musl-*) must reach /usr/lib BEFORE
+    //     the glibc multiarch dir — otherwise ld-musl binds the glibc-built
+    //     libstdc++ whose glibc-versioned imports (__cxa_thread_atexit_impl,
+    //     __libc_single_threaded, _dl_find_object, the fortify *_chk family,
+    //     ...) musl libc does not export → "Error relocating … symbol not
+    //     found" → exit(127).  We omit the glibc multiarch dir entirely so
+    //     nothing in the musl process resolves against the glibc tree.
+    //   * glibc binaries (PT_INTERP /lib64/ld-linux-*) keep the original
+    //     glibc-first order so their libs in /lib/x86_64-linux-gnu + /lib64
+    //     still resolve.
+    // The PT_INTERP of the binary we are about to exec is the authoritative,
+    // build-staging-independent signal for which libc it was linked against,
+    // and `data` already holds the full ELF image here.
+    const LD_PATH_MUSL: &str =
+        "LD_LIBRARY_PATH=/usr/lib:/usr/lib/firefox-esr:/opt/firefox:/disk/lib/firefox";
+    const LD_PATH_GLIBC: &str =
+        "LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib:/usr/lib/firefox-esr:/opt/firefox:/disk/lib/firefox";
+    let ld_library_path: &str = match crate::proc::elf::libc_flavor(&data) {
+        crate::proc::elf::LibcFlavor::Musl => LD_PATH_MUSL,
+        // Glibc and Unknown (static / unrecognised) both keep the historical
+        // glibc-first order — it is the long-standing default and a static
+        // binary does not consult LD_LIBRARY_PATH anyway.
+        _ => LD_PATH_GLIBC,
+    };
+
     let envp: &[&str] = &[
         "HOME=/home/user",
         "PATH=/bin:/disk/bin",
@@ -876,19 +908,17 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         "MOZ_X11_EGL=0",
         "MOZ_ACCELERATED=0",
         "LIBGL_ALWAYS_SOFTWARE=1",
-        // The path list covers both Firefox variants:
-        //   glibc: /lib/x86_64-linux-gnu (multiarch glibc tree), /opt/firefox
-        //          for libxul.so + Mozilla's own .so files (in-tree convention)
-        //   musl : /usr/lib (Alpine's flat support-lib tree) + /usr/lib/firefox-esr
-        //          (Alpine canonical Mozilla tree — DT_RUNPATH target baked
-        //          into every Mozilla DSO per readelf -d; see ELF gABI §5.4
-        //          "Shared Object Dependencies" and ld-musl(8) search order)
-        // /disk/lib/firefox is a legacy build-firefox.sh path retained for
-        // any caller using the in-tree built variant.
-        // LD_LIBRARY_PATH precedes DT_RUNPATH in the search order, so listing
-        // /usr/lib/firefox-esr here is a belt-and-braces guard for any
-        // dlopen("libfoo.so") call that lacks RUNPATH propagation.
-        "LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/usr/lib:/usr/lib/firefox-esr:/opt/firefox:/disk/lib/firefox",
+        // Variant-aware library search scope, selected above from the binary's
+        // PT_INTERP (LD_PATH_MUSL vs LD_PATH_GLIBC).  Common tail in both:
+        //   /usr/lib/firefox-esr — Alpine canonical Mozilla tree (DT_RUNPATH
+        //     target baked into every Mozilla DSO per readelf -d).
+        //   /opt/firefox         — Mozilla-official tarball tree.
+        //   /disk/lib/firefox    — legacy build-firefox.sh in-tree path.
+        // LD_LIBRARY_PATH precedes DT_RUNPATH in the search order (ELF gABI
+        // §5.4; ld.so(8) / ld-musl(8)), so listing /usr/lib/firefox-esr here is
+        // a belt-and-braces guard for any dlopen("libfoo.so") call lacking
+        // RUNPATH propagation.
+        ld_library_path,
         // libfontconfig-interposer.so — defensive FcPatternGetString *out
         // wrapper.  Real libfontconfig (PR #179) leaves *out untouched on
         // FcResultNoMatch per spec; Mozilla's gfxFcPlatformFontList caller

--- a/kernel/src/proc/elf.rs
+++ b/kernel/src/proc/elf.rs
@@ -1378,6 +1378,100 @@ pub fn is_elf(data: &[u8]) -> bool {
     data.len() >= 4 && data[0..4] == ELF_MAGIC
 }
 
+/// C-library flavour implied by an executable's `PT_INTERP` (program
+/// interpreter), used to pick a libc-appropriate runtime search scope before
+/// `exec()` lays out `envp`.
+///
+/// The dynamic linker named in `PT_INTERP` is the authoritative signal for
+/// which libc an executable was linked against:
+///   * `/lib/ld-musl-*`            ⇒ musl libc
+///   * `/lib64/ld-linux-*` / `/lib/ld-linux-*` ⇒ glibc
+/// (ELF gABI §5.4 "Program Interpreter"; `ld-musl(8)`, `ld.so(8)`.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LibcFlavor {
+    /// `PT_INTERP` names an `ld-musl-*` interpreter.
+    Musl,
+    /// `PT_INTERP` names an `ld-linux*` interpreter.
+    Glibc,
+    /// No `PT_INTERP` (static binary) or an unrecognised interpreter path.
+    Unknown,
+}
+
+/// Extract the `PT_INTERP` (program interpreter) path from an ELF image
+/// without loading it.  Returns `None` for static binaries (no `PT_INTERP`)
+/// or malformed images.
+///
+/// This is the same lookup the loader performs in `load_elf_with_args`, but
+/// split out so callers (e.g. the exec env builder) can learn the interpreter
+/// before the address space is created.  Per the ELF gABI, `PT_INTERP`
+/// (`p_type == 3`) points at a NUL-terminated path in the file at `p_offset`.
+pub fn pt_interp_path(data: &[u8]) -> Option<alloc::string::String> {
+    let header = validate_elf(data).ok()?;
+
+    let ph_offset = header.e_phoff as usize;
+    let ph_size = header.e_phentsize as usize;
+    let ph_count = header.e_phnum as usize;
+
+    // Same CWE-119 phdr-count cap as the loader, plus a minimum entry size so
+    // the in-bounds proof below holds.
+    if ph_count > MAX_PHDRS || ph_size < core::mem::size_of::<Elf64Phdr>() {
+        return None;
+    }
+
+    for i in 0..ph_count {
+        let offset = ph_offset.checked_add(i.checked_mul(ph_size)?)?;
+        if offset.checked_add(ph_size)? > data.len() {
+            continue;
+        }
+        // SAFETY: `offset + ph_size <= data.len()` and `ph_size >=
+        // size_of::<Elf64Phdr>()` were both checked above, so the read stays
+        // in-bounds.  Elf64Phdr is `repr(C)`; the file buffer is a heap Vec
+        // (8-byte aligned), matching the struct's alignment.
+        let phdr = unsafe { &*(data.as_ptr().add(offset) as *const Elf64Phdr) };
+        if phdr.p_type == PT_INTERP {
+            let path_start = phdr.p_offset as usize;
+            let path_end = path_start.checked_add(phdr.p_filesz as usize)?;
+            if path_end <= data.len() {
+                let raw = &data[path_start..path_end];
+                // Strip the NUL terminator.
+                let raw = raw.split(|&b| b == 0).next().unwrap_or(raw);
+                return Some(alloc::string::String::from_utf8_lossy(raw).into_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Classify the C-library flavour of an ELF image from its `PT_INTERP`.
+///
+/// Returns [`LibcFlavor::Unknown`] for static binaries and any interpreter
+/// path that matches neither the musl nor glibc dynamic-linker naming
+/// convention, leaving the caller free to fall back to a conservative default.
+pub fn libc_flavor(data: &[u8]) -> LibcFlavor {
+    match pt_interp_path(data) {
+        Some(interp) => libc_flavor_from_interp(&interp),
+        None => LibcFlavor::Unknown,
+    }
+}
+
+/// Classify a `PT_INTERP` path string into a [`LibcFlavor`].
+///
+/// Matching is on the interpreter *basename* convention so it is robust to
+/// the directory the linker lives in (`/lib`, `/lib64`, a sysroot prefix):
+///   * basename starts with `ld-musl-` ⇒ musl
+///   * basename starts with `ld-linux` ⇒ glibc
+/// Anything else is [`LibcFlavor::Unknown`].
+pub fn libc_flavor_from_interp(interp: &str) -> LibcFlavor {
+    let basename = interp.rsplit('/').next().unwrap_or(interp);
+    if basename.starts_with("ld-musl-") {
+        LibcFlavor::Musl
+    } else if basename.starts_with("ld-linux") {
+        LibcFlavor::Glibc
+    } else {
+        LibcFlavor::Unknown
+    }
+}
+
 /// Quick check: is this data a `#!` shebang script?
 pub fn is_shebang(data: &[u8]) -> bool {
     data.len() >= 2 && data[0] == b'#' && data[1] == b'!'

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1229,6 +1229,11 @@ pub fn run() -> ! {
     total += 1;
     if test_elf_dt_gnu_hash_accepted() { passed += 1; }
 
+    // ── Test 132b: ELF PT_INTERP libc-flavour classifier (variant signal) ─
+
+    total += 1;
+    if test_elf_libc_flavor() { passed += 1; }
+
     // ── Test 133: X11 BIG-REQUESTS — QueryExtension present + BigReqEnable ─
 
     total += 1;
@@ -3152,6 +3157,102 @@ fn test_perf_metrics() -> bool {
 
     let ok = timer_ok && heap_ok && uptime_ok;
     if ok { test_pass!("Performance metrics"); }
+    ok
+}
+
+/// Test PT_INTERP-based libc-flavour classification.
+///
+/// This is the variant signal that the GUI exec env builder uses to pick a
+/// libc-appropriate LD_LIBRARY_PATH (musl tree first for musl binaries, glibc
+/// multiarch tree for glibc binaries).  We verify both the pure string
+/// classifier and the end-to-end PT_INTERP extractor on a synthetic ELF.
+fn test_elf_libc_flavor() -> bool {
+    use crate::proc::elf::{libc_flavor, libc_flavor_from_interp, pt_interp_path, LibcFlavor};
+    test_header!("ELF libc-flavour (PT_INTERP) classifier");
+
+    let mut ok = true;
+
+    // ── 1. Pure string classifier ────────────────────────────────────────
+    let cases: &[(&str, LibcFlavor)] = &[
+        ("/lib/ld-musl-x86_64.so.1", LibcFlavor::Musl),
+        ("/usr/lib/ld-musl-x86_64.so.1", LibcFlavor::Musl),
+        ("/lib64/ld-linux-x86-64.so.2", LibcFlavor::Glibc),
+        ("/lib/ld-linux-x86-64.so.2", LibcFlavor::Glibc),
+        ("/lib/ld-linux.so.2", LibcFlavor::Glibc),
+        ("/some/other/interp", LibcFlavor::Unknown),
+        ("", LibcFlavor::Unknown),
+    ];
+    for (interp, want) in cases {
+        let got = libc_flavor_from_interp(interp);
+        if got != *want {
+            test_fail!("ELF libc-flavour", "{:?} → {:?}, want {:?}", interp, got, want);
+            ok = false;
+        } else {
+            test_println!("  {:<32} → {:?}", interp, got);
+        }
+    }
+
+    // ── 2. Static binary (HELLO_ELF) has no PT_INTERP → None / Unknown ────
+    let hello = &crate::proc::hello_elf::HELLO_ELF;
+    if pt_interp_path(hello).is_some() {
+        test_fail!("ELF libc-flavour", "static HELLO_ELF reported a PT_INTERP");
+        ok = false;
+    }
+    if libc_flavor(hello) != LibcFlavor::Unknown {
+        test_fail!("ELF libc-flavour", "static HELLO_ELF not classified Unknown");
+        ok = false;
+    } else {
+        test_println!("  static HELLO_ELF → no PT_INTERP, Unknown ✓");
+    }
+
+    // ── 3. Synthetic dynamic ELF with a PT_INTERP pointing at ld-musl ─────
+    // Build a minimal but spec-valid ELF64 image: a header that points at a
+    // single program header of type PT_INTERP, whose p_offset/p_filesz name a
+    // NUL-terminated interpreter string laid out right after the phdr.
+    const EHDR_SZ: usize = core::mem::size_of::<crate::proc::elf::Elf64Header>();
+    const PHDR_SZ: usize = core::mem::size_of::<crate::proc::elf::Elf64Phdr>();
+    let interp = b"/lib/ld-musl-x86_64.so.1\0";
+    let ph_off = EHDR_SZ;
+    let interp_off = EHDR_SZ + PHDR_SZ;
+
+    let mut img = alloc::vec![0u8; interp_off + interp.len()];
+    // e_ident: magic + class64 + LE + version
+    img[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+    img[4] = 2; // ELFCLASS64
+    img[5] = 1; // ELFDATA2LSB
+    img[6] = 1; // EV_CURRENT
+    // e_type = ET_DYN (3), e_machine = EM_X86_64 (62), e_version = 1
+    img[16..18].copy_from_slice(&3u16.to_le_bytes());
+    img[18..20].copy_from_slice(&62u16.to_le_bytes());
+    img[20..24].copy_from_slice(&1u32.to_le_bytes());
+    // e_phoff @ offset 32
+    img[32..40].copy_from_slice(&(ph_off as u64).to_le_bytes());
+    // e_phentsize @ 54, e_phnum @ 56
+    img[54..56].copy_from_slice(&(PHDR_SZ as u16).to_le_bytes());
+    img[56..58].copy_from_slice(&1u16.to_le_bytes());
+    // Program header: p_type = PT_INTERP (3) @ ph_off
+    img[ph_off..ph_off + 4].copy_from_slice(&3u32.to_le_bytes());
+    // p_offset @ ph_off+8, p_filesz @ ph_off+32
+    img[ph_off + 8..ph_off + 16].copy_from_slice(&(interp_off as u64).to_le_bytes());
+    img[ph_off + 32..ph_off + 40].copy_from_slice(&(interp.len() as u64).to_le_bytes());
+    // The interpreter string itself.
+    img[interp_off..interp_off + interp.len()].copy_from_slice(interp);
+
+    match pt_interp_path(&img) {
+        Some(p) if p == "/lib/ld-musl-x86_64.so.1" => {
+            test_println!("  synthetic ELF → PT_INTERP '{}' ✓", p);
+        }
+        other => {
+            test_fail!("ELF libc-flavour", "synthetic PT_INTERP = {:?}", other);
+            ok = false;
+        }
+    }
+    if libc_flavor(&img) != LibcFlavor::Musl {
+        test_fail!("ELF libc-flavour", "synthetic musl ELF not classified Musl");
+        ok = false;
+    }
+
+    if ok { test_pass!("ELF libc-flavour (PT_INTERP) classifier"); }
     ok
 }
 


### PR DESCRIPTION
## Problem

The GUI exec env builder (`kernel/src/gui/terminal.rs::spawn_async` — the path the `firefox-test` demo gate drives via `main.rs` `launch_process`) set a **single shared** `LD_LIBRARY_PATH` for both Firefox variants, with the glibc multiarch dir (`/lib/x86_64-linux-gnu`) ahead of the musl tree (`/usr/lib`).

The disk image is intentionally **mixed-ABI**: a glibc tree and a musl (Alpine) tree, each shipping its own `libstdc++.so.6` / `libgcc_s.so.1`. A dynamic linker resolves a soname by scanning `LD_LIBRARY_PATH` left-to-right and binding the **first** match (ELF gABI §5.4; `ld.so(8)` / `ld-musl(8)`). So the musl Firefox (`PT_INTERP /lib/ld-musl-x86_64.so.1`) bound the glibc-built `libstdc++` first, whose glibc-versioned imports (`__cxa_thread_atexit_impl@GLIBC_2.18`, `__libc_single_threaded@GLIBC_2.32`, `_dl_find_object@GLIBC_2.35`, the fortify `*_chk` family, …) musl libc does not export — yielding ~24 "Error relocating … symbol not found" failures and `exit_group(127)` at the natural demo exit (sc=121). Root-caused in `docs/LIBSTDCXX_RELOC_GAP_2026-05-29.md`.

## Variant signal: PT_INTERP (option A)

The fix selects `LD_LIBRARY_PATH` from the target binary's **`PT_INTERP`** at envp-build time. This is the authoritative, **staging-independent** signal for which libc the executable was linked against, and the ELF image is already in hand at that point in `spawn_async`.

A build-time cfg flag (option B) would be **wrong**: the same kernel binary runs against either disk image (`main.rs` probes the disk at runtime: `musl-132 → musl-esr → glibc`, first existing wins), so a per-binary PT_INTERP is the only correct signal. No design fork was hit.

- musl (`PT_INTERP /lib/ld-musl-*`) → `/usr/lib` first; glibc multiarch dir **omitted entirely** so nothing in the musl process resolves against the glibc tree.
- glibc (`PT_INTERP /lib64/ld-linux-*`) and static/unknown → **unchanged** glibc-first order (libs in `/lib/x86_64-linux-gnu` + `/lib64` still resolve).

## Changes

- `proc::elf`: new `pt_interp_path()`, `libc_flavor()`, `libc_flavor_from_interp()`, and a `LibcFlavor` enum — a clean split of the loader's existing PT_INTERP lookup so callers can classify a binary before its address space exists.
- `gui::terminal::spawn_async`: select `LD_PATH_MUSL` vs `LD_PATH_GLIBC` from `libc_flavor(&data)`.
- `test_runner.rs`: `test_elf_libc_flavor` — pure string classifier (musl/glibc/unknown), static `HELLO_ELF` (no PT_INTERP → Unknown), and a synthetic dynamic ELF with a PT_INTERP pointing at ld-musl.

## Verification

- `qemu-harness.py check` clean for both `test-mode` and `firefox-test`.
- test-mode KVM boot: `test_elf_libc_flavor` **passes**; surrounding ELF-cluster tests green.
- The 9 remaining suite failures are pre-existing **disk-fixture absences** (`/disk/bin/hello`, `tcc`, `busybox`, glibc interp) under the musl-staged `data.img` — `NotFound`/`InterpNotFound`, unrelated to this change.
- Full Firefox soak intentionally **not** run here — coordinator verifies on master post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)