### PR TITLE
signal+autopsy: log faulting GPRs (r14/rbp/rbx/rsi) on SIGSEGV delivery

### DIFF
--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1244,9 +1244,10 @@ pub unsafe fn deliver_sigsegv_from_isr(
     // never block other CPUs from looking up their own process entry.
     drop(procs);
     crate::serial_println!(
-        "[SIGNAL] SIGSEGV ISR delivery: PID={} CR2={:#x} user_rip={:#x} handler={:#x} new_rsp={:#x} siginfo={}",
+        "[SIGNAL] SIGSEGV ISR delivery: PID={} CR2={:#x} user_rip={:#x} handler={:#x} new_rsp={:#x} siginfo={} r14={:#x} rbp={:#x} rbx={:#x} rsi={:#x}",
         pid, cr2, user_rip, handler_addr, new_rsp,
-        if want_siginfo { "SA_SIGINFO" } else { "classic" }
+        if want_siginfo { "SA_SIGINFO" } else { "classic" },
+        isr_r14, isr_rbp, isr_rbx, isr_rsi
     );
     emit_signal_vma_banner(pid, user_rip, cr2, &vma_snapshot);
 

--- a/scripts/autopsy/presets.yaml
+++ b/scripts/autopsy/presets.yaml
@@ -215,6 +215,38 @@ presets:
         len: 64
 
   # ───────────────────────────────────────────────────────────────────────────
+  # sigsegv-user-gprs
+  # ───────────────────────────────────────────────────────────────────────────
+  # Capture the FAULTING USER register set at deliver_sigsegv_from_isr() entry.
+  # The kernel ISR stub pushes the 15 user GPRs immediately BELOW the
+  # InterruptFrame (lower VAs).  deliver_sigsegv_from_isr(cr2, error_code, frame)
+  # receives `frame` in RDX (sysV AMD64 ABI §3.2.3: arg0=RDI=cr2,
+  # arg1=RSI=error_code, arg2=RDX=frame).  Per the documented layout the GPR
+  # qwords sit at frame[-2]=rax … frame[-16]=r15 (frame[-5]=rsi, frame[-11]=rbx,
+  # frame[-12]=rbp, frame[-15]=r14).  Reading 144 bytes at (frame-128) captures
+  # all 16 pushed qwords plus the InterruptFrame's saved RIP/CS so the user
+  # fault context (which argv slot, which array base) is fully reconstructable.
+  sigsegv-user-gprs:
+    description: |
+      Faulting user GPRs at deliver_sigsegv_from_isr() entry.  frame is in RDX;
+      pushed user GPRs live at frame-128..frame.  Captures that window + the
+      InterruptFrame so rsi/r14/rbp/rbx (the option-array parse state) are
+      recoverable without a printk.
+    steps:
+      - name: regs
+        kind: regs
+      - name: pushed_gprs
+        kind: mem_via_reg
+        reg: rdx
+        offset: -128
+        len: 144
+      - name: interrupt_frame
+        kind: mem_via_reg
+        reg: rdx
+        offset: 0
+        len: 48
+
+  # ───────────────────────────────────────────────────────────────────────────
   # bugcheck-entry
   # ───────────────────────────────────────────────────────────────────────────
   # Symmetric to ssp-fail-snapshot but tuned for ke_bugcheck() entry.


### PR DESCRIPTION
## Summary
Observability one-liner to classify the FF-musl libxul SIGSEGV deterministically without GDB.

`deliver_sigsegv_from_isr` already decodes the pushed-GPR window into locals (`isr_r14`/`isr_rbp`/`isr_rbx`/`isr_rsi`) but the fatal-signal log line only printed CR2/user_rip/handler. This appends the four GPRs.

### Why
The current demo gate is a flaky SIGSEGV in libxul `nsCommandLine::Init` walking `argv` — it faults on `cmp byte [rsi], 0x2d` with `rsi=NULL`, i.e. some interior `argv[i]==NULL`. The kernel argv producer (`setup_user_stack`) is verified hole-free, so the NULL arises either from a corrupted user-stack pointer-slot or a heap-rebuilt argv. The decisive discriminator is **r14 (argv base)**: user-stack range vs heap. GDB-armed reproduction is unreliable (the fault resisted capture across 4 attempts), so a deterministic single-run print is the cheapest path: the next SIGSEGV now prints `r14`/`rbp`(=argc)/`rbx`(=index)/`rsi`(=NULL argv[i]) directly.

Also adds the additive `sigsegv-user-gprs` autopsy preset.

No new probe (augments an existing log line with registers already in scope); no behaviour change.