### PR TITLE
kernel/pipe: fix ABI — write int pipefd[2] (8 bytes), not 2×u64 (16 bytes)

### DIFF
--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -274,13 +274,13 @@ pub fn dispatch(
         }
         SYS_PIPE => {
             // pipe(fds_out) -> 0 or -errno
-            // Validate the user pointer before handing off: `sys_pipe` writes
-            // two u64 file descriptor numbers (16 bytes) to `fds_out`.
+            // pipe(2) ABI: writes int pipefd[2] = 8 bytes to fds_out.
+            // pipe(2): https://man7.org/linux/man-pages/man2/pipe.2.html
             // Defence-in-depth at the user/kernel boundary per CWE-119.
-            if !crate::syscall::validate_user_ptr(arg1, 16) {
+            if !crate::syscall::validate_user_ptr(arg1, 8) {
                 return -14; // EFAULT
             }
-            crate::syscall::sys_pipe(arg1 as *mut u64)
+            crate::syscall::sys_pipe(arg1 as *mut u32)
         }
         SYS_UNAME => {
             // uname(buf) -> 0

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -4624,16 +4624,16 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
 
         // ─── Phase 1 batch 2: small stubs / wrappers for bash + coreutils ─────
 
-        // 22: pipe(pipefd[2]) — same as pipe2 with no flags
-        // 22: pipe(pipefd) — user-mode entry gate.  Writes 2 × u64 = 16
-        // bytes via *pipefd and *pipefd.add(1).  CWE-823.
+        // 22: pipe(pipefd[2]) — create a pipe, writing int pipefd[2] (8 bytes)
+        // to the user buffer.  pipe(2): https://man7.org/linux/man-pages/man2/pipe.2.html
+        // The ABI is `int pipefd[2]` = 2 × 4-byte ints = 8 bytes total.
         22 => {
             if !crate::syscall::user_ptr_check_bypassed()
-                && !crate::syscall::validate_user_ptr(arg1, 16)
+                && !crate::syscall::validate_user_ptr(arg1, 8)
             {
                 return -14;
             }
-            crate::syscall::sys_pipe(arg1 as *mut u64)
+            crate::syscall::sys_pipe(arg1 as *mut u32)
         }
         // 26: msync(addr, length, flags) — writeback not yet implemented.
         // Returning 0 silently is dangerous (caller believes data is durable).

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -3401,14 +3401,21 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
     new_fd as i64
 }
 
-pub(crate) fn sys_pipe(fds_out: *mut u64) -> i64 {
+/// pipe(pipefd[2]) — create a pipe.
+///
+/// Writes exactly 8 bytes: `int pipefd[2]` = two 4-byte signed integers,
+/// as specified by pipe(2) — https://man7.org/linux/man-pages/man2/pipe.2.html
+/// and POSIX.1-2017.  The previous `*mut u64` signature wrote 16 bytes
+/// (2 × u64), which overran the caller's 8-byte buffer (CWE-787).
+///
+/// `fds_out` must point to a buffer of at least 8 bytes (2 × sizeof(int)).
+/// Pointer validation is performed at the user/kernel boundary
+/// (Linux dispatch arm 22; Aether dispatch); kernel-internal callers
+/// bypass — see sys_open_linux for the rationale.
+pub(crate) fn sys_pipe(fds_out: *mut u32) -> i64 {
     if fds_out.is_null() {
         return -22; // EINVAL
     }
-
-    // Pointer validation is done at the user/kernel boundary (Linux
-    // dispatch_body arm 22; Aether dispatch).  Kernel-internal callers
-    // bypass — see sys_open_linux for the rationale.
 
     let pipe_id = crate::ipc::pipe::create_pipe();
     let pid = crate::proc::current_pid_lockless();
@@ -3481,11 +3488,14 @@ pub(crate) fn sys_pipe(fds_out: *mut u64) -> i64 {
     proc.file_descriptors[ri] = Some(read_fd);
     proc.file_descriptors[wi] = Some(write_fd);
 
-    // Write [read_fd, write_fd] to user buffer
+    // Write exactly 8 bytes: int pipefd[2] per pipe(2) ABI.
+    // write_unaligned is used defensively; the caller's pipefd[] may not be
+    // 4-byte aligned (musl/glibc do not guarantee stack-frame alignment of
+    // individual locals beyond their declared type).
     unsafe {
         let _g = crate::arch::x86_64::smap::UserGuard::new();
-        *fds_out = ri as u64;
-        *fds_out.add(1) = wi as u64;
+        core::ptr::write_unaligned(fds_out,        ri as u32);
+        core::ptr::write_unaligned(fds_out.add(1), wi as u32);
     }
 
     crate::serial_println!("[SYSCALL] pipe() -> [{}, {}] (pipe_id={})", ri, wi, pipe_id);

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -13612,28 +13612,56 @@ fn test_phase1_batch2_syscalls() -> bool {
     let mut ok = true;
 
     // ─── pipe (22): create a pipe pair ──────────────────────────────────────
+    // pipe(2) ABI: int pipefd[2] = 8 bytes.  The kernel writes two u32 values.
+    // See: https://man7.org/linux/man-pages/man2/pipe.2.html
     {
-        // sys_pipe writes two u64 fd values into the buffer
-        let mut fds: [u64; 2] = [u64::MAX; 2];
-        let r = dispatch(22, fds.as_mut_ptr() as u64, 0, 0, 0, 0, 0);
-        let valid = r == 0 && fds[0] < 1024 && fds[1] < 1024 && fds[0] != fds[1];
+        // Layout: [read_fd(u32), write_fd(u32), sentinel(u32)]
+        // sentinel at byte offset 8 must not be touched — it guards the
+        // boundary that the old 16-byte (2×u64) write would have overrun,
+        // which previously clobbered the SSP stack canary in caller frames
+        // (CWE-787).
+        let mut buf: [u32; 3] = [0xFFFF_FFFF; 3];
+        let r = dispatch(22, buf.as_mut_ptr() as u64, 0, 0, 0, 0, 0);
+        let read_fd  = buf[0];
+        let write_fd = buf[1];
+        let sentinel = buf[2];
+
+        // Sentinel must be intact — the write must not have overrun 8 bytes.
+        if sentinel != 0xFFFF_FFFF {
+            test_fail!("pipe() sentinel", "OOB write detected: sentinel={:#010x}", sentinel);
+            ok = false;
+        }
+
+        let valid = r == 0
+            && (read_fd  as u64) < 1024
+            && (write_fd as u64) < 1024
+            && read_fd != write_fd;
         if valid {
-            test_println!("  pipe() -> read_fd={} write_fd={} ok", fds[0], fds[1]);
-            // Write then read back
+            test_println!(
+                "  pipe() -> read_fd={} write_fd={} sentinel=intact ok",
+                read_fd, write_fd
+            );
+            // Write then read back to confirm the FDs are functional.
             let msg: &[u8] = b"AstryxOS";
-            let w = dispatch(1, fds[1], msg.as_ptr() as u64, msg.len() as u64, 0, 0, 0);
+            let w = dispatch(
+                1, write_fd as u64, msg.as_ptr() as u64, msg.len() as u64, 0, 0, 0,
+            );
             let mut rbuf = [0u8; 8];
-            let rd = dispatch(0, fds[0], rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+            let rd = dispatch(0, read_fd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
             if w == msg.len() as i64 && rd == msg.len() as i64 && &rbuf == msg {
                 test_println!("  pipe write+read ok");
             } else {
                 test_fail!("pipe write/read", "w={} rd={}", w, rd);
                 ok = false;
             }
-            let _ = crate::vfs::close(pid, fds[0] as usize);
-            let _ = crate::vfs::close(pid, fds[1] as usize);
+            let _ = crate::vfs::close(pid, read_fd  as usize);
+            let _ = crate::vfs::close(pid, write_fd as usize);
+        } else if r == 0 {
+            // FDs out of range or equal — ABI failure.
+            test_fail!("pipe()", "bad fds: read={} write={}", read_fd, write_fd);
+            ok = false;
         } else {
-            test_fail!("pipe()", "r={} fds=[{},{}]", r, fds[0], fds[1]);
+            test_fail!("pipe()", "r={}", r);
             ok = false;
         }
     }
@@ -35547,8 +35575,9 @@ fn test_222_syscall_arg_validation_matrix() -> bool {
     );
 
     // ── Aether SYS_PIPE pointer-validation smoke test ────────────────────
-    // The Aether dispatch arm for SYS_PIPE (nr=24) now calls
-    // validate_user_ptr(fds_out, 16) before delegating to sys_pipe().
+    // The Aether dispatch arm for SYS_PIPE (nr=24) calls
+    // validate_user_ptr(fds_out, 8) before delegating to sys_pipe().
+    // pipe(2) ABI: int pipefd[2] = 8 bytes total.
     // Verify that a kernel-VA pointer returns EFAULT (-14).
     // Uses dispatch_aether (NOT dispatch_linux) to exercise the Aether path.
     // Per CWE-119 (memory bounds violation), defence-in-depth at the


### PR DESCRIPTION
## Summary

- **Bug**: `sys_pipe` wrote two `u64` values (16 bytes) to a buffer that the pipe(2) ABI defines as `int pipefd[2]` = 8 bytes. The 8-byte overrun landed in whatever follows the `pipefd[2]` array in the caller's stack frame — in Firefox musl's glxtest child-spawn path this was the SSP stack-canary slot, causing `__stack_chk_fail` → HLT → #GP.
- **Security**: Kernel OOB write into user stack — **CWE-787** (out-of-bounds write), **CWE-823** (use of out-of-range pointer offset). Every `pipe()` call from a Linux binary was affected.
- **Fix**: Change `sys_pipe` parameter from `*mut u64` to `*mut u32`; write exactly 8 bytes using `core::ptr::write_unaligned`, matching the existing `sys_pipe2_linux` implementation. Update both dispatch sites (Linux arm 22, Aether SYS_PIPE) and their `validate_user_ptr` size checks (16 → 8).
- **Spec reference**: [pipe(2) — Linux man-pages](https://man7.org/linux/man-pages/man2/pipe.2.html): `int pipe(int pipefd[2])` — `pipefd` is an array of two `int` values.

## Changed files

| File | What changed |
|---|---|
| `kernel/src/syscall/mod.rs` | `sys_pipe`: `*mut u64` → `*mut u32`, doc comment citing pipe(2) man page, `write_unaligned` writes |
| `kernel/src/subsys/linux/syscall.rs` | Dispatch arm 22: `validate_user_ptr(arg1, 16)` → 8; cast → `*mut u32`; stale comment replaced with man-page citation |
| `kernel/src/subsys/aether/syscall.rs` | SYS_PIPE arm: same size and cast fix |
| `kernel/src/test_runner.rs` | test 58: buffer `[u64;2]` → `[u32;3]` with sentinel at offset 8 that detects OOB writes; smoke-test comment updated |

## Callers

Two dispatch sites call `sys_pipe`: Linux arm 22 and Aether SYS_PIPE. Both are fixed. `sys_pipe2_linux` was already correct (`*mut u32` + `write_unaligned`) and is unchanged. No in-tree caller passed a `u64[2]` buffer.

## Test plan

- [ ] `python3 scripts/qemu-harness.py check` — build passes (verified locally: `{"ok":true,"rc":0}`)
- [ ] Test 58 (`test_phase1_batch2_syscalls`) now places a `0xFFFF_FFFF` sentinel at byte offset 8 and asserts it is intact after `pipe()` — directly guards the canary-clobber regression
- [ ] Coordinator to run `firefox-test --firefox-variant musl` post-merge to confirm glxtest #GP is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)