### PR TITLE
kernel/futex: compare FUTEX_WAIT/CMP_REQUEUE value as 32-bit (fix int sign-extension EAGAIN storm)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -8877,7 +8877,14 @@ pub fn sys_futex_linux(
                     Some(v) => v,
                     None => return -14, // EFAULT
                 };
-                if current as u64 != _val3 {
+                // Per futex(2), the futex word is 32-bit; compare only the low
+                // 32 bits of `val3`.  The `val3` argument is typed `int` in the
+                // C-library wrappers, so a value with bit 31 set arrives in the
+                // 64-bit syscall register sign-extended (high half all-ones).
+                // A full-width compare against the zero-extended 32-bit `*uaddr`
+                // would mismatch in the high half and spuriously return EAGAIN,
+                // breaking the pthread_cond broadcast/requeue handshake.
+                if current != (_val3 as u32) {
                     return -11; // EAGAIN — *uaddr changed under us
                 }
             }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -374,7 +374,21 @@ where
         Some(v) => v,
         None => return FutexWaitOutcome::Fault,
     };
-    if current as u64 != val {
+    // Per futex(2): "The futex word is a 32-bit field."  The FUTEX_WAIT
+    // comparison is `*uaddr == val` over those 32 bits only — the kernel
+    // must ignore any bits the caller placed above bit 31 of the `val`
+    // syscall argument.  This matters because the futex `val` argument is
+    // typed `int` in the C library wrappers (e.g. pthread_mutex_timedlock's
+    // `__timedwait(addr, val, …)` where `val` carries the mutex word with
+    // bit 31 — the contended-waiters bit — set).  Widening a negative `int`
+    // to the 64-bit syscall register sign-extends it: a futex word of
+    // 0x8000_0010 arrives as 0xFFFF_FFFF_8000_0010.  Comparing the
+    // zero-extended 32-bit `*uaddr` (0x0000_0000_8000_0010) against the full
+    // 64-bit `val` would then mismatch in the high half on every call,
+    // returning EAGAIN forever and never parking the waiter — a contended
+    // mutex's owner-handoff wait spins instead of sleeping.  Truncate `val`
+    // to 32 bits before the compare, matching the 32-bit futex-word contract.
+    if current != (val as u32) {
         return FutexWaitOutcome::ValueMismatch;
     }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1655,6 +1655,10 @@ pub fn run() -> ! {
     total += 1;
     if test_futex_wait_atomic_check_then_queue() { passed += 1; }
 
+    // ── Test 195b: FUTEX_WAIT value compare is 32-bit (int sign-extension) ──
+    total += 1;
+    if test_futex_wait_val_is_32bit() { passed += 1; }
+
     // ── Test 196: memfd_create MFD_CLOEXEC + MFD_ALLOW_SEALING + seals ──
     total += 1;
     if test_memfd_cloexec_sealing() { passed += 1; }
@@ -31817,6 +31821,117 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
 
     test_println!("  all {} waiters drained, no leaked queue entries ✓", N_WAITERS);
     test_pass!("FUTEX_WAIT atomic check-then-queue (lost-wakeup race)");
+    true
+}
+
+// ── Test: FUTEX_WAIT value comparison is 32-bit (sign-extension safe) ────
+//
+// Per futex(2), "the futex word is a 32-bit field"; the FUTEX_WAIT
+// comparison `*uaddr == val` is over those 32 bits only.  The futex `val`
+// argument is typed `int` in the C-library wrappers
+// (pthread_mutex_timedlock → __timedwait(addr, val, …)).  When a mutex word
+// with bit 31 set — the musl contended-waiters bit 0x8000_0000 — is passed
+// as that `int`, widening to the 64-bit syscall register sign-extends it:
+// the kernel receives 0xFFFF_FFFF_8000_0010 for a futex word of 0x8000_0010.
+//
+// A full-width compare against the zero-extended 32-bit `*uaddr` would
+// mismatch in the high half on EVERY call and return EAGAIN, so a waiter on
+// a contended mutex spins instead of parking — the observed 1.6-billion-call
+// FUTEX_WAIT storm with a frozen futex word.  This test pins the contract:
+// when the low 32 bits agree, the helper must Enqueue regardless of the high
+// 32 bits of `val`; when the low 32 bits differ it must report ValueMismatch.
+fn test_futex_wait_val_is_32bit() -> bool {
+    use core::sync::atomic::{AtomicU32, Ordering};
+    use crate::syscall::{FUTEX_WAITERS, FutexWaitOutcome, futex_wait_check_and_enqueue};
+
+    test_header!("FUTEX_WAIT 32-bit value compare (int sign-extension safe)");
+
+    // Synthetic key, well clear of any live mapping.
+    const SYNTH_PID:   u64 = 0xF00D_F00D_0000_0001;
+    const SYNTH_UADDR: u64 = 0x7EFF_F222_0000_0000;
+    // Futex word with bit 31 (musl waiters bit) set — exactly the value
+    // captured live at the Firefox main-thread mutex storm (_m_lock = waiters
+    // | EBUSY).
+    const WORD: u32 = 0x8000_0010;
+    // The sign-extended 64-bit `val` a musl `int` carrying WORD produces in
+    // the syscall register.
+    const VAL_SIGN_EXTENDED: u64 = 0xFFFF_FFFF_8000_0010;
+
+    static FUTEX_WORD: AtomicU32 = AtomicU32::new(WORD);
+    FUTEX_WORD.store(WORD, Ordering::SeqCst);
+
+    // Clean any stale queue entry from a prior run.
+    FUTEX_WAITERS.lock().remove(&(SYNTH_PID, SYNTH_UADDR));
+
+    let tid = crate::proc::current_tid();
+
+    // Case 1: low-32 bits agree, high bits all-ones (sign-extended int).
+    // MUST Enqueue (pre-fix this returned ValueMismatch → the storm).
+    let outcome = futex_wait_check_and_enqueue(
+        SYNTH_PID, SYNTH_UADDR, VAL_SIGN_EXTENDED, tid,
+        u64::MAX,
+        || Some(FUTEX_WORD.load(Ordering::SeqCst)),
+    );
+    let enqueued = matches!(outcome, FutexWaitOutcome::Enqueued);
+    // Immediately dequeue + un-block ourselves: we are the calling (test
+    // runner) thread, the helper marked us Blocked under THREAD_TABLE.  Undo
+    // that so the scheduler keeps running us, and clear the queue entry.
+    {
+        let mut waiters = FUTEX_WAITERS.lock();
+        if let Some(list) = waiters.get_mut(&(SYNTH_PID, SYNTH_UADDR)) {
+            list.retain(|&t| t != tid);
+            if list.is_empty() { waiters.remove(&(SYNTH_PID, SYNTH_UADDR)); }
+        }
+    }
+    {
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+            t.state = crate::proc::ThreadState::Ready;
+            t.wake_tick = 0;
+        }
+    }
+    if !enqueued {
+        test_fail!("futex_wait_val_is_32bit",
+            "sign-extended val {:#x} vs word {:#x} reported ValueMismatch — \
+             the FUTEX_WAIT compare is not 32-bit (would EAGAIN-storm)",
+            VAL_SIGN_EXTENDED, WORD);
+        return false;
+    }
+    test_println!("  case1: word={:#x} val={:#x} (low32 agree) → Enqueued ✓",
+        WORD, VAL_SIGN_EXTENDED);
+
+    // Case 2: low-32 bits genuinely differ → MUST ValueMismatch (the EAGAIN
+    // the comparison legitimately exists to produce; the fix must not mask it).
+    let bad_val: u64 = 0xFFFF_FFFF_8000_0011; // low32 = 0x8000_0011 != WORD
+    let outcome2 = futex_wait_check_and_enqueue(
+        SYNTH_PID, SYNTH_UADDR, bad_val, tid,
+        u64::MAX,
+        || Some(FUTEX_WORD.load(Ordering::SeqCst)),
+    );
+    // Defensive cleanup if it somehow enqueued.
+    {
+        let mut waiters = FUTEX_WAITERS.lock();
+        if let Some(list) = waiters.get_mut(&(SYNTH_PID, SYNTH_UADDR)) {
+            list.retain(|&t| t != tid);
+            if list.is_empty() { waiters.remove(&(SYNTH_PID, SYNTH_UADDR)); }
+        }
+        let mut threads = crate::proc::THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+            t.state = crate::proc::ThreadState::Ready;
+            t.wake_tick = 0;
+        }
+    }
+    if !matches!(outcome2, FutexWaitOutcome::ValueMismatch) {
+        test_fail!("futex_wait_val_is_32bit",
+            "low-32 mismatch (word {:#x} vs val-low32 {:#x}) did NOT report \
+             ValueMismatch — comparison too lax",
+            WORD, bad_val as u32);
+        return false;
+    }
+    test_println!("  case2: word={:#x} val-low32={:#x} (differ) → ValueMismatch ✓",
+        WORD, bad_val as u32);
+
+    test_pass!("FUTEX_WAIT 32-bit value compare (int sign-extension safe)");
     true
 }
 


### PR DESCRIPTION
## Summary

The Firefox demo blocker — a multi-billion-call `FUTEX_WAIT` storm where the main thread spins `pthread_mutex_timedlock -> __timedwait -> EAGAIN -> retry` forever against a contended `mozilla::Mutex` whose word never changes — is a **kernel ABI bug in the FUTEX_WAIT value comparison**, not a held-mutex deadlock and not a missing robust-list walk.

Per `futex(2)`, "the futex word is a 32-bit field" and the `FUTEX_WAIT` comparison `*uaddr == val` is over those 32 bits only. Our check-then-queue helper compared the **full 64-bit** `val` syscall argument against the zero-extended 32-bit `*uaddr`. That breaks for any futex word with **bit 31 set**.

### Root cause (live-captured)

The futex `val` argument is typed `int` in the C-library wrappers (`pthread_mutex_timedlock -> __timedwait(addr, val, ...)`). When a thread waits on a **contended** mutex, the C library passes the mutex word with the waiters bit set (`0x8000_0010`) as that `int`. Widening a negative `int` to the 64-bit syscall register **sign-extends** it, so the kernel receives `0xFFFF_FFFF_8000_0010` for a futex word of `0x8000_0010`.

The full-width compare `current as u64 != val` then mismatched in the high half on **every** call, returned `EAGAIN`, and the waiter spun instead of parking — so the main thread never slept to receive the owner's release wake.

Decisive live capture (instrumentation, since removed):

```
uaddr=0x...f64  val=0xffffffff80000010  val_lo32=0x80000010
live_uaddr32=0x80000010  high_bits_set=true  mismatch_only_in_high=true
```

The low 32 bits **matched exactly**; the only difference was the sign-extended high half.

### Fix

Truncate `val` to 32 bits before the compare (`current != val as u32`), matching the 32-bit futex-word contract. The same defect existed in the `FUTEX_CMP_REQUEUE` `*uaddr == val3` check (the `pthread_cond` broadcast/requeue path); fixed there too.

## Verification

Harness-only (`scripts/qemu-harness.py`), `firefox-test` feature, KVM:

| | pre-fix | post-fix |
|---|---|---|
| max syscall count | > 4.6 x 10^8 (storm, climbing) | ~2.8 x 10^3 (bounded) |
| futex word | frozen, no waiter ever enqueued | waiters enqueue + park |
| Firefox progress | wedged in storm forever | loads libpng16, spawns glxtest, reaches the next gate (argv-NULL SIGSEGV) and exits |

Reproduced across **two** independent runs with identical outcome. Firefox now advances past the FUTEX livelock entirely.

Adds a deterministic regression test `test_futex_wait_val_is_32bit` in `test_runner.rs` that drives `futex_wait_check_and_enqueue` with a sign-extended `val` and asserts low-32-agree -> `Enqueued`, low-32-differ -> `ValueMismatch`.

## Refs
- `futex(2)` — FUTEX_WAIT / FUTEX_CMP_REQUEUE value comparison; 32-bit futex word
- POSIX-1.2017 `pthread_mutex_lock(3)` / `pthread_mutex_timedlock(3)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)