### PR TITLE
tooling/harness+kdb: cond-autopsy probe, ff-progress detector, honest snap

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -368,6 +368,10 @@ pub fn dispatch(req: &str, out: &mut String) {
         #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
         "futex-set-cluster-wake" => op_futex_set_cluster_wake(req, out),
         "futex-ghost-hist" => op_futex_ghost_hist(req, out),
+        // cond-autopsy: one-shot musl pthread_cond/mutex wake-target-vs-
+        // wait-addr report.  Composes the live struct dump + parked waiters +
+        // recent wake targets + inferred lock holder into a single verdict.
+        "cond-autopsy"   => op_cond_autopsy(req, out),
         // INFRA-3 record/replay introspection.  Off-path when the
         // `record-replay` feature is OFF — the ops return a fixed
         // "feature off" JSON object so the KDB protocol surface is
@@ -2873,6 +2877,302 @@ fn op_futex_ghost_hist(req: &str, out: &mut String) {
 #[cfg(not(any(feature = "firefox-test", feature = "test-mode")))]
 fn op_futex_ghost_hist(_req: &str, out: &mut String) {
     out.push_str(r#"{"error":"futex-ghost-hist requires firefox-test or test-mode feature"}"#);
+}
+
+// ── cond-autopsy ────────────────────────────────────────────────────────────
+//
+// One-shot wake-target-vs-wait-addr report for a musl pthread_cond_t / mutex.
+//
+// The decisive recurring question at a condvar/mutex livelock is: "the waiter
+// parks on uaddr X, but the wake targets uaddr Y — what is the delta, who
+// holds the lock, and does the holder ever run?".  This op composes the
+// already-tracked pieces into ONE structured object so the answer is a single
+// argv call rather than five.
+//
+// Request: {"op":"cond-autopsy","pid":N,"addr":"0x..","half":N}  (half def 128)
+//
+// Response fields:
+//   pid, addr, half
+//   cr3                  — guest CR3 the user reads were resolved under
+//   struct.hex           — `STRUCT_WORDS` u64 words read live from `addr`
+//                          (LE-byte hex string), unmapped slots filled "..".
+//   struct.mutex/.cond   — labelled musl field decode (both sets emitted;
+//                          the caller picks the one matching the object).
+//   waiters[]            — every FUTEX_WAITERS entry in [addr-half, addr+half]
+//                          for `pid`: {tid, uaddr, delta, state, nr, rip}
+//   recent_wakes[]       — recent FUTEX_WAKE targets in the same window
+//                          (firefox-test/test-mode only): {tid, uaddr, delta}
+//   holder               — inferred lock owner {owner_tid, owner_state,
+//                          owner_runs, source}
+//   verdict_hint         — wake-address-mismatch | held-lock-deadlock |
+//                          owner-starved | true-lost-wakeup | benign-empty
+//   summary              — one-line human gloss of the verdict
+//
+// Public references: pthread_cond_signal(3p), pthread_mutex_lock(3p),
+// futex(2).  The musl struct field offsets used below match the public
+// `pthread_cond_t` / `pthread_mutex_t` layout (musl exposes `__u.__vi[]` and
+// the `_c_*` / `_m_*` accessor macros in its public headers).
+//
+// Bounded: ≤ 64 waiters, ≤ 64 wakes, 12 struct words → response < 4 KB.
+
+/// Number of 64-bit words dumped from the cond/mutex object (96 bytes —
+/// covers a full musl pthread_cond_t plus the head of an adjacent object).
+const COND_STRUCT_WORDS: u64 = 12;
+
+/// Decode the low-30-bit owner-tid field from a musl mutex `_m_lock` word.
+/// musl stores the owning kernel TID in the low bits of `_m_lock`
+/// (`__u.__vi[1]`, offset +4); the high bits carry FUTEX_WAITERS (0x8000_0000)
+/// and the robust/owner-dead markers.
+#[inline]
+fn musl_mutex_owner_tid(m_lock_word: u32) -> u32 { m_lock_word & 0x3FFF_FFFF }
+
+fn op_cond_autopsy(req: &str, out: &mut String) {
+    use core::fmt::Write;
+
+    let pid = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(p) => p,
+        None => { out.push_str(r#"{"error":"missing or bad 'pid'"}"#); return; }
+    };
+    let addr = match extract_field(req, "addr").and_then(|s| parse_u64(&s)) {
+        Some(a) => a,
+        None => { out.push_str(r#"{"error":"missing or bad 'addr'"}"#); return; }
+    };
+    if addr >= astryx_shared::KERNEL_VIRT_BASE {
+        out.push_str(r#"{"error":"addr must be a user (canonical low-half) VA"}"#);
+        return;
+    }
+    // `half` window for waiter / wake scan.  Default 128 B (covers a full
+    // pthread_cond_t with margin); clamp to a sane bound so the scan stays
+    // cheap and the response stays < 4 KB.
+    let half = extract_field(req, "half")
+        .and_then(|s| parse_u64(&s))
+        .unwrap_or(128)
+        .clamp(4, 0x400);
+
+    let cr3 = match crate::proc::get_process_cr3(pid) {
+        Some(c) => c,
+        None => { let _ = write!(out, r#"{{"error":"pid {} has no cr3"}}"#, pid); return; }
+    };
+
+    // ── Stage 1: live struct dump ──────────────────────────────────────
+    // Read COND_STRUCT_WORDS u64s via the foreign-CR3 software walk (cannot
+    // fault).  None for an unmapped slot → "..".  We keep both the raw word
+    // array (for the decode below) and the hex string (for the caller).
+    let mut words: [Option<u64>; COND_STRUCT_WORDS as usize] =
+        [None; COND_STRUCT_WORDS as usize];
+    let mut struct_hex = String::with_capacity(COND_STRUCT_WORDS as usize * 16);
+    let mut any_mapped = false;
+    for i in 0..COND_STRUCT_WORDS {
+        let va = addr.wrapping_add(i * 8);
+        match crate::proc::sample::read_user_u64_at(cr3, va) {
+            Some(w) => {
+                words[i as usize] = Some(w);
+                any_mapped = true;
+                // Little-endian byte order so the hex reads as memory bytes.
+                for b in 0..8 { let _ = write!(struct_hex, "{:02x}", (w >> (b * 8)) & 0xff); }
+            }
+            None => { struct_hex.push_str(".."); for _ in 0..14 { struct_hex.push('.'); } }
+        }
+    }
+
+    // Helper: extract a 32-bit field at byte offset `off` from the dumped
+    // words (assumes `off` is 4-byte aligned and within the dump).
+    let u32_at = |off: u64| -> Option<u32> {
+        let wi = (off / 8) as usize;
+        if wi >= words.len() { return None; }
+        words[wi].map(|w| if off % 8 == 0 { w as u32 } else { (w >> 32) as u32 })
+    };
+
+    // ── Stage 2: parked waiters in the window ──────────────────────────
+    struct WaiterRow { tid: u64, uaddr: u64, delta: i64 }
+    let lo = addr.saturating_sub(half);
+    let hi = addr.saturating_add(half);
+    let mut waiters_busy = false;
+    let mut waiter_rows: Vec<WaiterRow> = Vec::new();
+    match try_lock_brief(&crate::syscall::FUTEX_WAITERS) {
+        Some(w) => {
+            for (&(wpid, wuaddr), tids) in w.range((pid, lo)..=(pid, hi)) {
+                if wpid != pid { continue; }
+                if tids.is_empty() { continue; }
+                for &tid in tids.iter() {
+                    waiter_rows.push(WaiterRow {
+                        tid, uaddr: wuaddr,
+                        delta: wuaddr as i64 - addr as i64,
+                    });
+                    if waiter_rows.len() >= 64 { break; }
+                }
+                if waiter_rows.len() >= 64 { break; }
+            }
+        }
+        None => waiters_busy = true,
+    }
+
+    // ── Stage 3: thread states (for waiter + holder state lookup) ──────
+    // Snapshot tid → (state, runnable) so the emit phase needs no lock.
+    let mut tid_state: alloc::collections::BTreeMap<u64, (&'static str, bool)> =
+        alloc::collections::BTreeMap::new();
+    if let Some(tt) = try_lock_brief(&THREAD_TABLE) {
+        for t in tt.iter() {
+            let runnable = matches!(t.state,
+                crate::proc::ThreadState::Ready | crate::proc::ThreadState::Running);
+            tid_state.insert(t.tid, (thread_state_str(t.state), runnable));
+        }
+    }
+
+    // ── Stage 4: recent wake targets in the window ─────────────────────
+    // firefox-test/test-mode only — the per-CPU wake rings live in the
+    // feature-gated futex_cluster module.  Empty otherwise.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    let recent_wakes: alloc::vec::Vec<(u64, u64, i64)> =
+        crate::subsys::linux::futex_cluster::recent_wakes_near(addr, half);
+    #[cfg(not(any(feature = "firefox-test", feature = "test-mode")))]
+    let recent_wakes: alloc::vec::Vec<(u64, u64, i64)> = alloc::vec::Vec::new();
+
+    // ── Stage 5: holder inference ──────────────────────────────────────
+    // For a mutex the owner is the low-30 bits of `_m_lock` (offset +4).
+    // For a cond the "holder" is whichever thread most recently woke a
+    // NON-zero-delta target (the signaller advancing a paired mutex); we
+    // surface the mutex decode as primary and the cond signaller as a hint.
+    let m_lock = u32_at(4);
+    let m_owner_tid = m_lock.map(musl_mutex_owner_tid).filter(|&t| t != 0);
+    // Cond signaller hint: nearest non-zero-delta recent wake.
+    let cond_signaller: Option<u64> = recent_wakes.iter()
+        .filter(|&&(_, _, d)| d != 0)
+        .min_by_key(|&&(_, _, d)| d.unsigned_abs())
+        .map(|&(tid, _, _)| tid);
+    let (owner_tid, owner_source): (Option<u64>, &'static str) = match m_owner_tid {
+        Some(t) => (Some(t as u64), "m_lock"),
+        None => (cond_signaller, if cond_signaller.is_some() { "cond_signaller" } else { "none" }),
+    };
+    let owner_state_run = owner_tid.and_then(|t| tid_state.get(&t).copied());
+
+    // ── Stage 6: verdict ───────────────────────────────────────────────
+    // Decision logic (matches the 4-case audit shape):
+    //   benign-empty        : no waiter anywhere in the window
+    //   true-lost-wakeup     : a waiter parks EXACTLY at `addr` (delta 0) but
+    //                          the object shows no live owner & a wake fired
+    //   wake-address-mismatch: a waiter parks at a NON-zero delta and a
+    //                          recent wake targets a DIFFERENT slot in-window
+    //   held-lock-deadlock   : an owner is named and is NOT runnable
+    //   owner-starved        : an owner is named, IS runnable, yet a waiter
+    //                          is still parked (owner hasn't been scheduled)
+    let waiter_at_exact = waiter_rows.iter().any(|w| w.delta == 0);
+    let waiter_at_offset = waiter_rows.iter().any(|w| w.delta != 0);
+    let wake_offset_mismatch = recent_wakes.iter().any(|&(_, _, d)| d != 0)
+        && waiter_rows.iter().any(|w| !recent_wakes.iter().any(|&(_, u, _)| u == w.uaddr));
+    let (verdict, reason): (&'static str, &'static str) = if waiter_rows.is_empty() {
+        ("benign-empty", "no parked waiter in the cluster window")
+    } else if let Some((_, runnable)) = owner_state_run {
+        if !runnable {
+            ("held-lock-deadlock", "named lock owner is not runnable")
+        } else if waiter_at_offset || waiter_at_exact {
+            ("owner-starved", "owner is runnable but a waiter is still parked")
+        } else {
+            ("benign-empty", "owner runnable, no blocked waiter")
+        }
+    } else if wake_offset_mismatch || (waiter_at_offset && !waiter_at_exact) {
+        ("wake-address-mismatch", "waiter parked at a delta the wake never targeted")
+    } else if waiter_at_exact {
+        ("true-lost-wakeup", "waiter parked exactly at addr; no owner, wake missed")
+    } else {
+        ("benign-empty", "waiters present but classification inconclusive")
+    };
+
+    // ── Stage 7: emit JSON ─────────────────────────────────────────────
+    out.push('{');
+    j_kv(out, "pid", &alloc::format!("{}", pid));
+    j_str(out, "addr"); out.push(':'); j_hex(out, addr); out.push(',');
+    j_str(out, "cr3");  out.push(':'); j_hex(out, cr3);  out.push(',');
+    j_kv(out, "half", &alloc::format!("{}", half));
+
+    // struct
+    out.push_str("\"struct\":{");
+    j_kv_str(out, "hex", &struct_hex);
+    j_kv(out, "any_mapped", if any_mapped { "true" } else { "false" });
+    // mutex decode
+    out.push_str("\"mutex\":{");
+    if let Some(l) = m_lock {
+        j_str(out, "m_lock"); out.push(':'); j_hex(out, l as u64); out.push(',');
+        j_kv(out, "owner_tid", &alloc::format!("{}", musl_mutex_owner_tid(l)));
+        j_kv(out, "waiters_bit", if l & 0x8000_0000 != 0 { "true" } else { "false" });
+    }
+    if let Some(w) = u32_at(8) { j_str(out, "m_waiters"); out.push(':'); j_hex(out, w as u64); out.push(','); }
+    j_trim_comma(out); out.push_str("},");
+    // cond decode
+    out.push_str("\"cond\":{");
+    if let Some(s) = u32_at(8)  { j_str(out, "c_seq");      out.push(':'); j_hex(out, s as u64); out.push(','); }
+    if let Some(s) = u32_at(12) { j_str(out, "c_waiters");  out.push(':'); j_hex(out, s as u64); out.push(','); }
+    if let Some(s) = u32_at(0)  { j_str(out, "c_lock");     out.push(':'); j_hex(out, s as u64); out.push(','); }
+    j_trim_comma(out); out.push('}');   // close "cond"
+    out.push('}');                       // close "struct"
+    out.push(',');
+
+    // waiters
+    if waiters_busy { out.push_str("\"waiters_busy\":true,"); }
+    out.push_str("\"waiters\":[");
+    for (i, w) in waiter_rows.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        let (st, _) = tid_state.get(&w.tid).copied().unwrap_or(("?", false));
+        let (nr, rip) = match crate::proc::sample::read_sample(w.tid) {
+            Some(s) => (s.last_syscall_nr, s.last_user_rip),
+            None => (u64::MAX, 0),
+        };
+        out.push('{');
+        j_kv(out, "tid", &alloc::format!("{}", w.tid));
+        j_str(out, "uaddr"); out.push(':'); j_hex(out, w.uaddr); out.push(',');
+        j_kv(out, "delta", &alloc::format!("{}", w.delta));
+        j_kv_str(out, "state", st);
+        if nr != u64::MAX { j_kv(out, "nr", &alloc::format!("{}", nr)); }
+        j_str(out, "rip"); out.push(':'); j_hex(out, rip); out.push(',');
+        j_trim_comma(out);
+        out.push('}');
+    }
+    out.push_str("],");
+
+    // recent_wakes
+    out.push_str("\"recent_wakes\":[");
+    for (i, &(tid, u, d)) in recent_wakes.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        out.push('{');
+        j_kv(out, "tid", &alloc::format!("{}", tid));
+        j_str(out, "uaddr"); out.push(':'); j_hex(out, u); out.push(',');
+        j_kv(out, "delta", &alloc::format!("{}", d));
+        j_trim_comma(out);
+        out.push('}');
+    }
+    out.push_str("],");
+
+    // holder
+    out.push_str("\"holder\":{");
+    match owner_tid {
+        Some(t) => {
+            j_kv(out, "owner_tid", &alloc::format!("{}", t));
+            let (st, runs) = owner_state_run.unwrap_or(("unknown", false));
+            j_kv_str(out, "owner_state", st);
+            j_kv(out, "owner_runs", if runs { "true" } else { "false" });
+        }
+        None => { j_kv(out, "owner_tid", "0"); j_kv_str(out, "owner_state", "none"); j_kv(out, "owner_runs", "false"); }
+    }
+    j_kv_str(out, "source", owner_source);
+    j_trim_comma(out); out.push_str("},");
+
+    j_kv_str(out, "verdict_hint", verdict);
+    j_kv_str(out, "reason", reason);
+    j_trim_comma(out);
+    out.push('}');
+
+    // Serial mirror for TCP-drain recovery (mirrors op_thread_park_audit's
+    // [THREAD-PARK] side channel).  One compact line; the harness can
+    // reconstruct the verdict from serial even if the JSON envelope is
+    // truncated mid-flight under load.
+    crate::serial_println!(
+        "[COND-AUTOPSY] pid={} addr={:#x} verdict={} waiters={} recent_wakes={} \
+         owner_tid={} owner_runs={} reason={}",
+        pid, addr, verdict, waiter_rows.len(), recent_wakes.len(),
+        owner_tid.unwrap_or(0),
+        owner_state_run.map(|(_, r)| r).unwrap_or(false),
+        reason
+    );
 }
 
 fn file_type_str(ft: crate::vfs::FileType) -> &'static str {

--- a/kernel/src/subsys/linux/futex_cluster.rs
+++ b/kernel/src/subsys/linux/futex_cluster.rs
@@ -236,6 +236,41 @@ pub fn record_wait(pid: u64, uaddr: u64) {
     ring.push(WaitEntry { pid, uaddr });
 }
 
+/// Read-only accessor: every recent `FUTEX_WAKE` target within `half` bytes
+/// of `uaddr`, across all per-CPU wake-history rings.
+///
+/// Returns `(tid, entry_uaddr, signed_delta)` triples where
+/// `signed_delta = entry_uaddr − uaddr` (so a wake one cond-slot above the
+/// query reads `+0x04`).  De-duplicated by `(tid, entry_uaddr)` and capped at
+/// 64 entries so the response stays bounded.  Returns an empty vector when the
+/// cluster-wake feature is disabled on this build (mirroring `record_wake`'s
+/// `is_enabled()` gate), so a stock kernel produces nothing.
+///
+/// This is the one primitive the `cond-autopsy` kdb op needs that is not
+/// derivable host-side: the per-CPU wake rings are private to this module.
+/// No behaviour change — pure read of the existing rings.
+pub fn recent_wakes_near(uaddr: u64, half: u64) -> alloc::vec::Vec<(u64, u64, i64)> {
+    let mut out: alloc::vec::Vec<(u64, u64, i64)> = alloc::vec::Vec::new();
+    if !is_enabled() { return out; }
+    let lo = uaddr.saturating_sub(half);
+    let hi = uaddr.saturating_add(half);
+    for ring in WAKE_HISTORY.iter() {
+        // Brief try_lock: never block the kdb pump thread on a ring a
+        // concurrent FUTEX_WAKE happens to hold.  A missed ring is benign —
+        // the autopsy is a snapshot, not a ledger.
+        let Some(g) = ring.try_lock() else { continue };
+        for e in g.buf.iter() {
+            if e.tid == 0 && e.uaddr == 0 { continue; } // sentinel / unused
+            if e.uaddr < lo || e.uaddr > hi { continue; }
+            let delta = e.uaddr as i64 - uaddr as i64;
+            if out.iter().any(|&(t, u, _)| t == e.tid && u == e.uaddr) { continue; }
+            out.push((e.tid, e.uaddr, delta));
+            if out.len() >= 64 { return out; }
+        }
+    }
+    out
+}
+
 // ── Candidate selection ───────────────────────────────────────────────────
 
 /// Per-candidate annotation: why we admitted it through the safety harness.

--- a/scripts/ff_gates.yaml
+++ b/scripts/ff_gates.yaml
@@ -1,0 +1,69 @@
+# scripts/ff_gates.yaml
+#
+# Ordered Firefox-headless-screenshot gate ladder for
+# `qemu-harness.py ff-progress <sid>`.
+#
+# Each entry names a canonical progress marker in the session serial log.
+# `ff-progress` scans the log once, records the first line each gate is seen
+# at (plus the live syscall count at that point), and reports the DEEPEST gate
+# reached — replacing the recurring hand-grep "how far did this boot get?".
+#
+# Schema (per gate):
+#   id:           short stable identifier (used as the JSON key)
+#   marker_regex: Python regex matched against each serial line
+#   kind:         "line"     — anchored line scan (default), OR
+#                 "ipc-body" — substring scan: the marker lives INSIDE the
+#                              base64/escaped body="..." payload of an
+#                              `[FF/write]` IPC line, so it is NOT line-
+#                              anchored.  This is the one non-obvious gate.
+#   desc:         human-readable description (carried into the JSON output)
+#
+# The ladder is ORDER-SIGNIFICANT: gate N is "deeper" than gate N-1.  Future
+# agents extend the ladder by appending entries (additive — no code change;
+# ff-progress reads this file at runtime, mirroring the
+# scripts/differential/snapshots.yaml convention).
+#
+# Public references: the markers are AstryxOS test-runner / GUI / Linux-
+# personality serial output; the IPC bodies are Gecko PContent/PScreenshot
+# actor messages (Mozilla public IPDL protocol names).
+
+gates:
+  - id: lib-load
+    marker_regex: '\[FFTEST\]\s+Cached\s+\S*libxul\.so\s+\((?!0 pages)'
+    kind: line
+    desc: "libxul.so mapped/cached (real load, not the 0-page stub probe)"
+
+  - id: x11-ready
+    marker_regex: '\[FFTEST\]\s+X11 server ready'
+    kind: line
+    desc: "Xastryx server up; FF can connect to the display"
+
+  - id: compositor-init
+    marker_regex: '\[GUI\]\s+Compositor initialized'
+    kind: line
+    desc: "WebRender/compositor framebuffer initialized"
+
+  - id: ff-launch
+    marker_regex: '\[FFTEST\]\s+Launching\s+\S*firefox'
+    kind: line
+    desc: "firefox-bin exec'd"
+
+  - id: content-proc
+    marker_regex: '\[FF/write\]\s+pid=2\b'
+    kind: line
+    desc: "content process (pid 2) spawned and producing IPC"
+
+  - id: screenshot-actors
+    marker_regex: 'ScreenshotParent|getDimensions|sendQuery'
+    kind: ipc-body
+    desc: "HeadlessShell screenshot IPC actors loaded (ScreenshotParent/getDimensions/sendQuery) — the deep screenshot-IPC gate"
+
+  - id: draw-snapshot
+    marker_regex: 'drawSnapshot'
+    kind: ipc-body
+    desc: "drawSnapshot invoked — paint of the target page begins"
+
+  - id: png-write
+    marker_regex: 'Screenshot saved|out\.png|\[SCREENSHOT-B64:'
+    kind: line
+    desc: "PNG encoded / written — demo SUCCESS"

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -41,6 +41,20 @@ Tier 1 — session management:
     python3 scripts/qemu-harness.py snap <sid> save|load <name>
     python3 scripts/qemu-harness.py prune [--ttl DAYS]
     python3 scripts/qemu-harness.py results <sid>
+    python3 scripts/qemu-harness.py ff-progress <sid>
+        FF headless-screenshot gate ladder + DEEPEST gate reached (pure
+        serial-log scan; no kdb). Ladder in scripts/ff_gates.yaml (additive).
+        Reports lib-load -> x11-ready -> compositor-init -> ff-launch ->
+        content-proc -> screenshot-actors -> draw-snapshot -> png-write,
+        plus max_sc, reached_png, and terminal_cause. The authoritative
+        "how deep did this boot get + is it the screenshot wedge?" oracle.
+    python3 scripts/qemu-harness.py kdb <sid> cond-autopsy <pid> <cond_va> [<half>]
+        One-shot musl pthread_cond/mutex wake-target-vs-wait-addr report:
+        live struct dump + parked waiters in [va-half,va+half] (with delta to
+        the query) + recent FUTEX_WAKE targets + inferred lock holder +
+        verdict_hint (wake-address-mismatch | held-lock-deadlock |
+        owner-starved | true-lost-wakeup | benign-empty) + a one-line summary.
+        The decisive condvar-livelock probe in one argv call (half def 128).
     python3 scripts/qemu-harness.py read-png <sid> <dst.png> [--timeout-ms MS]
     python3 scripts/qemu-harness.py futex-wake-drill <sid> [--tid N]
                                             [--bucket-count K] [--window-lines L]
@@ -845,12 +859,18 @@ def _watcher_thread(sid: str, serial_log: str, qmp_sock: str, pid: int):
                     if m:
                         snap_name = f"{sid}-panic"
                         snap_ok = False
+                        snap_err = None
                         try:
                             resp = _qmp_command(qmp_sock,
                                                 "human-monitor-command",
                                                 {"command-line": f"savevm {snap_name}"},
                                                 connect_timeout=2.0)
-                            snap_ok = "error" not in resp
+                            # An HMP savevm failure rides in the `return`
+                            # string, not an `error` key — parse it so the
+                            # panic event reports a TRUE snapshot, not a
+                            # phantom one (same bug class as cmd_snap).
+                            snap_err = _hmp_error(resp)
+                            snap_ok = snap_err is None
                         except Exception:
                             pass
                         _emit_event(sid, {
@@ -858,6 +878,7 @@ def _watcher_thread(sid: str, serial_log: str, qmp_sock: str, pid: int):
                             "pattern": m.group(0),
                             "line": line,
                             "snapshot": snap_name if snap_ok else None,
+                            "snapshot_error": snap_err,
                         })
                 last_size = size
                 last_activity = time.monotonic()
@@ -3663,6 +3684,154 @@ def _classify_exit_cause(serial_log: str, running: bool) -> str:
     return "unknown_exit"
 
 
+_FF_GATES_PATH = _SCRIPTS_DIR / "ff_gates.yaml"
+
+# sc= appears on most [SC]/trace lines; capture the running counter so we can
+# tag each gate with the syscall count at which it was first reached and
+# report the deepest live sc.
+_FF_SC_RE = re.compile(rb"sc=(\d+)")
+# An [FF/write] IPC line carries its payload in body="...".  The screenshot
+# actor names live INSIDE that escaped payload, so ipc-body gates substring-
+# scan the whole line rather than anchoring.
+_FF_IPC_WRITE_RE = re.compile(rb"\[FF/write\]")
+
+
+def _load_ff_gates() -> list[dict]:
+    """Load the ordered FF gate ladder from scripts/ff_gates.yaml.
+
+    Returns a list of {id, marker_regex (compiled bytes), kind, desc} in
+    ladder order.  Falls back to a built-in minimal ladder if PyYAML is
+    missing or the file is absent so ff-progress always produces output.
+    """
+    fallback = [
+        {"id": "lib-load",          "marker_regex": rb"\[FFTEST\]\s+Cached\s+\S*libxul\.so\s+\((?!0 pages)", "kind": "line"},
+        {"id": "x11-ready",         "marker_regex": rb"\[FFTEST\]\s+X11 server ready", "kind": "line"},
+        {"id": "compositor-init",   "marker_regex": rb"\[GUI\]\s+Compositor initialized", "kind": "line"},
+        {"id": "ff-launch",         "marker_regex": rb"\[FFTEST\]\s+Launching\s+\S*firefox", "kind": "line"},
+        {"id": "content-proc",      "marker_regex": rb"\[FF/write\]\s+pid=2\b", "kind": "line"},
+        {"id": "screenshot-actors", "marker_regex": rb"ScreenshotParent|getDimensions|sendQuery", "kind": "ipc-body"},
+        {"id": "draw-snapshot",     "marker_regex": rb"drawSnapshot", "kind": "ipc-body"},
+        {"id": "png-write",         "marker_regex": rb"Screenshot saved|out\.png|\[SCREENSHOT-B64:", "kind": "line"},
+    ]
+    raw = None
+    if _FF_GATES_PATH.exists():
+        try:
+            import yaml
+            with _FF_GATES_PATH.open() as f:
+                doc = yaml.safe_load(f) or {}
+            raw = doc.get("gates")
+        except Exception:
+            raw = None
+    src = raw if raw else fallback
+    out: list[dict] = []
+    for g in src:
+        try:
+            rx = g["marker_regex"]
+            if isinstance(rx, str):
+                rx = rx.encode("utf-8", errors="replace")
+            out.append({
+                "id":    g["id"],
+                "regex": re.compile(rx),
+                "kind":  g.get("kind", "line"),
+                "desc":  g.get("desc", ""),
+            })
+        except (KeyError, re.error):
+            continue
+    return out
+
+
+def cmd_ff_progress(args):
+    """One-shot FF gate-ladder + deepest-reached detector.
+
+    Pure read-only serial-log scan; no kernel/kdb interaction.  Reports which
+    canonical Firefox-headless-screenshot gates the session reached, the
+    deepest one, the live syscall count at each, and the terminal cause —
+    automating the recurring "how deep did this boot get + is it the
+    screenshot wedge?" question.  The ladder is read from
+    scripts/ff_gates.yaml (additive; extend it to add gates)."""
+    sess = _load_session(args.sid)
+    serial_log = sess.get("serial_log", "")
+    if not serial_log or not Path(serial_log).exists():
+        _out({"error": f"no serial log for session {args.sid}"})
+        sys.exit(1)
+
+    gates = _load_ff_gates()
+    # Per-gate first-seen state.
+    seen: dict[str, dict] = {}      # id -> {first_line_no, first_sc}
+    line_no = 0
+    cur_sc = 0
+    max_sc = 0
+
+    try:
+        with Path(serial_log).open("rb") as fh:
+            for raw_line in fh:
+                line_no += 1
+                # Track the running syscall counter so each gate gets the sc
+                # at which it was first reached, and we can report deepest sc.
+                m = _FF_SC_RE.search(raw_line)
+                if m:
+                    try:
+                        cur_sc = int(m.group(1))
+                        if cur_sc > max_sc:
+                            max_sc = cur_sc
+                    except ValueError:
+                        pass
+                is_ipc = bool(_FF_IPC_WRITE_RE.search(raw_line))
+                for g in gates:
+                    if g["id"] in seen:
+                        continue
+                    if g["kind"] == "ipc-body" and not is_ipc:
+                        # ipc-body gates only match inside an [FF/write] body,
+                        # but still allow a bare line match as a fallback (some
+                        # markers also appear in plain log lines).
+                        if not g["regex"].search(raw_line):
+                            continue
+                    if g["regex"].search(raw_line):
+                        seen[g["id"]] = {
+                            "first_line_no": line_no,
+                            "first_sc": max_sc,
+                        }
+    except OSError as e:
+        _out({"error": f"cannot read serial log: {e}"})
+        sys.exit(1)
+
+    # Build the ordered gate report; deepest = last gate in ladder order that
+    # was reached.
+    gate_rows = []
+    deepest_gate = None
+    deepest_index = -1
+    for i, g in enumerate(gates):
+        s = seen.get(g["id"])
+        reached = s is not None
+        gate_rows.append({
+            "id":            g["id"],
+            "reached":       reached,
+            "first_sc":      (s["first_sc"] if reached else None),
+            "first_line_no": (s["first_line_no"] if reached else None),
+            "desc":          g["desc"],
+        })
+        if reached:
+            deepest_gate = g["id"]
+            deepest_index = i
+
+    pid = sess.get("pid", 0)
+    alive = _pid_alive(pid) if pid else False
+    terminal_cause = _classify_exit_cause(serial_log, alive)
+    reached_png = "png-write" in seen
+
+    _out({
+        "sid":            args.sid,
+        "running":        alive,
+        "deepest_gate":   deepest_gate,
+        "deepest_index":  deepest_index,
+        "max_sc":         max_sc,
+        "reached_png":    reached_png,
+        "terminal_cause": terminal_cause,
+        "total_lines":    line_no,
+        "gates":          gate_rows,
+    })
+
+
 def cmd_status(args):
     sid = args.sid
     p   = _session_path(sid)
@@ -3790,6 +3959,37 @@ def _follow_events(ep: Path):
             pass
 
 
+def _hmp_error(result: dict) -> Optional[str]:
+    """Extract a failure string from a `human-monitor-command` reply.
+
+    QMP `human-monitor-command` succeeds at the QMP layer even when the HMP
+    command itself fails — the HMP error text is delivered in the `return`
+    STRING, not in a top-level `error` key.  `savevm`/`loadvm` failures (no
+    snapshottable device, snapshot not found, image read-only) therefore look
+    like success to a naive `"error" in result` check, which is how phantom
+    snapshots were silently reported `ok:true`.
+
+    Returns the error text if the command failed, else None.  Checks both the
+    QMP-transport `error` key AND the HMP `return` text for the leading
+    `Error:` / `Error ` marker QEMU's monitor prints on failure.
+    """
+    if not isinstance(result, dict):
+        return f"unexpected QMP reply type: {type(result).__name__}"
+    if "error" in result:
+        return f"qmp: {result['error']}"
+    ret = result.get("return", "")
+    if isinstance(ret, str):
+        text = ret.strip()
+        # HMP prints "Error: <msg>" (and historically "Error <msg>") to the
+        # monitor on savevm/loadvm failure.  An empty return is success.
+        low = text.lower()
+        if low.startswith("error:") or low.startswith("error ") or \
+           "device has no snapshot" in low or "no block device can store" in low or \
+           "is not found" in low:
+            return text
+    return None
+
+
 def cmd_snap(args):
     sess     = _load_session(args.sid)
     qmp_sock = sess["qmp_sock"]
@@ -3809,10 +4009,26 @@ def cmd_snap(args):
         {"command-line": hmp_cmd},
         connect_timeout=5.0,
     )
-    if "error" in result:
-        _out({"ok": False, "qmp_error": result["error"]})
+    err = _hmp_error(result)
+    if err is not None:
+        # Surface the HMP error AND a remediation hint — full VM-state
+        # savevm needs a writable qcow2 device to hold the RAM blob; the
+        # default firefox-test boot disk (vvfat/raw) cannot store one.
+        _out({
+            "ok": False,
+            "hmp_error": err,
+            "name": name,
+            "op": op,
+            "remediation": (
+                "savevm/loadvm requires a writable qcow2 device to hold the "
+                "VM state. The default firefox-test data/boot disks are "
+                "raw/vvfat and cannot store a snapshot. Attach a qcow2 "
+                "scratch device at start (see snap-gate spec) before saving."
+            ),
+        })
     else:
-        _out({"ok": True, "name": name, "op": op})
+        _out({"ok": True, "name": name, "op": op,
+              "hmp_return": result.get("return", "") if isinstance(result, dict) else ""})
 
 
 def cmd_run_watcher(args):
@@ -4923,6 +5139,23 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
                     "(expected on|off|reset or none)"
                 )
         return req
+    if op == "cond-autopsy":
+        # One-shot musl pthread_cond/mutex wake-target-vs-wait-addr report.
+        #   kdb <sid> cond-autopsy <pid> <cond_va> [<half>]   (half default 128)
+        # Composes the live struct dump + parked waiters (FUTEX_WAITERS in
+        # [va-half, va+half]) + recent FUTEX_WAKE targets + inferred lock
+        # holder into ONE JSON object with a verdict_hint.  The cond_va is
+        # canonicalised to 0x-prefixed hex so the kernel parse_u64 sees the
+        # prefix (matching the arm-phys branch).  Requires --features kdb;
+        # the recent_wakes section additionally needs firefox-test/test-mode.
+        if len(rest) < 2:
+            raise ValueError(
+                "cond-autopsy requires <pid> <cond_va> [<half>]")
+        half = int(rest[2], 0) if len(rest) >= 3 else 128
+        return {"op": "cond-autopsy",
+                "pid": int(rest[0], 0),
+                "addr": f"0x{int(rest[1], 0):x}",
+                "half": half}
     raise ValueError(f"unknown kdb op: {op}")
 
 
@@ -5030,10 +5263,55 @@ def cmd_kdb(args):
     state["last_ping_unix"] = int(time.time())
     state["operations_called"] = int(state.get("operations_called", 0)) + 1
     state.setdefault("last_response", {})[args.op] = resp
+
+    # cond-autopsy: derive a one-line human summary so the recurring manual
+    # interpretation ("waiter at +delta, holder runnable?") is a glance.
+    # Purely additive — the machine-readable verdict_hint stays the source of
+    # truth; `summary` is a derived convenience key.
+    if args.op == "cond-autopsy" and isinstance(resp, dict) and "verdict_hint" in resp:
+        try:
+            resp["summary"] = _cond_autopsy_summary(resp)
+        except Exception:
+            pass
+
     try: cache.write_text(json.dumps(state))
     except OSError: pass
 
     _out(resp)
+
+
+def _cond_autopsy_summary(resp: dict) -> str:
+    """One-line gloss of a cond-autopsy response.
+
+    e.g. `VERDICT=wake-address-mismatch waiters=3@{+0x50,+0x54} holder=tid14`
+    `(blocked,runs=false) recent_wakes=2@{+0x50}`.
+    """
+    verdict = resp.get("verdict_hint", "?")
+    waiters = resp.get("waiters", []) or []
+    wakes   = resp.get("recent_wakes", []) or []
+    holder  = resp.get("holder", {}) or {}
+
+    def _deltas(rows):
+        seen = []
+        for r in rows:
+            try:
+                d = int(r.get("delta", 0))
+            except (TypeError, ValueError):
+                continue
+            tag = f"+0x{d:x}" if d >= 0 else f"-0x{-d:x}"
+            if tag not in seen:
+                seen.append(tag)
+        return ("{" + ",".join(seen[:6]) + "}") if seen else "{}"
+
+    w_part = f"waiters={len(waiters)}@{_deltas(waiters)}"
+    k_part = f"recent_wakes={len(wakes)}@{_deltas(wakes)}"
+    ot = holder.get("owner_tid", 0)
+    if ot and str(ot) != "0":
+        h_part = (f"holder=tid{ot}({holder.get('owner_state','?')},"
+                  f"runs={str(holder.get('owner_runs', False)).lower()})")
+    else:
+        h_part = "holder=none"
+    return f"VERDICT={verdict} {w_part} {h_part} {k_part}"
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -9898,6 +10176,10 @@ def main():
         "coverage-flush", "proc-metrics", "thread-park-audit",
         "rip-trace",
         "futex-ghost-hist",
+        # One-shot musl pthread_cond/mutex wake-target-vs-wait-addr report:
+        # struct dump + parked waiters + recent wakes + holder + verdict.
+        # See subsys/linux/futex_cluster.rs::recent_wakes_near + op_cond_autopsy.
+        "cond-autopsy",
         # Terse file-backed VMA map; one entry per VMA with first_page_phys.
         "procmaps",
         # FUTEX_WAKE cluster-wake compensation (firefox-test/test-mode only).
@@ -9919,7 +10201,8 @@ def main():
                              "syscall-trend [<seconds> [<pid>]] (def 5 0), "
                              "dmesg [tail], syms <name|0xaddr>, "
                              "mem <addr> <len>, "
-                             "rip-trace <tid> [<ms>] (def ms=1000)")
+                             "rip-trace <tid> [<ms>] (def ms=1000), "
+                             "cond-autopsy <pid> <cond_va> [<half>] (def half=128)")
     p_kdb.add_argument("--timeout", type=float, default=30.0,
                         help="Overall deadline in seconds (default 30.0). "
                              "Wraps retry/backoff for BSP starvation tolerance.")
@@ -10103,6 +10386,17 @@ def main():
     p_results = sub.add_parser("results",
         help="Parse per-test JSONL results from the session's serial log")
     p_results.add_argument("sid")
+
+    # ff-progress — structured FF gate-ladder + deepest-reached detector.
+    p_ffprog = sub.add_parser(
+        "ff-progress",
+        help="[Tier0] FF headless-screenshot gate ladder + deepest gate "
+             "reached (pure serial-log scan; no kdb). Ladder is read from "
+             "scripts/ff_gates.yaml (additive). Reports lib-load -> x11-ready "
+             "-> compositor-init -> ff-launch -> content-proc -> "
+             "screenshot-actors -> draw-snapshot -> png-write, plus max_sc "
+             "and terminal_cause.")
+    p_ffprog.add_argument("sid")
 
     # scrings — parse firefox-test syscall ring-buffer dumps from serial log.
     p_scrings = sub.add_parser(
@@ -10549,6 +10843,7 @@ def main():
         # Housekeeping / reporting
         "prune":   cmd_prune,
         "results": cmd_results,
+        "ff-progress": cmd_ff_progress,
         "scrings": cmd_scrings,
         "stack":   cmd_stack,
         "ustack":  cmd_ustack,


### PR DESCRIPTION
## Summary

Three additive debug-tooling additions for the current FF-demo deep-gate stage (FF now reaches the screenshot-IPC condvar wedge at sc>700k, but each boot to that gate costs 30-50 min). Every tool is a one-shot `argv -> structured JSON -> exit` invocation per the harness contract; new JSON fields/subcommands only, **no renames**.

### 1. kdb `cond-autopsy <pid> <cond_va> [<half>]` — the decisive condvar-livelock probe
Composes in ONE call what previously took five separate kdb queries plus manual delta math:
- **live struct dump** — 12 u64 words read via foreign-CR3 software walk (cannot fault), decoded as BOTH musl `pthread_mutex_t` (`m_lock` owner-tid / waiters-bit, `m_waiters`) and `pthread_cond_t` (`c_seq`, `c_waiters`, `c_lock`)
- **parked waiters** in `[va-half, va+half]` from `FUTEX_WAITERS`, each with its **signed delta** to the query, thread state, last syscall nr, live user rip
- **recent FUTEX_WAKE targets** in the same window (new accessor `futex_cluster::recent_wakes_near`; firefox-test/test-mode only)
- **inferred lock holder** (mutex owner-tid word, else nearest non-zero-delta signaller) + its runnability from the scheduler
- **`verdict_hint`**: `wake-address-mismatch` | `held-lock-deadlock` | `owner-starved` | `true-lost-wakeup` | `benign-empty`, plus a one-line human `summary` (e.g. `VERDICT=wake-address-mismatch waiters=3@{+0x50,+0x54} holder=tid14(blocked,runs=false) recent_wakes=1@{+0x50}`)

Mirrors a `[COND-AUTOPSY]` serial line for TCP-drain recovery. Bounded (≤64 waiters, ≤64 wakes, 12 words) so the response stays <4 KB.

**Validated live** on the real `…e58` g_cond: reads `c_seq=0`/`c_waiters=0`, sees tid2's wake at delta 0, no parked waiter → verdict `benign-empty` — reproducing the documented "the `…e58` broadcast is a red herring" finding in a single argv call.

### 2. `ff-progress <sid>` — structured FF gate-ladder + deepest-reached detector
Pure read-only serial scan (no kdb). Reports the ladder `lib-load → x11-ready → compositor-init → ff-launch → content-proc → screenshot-actors → draw-snapshot → png-write`, the deepest gate reached, `max_sc`, `reached_png`, and `terminal_cause`. Ladder is data-driven from `scripts/ff_gates.yaml` (additive; mirrors the `differential/snapshots.yaml` read-at-runtime convention).

The screenshot-actor gate is the one non-obvious parse: `ScreenshotParent`/`getDimensions`/`sendQuery` live INSIDE `[FF/write] body="..."` IPC payloads, so that gate is an `ipc-body` substring scan, not line-anchored.

**Validated end-to-end** against a real deep-gate log: `deepest=screenshot-actors, max_sc=759652`, drawSnapshot/png not reached.

### 3. `snap` honesty fix — stop reporting phantom snapshots
`human-monitor-command` succeeds at the QMP layer even when the inner HMP `savevm`/`loadvm` fails; the error rides in the `return` STRING, not an `error` key — so `snap save` reported `ok:true` on a failed snapshot (phantom snapshots that every later agent then trusted). New `_hmp_error` helper parses the HMP return text; `cmd_snap` and the watcher panic-path now surface `ok:false` + `hmp_error` + a remediation hint.

**Validated live**: the default vvfat boot disk now correctly reports `"vvfat (rw) ... does not support live migration"` instead of a silent phantom ok. This is the prerequisite for the deferred snapshot-library work (spec'd below).

## Verification
- kernel `cargo check` green for: default (no features), `test-mode` (CI build), `kdb`, `firefox-test,kdb`, `test-mode,kdb`
- fault-immunity lint OK; python syntax OK
- `cond-autopsy`, `ff-progress`, and `snap` all exercised against a live `firefox-test,kdb` boot

## Deferred specs (follow-up)
- **snap-gate library**: attach a dedicated qcow2 scratch device at start to hold the savevm RAM blob (vvfat boot disk blocks live migration) + `snap-gate save/load/list` with a persisted gate manifest under `~/.astryx-harness/snapshots/`, keyed on kernel+data.img sha. Collapses the 30-50 min reboot to a sub-second `loadvm` — biggest time sink. Needs a verification gate (round-trip the live FF process+TLS state, confirm via `ff-progress` the restored guest is still at the gate).
- **`user-rip <sid> <tid>`**: thin specialization of `rip-walk` selecting the CPU whose active process matches the tid, returning the saved USER rip (generalizes the GDB-break-at-handler technique).
- **`golden-diff <sid> <marker>`**: align live [SC] trace to the golden FF→PNG strace at a marker, name the first divergence (needs a pointer-arg canonicalizer).
- **`race-start --until <marker> --count N`**: parallel-boot, return first session to hit a marker (beats the flaky sc~12k split). Pairs with `ff-progress` as the marker oracle.

Public references: pthread_cond_signal(3p), pthread_mutex_lock(3p), futex(2); musl public pthread struct layouts; Gecko IPDL public actor names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)