### PR TITLE
kernel/gui: FF Step 3 — force single-process mode for headless screenshot

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -897,12 +897,23 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // Reports/ creation and the subsequent fatal-on-error writes that
         // bubble up through CrashReporter::SetupExtraData().
         "MOZ_CRASHREPORTER_DISABLE=1",
-        // E10S (multi-process) is left enabled so libxul attempts to launch
-        // plugin-container.  This drives the parent through
-        // GeckoChildProcessHost::PerformAsyncLaunch (chromium IPC LaunchProcess
-        // path), which exercises clone(), execve(), socketpair(AF_UNIX,
-        // SOCK_SEQPACKET), and SCM_RIGHTS cmsg delivery — all needed for
-        // issue #88.  See https://wiki.mozilla.org/Electrolysis.
+        // Force single-process (no content-child) mode so the headless
+        // --screenshot path uses the in-process paint branch of
+        // CrossProcessPaint::Start.  When e10s is disabled,
+        // WindowGlobalParent::IsInProcess() returns true and
+        // drawSnapshot() records the page directly in the parent process
+        // without spawning a content child, without AF_UNIX SCM_RIGHTS
+        // fd-passing, and without memfd/shm round-trips — dropping the
+        // entire content-process cluster off the critical path.
+        //
+        // MOZ_DISABLE_NONLOCAL_CONNECTIONS=1 (set above) satisfies the
+        // AreNonLocalConnectionsDisabled() gate in MOZILLA_OFFICIAL
+        // release builds, after which MOZ_FORCE_DISABLE_E10S=1 is
+        // honoured.
+        //
+        // See: https://wiki.mozilla.org/Electrolysis
+        //      https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
+        "MOZ_FORCE_DISABLE_E10S=1",
         // Skip GPU/glxtest process — software rendering only.
         "MOZ_GFX_TESTING_NO_CHILD_PROCESS=1",
         "MOZ_X11_EGL=0",


### PR DESCRIPTION
## Summary

- Adds `MOZ_FORCE_DISABLE_E10S=1` to the Firefox launch environment in `kernel/src/gui/terminal.rs`
- Removes the outdated comment explaining why E10S was *left on* (it described issue #88 IPC exercising, which is no longer a goal)
- Replaces it with a correct rationale: in-process CrossProcessPaint, no content-child, no AF_UNIX SCM_RIGHTS, no memfd/shm

## Motivation (FF Step 3)

The headless `--screenshot` path in Firefox calls `drawSnapshot()` on the browsing context's `WindowGlobalParent`. That internally calls `CrossProcessPaint::Start`, which has two branches:

```
if (aRoot->IsInProcess()) {
    // IN-PROCESS: calls PaintFragment::Record directly — no IPC
} else {
    // CROSS-PROCESS: queues a paint request to the content child via IPC
}
```

`IsInProcess()` returns true only when the window lives in the parent process (single-process / e10s-disabled mode). With e10s enabled (the previous default), Firefox spawned a content-child process, driving `{clone, execve, socketpair(AF_UNIX, SOCK_SEQPACKET), SCM_RIGHTS cmsg, memfd}` — the cluster that currently flakily SIGSEGVs or livelock-futexes around sc~53k.

Forcing single-process drops that cluster entirely, so `drawSnapshot` executes entirely in the parent and the only remaining path to the PNG is the software renderer → canvas → IOUtils.write.

## The lever — why MOZ_FORCE_DISABLE_E10S=1 works for this binary

This is Firefox 115.15.0 ESR, a `MOZILLA_OFFICIAL` release build.  In such builds the `BrowserTabsRemoteAutostart()` function (which drives `Services.appinfo.browserTabsRemoteAutostart`) honours `MOZ_FORCE_DISABLE_E10S=1` only when `AreNonLocalConnectionsDisabled()` returns true.  That flag is set by `MOZ_DISABLE_NONLOCAL_CONNECTIONS=1`, which is **already present** in the launch envp (set in a prior PR).  So the two-var sequence is:

1. `MOZ_DISABLE_NONLOCAL_CONNECTIONS=1` → `AreNonLocalConnectionsDisabled() = true`
2. `MOZ_FORCE_DISABLE_E10S=1` → `gBrowserTabsRemoteAutostart = false`
3. `XRE_IsE10sParentProcess()` → `false`; `FissionAutostart` → `false`

## HeadlessShell `remote="true"` — does it bypass this?

`HeadlessShell.sys.mjs` creates `<browser remote="true">` and calls `E10SUtils.getRemoteTypeForURI(url, true, ...)` with the second argument (`aMultiProcess`) hardcoded to `true`.  This means `getRemoteTypeForURI` returns `"web"` regardless of `browserTabsRemoteAutostart`.

However, that `remoteType` option is only used by `loadURI` to *request* a process for the navigation.  When `XRE_IsE10sParentProcess()` is false, no `ContentParent` is running, no `BrowserParent` is attached to the `<browser>` element, and the navigation completes in the parent process.  The resulting `WindowGlobalParent` has `InProcessParent` as its manager rather than a `BrowserParent`, so `IsInProcess()` returns true.

No pref injection (user.js) is needed — the env var is sufficient.

## Diff

Single file, single env string added + comment updated.  +17/-6 lines.

## Test plan

- [ ] Build check: `python3 scripts/qemu-harness.py check` — passes (verified locally)
- [ ] Coordinator to run a full Firefox-musl soak post-merge and observe whether the run gets further (sc count, whether SIGSEGV/livelock still appears, whether `Screenshot saved to:` appears in the log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)