### PR TITLE
kernel/proc+syscall: demand-fault CLONE_CHILD_CLEARTID exit write (fixes musl __tl_unlock)

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1919,12 +1919,50 @@ pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
 }
 
 /// Write a 32-bit value to a virtual address through the given CR3's page tables.
-/// Used for CLONE_CHILD_SETTID.
+///
+/// Used for CLONE_CHILD_SETTID and — critically — for CLONE_CHILD_CLEARTID on
+/// the thread-exit path (`proc::exit_thread`).  Per clone(2)
+/// `CLONE_CHILD_CLEARTID` and `set_tid_address(2)`, the kernel must zero the
+/// `clear_child_tid` word in the *dying thread's* address space and then
+/// futex-wake any waiter — this is how a surviving thread that parked on that
+/// word (e.g. via a `while (*addr == val) futex(FUTEX_WAIT, …)` loop) learns the
+/// thread has gone.  If the write is dropped, the woken waiter re-reads the old
+/// value and re-parks forever (POSIX futex(2) semantics: a wake without the
+/// guarded value actually changing is a spurious wake the waiter ignores).
+///
+/// The target word is not guaranteed to be backed by a present, writable PTE at
+/// exit time: the page may be lazily demand-paged (never touched in this CR3),
+/// or present-but-read-only after a copy-on-write fork.  Silently skipping the
+/// write in those cases is the bug this function guards against.  We therefore
+/// resolve the page the same way a hardware write fault would — demand-fault an
+/// anonymous page in, or break COW — before performing the store, mirroring the
+/// page-fault handler's anonymous/COW install logic (Intel SDM Vol. 3A §4.10.5,
+/// §8.2.3 for the ordering used around the install).
 pub(crate) fn write_u32_to_user(cr3: u64, vaddr: u64, val: u32) {
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
-    use crate::mm::vmm::{read_pte, ADDR_MASK, PAGE_PRESENT};
-    let pte = read_pte(cr3, vaddr);
-    if pte & PAGE_PRESENT == 0 { return; }
+    use crate::mm::vmm::{read_pte, ADDR_MASK, PAGE_PRESENT, PAGE_WRITABLE};
+
+    let mut pte = read_pte(cr3, vaddr);
+
+    // Slow path: the PTE is non-present (lazily demand-paged) or present but
+    // not writable (copy-on-write).  Resolve it through the owning VmSpace so
+    // the store below always lands on the exact frame the surviving thread
+    // reads.  On any unrecoverable condition (no VMA, non-writable VMA, OOM)
+    // `resolve_user_write_page` returns false and we fall through without
+    // writing — the same observable outcome as the historical no-op, but only
+    // for genuinely-unmapped targets rather than every lazily-paged one.
+    if pte & PAGE_PRESENT == 0 || pte & PAGE_WRITABLE == 0 {
+        if !resolve_user_write_page(cr3, vaddr) {
+            return;
+        }
+        pte = read_pte(cr3, vaddr);
+        // If resolution still did not leave us a present, writable PTE, abort
+        // rather than write through a stale/RO translation.
+        if pte & PAGE_PRESENT == 0 || pte & PAGE_WRITABLE == 0 {
+            return;
+        }
+    }
+
     let phys = (pte & ADDR_MASK) + (vaddr & 0xFFF);
     // W215 axis-B probe: check if the resolved phys page is cache-resident.
     // This writer hits via PHYS_OFF direct map, bypassing user-PTE permission
@@ -1952,6 +1990,134 @@ pub(crate) fn write_u32_to_user(cr3: u64, vaddr: u64, val: u32) {
     unsafe {
         core::ptr::write_volatile((PHYS_OFF + phys) as *mut u32, val);
     }
+    // Publish the store before any subsequent futex wake.  The dying thread's
+    // CLEARTID write is the userspace unlock the surviving waiter is parked on
+    // (clone(2) CLONE_CHILD_CLEARTID); the waiter re-checks `*addr == val`
+    // after being woken (POSIX futex(2)), so the zero must be globally visible
+    // before `futex_wake_for_exit` runs or the waiter re-parks.  A release
+    // fence orders this store ahead of the wake's queue mutation (Intel SDM
+    // Vol. 3A §8.2.2 — stores are not reordered with older stores, but the
+    // fence also forbids the compiler from sinking the write past the wake).
+    core::sync::atomic::fence(core::sync::atomic::Ordering::Release);
+}
+
+/// Demand-fault (or COW-break) the user page containing `vaddr` in the address
+/// space identified by `cr3`, so a subsequent direct write through the PHYS_OFF
+/// direct map lands on a present, writable, process-private frame.
+///
+/// This is the non-interrupt-context analogue of the write-fault arms of
+/// `arch::x86_64::idt::handle_page_fault`: it is invoked from the thread-exit
+/// path (`write_u32_to_user` → CLONE_CHILD_CLEARTID) where no real `#PF` will
+/// be taken because the write goes through the kernel direct map rather than
+/// the user PTE.  It reproduces only the two arms reachable for a
+/// `clear_child_tid` target — which musl/glibc guarantee is a writable libc
+/// global (anonymous `.bss`/`.data`) or a COW page after fork:
+///
+///   * **not-present + writable anonymous VMA** → allocate a zeroed frame and
+///     install it RW|User (clone(2) guarantees the word is mapped; an unwritten
+///     `.bss`/lock word reads as zero, which is the correct content).
+///   * **present + read-only COW** → if the frame is shared (`refcount > 1`)
+///     copy it to a private frame, else flip the existing frame writable;
+///     shoot down stale read-only TLB entries on sibling CPUs.
+///
+/// Returns `true` if the page is now present and writable, `false` for any
+/// unrecoverable case (no covering VMA, a non-writable VMA, OOM) — in which
+/// case the caller declines the write, preserving the historical no-op outcome
+/// but only for genuinely-unresolvable targets.
+///
+/// Locking: takes `PROCESS_TABLE` only in short snapshot critical sections and
+/// drops it before `map_page_in` / `write_pte` (which take the per-CR3 `mm_sem`
+/// in read mode).  It is called from `exit_thread` with no table lock held, so
+/// no lock-order inversion is introduced.  Cite Intel SDM Vol. 3A §4.10.5
+/// (TLB/paging-structure caches) and §8.2.3 (memory-ordering of stores).
+fn resolve_user_write_page(cr3: u64, vaddr: u64) -> bool {
+    use crate::mm::vmm::{
+        read_pte, map_page_in, write_pte, ADDR_MASK,
+        PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER,
+    };
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    let page_addr = crate::mm::vma::page_align_down(vaddr);
+
+    let pte = read_pte(cr3, page_addr);
+
+    // ── Arm A: present-but-read-only — break copy-on-write ──────────────────
+    if pte & PAGE_PRESENT != 0 {
+        if pte & PAGE_WRITABLE != 0 {
+            return true; // already writable; nothing to do
+        }
+        // Confirm the VMA actually permits writes before breaking COW; a
+        // genuinely read-only mapping (e.g. a const .rodata word) must not be
+        // promoted — that would be a real protection error.
+        let writable_vma = {
+            let procs = crate::proc::PROCESS_TABLE.lock();
+            procs.iter()
+                .find(|p| p.cr3 == cr3)
+                .and_then(|p| p.vm_space.as_ref())
+                .and_then(|vs| vs.find_vma(page_addr))
+                .map(|vma| vma.prot & crate::mm::vma::PROT_WRITE != 0)
+                .unwrap_or(false)
+        };
+        if !writable_vma {
+            return false;
+        }
+        let old_phys = pte & ADDR_MASK;
+        let flags = (pte & !ADDR_MASK) | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+        if crate::mm::refcount::page_ref_count(old_phys) > 1 {
+            // Shared frame — copy to a private one.
+            let new_phys = match crate::mm::pmm::alloc_page() {
+                Some(p) => p,
+                None => return false,
+            };
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    (PHYS_OFF + old_phys) as *const u8,
+                    (PHYS_OFF + new_phys) as *mut u8,
+                    crate::mm::pmm::PAGE_SIZE,
+                );
+            }
+            let _ = crate::mm::refcount::page_ref_dec(old_phys);
+            crate::mm::refcount::page_ref_set(new_phys, 1);
+            map_page_in(cr3, page_addr, new_phys, flags);
+        } else {
+            // Sole owner — just flip the writable bit in place.
+            write_pte(cr3, page_addr, old_phys | flags);
+        }
+        crate::mm::tlb::shootdown_page(cr3, page_addr);
+        return true;
+    }
+
+    // ── Arm B: not present — demand-fault an anonymous frame ────────────────
+    // Look up the covering VMA and require it to be writable (a clear_child_tid
+    // target is always a writable libc global per clone(2)).  We install a
+    // zeroed RW|User frame; for an untouched .bss/lock word zero IS the correct
+    // file/anon content, and the caller immediately overwrites it with the
+    // CLEARTID value anyway.
+    let install_flags = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter()
+            .find(|p| p.cr3 == cr3)
+            .and_then(|p| p.vm_space.as_ref())
+            .and_then(|vs| vs.find_vma(page_addr))
+        {
+            Some(vma) if vma.prot & crate::mm::vma::PROT_WRITE != 0 => {
+                // Build flags from the VMA but force writable+user+present; the
+                // VMA's own to_page_flags already encodes NX correctly.
+                vma.to_page_flags() | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER
+            }
+            _ => return false, // no VMA, or non-writable VMA → real error
+        }
+    };
+    let phys = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => return false,
+    };
+    unsafe {
+        core::ptr::write_bytes((PHYS_OFF + phys) as *mut u8, 0, crate::mm::pmm::PAGE_SIZE);
+    }
+    crate::mm::refcount::page_ref_set(phys, 1);
+    map_page_in(cr3, page_addr, phys, install_flags);
+    crate::mm::vmm::invlpg(page_addr);
+    true
 }
 
 // ===== waitpid() Implementation =============================================

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1009,6 +1009,10 @@ pub fn run() -> ! {
     total += 1;
     if test_cleartid_futex_wake() { passed += 1; }
 
+    // ── Test 98f: CLONE_CHILD_CLEARTID write lands on a non-present page ──
+    total += 1;
+    if test_cleartid_write_demand_faults() { passed += 1; }
+
     // ── Test 99: procfs self/maps — per-process VMA listing ──────────────
 
     total += 1;
@@ -27266,6 +27270,210 @@ fn test_cleartid_futex_wake() -> bool {
     }
 
     test_pass!("CLONE_CHILD_CLEARTID exit-time futex wake (key match + dequeue)");
+    true
+}
+
+/// Regression test for the CLONE_CHILD_CLEARTID exit-time write being dropped
+/// when the target page's PTE is non-present (lazily demand-paged) or
+/// present-but-read-only (copy-on-write).
+///
+/// This guards the musl `__thread_list_lock` contract: musl sets the exiting
+/// thread's `clear_child_tid` to `&__thread_list_lock`, so the kernel's
+/// write-of-zero on thread exit IS the userspace `__tl_unlock` that a surviving
+/// thread parked on via `while (*addr == val) futex(FUTEX_WAIT, …)`.  Before
+/// the fix, `write_u32_to_user` no-op'd on a non-present PTE; the woken waiter
+/// re-read the OLD value and re-parked forever.  Refs: clone(2)
+/// CLONE_CHILD_CLEARTID, set_tid_address(2), futex(2), POSIX.
+///
+/// The test exercises both resolvable arms plus the futex-wake ordering:
+///   Part A — target word on a NOT-PRESENT page of a writable anon VMA: the
+///            write must demand-fault the page in and land zero.
+///   Part B — a parked FUTEX waiter on that word is released by the same
+///            exit-path wake that follows the write.
+///   Part C — target word on a PRESENT, read-only (sole-owner COW) page: the
+///            write must break COW and land zero.
+fn test_cleartid_write_demand_faults() -> bool {
+    test_header!("CLONE_CHILD_CLEARTID write lands on non-present / COW page");
+
+    use crate::mm::vmm::{read_pte, map_page_in, PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER};
+    use crate::syscall::{write_u32_to_user_pub, futex_wake_for_exit, FUTEX_WAITERS};
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+
+    let test_pid: u64 = 9971;
+
+    // 1. Build a fresh user address space.
+    let mut vm = match crate::mm::vma::VmSpace::new_user() {
+        Some(vs) => vs,
+        None => { test_fail!("cleartid_demand", "VmSpace::new_user() OOM"); return false; }
+    };
+    let cr3 = vm.cr3;
+
+    // 2. Insert a writable anonymous VMA — the shape of a libc .bss global like
+    //    musl's __thread_list_lock.  Two pages: page 0 stays untouched (Part A),
+    //    page 1 we pre-populate read-only to exercise the COW arm (Part C).
+    let vma_base: u64 = 0x4000_0000;
+    let vma_len: u64 = 0x2000;
+    {
+        use crate::mm::vma::*;
+        let vma = VmArea {
+            base: vma_base,
+            length: vma_len,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_PRIVATE | MAP_ANONYMOUS,
+            backing: VmBacking::Anonymous,
+            name: "[test-tllock]",
+        };
+        if vm.insert_vma(vma).is_err() {
+            test_fail!("cleartid_demand", "insert_vma failed");
+            return false;
+        }
+    }
+
+    // 3. Register a synthetic process holding this VmSpace so the resolver's
+    //    `find(|p| p.cr3 == cr3)` VMA lookup succeeds.
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        let proc = crate::proc::Process {
+            pid: test_pid,
+            parent_pid: 0,
+            name: { let mut n = [0u8;64]; n[..7].copy_from_slice(b"tllock!"); n },
+            state: crate::proc::ProcessState::Active,
+            cr3,
+            threads: alloc::vec::Vec::new(),
+            exit_code: 0,
+            file_descriptors: alloc::vec::Vec::new(),
+            cwd: alloc::string::String::from("/"),
+            uid: 0, gid: 0, euid: 0, egid: 0,
+            pgid: test_pid as u32, sid: test_pid as u32,
+            no_new_privs: false,
+            cap_permitted: !0u64, cap_effective: !0u64,
+            rlimits_soft: [u64::MAX; 16],
+            supplementary_groups: alloc::vec::Vec::new(),
+            umask: 0o022,
+            vm_space: Some(vm),
+            signal_state: Some(crate::signal::SignalState::new()),
+            linux_abi: true,
+            handle_table: None,
+            subsystem: crate::win32::SubsystemType::Linux,
+            token_id: None,
+            exe_path: None,
+            epoll_sets: alloc::vec::Vec::new(),
+            auxv: alloc::vec::Vec::new(),
+            envp: alloc::vec::Vec::new(),
+            alarm_deadline_ticks: 0,
+            alarm_interval_ticks: 0,
+            pdeath_signal: 0,
+        };
+        procs.push(proc);
+    }
+
+    // Helper to remove the synthetic process and reclaim its VmSpace on any exit.
+    let teardown = || {
+        let old = {
+            let mut procs = crate::proc::PROCESS_TABLE.lock();
+            let old = procs.iter_mut().find(|p| p.pid == test_pid)
+                .and_then(|p| p.vm_space.take());
+            procs.retain(|p| p.pid != test_pid);
+            old
+        };
+        if let Some(space) = old { crate::proc::free_vm_space(space); }
+        FUTEX_WAITERS.lock().remove(&(test_pid, 0)); // belt-and-braces
+    };
+
+    // ── Part A: write to a word on a NOT-PRESENT page ───────────────────────
+    let addr_a: u64 = vma_base + 0x40; // page 0, never touched
+    if read_pte(cr3, addr_a) & PAGE_PRESENT != 0 {
+        teardown();
+        test_fail!("cleartid_demand", "precondition: addr_a PTE already present");
+        return false;
+    }
+    test_println!("  Part A: addr_a={:#x} PTE non-present (precondition) ✓", addr_a);
+
+    // The exit path writes 0; emulate a surviving waiter that parked while the
+    // word held a non-zero lock value.  Register the waiter first, then perform
+    // the write+wake in the same order exit_thread does.
+    let waiter_tid: u64 = 0x5151;
+    {
+        let mut waiters = FUTEX_WAITERS.lock();
+        waiters.entry((test_pid, addr_a)).or_insert_with(alloc::vec::Vec::new).push(waiter_tid);
+    }
+
+    write_u32_to_user_pub(cr3, addr_a, 0);
+
+    // (a) PTE must now be present + writable + user.
+    let pte_a = read_pte(cr3, addr_a);
+    if pte_a & PAGE_PRESENT == 0 || pte_a & PAGE_WRITABLE == 0 || pte_a & PAGE_USER == 0 {
+        FUTEX_WAITERS.lock().remove(&(test_pid, addr_a));
+        teardown();
+        test_fail!("cleartid_demand", "addr_a PTE not present/writable/user after write: {:#x}", pte_a);
+        return false;
+    }
+    // (b) The word must read 0 through the resolved frame.
+    let phys_a = (pte_a & crate::mm::vmm::ADDR_MASK) + (addr_a & 0xFFF);
+    let read_back_a = unsafe { core::ptr::read_volatile((PHYS_OFF + phys_a) as *const u32) };
+    if read_back_a != 0 {
+        FUTEX_WAITERS.lock().remove(&(test_pid, addr_a));
+        teardown();
+        test_fail!("cleartid_demand", "addr_a read-back {:#x}, expected 0", read_back_a);
+        return false;
+    }
+    test_println!("  Part A: write landed on demand-faulted page, reads 0 ✓");
+
+    // ── Part B: the parked waiter is released by the exit-path wake ─────────
+    futex_wake_for_exit(test_pid, addr_a, 1);
+    let still_parked = {
+        let waiters = FUTEX_WAITERS.lock();
+        waiters.get(&(test_pid, addr_a)).map(|v| v.contains(&waiter_tid)).unwrap_or(false)
+    };
+    if still_parked {
+        FUTEX_WAITERS.lock().remove(&(test_pid, addr_a));
+        teardown();
+        test_fail!("cleartid_demand", "waiter still parked after write+wake (lost wakeup)");
+        return false;
+    }
+    test_println!("  Part B: parked waiter released after write+wake (sees 0) ✓");
+
+    // ── Part C: write to a PRESENT, read-only sole-owner page (break COW) ───
+    let addr_c: u64 = vma_base + 0x1000 + 0x80; // page 1
+    let phys_c = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => { teardown(); test_fail!("cleartid_demand", "OOM for COW page"); return false; }
+    };
+    unsafe {
+        // Seed a non-zero pattern so we can prove the write actually happened.
+        core::ptr::write_bytes((PHYS_OFF + phys_c) as *mut u8, 0xAB, crate::mm::pmm::PAGE_SIZE);
+    }
+    crate::mm::refcount::page_ref_set(phys_c, 1); // sole owner
+    // Install read-only (no PAGE_WRITABLE) to force the COW arm.
+    let page_c = crate::mm::vma::page_align_down(addr_c);
+    map_page_in(cr3, page_c, phys_c, PAGE_PRESENT | PAGE_USER);
+    let pre_c = read_pte(cr3, addr_c);
+    if pre_c & PAGE_PRESENT == 0 || pre_c & PAGE_WRITABLE != 0 {
+        teardown();
+        test_fail!("cleartid_demand", "precondition: addr_c not present-RO: {:#x}", pre_c);
+        return false;
+    }
+    test_println!("  Part C: addr_c={:#x} PTE present read-only (precondition) ✓", addr_c);
+
+    write_u32_to_user_pub(cr3, addr_c, 0);
+
+    let post_c = read_pte(cr3, addr_c);
+    if post_c & PAGE_PRESENT == 0 || post_c & PAGE_WRITABLE == 0 {
+        teardown();
+        test_fail!("cleartid_demand", "addr_c not writable after COW-break: {:#x}", post_c);
+        return false;
+    }
+    let phys_c2 = (post_c & crate::mm::vmm::ADDR_MASK) + (addr_c & 0xFFF);
+    let read_back_c = unsafe { core::ptr::read_volatile((PHYS_OFF + phys_c2) as *const u32) };
+    if read_back_c != 0 {
+        teardown();
+        test_fail!("cleartid_demand", "addr_c read-back {:#x}, expected 0", read_back_c);
+        return false;
+    }
+    test_println!("  Part C: write broke COW and landed 0 ✓");
+
+    teardown();
+    test_pass!("CLONE_CHILD_CLEARTID write lands on non-present / COW page");
     true
 }
 


### PR DESCRIPTION
## Problem

On thread exit the kernel must zero the dying thread's `clear_child_tid` word and futex-wake any waiter (clone(2) `CLONE_CHILD_CLEARTID`, set_tid_address(2)). musl points the exiting thread's `clear_child_tid` at `__thread_list_lock`, so the kernel's write-of-zero **is** the userspace `__tl_unlock`: a surviving thread parks on that word via `while (*addr == val) futex(FUTEX_WAIT, …)` and only escapes when it observes 0.

`write_u32_to_user` walked the dying thread's page tables and wrote the zero through the PHYS_OFF direct map, but **silently returned when the target PTE was non-present** — it never demand-faulted or COW-resolved the page. When the `__thread_list_lock` page was lazily demand-paged (or read-only after a COW fork), the write was dropped while the futex wake still fired; the woken waiter re-read the **old** value and re-parked forever.

**Live capture:** Firefox/musl plateaued with the main thread (TID 2) parked in `FUTEX_WAIT(uaddr=&__thread_list_lock, val=3)` after the exiting sibling (TID 3) ran CLEARTID + `FUTEX_WAKE_EXIT woken=[2]`; the zero never became visible, so TID 2 re-parked at the same uaddr with val=3 and both vCPUs idle-halted.

## Fix

Before the store, resolve a non-present or read-only target page the same way a hardware write fault would (new `resolve_user_write_page`, the non-interrupt-context analogue of the page-fault handler's anon/COW arms):

- **not-present + writable anonymous VMA** → allocate a zeroed frame, install RW|User.
- **present + read-only COW** → private copy if the frame is shared (refcount > 1), in-place writable flip if sole owner; cross-CPU TLB shootdown of stale RO entries.
- **genuinely unmapped / non-writable VMA** → decline the write (the historical no-op outcome, now only for truly-unresolvable addresses).

A `Release` fence publishes the store before `futex_wake_for_exit` so the woken waiter observes 0 and escapes its retry loop. The PTE-present fast path is unchanged.

## Test

`test_runner` Test 98f (`test_cleartid_write_demand_faults`):
- **Part A** — writable anon VMA, not-present target word: the exit-time write demand-faults the page and the word reads 0.
- **Part B** — a parked `FUTEX_WAITERS` entry on that word is released by the following `futex_wake_for_exit`.
- **Part C** — a present read-only (sole-owner COW) target is promoted writable and the write lands 0.

All three parts PASS in `test-mode`.

## Verification

- `qemu-harness.py check` (default + `firefox-test`): both `ok: true, rc: 0`.
- `test-mode` boot: new Test 98f passes; the only failing tests are the pre-existing environmental fixtures (`/disk/bin/{hello,tcc,busybox,glibc_hello}` not staged + a host `monotonic-rate` timer flake) — identical to the baseline, no new failures.
- The end-to-end Firefox/musl repro was not run in this dispatch (coordinator verifies post-merge); the unit test directly guards the `__tl_unlock` contract (write-lands + waiter-released + COW-break).

Refs: clone(2) `CLONE_CHILD_CLEARTID`, set_tid_address(2), futex(2), POSIX; Intel SDM Vol. 3A §4.10.5 (TLB/paging-structure caches), §8.2.2/§8.2.3 (memory ordering of stores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)