### PR TITLE
kernel/ipc+linux: close POLL_BELL check-and-park lost-wakeup (prepare-to-wait)

### DIFF
--- a/kernel/src/ipc/waitlist.rs
+++ b/kernel/src/ipc/waitlist.rs
@@ -254,14 +254,55 @@ pub static POLL_BELL_RESYNC_WAKES: AtomicU64 = AtomicU64::new(0);
 /// `ring_poll_bell_for`, the resync floor is purely a safety net for
 /// future sources (or third-party fds) that have not yet been added
 /// to the bell — it is sized accordingly (1 s, was 100 ms pre-wiring).
-pub fn wait_poll_event(caller_deadline: u64) {
+///
+/// ## Lost-wakeup correctness (prepare-to-wait / recheck-under-lock)
+///
+/// The caller's fd-readiness scan (`poll_revents` / `epoll_poll_events`)
+/// runs in a *different* lock domain (`PROCESS_TABLE` + the per-fd
+/// pipe/socket/eventfd state locks) from the bell.  A naive
+/// `scan → if not-ready park` has a lost-wakeup window: between the
+/// scan reading "not ready" and this function taking `POLL_BELL`, a
+/// writer can run `ring_poll_bell_for → drain_all()`, find the waiter
+/// list empty, and consume the readiness edge — the parker then sleeps
+/// with the wakeup already gone, only recovering at the
+/// `RESYNC_INTERVAL_TICKS` (≈1 s) floor.  This is the classic
+/// prepare-to-wait / lost-wakeup hazard (cf. `poll(2)`, `epoll(7)`,
+/// `man 7 futex` "futex word recheck"): the condition must be
+/// re-tested *after* committing to the wait queue but *before*
+/// sleeping, atomically with respect to the waker.
+///
+/// `ready_now` is the caller's readiness re-scan.  This function holds
+/// `POLL_BELL` and calls `ready_now()`; if it reports readiness, the
+/// caller is NOT enqueued and NOT scheduled away — `true` is returned
+/// so the caller drops straight back into its evaluate-and-return path.
+/// Otherwise the caller is enqueued *under the same `POLL_BELL` hold*
+/// that gated the recheck, so any `ring_poll_bell_for` that races
+/// between the recheck and `schedule()` is serialized behind the bell
+/// lock and therefore observes the now-enqueued waiter — no edge can
+/// be lost.  Returns `false` if it actually parked.
+///
+/// ### Lock order (no inversion)
+///
+/// While holding `POLL_BELL` this function acquires, *sequentially and
+/// non-nested*, first whatever locks `ready_now()` needs
+/// (`PROCESS_TABLE` + per-fd state, all released before it returns),
+/// then `THREAD_TABLE` via `enqueue_self_blocked`.  The new edge is
+/// `POLL_BELL → PROCESS_TABLE`.  No bell *writer* ever rings the bell
+/// while holding `PROCESS_TABLE` (every `ring_poll_bell_for` site drops
+/// the process/state lock first — see `signal::kill`, the alarm
+/// dispatcher, and the pipe/eventfd/unix wake paths), so the reverse
+/// edge `PROCESS_TABLE → POLL_BELL` does not exist and the addition is
+/// inversion-free.  `POLL_BELL` is never held across `schedule()`.
+pub fn wait_poll_event(caller_deadline: u64, mut ready_now: impl FnMut() -> bool) -> bool {
     /// Maximum ticks to park before the outer loop rescans.  100 ticks
     /// = 1 s at `TICK_HZ=100`.  Pre-wiring this was 100 ms because the
     /// bell missed timerfd / signalfd / inotify / unix-shutdown /
     /// signal-injection readiness; with those sources now wired, the
     /// floor exists only as a backstop for future readiness sources
     /// that have not yet been ring-bell-wired, and a 1 s rescan keeps
-    /// CPU overhead in the long-quiet case ~10× lower.
+    /// CPU overhead in the long-quiet case ~10× lower.  It is retained
+    /// as belt-and-braces even though the recheck-under-lock above
+    /// closes the structural lost-wakeup window for every wired source.
     const RESYNC_INTERVAL_TICKS: u64 = 100;
     let tid = crate::proc::current_tid();
     let now = crate::arch::x86_64::irq::get_ticks();
@@ -273,7 +314,22 @@ pub fn wait_poll_event(caller_deadline: u64) {
     let wake_tick = caller_deadline.min(resync_tick);
 
     let mut bell = POLL_BELL.lock();
+    // Recheck readiness WHILE HOLDING the bell lock.  If a watched fd
+    // became ready in the window between the caller's last scan and
+    // now, bail without parking: returning `true` tells the caller to
+    // re-evaluate and return ready, and because we never enqueued there
+    // is nothing to clean up.  A writer racing here is serialized on
+    // `POLL_BELL` — it either ran before us (we observe ready) or after
+    // us (we are enqueued and it drains us).
+    if ready_now() {
+        drop(bell);
+        return true;
+    }
     bell.enqueue_self_blocked(tid, wake_tick);
+    // Drop the bell AFTER enqueue but BEFORE schedule(): a wake that
+    // arrives between here and schedule() finds us already on the list
+    // and flips us Blocked→Ready, so the schedule() (or the scheduler
+    // tick) returns us promptly rather than losing the wake.
     drop(bell);
     crate::sched::schedule();
     // Classify the wake: if we are still on the bell list, the
@@ -286,6 +342,7 @@ pub fn wait_poll_event(caller_deadline: u64) {
     } else {
         POLL_BELL_BELL_WAKES.fetch_add(1, Ordering::Relaxed);
     }
+    false
 }
 
 /// Ring the poll bell — wake every thread parked in `wait_poll_event`.

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1489,13 +1489,28 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     // `u64::MAX` for infinite waits, the bell is the only
                     // wake mechanism — its single firing point is every
                     // pipe/eventfd write).
-                    crate::ipc::waitlist::wait_poll_event(deadline_tick);
-                    // Pump X11 so replies appear in socket buffers.
-                    crate::x11::poll();
-                    // Pump the NIC RX ring + UDP/TCP demux so wire-side
-                    // events become poll-visible.  See the matching
-                    // pre-wait pump above for the rationale.
-                    crate::net::poll();
+                    //
+                    // The readiness closure passed here is re-run by
+                    // `wait_poll_event` *under the POLL_BELL lock* before it
+                    // commits to parking, closing the check-and-park
+                    // lost-wakeup window: a writer that rings the bell
+                    // between our last `do_check` and the park is serialized
+                    // on POLL_BELL, so it either makes us observe ready in
+                    // the recheck (we skip parking) or finds us already
+                    // enqueued (it drains us).  `do_check(false, false)` is a
+                    // side-effect-light readiness probe (it only writes the
+                    // idempotent revents bits, recomputed after the wake).
+                    let ready_in_window =
+                        crate::ipc::waitlist::wait_poll_event(
+                            deadline_tick, || do_check(false, false) > 0);
+                    if !ready_in_window {
+                        // We actually parked and woke — pump X11 so replies
+                        // appear in socket buffers, and pump the NIC RX ring +
+                        // UDP/TCP demux so wire-side events become poll-
+                        // visible.  See the matching pre-wait pump above.
+                        crate::x11::poll();
+                        crate::net::poll();
+                    }
                     let r = do_check(true, true);
                     if r > 0 {
                         #[cfg(feature = "firefox-test")]
@@ -5209,6 +5224,27 @@ fn sys_select_linux(
         }
     }
 
+    // Read-only readiness probe: returns true if any still-requested fd is
+    // currently ready, WITHOUT clearing any fd_set bits.  Used as the
+    // recheck-under-lock predicate for `wait_poll_event` so the
+    // check-and-park lost-wakeup window is closed without destructively
+    // mutating the caller's fd_set during the recheck (the authoritative
+    // bit-clearing `do_rescan` runs only after we decide to return).
+    let probe_ready = || -> bool {
+        for fd in 0..nfds {
+            let byte_off = (fd / 8) as u64;
+            let bit      = 1u8 << (fd % 8);
+            let r_req = readfds  != 0 && fdset_read_bit(readfds,  byte_off, bit, kernel_dispatch);
+            let w_req = writefds != 0 && fdset_read_bit(writefds, byte_off, bit, kernel_dispatch);
+            if !r_req && !w_req { continue; }
+            let revents = crate::syscall::poll_revents(pid, fd, if r_req { 0x0001 } else { 0x0004 });
+            const READABLE_MASK: u16 = 0x0001 | 0x0010;
+            if r_req && revents & READABLE_MASK != 0 { return true; }
+            if w_req && revents & 0x0004 != 0 { return true; }
+        }
+        false
+    };
+
     let do_rescan = |ready: &mut i64| {
         *ready = 0;
         for fd in 0..nfds {
@@ -5274,8 +5310,18 @@ fn sys_select_linux(
                 // sleep.  The bell wakes us when any pipe/eventfd state
                 // change occurs; the scheduler tick wakes us at the
                 // deadline.  Either path drops back into the rescan.
-                crate::ipc::waitlist::wait_poll_event(deadline_tick);
-                crate::x11::poll();
+                //
+                // `probe_ready` is re-run under the POLL_BELL lock before
+                // committing to park (prepare-to-wait), closing the
+                // check-and-park lost-wakeup window; it is read-only so the
+                // authoritative bit-clearing `do_rescan` below stays the
+                // single fd_set mutator.
+                let ready_in_window =
+                    crate::ipc::waitlist::wait_poll_event(
+                        deadline_tick, &probe_ready);
+                if !ready_in_window {
+                    crate::x11::poll();
+                }
                 do_rescan(&mut ready);
                 if ready > 0 { break; }
                 if signal_pending(pid) { return -4; } // EINTR
@@ -9621,6 +9667,21 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
         }
     };
 
+    // Read-only readiness probe over the watch snapshot — true if any
+    // watched fd currently has a deliverable event.  Mirrors `do_poll`'s
+    // interest/ERR/HUP masking but allocates nothing and pushes nothing;
+    // used as the recheck-under-lock predicate for `wait_poll_event` so
+    // the check-and-park lost-wakeup window is closed (prepare-to-wait).
+    let probe_ready = || -> bool {
+        for &(fd, subscribed, _data) in &watches_snap {
+            let ready_ev = epoll_poll_events(pid, fd);
+            let interest =
+                (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
+            if interest != 0 { return true; }
+        }
+        false
+    };
+
     let mut fired: alloc::vec::Vec<EpollEvent> = alloc::vec::Vec::new();
     do_poll(&mut fired);
 
@@ -9656,7 +9717,22 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
                 // tick wakes us at the deadline.  Replaces the prior
                 // 10 ms-tick sleep loop and is the change responsible for
                 // closing the post-PR-#119 epoll-spin plateau.
-                crate::ipc::waitlist::wait_poll_event(deadline_tick);
+                //
+                // `probe_ready` is re-run under the POLL_BELL lock before
+                // the park commits (prepare-to-wait), so a writer that makes
+                // a watched fd ready in the window between our last `do_poll`
+                // and the park cannot lose the readiness edge: it is
+                // serialized on POLL_BELL and either makes the recheck
+                // observe ready (we skip parking) or finds us enqueued (it
+                // drains us).  The wake-side net/x11 pumps run only when we
+                // actually parked.
+                let ready_in_window =
+                    crate::ipc::waitlist::wait_poll_event(
+                        deadline_tick, &probe_ready);
+                if ready_in_window {
+                    do_poll(&mut fired);
+                    if !fired.is_empty() { break; }
+                }
                 // Pump the NIC RX ring and TCP timers on every wakeup.
                 // This is the symmetric partner to the identical call in
                 // poll(2) (~line 1447).  Without it, a tokio/reqwest runtime

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -201,6 +201,10 @@ pub fn run() -> ! {
     total += 1;
     if test_poll_bell_source_attribution() { passed += 1; }
 
+    // ── Test 0bx2: poll-bell check-and-park recheck-under-lock ────────────
+    total += 1;
+    if test_poll_bell_recheck_under_lock() { passed += 1; }
+
     // ── Test 0bc: POLLHUP on pipe read-end after writer close ─────────────
     total += 1;
     if test_pipe_pollhup_on_writer_close() { passed += 1; }
@@ -31534,6 +31538,141 @@ fn test_poll_bell_source_attribution() -> bool {
     test_println!("  all {} tagged sources bumped their own slot; `other` unchanged ✓",
         sources_to_ring.len());
     test_pass!("poll-bell per-source attribution counters");
+    true
+}
+
+// ── Test 0bx2: poll-bell check-and-park recheck-under-lock (TOCTOU) ──────────
+//
+// Regression for the `wait_poll_event` check-and-park lost-wakeup window.
+// Pre-fix, `wait_poll_event` unconditionally enqueued the caller and called
+// `schedule()`: a writer that rang the bell in the window between the
+// caller's last readiness scan (a *different* lock domain) and the
+// `POLL_BELL.lock()` would `drain_all()` an empty waiter list, consuming the
+// readiness edge, and the parker then slept until the ≈1 s `RESYNC_INTERVAL`
+// floor — presenting as a spinning/frozen event loop (`poll(2)`, `epoll(7)`
+// self-pipe `ScheduleWork` wakeups hit this window every iteration).
+//
+// The fix re-runs the caller's readiness predicate WHILE HOLDING `POLL_BELL`
+// (prepare-to-wait / recheck-under-lock, the standard lost-wakeup remedy).
+// This test asserts the two halves of that contract directly, without a
+// non-deterministic two-thread race:
+//
+//   1. Ready-in-window: when the readiness closure reports `true`, the helper
+//      MUST return `true` and MUST NOT park (no waiter enqueued, no
+//      `schedule()` — verified by an unchanged parked-waiter count and the
+//      fact that the call returns on the same thread without yielding).
+//   2. Not-ready: when the closure reports `false` *and* the deadline is
+//      already in the past, the helper parks but the scheduler-tick deadline
+//      is honoured (it returns rather than hanging), and on return the waiter
+//      is no longer parked.
+//
+// The decisive assertion is #1: it is exactly the edge a racing writer would
+// otherwise lose — a watched fd that became ready in the check-and-park
+// window is caught by the under-lock recheck and the caller never sleeps.
+fn test_poll_bell_recheck_under_lock() -> bool {
+    use crate::ipc::waitlist::{
+        wait_poll_event, poll_bell_waiter_count,
+        POLL_BELL_BELL_WAKES, POLL_BELL_RESYNC_WAKES,
+    };
+    use core::sync::atomic::Ordering;
+
+    test_header!("poll-bell check-and-park recheck-under-lock (lost-wakeup TOCTOU)");
+
+    // Pre-conditions: nobody parked on the bell at test entry.
+    let parked0 = poll_bell_waiter_count();
+    if parked0 != 0 {
+        test_fail!("poll_bell_recheck",
+            "unexpected {} pre-parked bell waiters at test entry", parked0);
+        return false;
+    }
+    let bw0 = POLL_BELL_BELL_WAKES.load(Ordering::Relaxed);
+    let rw0 = POLL_BELL_RESYNC_WAKES.load(Ordering::Relaxed);
+
+    // ── Case 1: ready-in-window — recheck closure reports ready ──────────
+    // Deadline `u64::MAX` (infinite) proves the return is driven by the
+    // under-lock recheck, NOT by a timeout: pre-fix this call would have
+    // enqueued + schedule()'d and only the bell or resync could return it.
+    // The closure simulates "an fd became ready in the check-and-park
+    // window".  Must return true and leave zero waiters parked.
+    let ready_ret = wait_poll_event(u64::MAX, || true);
+    if !ready_ret {
+        test_fail!("poll_bell_recheck",
+            "ready-in-window recheck returned false (should bail without parking)");
+        return false;
+    }
+    let parked1 = poll_bell_waiter_count();
+    if parked1 != 0 {
+        test_fail!("poll_bell_recheck",
+            "ready-in-window path enqueued a waiter (count={}); must not park", parked1);
+        return false;
+    }
+    // It must not have classified as a bell/resync wake — it never parked.
+    let bw1 = POLL_BELL_BELL_WAKES.load(Ordering::Relaxed);
+    let rw1 = POLL_BELL_RESYNC_WAKES.load(Ordering::Relaxed);
+    if bw1 != bw0 || rw1 != rw0 {
+        test_fail!("poll_bell_recheck",
+            "ready-in-window path bumped a wake counter (bell {}->{}, resync {}->{}); \
+             it must short-circuit before parking", bw0, bw1, rw0, rw1);
+        return false;
+    }
+    test_println!("  case1: ready-in-window recheck bailed without parking ✓");
+
+    // ── Case 1b: the recheck closure IS consulted (it gates the bail) ────
+    // A `wait_poll_event` that ignored the closure and unconditionally
+    // parked would never call it; assert the closure ran exactly once and
+    // that its `true` is what produced the no-park bail.  This is the
+    // decisive lost-wakeup edge — a writer that makes an fd ready in the
+    // check-and-park window is observed by the under-lock recheck.
+    let mut calls = 0u32;
+    let ready_ret_1b = wait_poll_event(u64::MAX, || { calls += 1; true });
+    if !ready_ret_1b || calls != 1 || poll_bell_waiter_count() != 0 {
+        test_fail!("poll_bell_recheck",
+            "recheck not consulted under lock (ret={} calls={} parked={}); \
+             the closure must gate the bail", ready_ret_1b, calls, poll_bell_waiter_count());
+        return false;
+    }
+    test_println!("  case1b: recheck closure consulted under lock (calls=1) ✓");
+
+    // ── Case 2: not-ready enqueue mechanics (WaitList-level, NO TID-0 park)
+    //
+    // The not-ready branch of `wait_poll_event` calls
+    // `enqueue_self_blocked` then `schedule()`.  We must NOT drive that
+    // branch from this test: the kernel-smoke test runner IS TID 0 (the
+    // BSP main thread), and parking TID 0 corrupts the scheduler (TID 0 is
+    // the BSP's only Ready candidate on CPU 0 — see the `vfork`/`futex`
+    // TID-0 notes elsewhere in this file).  So we exercise the same
+    // enqueue/drain mechanics one layer down, on a private `WaitList`,
+    // proving the not-ready path's building blocks are correct without
+    // ever transitioning TID 0 to Blocked.
+    {
+        use crate::ipc::waitlist::{WaitList, wake_tids};
+        let mut wl = WaitList::new();
+        if !wl.is_empty() {
+            test_fail!("poll_bell_recheck", "fresh WaitList not empty");
+            return false;
+        }
+        // A writer racing AFTER enqueue must find the waiter and be able to
+        // drain it — this is the half that makes a post-recheck wake safe.
+        // Use a synthetic TID that matches no real thread so `wake_tids`'
+        // THREAD_TABLE pass is a no-op (no scheduler state touched).
+        const SYNTH_TID: u64 = u64::MAX - 1;
+        wl.enqueue_self_blocked(SYNTH_TID, u64::MAX);
+        if wl.len() != 1 {
+            test_fail!("poll_bell_recheck", "enqueue did not register waiter (len={})", wl.len());
+            return false;
+        }
+        let drained = wl.drain_all();
+        if drained != [SYNTH_TID] || !wl.is_empty() {
+            test_fail!("poll_bell_recheck",
+                "drain_all did not return the enqueued waiter (drained={:?}, empty={})",
+                drained, wl.is_empty());
+            return false;
+        }
+        wake_tids(&drained); // no-op for the synthetic tid; asserts no panic
+    }
+    test_println!("  case2: not-ready enqueue/drain mechanics correct (no TID-0 park) ✓");
+
+    test_pass!("poll-bell check-and-park recheck-under-lock (lost-wakeup TOCTOU)");
     true
 }
 


### PR DESCRIPTION
## Summary

`wait_poll_event` (the global poll/select/epoll wake-bell park core) had a
**check-and-park lost-wakeup window**. It parked unconditionally — took
`POLL_BELL`, enqueued the caller, dropped the lock, `schedule()` — while the
fd-readiness scan that decides *whether* to park (`do_poll`/`poll_revents` in
the `poll(2)`/`select(2)`/`epoll_wait(2)` loops) runs in a **different lock
domain** (`PROCESS_TABLE` + per-fd pipe/socket/eventfd state) and was **not
re-checked under the bell lock** before committing to `schedule()`.

A writer running `ring_poll_bell_for → drain_all()` in the window between the
empty readiness scan and `POLL_BELL.lock()` finds an empty waiter list,
consumes the readiness edge, and the parker then sleeps with the wakeup
already gone — recovering only at the `RESYNC_INTERVAL_TICKS` (~1 s) floor.
The libevent self-pipe `ScheduleWork()` self-wake hits this window every
iteration and it widens under SMP, presenting as a spinning/frozen event loop.

This is the classic **prepare-to-wait / lost-wakeup** hazard (cf. `poll(2)`,
`epoll(7)`, and the "futex word recheck" discipline in `man 7 futex`).

## Fix

`wait_poll_event(deadline, ready_now)` re-runs the caller's readiness
predicate **while holding `POLL_BELL`**:

- ready in window → return `true`, neither enqueue nor `schedule()` (caller
  re-evaluates and returns ready);
- not ready → enqueue under the **same bell hold** that gated the recheck, so
  any `ring_poll_bell_for` racing between the recheck and `schedule()` is
  serialized behind the bell lock and observes the now-enqueued waiter. No
  edge can be lost.

All three POLL_BELL consumers converted: poll/ppoll (nr 7), select
(`sys_select_linux`), `sys_epoll_wait`. select/epoll use a read-only
`probe_ready` so the authoritative bit-clearing / event-building scan stays
the single mutator. The `RESYNC` backstop is retained as belt-and-braces.

## Lock order (no inversion, no hang)

New edge under the bell: `POLL_BELL → PROCESS_TABLE` (then, separately,
`THREAD_TABLE` via `enqueue_self_blocked`). **No bell writer ever rings while
holding `PROCESS_TABLE`** — every `ring_poll_bell_for` site drops the
process/state lock first (`signal::kill`, the alarm dispatcher, and the
pipe/eventfd/unix wake paths) — so the reverse edge does not exist.
`POLL_BELL` is never held across `schedule()`.

## Tests

Adds a `test_runner.rs` regression test for the recheck-under-lock path:
ready-in-window must bail without parking (the exact edge a racing writer
would lose), the closure must be consulted under the lock, and the not-ready
enqueue/drain mechanics are verified one layer down on a private `WaitList`
with a synthetic TID — the smoke runner is **TID 0 / the BSP main thread** and
must never be parked.

## Validation

Full kernel-smoke (`qemu-harness.py ci-run`, KVM) run locally on this branch
**and** on pristine `master` in the same environment:

- New regression test **passes** (ready-in-window, closure-consulted, and
  enqueue/drain sub-cases all green); no hang/timeout; the suite runs to
  completion.
- Failure set on this branch is a **subset** of pristine master's — every
  failure (`Musl hello`, `TCC compile`, `busybox basic`, `sigchld`,
  `ascension`, `monotonic-rate`, `glibc_hello`, `dynamic_elf`) reproduces on
  master and is a pre-existing local data.img-fixture gap / known glibc &
  timer flake, none related to poll/select/epoll. CI regenerates the data
  disk + builds tcc/busybox, so these do not fire there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)