### PR TITLE
kernel/net+linux: AF_UNIX POLLOUT writable-gate + recv-drain write-space wake (ABI #1+#2)

### DIFF
--- a/kernel/src/ipc/waitlist.rs
+++ b/kernel/src/ipc/waitlist.rs
@@ -200,19 +200,28 @@ pub enum PollBellSource {
     /// would only re-evaluate on the 1 s resync floor, defeating the
     /// short timeouts DNS resolvers expect (RFC 1035 §4.2.1).
     InetRx       = 8,
+    /// `crate::net::unix::read_msg` recv-drain — a reader consuming bytes
+    /// frees room in the recv ring, which makes the *peer's* write side
+    /// newly `POLLOUT`-ready.  Rung so a peer parked in `poll`/`epoll_wait`
+    /// waiting for the socket to become writable re-checks immediately,
+    /// rather than only on the resync floor (`man 7 unix`, the recv-side
+    /// write-space wake).  Distinct from `UnixWrite` (data-arrival, which
+    /// makes the reader `POLLIN`-ready) so kdb attribution stays honest.
+    UnixRead     = 9,
     /// Catch-all for ad-hoc readiness sources that have not yet been
     /// given their own variant (kept last for ABI tail-stability).
-    Other        = 9,
+    Other        = 10,
 }
 
 /// Number of `PollBellSource` variants — keep in sync with the enum.
-pub const N_BELL_SOURCES: usize = 10;
+pub const N_BELL_SOURCES: usize = 11;
 
 /// Stable string label for each `PollBellSource`, used by kdb to
 /// render the per-source counters.  Indexed by the enum's discriminant.
 pub const BELL_SOURCE_NAMES: [&str; N_BELL_SOURCES] = [
     "pipe", "eventfd", "unix_write", "unix_shutdown",
-    "timerfd", "signalfd", "inotify", "signal_inject", "inet_rx", "other",
+    "timerfd", "signalfd", "inotify", "signal_inject", "inet_rx",
+    "unix_read", "other",
 ];
 
 /// Per-source ring counters.  Bumped (Relaxed) at every successful
@@ -223,7 +232,7 @@ pub static BELL_RINGS_BY_SOURCE: [AtomicU64; N_BELL_SOURCES] = [
     AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
     AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
     AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
-    AtomicU64::new(0),
+    AtomicU64::new(0), AtomicU64::new(0),
 ];
 
 /// Cumulative number of `wait_poll_event` calls that woke via a bell

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -500,6 +500,14 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
     // still queued in our recv_buf.  Matches Linux AF_UNIX behaviour.
     if s.shut_rd { return Ok((0, 0)); }
 
+    // Number of bytes the drain frees from *our* recv ring.  Draining recv
+    // space makes the *peer's* write side newly POLLOUT-ready, so once we
+    // have dropped the TABLE lock we ring the write-side poll bell for any
+    // peer parked in poll/epoll_wait waiting to become writable (`man 7
+    // unix` recv-side write-space wake).  0 ⇒ nothing drained ⇒ no edge.
+    let drained: usize;
+    let result: Result<(usize, usize), i64>;
+
     if s.kind == SockKind::SeqPacket {
         // SEQPACKET: dequeue exactly one message, truncating any tail that
         // does not fit per `man 7 unix` §SOCK_SEQPACKET.
@@ -515,12 +523,26 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
         for _ in 0..discard {
             s.recv_head = (s.recv_head + 1) % RECV_BUF_CAP;
         }
-        return Ok((copied, discard));
+        // The whole message (copied + discarded tail) leaves the recv ring.
+        drained = copied + discard;
+        result  = Ok((copied, discard));
+    } else {
+        // STREAM: byte-stream — copy as many bytes as fit, no boundaries.
+        if s.recv_available() == 0 { return Err(-11); }
+        let copied = s.pop(buf);
+        drained = copied;
+        result  = Ok((copied, 0));
     }
 
-    // STREAM: byte-stream — copy as many bytes as fit, no boundaries.
-    if s.recv_available() == 0 { return Err(-11); }
-    Ok((s.pop(buf), 0))
+    // Drop the TABLE lock before ringing so a peer waking on the bell does
+    // not contend on TABLE during its re-evaluation pass (same discipline
+    // as `write()` / `shutdown()`).
+    drop(t);
+    if drained > 0 {
+        crate::ipc::waitlist::ring_poll_bell_for(
+            crate::ipc::waitlist::PollBellSource::UnixRead);
+    }
+    result
 }
 
 /// Half-close per IEEE 1003.1 §shutdown.  `shut_rd_flag` / `shut_wr_flag`
@@ -688,6 +710,44 @@ pub fn fully_hung_up(id: u64) -> bool {
     if peer == u64::MAX { return false; }
     if (peer as usize) >= MAX_UNIX_SOCKETS { return false; }
     t.0[peer as usize].state == UnixState::Free
+}
+
+/// Returns true if a `write(2)` on socket `id` would make progress right now —
+/// the AF_UNIX equivalent of the `POLLOUT` / `EPOLLOUT` writable predicate.
+///
+/// For our in-memory backend a STREAM `write()` pushes bytes directly into the
+/// *peer's* `recv_buf`; the call returns `-EAGAIN` exactly when that ring has no
+/// free space (`recv_space() == 0`).  A faithful `poll(2)` / `epoll_wait(2)`
+/// must therefore gate `POLLOUT` / `EPOLLOUT` on the peer having recv-buffer
+/// room, rather than advertising the socket writable unconditionally — an
+/// always-writable report makes a producer blocked on a full socket busy-spin
+/// `poll → write → EAGAIN`, the stuck-producer pattern `poll(2)` exists to
+/// avoid (`man 7 unix`, `man 2 poll`).
+///
+/// Per the long-standing AF_UNIX rule — writable is also reported once the
+/// write side can no longer block, so a blocked writer is released to observe
+/// the terminal `-EPIPE` instead of hanging forever:
+///   * not in `Connected` state (unbound / listening / disconnected) — a
+///     `write()` returns immediately (`-ENOTCONN` / `-EPIPE`), never blocks;
+///   * locally `shut_wr` — `write()` returns `-EPIPE` immediately;
+///   * peer slot gone — `write()` returns `-EPIPE` immediately.
+/// In all of those cases the call completes without blocking, so `POLLOUT`
+/// is the correct, stuck-socket-avoiding answer.
+pub fn writable(id: u64) -> bool {
+    if id as usize >= MAX_UNIX_SOCKETS { return false; }
+    let t = TABLE.lock();
+    let s = &t.0[id as usize];
+    if s.state == UnixState::Free { return true; }     // closed: write → EPIPE, no block
+    if s.state != UnixState::Connected { return true; } // not connected: never blocks
+    if s.shut_wr { return true; }                       // SHUT_WR: write → EPIPE, no block
+    let peer = s.peer_id;
+    if peer == u64::MAX || (peer as usize) >= MAX_UNIX_SOCKETS { return true; }
+    let peer = &t.0[peer as usize];
+    if peer.state == UnixState::Free { return true; }   // peer gone: write → EPIPE, no block
+    // Genuinely connected, write side open, peer alive: writable iff the peer's
+    // recv ring has room for at least one byte — the exact condition under
+    // which our STREAM/SEQPACKET `write()` returns >0 rather than -EAGAIN.
+    peer.recv_space() > 0
 }
 
 pub fn bytes_available(id: u64) -> usize {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -9447,7 +9447,14 @@ fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
                 // AF_INET goes through the protocol's `socket_has_data`
                 // — same shape, distinct backend.
                 if flags & UNIX_SOCK_BIT != 0 {
-                    let mut ev = EPOLLOUT;
+                    // EPOLLOUT only when a `write()` would make progress — the
+                    // peer's recv ring has room, or the write side can no
+                    // longer block (SHUT_WR / peer-gone / not-connected, where
+                    // `write()` returns -EPIPE without blocking).  Advertising
+                    // writable unconditionally makes a producer blocked on a
+                    // full socket busy-spin epoll_wait→write→EAGAIN, the
+                    // stuck-producer pattern `epoll(7)` / `poll(2)` avoid.
+                    let mut ev = if crate::net::unix::writable(inode) { EPOLLOUT } else { 0 };
                     let has_d = crate::net::unix::has_data(inode);
                     if has_d {
                         ev |= EPOLLIN;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -3960,7 +3960,14 @@ pub(crate) fn poll_revents(pid: u64, fd: usize, events: u16) -> u16 {
         }
         let mut rev = 0u16;
         if readable { rev |= events & POLLIN; }
-        rev |= events & POLLOUT; // connected sockets always writable
+        // POLLOUT only when a `write()` would make progress — i.e. the peer's
+        // recv ring has room (or the write side can no longer block, e.g.
+        // SHUT_WR / peer-gone / not-connected, where `write()` returns -EPIPE
+        // / -ENOTCONN without blocking).  Advertising writable unconditionally
+        // makes a producer blocked on a full socket busy-spin poll→write→EAGAIN
+        // — the stuck-producer pattern `poll(2)` exists to avoid (`man 2 poll`,
+        // `man 7 unix`).
+        if crate::net::unix::writable(uid) { rev |= events & POLLOUT; }
         // `poll(2)` distinguishes a read-side half-close from a full
         // hang-up, so we report them separately (matching the `epoll(7)`
         // EPOLLRDHUP / EPOLLHUP split):

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -670,6 +670,10 @@ pub fn run() -> ! {
     total += 1;
     if test_unix_socketpair() { passed += 1; }
 
+    // ── AF_UNIX POLLOUT writable-gate + recv-drain write-space wake ────────
+    total += 1;
+    if test_unix_pollout_writable_gate() { passed += 1; }
+
     // ── Test 54: AF_UNIX bind/listen/connect/accept ───────────────────────
 
     total += 1;
@@ -13136,6 +13140,114 @@ fn test_unix_socketpair() -> bool {
     crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
 
     test_pass!("AF_UNIX socketpair round-trip");
+    true
+}
+
+// ── AF_UNIX POLLOUT writable-gate + recv-drain write-space wake ────────────────
+//
+// Proves the two AF_UNIX readiness ABI fixes against `man 7 unix` / `man 2
+// poll`:
+//   (1) POLLOUT/EPOLLOUT is reported only when a `write()` would make progress
+//       — i.e. the peer's recv ring has room.  A socket whose peer recv ring is
+//       full must NOT advertise writable (else a blocked producer busy-spins
+//       poll→write→EAGAIN).
+//   (2) A reader draining recv space rings the write-side poll bell, so a peer
+//       parked in poll-for-writable re-checks immediately rather than only on
+//       the resync floor (the recv-side write-space wake).
+fn test_unix_pollout_writable_gate() -> bool {
+    use crate::net::unix;
+    use crate::ipc::waitlist::{BELL_RINGS_BY_SOURCE, PollBellSource};
+    test_header!("AF_UNIX POLLOUT writable-gate + recv-drain write-space wake");
+
+    // socketpair: a write on `a` lands in `b`'s recv ring and vice-versa, so
+    // `writable(a)` is gated on `b`'s recv_space().
+    let (a, b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("unix_pollout_gate", "socketpair returned MAX");
+        return false;
+    }
+
+    // Fresh, empty pair → both ends writable (peer recv ring empty).
+    if !unix::writable(a) {
+        test_fail!("unix_pollout_gate", "fresh socket a not writable");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  fresh pair: writable(a)=true ✓");
+
+    // Fill `b`'s recv ring by writing to `a` until a write returns -EAGAIN
+    // (-11): the ring is then full and `a` must report NOT writable.  Use a
+    // 4 KiB chunk; recv ring is 32 KiB so this terminates after ~8 writes.
+    let chunk = [0xa5u8; 4096];
+    let mut total: i64 = 0;
+    loop {
+        let n = unix::write(a, &chunk);
+        if n == -11 { break; }            // EAGAIN — peer ring full
+        if n <= 0 {
+            test_fail!("unix_pollout_gate", "unexpected write ret {}", n);
+            unix::close(a); unix::close(b);
+            return false;
+        }
+        total += n;
+        if total > 1 << 20 {              // safety: ring is only 32 KiB
+            test_fail!("unix_pollout_gate", "ring never filled (wrote {})", total);
+            unix::close(a); unix::close(b);
+            return false;
+        }
+    }
+    test_println!("  filled peer recv ring with {} bytes (write→EAGAIN) ✓", total);
+
+    // Peer ring full → `a` must NOT be writable (gap #1).  Before the fix this
+    // returned true unconditionally and a producer would busy-spin.
+    if unix::writable(a) {
+        test_fail!("unix_pollout_gate",
+            "socket a still writable with full peer recv ring (POLLOUT gate)");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  peer ring full: writable(a)=false ✓ (gap #1)");
+
+    // Snapshot the UnixRead (recv-drain) bell counter; draining `b` must ring
+    // it so a peer parked in poll-for-writable re-checks (gap #2).
+    let before = BELL_RINGS_BY_SOURCE[PollBellSource::UnixRead as usize]
+        .load(core::sync::atomic::Ordering::Relaxed);
+
+    // Drain `b` fully — read everything that was written.
+    let mut sink = [0u8; 4096];
+    let mut drained: i64 = 0;
+    loop {
+        let n = unix::read(b, &mut sink);
+        if n <= 0 { break; }              // EAGAIN/EOF — nothing left
+        drained += n;
+    }
+    test_println!("  drained {} bytes from b", drained);
+
+    let after = BELL_RINGS_BY_SOURCE[PollBellSource::UnixRead as usize]
+        .load(core::sync::atomic::Ordering::Relaxed);
+    if after <= before {
+        test_fail!("unix_pollout_gate",
+            "recv drain did not ring UnixRead bell (before={} after={}) — \
+             a peer parked in poll-for-writable would never re-check (gap #2)",
+            before, after);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  recv drain rang UnixRead poll bell ({}→{}) ✓ (gap #2)",
+        before, after);
+
+    // After draining, `a` is writable again (peer ring has room) — POLLOUT
+    // re-asserts.
+    if !unix::writable(a) {
+        test_fail!("unix_pollout_gate", "socket a not writable after drain");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  after drain: writable(a)=true ✓ (POLLOUT re-asserts)");
+
+    unix::close(a);
+    unix::close(b);
+    test_pass!("AF_UNIX POLLOUT writable-gate + recv-drain wake");
     true
 }
 
@@ -31586,10 +31698,10 @@ fn test_poll_bell_source_attribution() -> bool {
     }
 
     // Ring one of each tagged source.  Update the array length any time
-    // a new source variant lands in `PollBellSource` (currently 9 tagged
+    // a new source variant lands in `PollBellSource` (currently 10 tagged
     // variants — `Other` stays untagged by design so it can absorb
     // ad-hoc callers without skewing the per-source attribution).
-    let sources_to_ring: [PollBellSource; 9] = [
+    let sources_to_ring: [PollBellSource; 10] = [
         PollBellSource::Pipe,
         PollBellSource::Eventfd,
         PollBellSource::UnixWrite,
@@ -31599,6 +31711,7 @@ fn test_poll_bell_source_attribution() -> bool {
         PollBellSource::Inotify,
         PollBellSource::SignalInject,
         PollBellSource::InetRx,
+        PollBellSource::UnixRead,
     ];
     for s in &sources_to_ring {
         ring_poll_bell_for(*s);


### PR DESCRIPTION
## Summary

Two AF_UNIX readiness ABI-fidelity gaps confirmed by a reference cross-walk. Both are mandatory before multiprocess/IPC paths exercise AF_UNIX sockets under flow control. Fixes make `poll(2)`/`epoll_wait(2)` behave per `man 7 unix`, `man 2 poll`, `epoll(7)`.

### Gap #1 — unconditional POLLOUT/EPOLLOUT with no peer recv-space check
`poll_revents` (poll(2)) and `epoll_poll_events` (epoll) advertised an AF_UNIX socket writable unconditionally. A producer blocked on a socket whose peer recv ring is full would busy-spin `poll → write → EAGAIN` — the stuck-producer pattern `poll(2)` exists to prevent.

**Fix:** new `net::unix::writable(id)` gates POLLOUT on the peer's recv ring having room — the exact condition under which our STREAM/SEQPACKET `write()` returns `>0` rather than `-EAGAIN`. It still reports writable once the write side can no longer block (SHUT_WR / peer-gone / not-connected, where `write()` completes immediately with `-EPIPE`/`-ENOTCONN`) so a blocked writer is released to observe the terminal condition instead of hanging — the long-standing "writable on peer-shutdown prevents stuck sockets" rule.

### Gap #2 — recv drain produced no POLLOUT readiness edge
A reader draining recv space never woke a peer parked in poll-for-writable, so the peer only re-checked on the resync floor.

**Fix:** `net::unix::read_msg` rings the poll bell on any recv drain (the recv-side write-space wake), under a new `PollBellSource::UnixRead` variant so kdb attribution stays distinct from data-arrival (`UnixWrite`).

## Test

`test_unix_pollout_writable_gate` (test_runner.rs): fills a socketpair's peer recv ring to capacity (write→EAGAIN), asserts `writable(a)==false` + POLLOUT clears, drains the peer, asserts the `UnixRead` poll bell fired and `writable(a)==true` (POLLOUT re-asserts). The existing poll-bell attribution test is updated for the new variant.

**Harness verification** (`--features test-mode`, KVM): 174/180 kernel tests pass including the new test and all unix/poll/epoll/poll-bell tests. The 6 failures are pre-existing environment fixtures unrelated to this change (`/disk/bin/{hello,tcc,busybox}` NotFound in the worktree's symlinked data.img, plus a monotonic-rate timer flake) — they fail identically on master.

## Specs matched
- `poll(2)`, `epoll(7)`: POLLOUT/EPOLLOUT reported only when a write would not block.
- `unix(7)`: recv-side write-space wake; writable-on-peer-shutdown to avoid stuck sockets.
- POSIX.1-2017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)