### PR TITLE
kernel/linux: mremap in-place grow must not clobber adjacent mapping (GATE-A argv-NULL fix)

### DIFF
--- a/docs/LINUX_SYSCALL_COVERAGE.md
+++ b/docs/LINUX_SYSCALL_COVERAGE.md
@@ -147,7 +147,7 @@ Ranked by frequency in real program traces. Syscalls that would most unblock rea
 | 22 | `pipe` | Full |
 | 23 | `select` | Implemented; fd_set bitmask, X11 pump, yielding |
 | 24 | `sched_yield` | Full |
-| 25 | `mremap` | Full; shrink, grow in-place, MREMAP_MAYMOVE |
+| 25 | `mremap` | Full; shrink, non-destructive in-place grow (MAP_FIXED_NOREPLACE), MREMAP_MAYMOVE relocate |
 | 28 | `madvise` | Partial; MADV_DONTNEED/FREE frees pages; others no-op |
 | 29 | `shmget` | Full; SysV SHM |
 | 30 | `shmat` | Full |

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -5553,6 +5553,17 @@ fn sys_mremap(old_addr: u64, old_size: u64, new_size: u64, flags: u64, new_addr:
     if new_size == 0 { return -22; } // EINVAL
     const MREMAP_MAYMOVE: u64 = 1;
     const MREMAP_FIXED:   u64 = 2;
+    // MAP_FIXED_NOREPLACE (Linux 4.17+) — non-destructive fixed placement:
+    // sys_mmap returns EEXIST (-17) instead of clobbering an existing VMA.
+    // The in-place mremap grow MUST be non-destructive: per mremap(2), if the
+    // region just past the old mapping is not free the in-place expansion
+    // fails (and MREMAP_MAYMOVE then relocates) — it must NEVER overwrite an
+    // adjacent mapping.  Using plain MAP_FIXED here corrupted whatever sat at
+    // `old_addr+old_size`; when that was the top initial-stack page (argc/argv
+    // per System V x86-64 psABI §3.4.1) it erased the command line, surfacing
+    // as the upstream `argv[1]==NULL` crash.  Ref: man7 mremap(2), mmap(2)
+    // (MAP_FIXED_NOREPLACE).
+    const MAP_FIXED_NOREPLACE: u32 = 0x0010_0000;
 
     // Shrink: munmap the tail and return the same address.
     if new_size <= old_size {
@@ -5567,13 +5578,18 @@ fn sys_mremap(old_addr: u64, old_size: u64, new_size: u64, flags: u64, new_addr:
     let ext_addr = old_addr + old_size;
 
     if flags & MREMAP_FIXED == 0 {
-        // Attempt in-place: MAP_FIXED at the adjacent address.
+        // Attempt in-place: NON-DESTRUCTIVE fixed placement at the adjacent
+        // address.  MAP_FIXED_NOREPLACE returns EEXIST (-17) if that range is
+        // already mapped, so an occupied neighbour (e.g. the initial stack)
+        // is left intact and we fall through to the move path below — exactly
+        // the mremap(2) contract.  (Previously this used plain MAP_FIXED,
+        // which clobbered the neighbour.)
         let r = crate::syscall::sys_mmap(ext_addr, ext_size, 0x3 /*PROT_READ|PROT_WRITE*/,
-            MAP_ANONYMOUS | MAP_FIXED, u64::MAX, 0);
+            MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, u64::MAX, 0);
         if r == ext_addr as i64 {
-            return old_addr as i64; // grown in place
+            return old_addr as i64; // grown in place (range was free)
         }
-        // In-place failed; move if allowed.
+        // In-place failed (range occupied → EEXIST, or other error); move if allowed.
         if flags & MREMAP_MAYMOVE != 0 {
             let dest = crate::syscall::sys_mmap(0, new_size, 0x3, MAP_ANONYMOUS, u64::MAX, 0);
             if dest < 0 { return -12; } // ENOMEM

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1234,6 +1234,11 @@ pub fn run() -> ! {
     total += 1;
     if test_mremap_shrink() { passed += 1; }
 
+    // ── Test 126b: mremap grow must NOT clobber an adjacent mapping ───────────
+
+    total += 1;
+    if test_mremap_grow_preserves_neighbour() { passed += 1; }
+
     // ── Test 127: set_robust_list / get_robust_list roundtrip ────────────────
 
     total += 1;
@@ -25295,6 +25300,93 @@ fn test_mremap_shrink() -> bool {
     let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x2000, 0, 0, 0, 0);
 
     test_pass!("mremap shrink: sentinel readable, addr unchanged ✓");
+    true
+}
+
+// ── Test 122b: mremap grow must relocate, never clobber a neighbour ───────────
+//
+// Per mremap(2): when the page(s) immediately after the old mapping are not
+// free, an in-place grow MUST fail; with MREMAP_MAYMOVE the kernel relocates
+// the mapping instead.  It must NEVER overwrite the adjacent mapping.  A prior
+// implementation used MAP_FIXED for the in-place attempt, which destructively
+// freed and re-zeroed whatever occupied `old_addr+old_size` — when that
+// happened to be the top initial-stack page (argc/argv, System V x86-64 psABI
+// §3.4.1) it surfaced as an upstream `argv[1]==NULL` crash.  This test pins the
+// neighbour-preservation invariant directly.
+
+fn test_mremap_grow_preserves_neighbour() -> bool {
+    test_header!("mremap(25): grow with MAYMOVE relocates, never clobbers neighbour");
+
+    // Reserve a 3-page region, then split it so we have a 1-page mapping A
+    // immediately followed by a 2-page neighbour B that is definitely occupied.
+    // mmap a single 3-page block first so the two sub-mappings are adjacent.
+    let block = crate::syscall::dispatch_linux_kernel(
+        9, 0, 0x3000, 3, 0x22 /*MAP_PRIVATE|MAP_ANONYMOUS*/, u64::MAX, 0,
+    );
+    if block <= 0 {
+        test_fail!("mremap_grow_neighbour", "mmap 3-page block failed: {}", block);
+        return false;
+    }
+    let a_addr = block as u64;           // 1-page mapping A
+    let b_addr = a_addr + 0x1000;        // 2-page neighbour B, immediately after A
+    test_println!("  A @ {:#x} (1 page), neighbour B @ {:#x} (2 pages) ✓", a_addr, b_addr);
+
+    // Plant a sentinel in B's first page.  UserGuard: user-VA, CR4.SMAP active.
+    const SENTINEL: u64 = 0x1357_9BDF_2468_ACE0u64;
+    unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::write(b_addr as *mut u64, SENTINEL);
+    }
+
+    // mremap(A, old=0x1000, new=0x2000, MREMAP_MAYMOVE=1).  The page just after
+    // A (== b_addr) is occupied by B, so the in-place grow must fail and the
+    // kernel must relocate A to a fresh address — leaving B untouched.
+    let new_addr = crate::syscall::dispatch_linux_kernel(
+        25,
+        a_addr,   // old_addr
+        0x1000,   // old_size
+        0x2000,   // new_size
+        1,        // flags = MREMAP_MAYMOVE
+        0, 0,
+    );
+    test_println!("  mremap(grow A, MAYMOVE) = {:#x}", new_addr as u64);
+    if new_addr <= 0 {
+        test_fail!("mremap_grow_neighbour", "mremap failed: {}", new_addr);
+        return false;
+    }
+
+    // The neighbour B's sentinel MUST survive — the bug freed+zeroed it.
+    let surv = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::read(b_addr as *const u64)
+    };
+    if surv != SENTINEL {
+        test_fail!(
+            "mremap_grow_neighbour",
+            "neighbour clobbered: B[0]={:#x} expected {:#x} (mremap grew into occupied page)",
+            surv, SENTINEL
+        );
+        return false;
+    }
+
+    // A must have relocated (its old slot collided with B), so the returned
+    // address must differ from a_addr.  Being permissive: accept either a
+    // relocation OR an in-place that did not touch B (sentinel already checked).
+    if (new_addr as u64) == a_addr {
+        test_fail!(
+            "mremap_grow_neighbour",
+            "mremap returned the old base {:#x} despite occupied neighbour — \
+             in-place grow must have failed and relocated",
+            a_addr
+        );
+        return false;
+    }
+
+    // Cleanup: free the relocated mapping and the original block.
+    let _ = crate::syscall::dispatch_linux_kernel(11, new_addr as u64, 0x2000, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux_kernel(11, a_addr, 0x3000, 0, 0, 0, 0);
+
+    test_pass!("mremap grow relocated A, neighbour B sentinel intact ✓");
     true
 }
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -312,6 +312,27 @@ class GdbClient:
         resp = self.send(f"z0,{addr:x},1")
         return resp == "OK"
 
+    # ── hardware watchpoints (Z2/Z3/Z4 packets) ──────────────────────────────
+    #
+    # GDB remote-protocol watchpoint kinds (see the GDB Remote Serial Protocol
+    # "Z/z packets" spec): Z2 = write watchpoint, Z3 = read watchpoint,
+    # Z4 = access (read|write) watchpoint.  QEMU's gdbstub maps these onto the
+    # x86 debug registers (DR0..DR3 + DR7) so they fire on the EXACT store that
+    # touches the watched bytes — this is what lets us name an out-of-band
+    # writer without polluting the kernel with a probe.
+
+    def set_watch(self, addr: int, length: int = 8, kind: str = "write") -> bool:
+        """Arm a hardware watchpoint via Z2/Z3/Z4.  Returns True on stub ack."""
+        z = {"write": "Z2", "read": "Z3", "access": "Z4"}.get(kind, "Z2")
+        resp = self.send(f"{z},{addr:x},{length:x}")
+        return resp == "OK"
+
+    def del_watch(self, addr: int, length: int = 8, kind: str = "write") -> bool:
+        """Remove a hardware watchpoint via z2/z3/z4."""
+        z = {"write": "z2", "read": "z3", "access": "z4"}.get(kind, "z2")
+        resp = self.send(f"{z},{addr:x},{length:x}")
+        return resp == "OK"
+
     def vcont_step(self) -> str:
         """Single-step via vCont;s. Returns stop-reply payload."""
         # First check vCont is supported
@@ -4032,6 +4053,122 @@ def cmd_cont(args):
         gdb.close()
 
     _out({"ok": True, "note": "kernel running", "reply": resp})
+
+
+def cmd_watch(args):
+    """
+    Arm a HARDWARE write watchpoint on a guest VA, resume, and capture the
+    EXACT store that writes to it — naming the writer RIP + register context
+    and classifying it kernel-mode vs user-mode.
+
+    This is the "name the out-of-band writer" tool: the legitimate kernel
+    argv-build store happens before the watch is armed (we arm at a chosen
+    break-point, after the stack is built), so the FIRST fire after arming is
+    the offending later store.  Use --skip N to let the first N fires pass
+    (e.g. if a legitimate write to the slot precedes the corrupting one).
+
+    Contract: session started with --gdb-port.  One-shot JSON on stdout.
+    """
+    sess = _load_session(args.sid)
+    port = _get_gdb_port(sess)
+
+    try:
+        addr = int(args.addr, 0)
+    except ValueError:
+        _err(f"Invalid watch address: {args.addr}")
+
+    length = args.length
+    kind   = args.kind
+    skip   = max(0, args.skip)
+    timeout_s = args.timeout_ms / 1000.0
+
+    gdb = GdbClient("127.0.0.1", port)
+    if not gdb.connect():
+        _err(f"Cannot connect to GDB stub on port {port} (tried {port}..{port+4})")
+
+    fires = []
+    armed = False
+    try:
+        # If the caller wants us to break at a symbol/addr first (so the watch
+        # is armed only after the stack region is mapped), honour --break.
+        if getattr(args, "brk", None):
+            try:
+                brk_addr = int(args.brk, 0)
+            except ValueError:
+                # Try resolving as a kernel symbol.
+                r = _resolve_symbol(_get_kernel_elf(), args.brk)
+                brk_addr = int(r["address"], 0) if r and r.get("address") else None
+            if brk_addr is not None:
+                gdb.set_bp(brk_addr)
+                gdb.cont_no_wait()
+                gdb.wait_for_stop(timeout_s)
+                gdb.del_bp(brk_addr)
+
+        armed = gdb.set_watch(addr, length, kind)
+        if not armed:
+            _out({"ok": False, "error": f"stub rejected watchpoint Z@{hex(addr)} "
+                                        f"(len={length},kind={kind}) — DRs exhausted?"})
+            return
+
+        hit_count = 0
+        # We allow (skip + 1) fires total; the (skip+1)-th is the one we report.
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            gdb.cont_no_wait()
+            stop = gdb.wait_for_stop(max(1.0, deadline - time.monotonic()))
+            if stop is None:
+                break  # timed out with no fire
+            hit_count += 1
+            try:
+                regs = gdb.read_regs()
+            except Exception:
+                regs = {}
+            rip = int(regs.get("rip", "0x0"), 0)
+            # x86-64 canonical kernel half-space: high bit set (0xffff8.. and up).
+            is_kernel = rip >= 0xFFFF_8000_0000_0000
+            # Read the watched slot's current value + the instruction bytes at RIP.
+            try:
+                slot_val = gdb.read_mem(addr, length).hex()
+            except Exception:
+                slot_val = None
+            try:
+                code = gdb.read_mem(rip, 16).hex()
+            except Exception:
+                code = None
+            fire = {
+                "fire_index": hit_count,
+                "rip":        hex(rip),
+                "mode":       "kernel" if is_kernel else "user",
+                "slot_now":   slot_val,
+                "code_at_rip": code,
+                "regs":       regs,
+            }
+            fires.append(fire)
+            if hit_count > skip:
+                break  # this is the fire we care about
+
+        # Disarm before returning so we don't leave a DR busy for the next run.
+        try:
+            gdb.del_watch(addr, length, kind)
+        except Exception:
+            pass
+    except Exception as e:
+        _err(f"GDB watch error: {e}")
+    finally:
+        gdb.close()
+
+    reported = fires[skip] if len(fires) > skip else (fires[-1] if fires else None)
+    _out({
+        "ok":        True,
+        "watch_addr": hex(addr),
+        "length":    length,
+        "kind":      kind,
+        "skip":      skip,
+        "armed":     armed,
+        "fire_count": len(fires),
+        "writer":    reported,
+        "all_fires": fires,
+    })
 
 
 def cmd_pause(args):
@@ -9661,6 +9798,27 @@ def main():
     p_cont = sub.add_parser("cont", help="[Tier2] Continue execution via GDB vCont;c")
     p_cont.add_argument("sid")
 
+    # watch — hardware write watchpoint; names the out-of-band writer
+    p_watch = sub.add_parser(
+        "watch",
+        help="[Tier2] Arm a HW write watchpoint on a VA, resume, and capture "
+             "the exact store that writes it (writer RIP + kernel/user mode "
+             "+ register context). Names out-of-band stack-slot writers.")
+    p_watch.add_argument("sid")
+    p_watch.add_argument("addr", help="Guest VA to watch (hex or decimal)")
+    p_watch.add_argument("--length", type=int, default=8,
+                          help="Watch width in bytes (default 8)")
+    p_watch.add_argument("--kind", choices=["write", "read", "access"],
+                          default="write", help="Watchpoint kind (default write)")
+    p_watch.add_argument("--skip", type=int, default=0,
+                          help="Let the first N fires pass before reporting "
+                               "(e.g. skip the legitimate argv-build store)")
+    p_watch.add_argument("--break", dest="brk", default=None,
+                          help="Break at this symbol/addr FIRST (so the watch "
+                               "is armed only after the stack is mapped)")
+    p_watch.add_argument("--timeout-ms", type=int, default=120000,
+                          help="Overall budget for catching the writer")
+
     # pause
     p_pause = sub.add_parser("pause", help="[Tier2] Pause QEMU via QMP stop")
     p_pause.add_argument("sid")
@@ -10369,6 +10527,7 @@ def main():
         "bp":     cmd_bp,
         "step":   cmd_step,
         "cont":   cmd_cont,
+        "watch":  cmd_watch,
         "pause":  cmd_pause,
         "resume": cmd_resume,
         "autopsy": cmd_autopsy,


### PR DESCRIPTION
## Summary

Fixes the long-standing **GATE-A** Firefox demo blocker: a SIGSEGV in
`nsCommandLine::Init` from dereferencing a NULL `argv[1]`. Root cause is a
kernel `mremap` ABI bug, not a userspace issue.

## Root cause

`sys_mremap`'s in-place grow attempt mapped the page(s) just past the old
mapping (`old_addr + old_size`) with plain **`MAP_FIXED`**. `MAP_FIXED` is
*destructive* — it unmaps and frees whatever already occupies that range.

When the page immediately after the mapping was the **top initial-process-stack
page** (which holds `argc` + the `argv` pointer array + the argv strings + envp
+ auxv, per the System V x86-64 psABI initial-stack layout), the in-place grow
freed that frame. The frame was then recycled and zeroed, erasing the command
line. Upstream binaries (here, musl's `mremap` called from libxul startup) that
re-read `argv` afterward then dereference a NULL `argv[i]` → SIGSEGV.

The flakiness reported for GATE-A was simply *whether* the read raced the
clobber; the clobber itself happened on essentially every run.

### How it was localized

A GDB hardware write watchpoint on the argv slot never fired (the zeroing went
through the kernel physmap alias, not the user VA), which ruled out a userspace
store. Targeted range-keyed probes then caught
`unmap_and_free_range_in(base=0x7ffffffef000, len=0x1000)`, and a syscall-level
probe named the exact caller and user RIP:
`[ARGV-ZERO/MMAP-FIXED] base=0x7ffffffef000 user_rip=…` → resolved to musl
`mremap` → our `sys_mremap` in-place `MAP_FIXED`. (All probes removed; only the
fix + test remain.)

## Fix

Per `mremap(2)`: if the region immediately after a mapping is not free, the
in-place expansion must **fail**; with `MREMAP_MAYMOVE` the kernel relocates the
mapping instead. The in-place attempt must never overwrite an adjacent mapping.

Use **`MAP_FIXED_NOREPLACE`** (already supported — returns `EEXIST` on overlap)
for the in-place attempt. On `EEXIST` the in-place grow fails and we fall
through to the existing move path. When the adjacent range *is* free,
`MAP_FIXED_NOREPLACE` behaves identically to `MAP_FIXED` — no fast-path
regression. The `MREMAP_FIXED` branch (explicit caller-chosen destination) keeps
`MAP_FIXED`, which is correct there.

## Tests

- New regression test `test_mremap_grow_preserves_neighbour`: mmaps an adjacent
  neighbour, plants a sentinel, `mremap(grow, MREMAP_MAYMOVE)` over it, and
  asserts the neighbour's sentinel survives and the mapping relocated.
  **PASS** in test-mode.
- Existing mremap grow/shrink tests still pass.

## Verification (Firefox)

Before: deterministic-ish SIGSEGV at `nsCommandLine::Init` (argv[1]=NULL) around
sc≈995.

After: **GATE-A clears.** No `SIGSEGV ISR delivery`, no `nsCommandLine` crash.
Firefox advances from sc≈995 to **sc≈9800+ with 202 threads**, spawns a content
child (pid 2) that runs and `exit_group(0)`s cleanly. The next blocker is the
separate GATE-B futex region (out of scope here).

## Tooling

Also extends `scripts/qemu-harness.py` with an additive `watch` subcommand
(GDB hardware write/read/access watchpoint via `Z2`/`Z3`/`Z4`) that names
out-of-band memory writers by RIP and kernel/user mode. No change to existing
subcommands.

## References (public specs)

- man7 `mremap(2)` — in-place expansion fails if the adjacent area is not free;
  `MREMAP_MAYMOVE` relocates.
- man7 `mmap(2)` — `MAP_FIXED_NOREPLACE` returns `EEXIST` on overlap.
- System V x86-64 psABI §3.4.1 — initial process stack (argc/argv/envp/auxv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)