### PR TITLE
kernel: nit cleanup — correct stale comments from PR #468/#469

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2158,6 +2158,15 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // as the final owner.  This keeps the common single-thread path fast
     // (no sibling → free immediately) while making the multi-thread path
     // safe (CLONE_THREAD: wait for Running siblings to drain off-CPU).
+    //
+    // Contention note: THREAD_TABLE is a spin::Mutex.  This lock
+    // acquisition is on the exit path — interrupts are enabled and the
+    // calling CPU is about to schedule away, so contention with a
+    // concurrent timer ISR or AP scheduler is bounded to a short
+    // critical section (one iter + state compare).  If SMP thread counts
+    // grow large enough that the linear scan becomes a latency concern,
+    // consider an atomic per-process Running-thread counter as a fast
+    // pre-check before taking the lock.
     let any_sibling_running = {
         let threads = THREAD_TABLE.lock();
         threads.iter().any(|t| {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3439,9 +3439,13 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             crate::syscall::sys_exec(arg1, path_bytes.len() as u64, arg2, arg3)
         }
         // 60: exit(status)
+        // exit_thread() loops on schedule() until this thread is switched
+        // away permanently; it never returns.  The trailing `0` satisfies
+        // the type-checker (dispatch_body returns i64) but is dead code —
+        // POSIX exit(2): "The exit() function shall not return."
         60 => {
             crate::proc::exit_thread(arg1 as i64);
-            0
+            0 // dead — exit_thread diverges
         }
         // 61: wait4(pid, wstatus, options, rusage)
         61 => crate::syscall::sys_waitpid(arg1 as i64, arg3 as u32),
@@ -3635,10 +3639,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             sys_clock_gettime(arg1, arg2)
         }
         // 231: exit_group(status) — terminate all threads in the process
+        // exit_group() marks all sibling threads Dead, frees process memory,
+        // and loops on schedule() until this thread is switched away; it
+        // never returns.  The trailing `0` is dead code — POSIX exit(2):
+        // "The exit() function shall not return."
         231 => {
             crate::serial_println!("[SYSCALL/Linux] exit_group({})", arg1 as i32);
             crate::proc::exit_group(arg1 as i64);
-            0
+            0 // dead — exit_group diverges
         }
         // 234: tgkill(tgid, tid, sig)
         // Sends signal `sig` to thread `tid` in thread group `tgid`.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -22098,10 +22098,11 @@ fn test_execve_no_pmm_leak() -> bool {
         //
         // When a thread exits, its kernel stack is pushed to the dead-stack
         // cache by `reap_dead_threads_sched`.  The cache withholds the entry
-        // from re-issue until every CPU has advanced its per-CPU timer-ISR
-        // counter by at least DEAD_STACK_QUIESCE_TICKS (= 2) beyond the push
-        // snapshot (Intel SDM Vol. 3A §11.10 coherence: a CPU's in-flight
-        // stack reads are only retired after a full timer-ISR round-trip).
+        // from re-issue until the global `TICK_COUNT` has advanced by at least
+        // DEAD_STACK_QUIESCE_TICKS (= 2) ticks beyond the push snapshot
+        // (20 ms wall-clock at TICK_HZ=100).  This ensures any in-flight
+        // `switch_context_asm` on another CPU has retired before the kstack
+        // frame is handed out for reuse (Intel SDM Vol. 3A §6.14).
         //
         // Without this wait: the next iteration's `alloc_kernel_stack` finds
         // the cache entry non-quiesced and falls back to `pmm::alloc_pages`,
@@ -22110,12 +22111,9 @@ fn test_execve_no_pmm_leak() -> bool {
         // iteration adds exactly KERNEL_STACK_PAGES (64) to the PMM leak.
         //
         // Fix: call `sched::wait_dead_stacks_quiesced()`, which spins with
-        // interrupts enabled until every per-CPU timer-ISR counter (the
-        // same counters checked by `entry_is_quiesced`) has advanced by
-        // DEAD_STACK_QUIESCE_TICKS + 1 beyond a fresh baseline.  Unlike
-        // waiting on the global TICK_COUNT (which is TSC-derived and can be
-        // advanced by CPU 1 only), this directly unblocks the
-        // quiescence gate for ALL CPUs.
+        // interrupts enabled until `TICK_COUNT` (the same counter checked by
+        // `entry_is_quiesced`) has advanced by DEAD_STACK_QUIESCE_TICKS + 1
+        // beyond a fresh baseline.
         //
         // Yield twice first to ensure reap_dead_threads_sched() has run and
         // pushed the child's kstack to the cache before we wait for quiescence.


### PR DESCRIPTION
## Summary

Three comment-only fixes following up on PR #468 and PR #469. No logic changes.

- **test_runner.rs** (~line 22097): The quiescence-wait comment described the old per-CPU `TIMER_ISR_PER_CPU[i]` scheme and incorrectly framed the global `TICK_COUNT` as something that could only be advanced by a single CPU. PR #468 replaced that scheme with a single global `TICK_COUNT` comparison; the comment now matches the actual implementation and cites Intel SDM Vol. 3A §6.14.

- **proc/mod.rs** (`exit_group_inner`, ~line 2162): The Running-sibling guard added by PR #468 acquires `THREAD_TABLE` (a `spin::Mutex`) on the exit path with no contention documentation. Added a note: the critical section is bounded (one linear scan + state compare), contention is transient (caller is about to schedule away), and flags a potential future optimisation (per-process atomic Running-thread counter) if thread counts grow large enough.

- **subsys/linux/syscall.rs** (arms 60 and 231): Both `sys_exit` and `sys_exit_group` arms return a trailing `0` that is unreachable dead code — both callees loop on `schedule()` and never return. Added comments documenting the `0` as dead code, citing POSIX `exit(2)`.

## Test plan

- [x] Build clean: `python3 scripts/qemu-harness.py check` → `{"ok": true, "rc": 0}`
- [x] Diff is comment-only — no logic changes, no test changes needed
- [x] No existing tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)