### PR TITLE
kernel/vfs/ext2 + mm/cache: a device read error is not EOF — never zero-install a failed covering read

### DIFF
--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -735,23 +735,41 @@ pub fn prepopulate_file(path: &str) -> usize {
         // one virtio request per up-to-1 MiB-aligned segment of the burst.
         // (`fs` was snapshotted above; MOUNTS is not held during the read.)
         //
-        // Per POSIX read(2), a successful read may return fewer bytes than
-        // requested (short read).  We MUST honour the returned length —
-        // bytes beyond it in chunk_buf are stale heap content from prior
-        // iterations and must not be installed into the page cache.
+        // A DEVICE READ ERROR is NOT end-of-file.  The FS `read` contract is
+        // that an I/O failure during a covering read returns Err (per POSIX
+        // read(2): an I/O error returns -1, not a short count).  We MUST NOT
+        // zero-fill and install the unread tail on such a failure — that would
+        // poison the page cache with all-zero pages over real file contents
+        // (e.g. a shared library's tail code pages), corrupting it for every
+        // subsequent mapper.  The correct recovery is to leave the failed
+        // chunk's pages ABSENT: do not install anything, abandon the rest of
+        // the prepopulate for this file, and let the later demand-fault path
+        // re-read (and, on a persistent failure, deliver SIGBUS/SIGSEGV
+        // instead of executing zeroed code).  Genuine sparse holes still read
+        // as zero in-band (the FS returns Ok with the hole zero-filled), so a
+        // legitimate short read is an `Ok(n)` we honour below.
         let read_buf = &mut chunk_buf[..this_chunk];
         let bytes_read = match fs.read(inode, chunk_start, read_buf) {
             Ok(n) => n,
-            Err(_) => break,
+            Err(_) => {
+                crate::serial_println!(
+                    "[CACHE] prepopulate {}: device read error at off={:#x} \
+                     (inode={:#x}) — leaving pages absent for demand-fault retry",
+                    path, chunk_start, inode,
+                );
+                break;
+            }
         };
         if bytes_read == 0 {
-            // EOF or transient zero-return: skip this chunk and advance so
-            // the outer loop does not spin forever.
+            // EOF: skip this chunk and advance so the outer loop does not spin.
             offset = chunk_start + this_chunk as u64;
             continue;
         }
-        // Zero-fill the unread tail of chunk_buf so subsequent page-slicing
-        // below never copies stale heap bytes into the page cache.
+        // A genuine short read (`bytes_read < this_chunk`) now only happens at
+        // EOF or a trailing sparse hole — both of which read as zero by
+        // definition.  Zero-fill the unread tail of chunk_buf so page-slicing
+        // below never copies stale heap bytes into the page cache.  (A device
+        // error cannot reach here: it returned Err above.)
         if bytes_read < this_chunk {
             // SAFETY: read_buf covers [0..this_chunk]; bytes_read <= this_chunk.
             unsafe {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -382,6 +382,8 @@ pub fn run() -> ! {
     total += 1;
     if test_ext2_read_coalesce() { passed += 1; }
     total += 1;
+    if test_ext2_read_device_error_not_eof() { passed += 1; }
+    total += 1;
     if test_ext2_readdir_noncontig() { passed += 1; }
     total += 1;
     if test_ext2_trunc_shrink() { passed += 1; }
@@ -5985,6 +5987,245 @@ fn test_ext2_read_coalesce() -> bool {
     }
 
     test_pass!("EXT2-READ-COALESCE");
+    true
+}
+
+// ── EXT2-READERR: a device read error during a covering read is NOT EOF ──
+//
+// Regression guard for the page-cache corruption class where a transient
+// block-device read error in the MIDDLE of a multi-block file read was
+// silently collapsed into a short return indistinguishable from a genuine
+// end-of-file / sparse-hole short read.  The bulk prepopulate path
+// (`mm::cache::prepopulate_file`) then zero-filled the unread tail and
+// installed all-zero pages into the page cache as authoritative file
+// contents — corrupting (for example) the tail code pages of a shared
+// library so the dynamic loader executed against a zeroed instruction page.
+//
+// The POSIX invariant (read(2): a read interrupted by an error "shall
+// return -1") and the page-cache filler contract (an I/O error must NOT
+// produce an up-to-date zero page; the page is left absent so a later
+// access re-reads) require that a device error during a covering read be
+// DISTINGUISHABLE from EOF.  Concretely for our VFS `read`:
+//
+//   * a read that ends because it reached i_size (EOF) or filled the buffer
+//     returns `Ok(n)` (a genuine short read is permitted);
+//   * a read whose underlying device I/O FAILS before the covering range is
+//     satisfied returns `Err(..)` — it MUST NOT return `Ok(partial)`.
+//
+// A genuine sparse hole (resolve_block == 0) is the ONLY legitimate
+// zero-fill and is exercised by EXT2-READ-COALESCE.
+
+/// Arc-sharing block-device shim: lets a test retain a handle to the in-memory
+/// image while also handing a `Box<dyn BlockDevice>` to `Ext2Fs::new`.
+struct ArcDevShim(alloc::sync::Arc<crate::drivers::block::MutableMemoryBlockDevice>);
+impl crate::drivers::block::BlockDevice for ArcDevShim {
+    fn sector_count(&self) -> u64 {
+        self.0.sector_count()
+    }
+    fn read_sectors(
+        &self,
+        lba: u64,
+        count: u32,
+        buf: &mut [u8],
+    ) -> Result<(), crate::drivers::block::BlockError> {
+        self.0.read_sectors(lba, count, buf)
+    }
+    fn write_sectors(
+        &self,
+        lba: u64,
+        count: u32,
+        data: &[u8],
+    ) -> Result<(), crate::drivers::block::BlockError> {
+        self.0.write_sectors(lba, count, data)
+    }
+}
+
+/// A block device that returns `IoError` for any read overlapping an armed
+/// sector window.  Arming modes:
+///   * `u32::MAX` remaining — the window always errors (hard device fault);
+///   * `n` remaining — the window errors for the first `n` reads that touch it,
+///     then succeeds (models a retryable queue-full / timeout that the FS read
+///     path must NOT mistake for EOF).
+struct FaultInjectBlockDevice {
+    inner: alloc::sync::Arc<crate::drivers::block::MutableMemoryBlockDevice>,
+    fault_lo: u64,
+    fault_hi: u64,
+    remaining: core::sync::atomic::AtomicU32,
+}
+
+impl FaultInjectBlockDevice {
+    fn overlaps(&self, lba: u64, count: u32) -> bool {
+        lba < self.fault_hi && lba + count as u64 > self.fault_lo
+    }
+}
+
+impl crate::drivers::block::BlockDevice for FaultInjectBlockDevice {
+    fn sector_count(&self) -> u64 {
+        self.inner.sector_count()
+    }
+    fn read_sectors(
+        &self,
+        lba: u64,
+        count: u32,
+        buf: &mut [u8],
+    ) -> Result<(), crate::drivers::block::BlockError> {
+        use core::sync::atomic::Ordering;
+        if self.overlaps(lba, count) {
+            loop {
+                let cur = self.remaining.load(Ordering::Acquire);
+                if cur == 0 {
+                    break; // exhausted: fall through to a real read
+                }
+                let next = if cur == u32::MAX { u32::MAX } else { cur - 1 };
+                if self
+                    .remaining
+                    .compare_exchange(cur, next, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return Err(crate::drivers::block::BlockError::IoError);
+                }
+            }
+        }
+        self.inner.read_sectors(lba, count, buf)
+    }
+    fn write_sectors(
+        &self,
+        lba: u64,
+        count: u32,
+        data: &[u8],
+    ) -> Result<(), crate::drivers::block::BlockError> {
+        self.inner.write_sectors(lba, count, data)
+    }
+}
+
+fn test_ext2_read_device_error_not_eof() -> bool {
+    test_header!("EXT2-READERR: device read error mid-file returns Err, never silent zero-EOF");
+    use crate::drivers::block::MutableMemoryBlockDevice;
+    use crate::vfs::ext2::Ext2Fs;
+    use crate::vfs::FileSystemOps;
+
+    // An 8 KiB (8 × 1 KiB blocks) contiguous file on inode 11.  mke2fs-style
+    // sequential allocation makes the 8 blocks physically contiguous, so a
+    // whole-file read takes the coalescing fast path — exactly the
+    // shared-library load shape.
+    let payload: alloc::vec::Vec<u8> =
+        (0..8 * 1024u32).map(|i| ((i * 31 + 7) & 0xFF) as u8).collect();
+
+    // Build the fixture once: write the file through a shared-Arc device, then
+    // snapshot the resulting on-disk image so every sub-case re-mounts the same
+    // bytes (behind a clean device or a fault injector).
+    let backing = alloc::sync::Arc::new(MutableMemoryBlockDevice::new(build_ext2_test_image()));
+    {
+        let fs = Ext2Fs::new(alloc::boxed::Box::new(ArcDevShim(backing.clone())))
+            .expect("clean mount for fixture");
+        if fs.write(11, 0, &payload).expect("write 8K") != payload.len() {
+            test_fail!("EXT2-READERR", "short write building fixture");
+            return false;
+        }
+    }
+    let clean_img = backing.snapshot();
+
+    // Resolve the file's TAIL block (logical block 7) to its physical sectors.
+    let (tail_lba, tail_sectors) = {
+        let dev = alloc::boxed::Box::new(MutableMemoryBlockDevice::new(clean_img.clone()));
+        let fs = Ext2Fs::new(dev).expect("remount clean for probe");
+        match fs.resolve_block_sectors_for_test(11, 7) {
+            Some(v) => v,
+            None => {
+                test_fail!("EXT2-READERR", "could not resolve tail block sectors");
+                return false;
+            }
+        }
+    };
+
+    // ── Case 1: persistent device fault on the tail block ────────────────────
+    // A whole-file read covers [0, 8 KiB).  The first 7 blocks read cleanly;
+    // the device errors on the 8th.  The covering read CANNOT be satisfied —
+    // `read` must return Err, NOT Ok(7168) (which the caller would treat as a
+    // benign EOF short read and zero-fill the tail into the page cache).
+    {
+        let dev = alloc::boxed::Box::new(FaultInjectBlockDevice {
+            inner: alloc::sync::Arc::new(MutableMemoryBlockDevice::new(clean_img.clone())),
+            fault_lo: tail_lba,
+            fault_hi: tail_lba + tail_sectors as u64,
+            remaining: core::sync::atomic::AtomicU32::new(u32::MAX),
+        });
+        let fs = Ext2Fs::new(dev).expect("mount behind fault injector");
+        let mut full = alloc::vec![0xEEu8; payload.len()];
+        match fs.read(11, 0, &mut full) {
+            Ok(n) => {
+                test_fail!(
+                    "EXT2-READERR",
+                    "covering read over a device error returned Ok({}) — a \
+                     silent partial indistinguishable from EOF; the tail would \
+                     be zero-installed into the page cache",
+                    n
+                );
+                return false;
+            }
+            Err(_) => { /* correct: a device error is not EOF */ }
+        }
+    }
+
+    // ── Case 2: transient fault that clears on retry ─────────────────────────
+    // A single-shot device error: the read path either surfaces Err (caller
+    // re-faults and retries) OR transparently retries to success.  Either way
+    // the bytes returned on a SUCCESSFUL read must be the real file bytes —
+    // never a zero tail.
+    {
+        let dev = alloc::boxed::Box::new(FaultInjectBlockDevice {
+            inner: alloc::sync::Arc::new(MutableMemoryBlockDevice::new(clean_img.clone())),
+            fault_lo: tail_lba,
+            fault_hi: tail_lba + tail_sectors as u64,
+            remaining: core::sync::atomic::AtomicU32::new(1),
+        });
+        let fs = Ext2Fs::new(dev).expect("mount behind transient fault injector");
+        let mut full = alloc::vec![0xEEu8; payload.len()];
+        match fs.read(11, 0, &mut full) {
+            Ok(n) => {
+                if n != payload.len() || full != payload {
+                    test_fail!(
+                        "EXT2-READERR",
+                        "transient fault: Ok({}) but contents diverge — a retry \
+                         path must yield the true bytes, never a zero tail",
+                        n
+                    );
+                    return false;
+                }
+            }
+            Err(_) => {
+                // The 1-shot fault is now spent; re-read must succeed with the
+                // true bytes (the caller's correct recovery is to re-fault).
+                let mut again = alloc::vec![0xEEu8; payload.len()];
+                let r = fs.read(11, 0, &mut again).expect("re-read after spent fault");
+                if r != payload.len() || again != payload {
+                    test_fail!("EXT2-READERR", "post-fault re-read mismatch (r={})", r);
+                    return false;
+                }
+            }
+        }
+    }
+
+    // ── Case 3: a genuine EOF short read still returns Ok ─────────────────────
+    // Reading past i_size must NOT regress to Err — only a DEVICE error does.
+    {
+        let dev = alloc::boxed::Box::new(MutableMemoryBlockDevice::new(clean_img.clone()));
+        let fs = Ext2Fs::new(dev).expect("mount clean for EOF case");
+        let mut over = alloc::vec![0u8; 16 * 1024];
+        let n = match fs.read(11, 0, &mut over) {
+            Ok(n) => n,
+            Err(_) => {
+                test_fail!("EXT2-READERR", "genuine EOF short read regressed to Err");
+                return false;
+            }
+        };
+        if n != payload.len() || over[..payload.len()] != payload[..] {
+            test_fail!("EXT2-READERR", "EOF short read wrong length/contents (n={})", n);
+            return false;
+        }
+    }
+
+    test_pass!("EXT2-READERR");
     true
 }
 

--- a/kernel/src/vfs/ext2.rs
+++ b/kernel/src/vfs/ext2.rs
@@ -544,6 +544,29 @@ impl Ext2Fs {
         })
     }
 
+    /// Test-only: resolve a file's logical block index to its on-disk
+    /// `(start_sector, sector_count)` range.
+    ///
+    /// Lets a fault-injection harness arm a device error on the exact sectors
+    /// that back a chosen block of a file (e.g. the tail block of a multi-block
+    /// library) without baking in any allocator-placement assumption. Returns
+    /// `None` if the inode does not exist or the logical block is a hole.
+    #[doc(hidden)]
+    pub fn resolve_block_sectors_for_test(
+        &self,
+        inode_num: u64,
+        block_idx: usize,
+    ) -> Option<(u64, u16)> {
+        let ino = self.read_inode(inode_num)?;
+        let block_num = self.resolve_block(&ino, block_idx);
+        if block_num == 0 {
+            return None; // hole — no backing sectors
+        }
+        let sectors_per_block = (self.block_size / 512) as u16;
+        let start_sector = block_num as u64 * sectors_per_block as u64;
+        Some((start_sector, sectors_per_block))
+    }
+
     /// Dispatch a sector-level read through whichever reader the FS holds.
     fn read_sectors_inner(&self, sector: u64, count: u16, buf: &mut [u8])
         -> Result<(), &'static str>
@@ -561,6 +584,34 @@ impl Ext2Fs {
             }
             BlockReader::Fn(f) => f(sector, count, buf),
         }
+    }
+
+    /// Sector read with a bounded retry for transient device errors.
+    ///
+    /// A block device may report a *retryable* condition (a queue-full / busy
+    /// timeout that resolves once the device drains) as an error.  Treating
+    /// such a transient failure as a hard error — and worse, as end-of-file —
+    /// would poison the page cache with zeros (see `read_inode_data`).  We
+    /// therefore retry a small, bounded number of times before surfacing the
+    /// error to the caller.  This is NOT a substitute for genuine error
+    /// handling: after the retry budget is exhausted the error propagates so
+    /// the read path can fail the covering read rather than silently truncate
+    /// it.  POSIX read(2): a read interrupted by an error returns -1, not a
+    /// short count that masquerades as EOF.
+    fn read_sectors_retry(&self, sector: u64, count: u16, buf: &mut [u8])
+        -> Result<(), &'static str>
+    {
+        // 3 attempts total (1 + 2 retries): enough to ride out a momentary
+        // queue-full / yield window without unbounded spinning on a hard fault.
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut last = Ok(());
+        for _ in 0..MAX_ATTEMPTS {
+            last = self.read_sectors_inner(sector, count, buf);
+            if last.is_ok() {
+                return Ok(());
+            }
+        }
+        last
     }
 
     /// Write `count` sectors starting at `sector` from `data`.
@@ -586,6 +637,16 @@ impl Ext2Fs {
         let sectors_per_block = (self.block_size / 512) as u16;
         let start_sector = block_num as u64 * sectors_per_block as u64;
         self.read_sectors_inner(start_sector, sectors_per_block, buf)
+    }
+
+    /// Read a block with the bounded transient-error retry (see
+    /// [`Ext2Fs::read_sectors_retry`]).  Used on the file-data read path so a
+    /// momentary device hiccup does not surface as a (corrupting) silent short
+    /// read.
+    fn read_block_retry(&self, block_num: u32, buf: &mut [u8]) -> Result<(), &'static str> {
+        let sectors_per_block = (self.block_size / 512) as u16;
+        let start_sector = block_num as u64 * sectors_per_block as u64;
+        self.read_sectors_retry(start_sector, sectors_per_block, buf)
     }
 
     /// Write a whole block to the filesystem.
@@ -656,12 +717,23 @@ impl Ext2Fs {
     /// madvise(2) MADV_SEQUENTIAL for the conceptual access pattern this
     /// optimises.
     ///
-    /// Behaviour is byte-for-byte identical to the per-block loop it replaces:
-    /// sparse blocks still read as zero, the result is still clamped to EOF
-    /// (`i_size`), and a block-device error still yields a short read.
-    fn read_inode_data(&self, inode: &Ext2Inode, offset: u64, buf: &mut [u8]) -> usize {
+    /// On success returns the number of bytes read: a value < `buf.len()` is a
+    /// genuine short read because the request ran past `i_size` (EOF).  A block
+    /// **device error** during the covering read is NOT EOF — it returns
+    /// `Err(..)` so the caller can fail the read rather than mistake the unread
+    /// tail for end-of-file.  This is the load-bearing distinction: the page
+    /// cache treats whatever it gets as authoritative file contents, so a
+    /// device error silently collapsed into a short count would let the
+    /// prepopulate / demand-fault path install ZERO pages over real file data
+    /// (e.g. a shared library's tail code pages), corrupting it permanently.
+    /// POSIX read(2): a read interrupted by an error returns -1, not a short
+    /// count indistinguishable from EOF.  Genuine sparse blocks
+    /// (`resolve_block == 0`) are the only legitimate in-band zero-fill.
+    fn read_inode_data(&self, inode: &Ext2Inode, offset: u64, buf: &mut [u8])
+        -> Result<usize, &'static str>
+    {
         let file_size = inode.size as u64;
-        if offset >= file_size { return 0; }
+        if offset >= file_size { return Ok(0); }
 
         let bs = self.block_size as u64;
         let to_read = buf.len().min((file_size - offset) as usize);
@@ -677,7 +749,10 @@ impl Ext2Fs {
 
             let block_num = self.resolve_block(inode, block_idx);
 
-            // Sparse block (hole) — fill with zeros, no device I/O.
+            // Sparse block (hole) — fill with zeros, no device I/O.  This is
+            // the ONLY legitimate in-band zero-fill: the block genuinely has no
+            // backing storage, so reading it as zero is correct per the ext2
+            // sparse-file semantics (a hole reads as zero).
             if block_num == 0 {
                 let n = (self.block_size - off_in_block).min(to_read - read_total);
                 buf[read_total..read_total + n].fill(0);
@@ -715,24 +790,23 @@ impl Ext2Fs {
                 let start_sector = block_num as u64 * sectors_per_block;
                 let sector_count = (run_blocks as u64 * sectors_per_block) as u16;
                 let dst = &mut buf[read_total..read_total + run_bytes];
-                if self.read_sectors_inner(start_sector, sector_count, dst).is_err() {
-                    break;
-                }
+                // A device error here is NOT EOF: fail the read so the caller
+                // never installs a zero-filled tail as if it were file data.
+                self.read_sectors_retry(start_sector, sector_count, dst)?;
                 read_total += run_bytes;
                 continue;
             }
 
             // Slow path: unaligned head/tail — read one block through the
-            // bounce buffer and copy the overlapping window.
-            if self.read_block(block_num, &mut block_buf).is_err() {
-                break;
-            }
+            // bounce buffer and copy the overlapping window.  Same rule: a
+            // device error is propagated, not swallowed as a short read.
+            self.read_block_retry(block_num, &mut block_buf)?;
             let n = (self.block_size - off_in_block).min(to_read - read_total);
             buf[read_total..read_total + n].copy_from_slice(&block_buf[off_in_block..off_in_block + n]);
             read_total += n;
         }
 
-        read_total
+        Ok(read_total)
     }
 
     /// Resolve a logical block index to a physical block number.
@@ -1966,7 +2040,19 @@ impl Ext2Fs {
             return entries;
         }
         let mut data = alloc::vec![0u8; size];
-        self.read_inode_data(inode, 0, &mut data);
+        // A device error while reading the directory blocks must not be
+        // mistaken for a valid (empty/short) directory.  We parse only the
+        // bytes successfully read; on a hard device error we return the
+        // entries parsed so far (none, since the buffer is still zeroed),
+        // matching the conservative readdir(3) behaviour used by the
+        // corruption guards below — never fabricate entries from zeroed bytes.
+        let valid_len = self
+            .read_inode_data(inode, 0, &mut data)
+            .unwrap_or(0);
+        let size = valid_len.min(size);
+        if size < EXT2_DIR_HDR {
+            return entries;
+        }
 
         let max_inumber = self.superblock.inodes_count;
         // Defensive iteration bound: each iteration must consume at least
@@ -2100,9 +2186,14 @@ impl Ext2Fs {
                 .ok()
                 .map(|s| s.to_string());
         }
-        // Slow symlink — read the target out of file-data blocks.
+        // Slow symlink — read the target out of file-data blocks.  A device
+        // error reading the target is a failure to resolve the link, not an
+        // empty target: return None rather than decode a zeroed buffer.
         let mut data = alloc::vec![0u8; size as usize];
-        let got = self.read_inode_data(inode, 0, &mut data);
+        let got = match self.read_inode_data(inode, 0, &mut data) {
+            Ok(n) => n,
+            Err(_) => return None,
+        };
         if got == 0 {
             return None;
         }
@@ -2303,7 +2394,11 @@ impl FileSystemOps for Ext2Fs {
 
     fn read(&self, inode: u64, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
         let ino = self.read_inode(inode).ok_or(VfsError::NotFound)?;
-        Ok(self.read_inode_data(&ino, offset, buf))
+        // A device read error during a covering read maps to VfsError::Io
+        // (EIO) — NOT a silent short read.  Callers (page-cache prepopulate,
+        // demand-fault) rely on this to avoid installing zero pages over real
+        // file data; per POSIX read(2) an I/O error is distinct from EOF.
+        self.read_inode_data(&ino, offset, buf).map_err(|_| VfsError::Io)
     }
 
     fn write(&self, inode: u64, offset: u64, data: &[u8]) -> VfsResult<usize> {


### PR DESCRIPTION
## Summary

Fixes a flaky page-cache corruption: a transient block-device read error in
the middle of a multi-block file read was silently collapsed into a short
return **indistinguishable from EOF**, and the page-cache bulk prepopulate
path then zero-filled the unread tail and installed **all-zero pages** as
authoritative file contents. For a shared library this corrupts the tail
code pages, so the dynamic loader executes a zeroed instruction page
(Exec-format fault / wrong-branch livelock; the directory-block variant
surfaces as a spurious lib `ENOENT`). The corruption is permanent because
the prepopulate path never re-reads.

## Root cause

`Ext2Fs::read_inode_data` returned a bare `usize`. On a device read error
mid-read it silently `break`'d and returned a **partial** count; `read`
wrapped that in `Ok(..)`, so a hard I/O error became `Ok(partial)` —
identical to a benign past-EOF short read. `mm::cache::prepopulate_file`
then zero-filled `[partial, this_chunk)` and installed zero pages, with no
guard on the demo build to detect the divergence.

## Fix

A failed covering read must be distinguishable from EOF. Per **POSIX
`read(2)`**, a read interrupted by an error returns `-1` (it does not return
a short count that masquerades as EOF); the page-cache filler contract
leaves a page **absent** on I/O error so a later access re-reads rather than
seeing an up-to-date zero page.

- `read_inode_data` now returns `Result<usize, &'static str>`. A device
  error on either the coalesced fast path or the bounce-buffer slow path
  propagates `Err`. A short `Ok(n)` can now only mean EOF or a trailing
  **sparse hole** — both legitimately zero. Genuine sparse blocks
  (`resolve_block == 0`) remain the **only** in-band zero-fill (per the ext2
  sparse-file semantics: a hole reads as zero).
- A small **bounded retry** (3 attempts) rides out a momentary retryable
  device condition (queue-full / busy timeout) before surfacing the error.
- `read` maps a device error to `VfsError::Io` (EIO). `read_dir_entries` and
  the slow-symlink decoder treat a failed read as "no readable data" rather
  than decoding a zeroed buffer (never fabricate entries from zeros).
- `prepopulate_file` no longer zero-installs on `Err`: it leaves the chunk's
  pages **absent** so the demand-fault path re-reads (and, on a persistent
  failure, delivers SIGBUS/SIGSEGV instead of executing zeroed code). The
  demand-fault sites already free-frame-and-fail on a `read` error, so the
  same source-level fix closes both paths.

## Test (dispositive before/after)

`EXT2-READERR` (`test_ext2_read_device_error_not_eof`) uses a
fault-injecting block device armed on a file's tail block:

- **persistent** fault over a covering read MUST return `Err` (not
  `Ok(partial)`);
- a **transient** (1-shot) fault yields the true bytes on retry, never zeros;
- a genuine **past-EOF** read still returns `Ok(n)` (no regression).

Confirmed: the test **FAILS** on the pre-fix kernel
(`covering read over a device error returned Ok(0)`) and **PASSES** after.
All 28 EXT2 / FAT32 / VFS / page-cache-coherency tests remain green
(`EXT2-READ-COALESCE` confirms genuine sparse-hole zero-fill is preserved).

The 7 unrelated suite failures (`Musl hello`, `glibc_hello`, `sigchld`,
`ascension`, `TCC compile`, `busybox basic`, `monotonic-rate`) are
pre-existing fixture-absence (`/disk/bin/hello: NotFound`, `InterpNotFound`)
and host-timing issues — none touch the FS layer.

## Follow-up (kmd)

Investigate why the underlying multi-sector device read errors transiently
under load — a retryable queue-full / yield condition mis-reported as a hard
error. The filesystem fix (never zero-install a failed read) is the
correctness fix regardless of the device cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)