### PR TITLE
test_runner: fix pipe-fd buffers to u32[2] (epoll tests) — follow-up to #473

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -13935,7 +13935,7 @@ fn test_epoll_and_proc_fd() -> bool {
 
         // ─── 7. Pipe + epoll EPOLLIN test ───────────────────────────────────
         {
-            let mut pipe_fds: [u64; 2] = [u64::MAX; 2];
+            let mut pipe_fds: [u32; 2] = [u32::MAX; 2]; // pipe(2) writes int[2] (u32); see PR #473
             let pr = dispatch(22, pipe_fds.as_mut_ptr() as u64, 0, 0, 0, 0, 0);
             if pr == 0 {
                 let rfd = pipe_fds[0] as usize;
@@ -14007,7 +14007,7 @@ fn test_epoll_and_proc_fd() -> bool {
         {
             let epfd3 = dispatch(291, 0, 0, 0, 0, 0, 0);
             if epfd3 >= 0 {
-                let mut pipe_fds: [u64; 2] = [u64::MAX; 2];
+                let mut pipe_fds: [u32; 2] = [u32::MAX; 2]; // pipe(2) writes int[2] (u32); see PR #473
                 if dispatch(22, pipe_fds.as_mut_ptr() as u64, 0, 0, 0, 0, 0) == 0 {
                     let rfd = pipe_fds[0] as usize;
                     let wfd = pipe_fds[1] as usize;


### PR DESCRIPTION
## Summary
Follow-up to #473. That PR fixed `sys_pipe` to write the pipe fds as `int[2]` (two u32, 8 bytes) per the [pipe(2)](https://man7.org/linux/man-pages/man2/pipe.2.html) ABI, and updated test 58's buffer — but **two more in-kernel callers** in `test_epoll_and_proc_fd` (`kernel/src/test_runner.rs`) still declared `let mut pipe_fds: [u64; 2]`.

Post-#473 those read a packed `(wfd<<32 | rfd)` garbage read-fd and registered epoll on it, so the **`pipe EPOLLIN`** and **`epoll_wait ready-fast-path`** tests saw `events=0x0` and failed the kernel-smoke suite.

## Fix
Change both buffers to `[u32; 2]` to match the ABI. The fd reads (`pipe_fds[0] as usize`) are unchanged. **Test-only diff** — restores kernel-smoke to green.

## Context
This is the test-side fallout of the demo-gate-advancing #473 (which fixed a CWE-787 kernel OOB write that was clobbering libxul's SSP canary). No kernel-logic change.