### PR TITLE
docs: GitHub Pages site (Jekyll + just-the-docs)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+name: Deploy docs (GitHub Pages)
+
+# Builds the Jekyll site under docs/ (just-the-docs remote theme) and deploys it
+# to GitHub Pages. Triggers only on changes to the docs site, plus manual runs.
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch: {}
+
+# Allow GITHUB_TOKEN to deploy to Pages and verify the deployment origin.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Jekyll site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Only deploy from master pushes / manual runs — PRs build for validation
+    # but must not publish.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,22 @@
+# Gemfile for the AstryxOS documentation site (docs/).
+#
+# The site is built by GitHub Pages using the github-pages gem, which pins a
+# Jekyll + plugin set compatible with the Pages build environment. The
+# just-the-docs theme is pulled in via `remote_theme` in _config.yml, so it is
+# not listed as a hard dependency here; jekyll-remote-theme (bundled with
+# github-pages) fetches it at build time.
+#
+# To build locally:  bundle install && bundle exec jekyll build
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+
+# Plugins referenced by _config.yml.
+group :jekyll_plugins do
+  gem "jekyll-remote-theme"
+  gem "jekyll-seo-tag"
+end
+
+# Windows / JRuby support and a faster file watcher (harmless elsewhere).
+gem "webrick", "~> 1.8"
+gem "wdm", "~> 0.1", platforms: [:mingw, :x64_mingw, :mswin]

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,102 @@
+# AstryxOS documentation site — Jekyll + just-the-docs (GitHub Pages remote theme)
+#
+# GitHub Pages builds Jekyll natively, so this site needs no custom build
+# pipeline beyond the remote_theme below. Page order is set per-page via the
+# `nav_order` front-matter key; client-side search, the nav sidebar, the
+# mobile-responsive layout, and code-block highlighting all ship with the theme.
+
+title: AstryxOS
+description: >-
+  A hybrid-kernel operating system, written from scratch in Rust, that runs
+  upstream unmodified binaries from other operating systems.
+remote_theme: just-the-docs/just-the-docs
+
+# Site URL config is set by GitHub Pages at build time; baseurl is left blank so
+# the site works for both a user/repo page and a custom domain. If this deploys
+# to https://<user>.github.io/AstryxOS/, set baseurl to "/AstryxOS".
+url: ""
+baseurl: ""
+
+# --- just-the-docs options ---------------------------------------------------
+
+# Client-side search (ships with the theme; no external service).
+search_enabled: true
+search:
+  heading_level: 2
+  previews: 3
+  preview_words_before: 5
+  preview_words_after: 10
+  tokenizer_separator: /[\s/]+/
+
+# Show a "table of contents" heading list on pages.
+heading_anchors: true
+
+# Collapse long auxiliary pages out of the top-level nav. The five authored
+# guides carry explicit nav_order; everything else in docs/ is reference
+# material reachable via in-page links and search rather than the sidebar.
+nav_external_links:
+  - title: AstryxOS on GitHub
+    url: https://github.com/me1iissa/AstryxOS
+
+# Footer / repo links.
+gh_edit_link: true
+gh_edit_link_text: Edit this page on GitHub
+gh_edit_repository: https://github.com/me1iissa/AstryxOS
+gh_edit_branch: master
+gh_edit_source: docs
+gh_edit_view_mode: tree
+
+color_scheme: dark
+
+# Callout styles used in the authored pages ({: .note }, {: .warning }).
+callouts:
+  note:
+    title: Note
+    color: blue
+  warning:
+    title: Warning
+    color: red
+
+# --- Jekyll build options ----------------------------------------------------
+
+# Exclude the large corpus of investigation/audit markdown from the built site
+# so only the curated guides are published. These remain in the repo and are
+# linked directly where referenced.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor
+  - .bundle
+  - "*_artifacts"
+
+# Keep dated investigation reports out of the auto-generated nav; they are still
+# served (linked from the guides) but should not clutter the sidebar.
+defaults:
+  - scope:
+      path: ""
+    values:
+      nav_exclude: true
+  - scope:
+      path: "index.md"
+    values:
+      nav_exclude: false
+  - scope:
+      path: "architecture.md"
+    values:
+      nav_exclude: false
+  - scope:
+      path: "getting-started.md"
+    values:
+      nav_exclude: false
+  - scope:
+      path: "running-upstream-binaries.md"
+    values:
+      nav_exclude: false
+  - scope:
+      path: "dev-tooling.md"
+    values:
+      nav_exclude: false
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,253 @@
+---
+title: Architecture
+nav_order: 2
+---
+
+# Architecture
+
+AstryxOS is a hybrid kernel for UEFI x86-64. Its design borrows the NT
+subsystem model: a compact **executive** at the centre, a **Hardware
+Abstraction Layer** beneath it, and **personality subsystems** layered above
+that each present one operating system's native ABI. Everything below a
+personality — memory, scheduling, the VFS, IPC, networking, drivers — is shared.
+Everything a personality adds is a thin translation from one OS's syscall and
+binary conventions into executive primitives.
+
+This page describes the layers from the top down.
+
+{: .note }
+Where this page references behaviour mandated by a standard, it cites the public
+specification: the System V x86-64 psABI and the ELF standard for binary
+layout; the Intel® 64 and IA-32 Architectures Software Developer's Manual
+(Intel SDM) for `SYSCALL`/`SYSRET` and paging; POSIX and the Linux man-pages
+for syscall semantics; and the relevant RFCs for the network stack.
+
+---
+
+## Personalities — the multi-ABI surface
+
+A *personality subsystem* owns two things: a **syscall entry surface** and a
+**binary loader**. A program never learns it is on AstryxOS; it makes the calls
+it was compiled to make and gets the semantics it expects back.
+
+| Personality | Entry surface | Binaries it loads | Maturity |
+|---|---|---|---|
+| **Linux x86-64** | the `SYSCALL` instruction (per the x86-64 psABI and the Intel SDM Vol. 2) | static ELF, PIE (`ET_DYN`), and fully dynamic ELF via the system's `ld.so` | Real upstream glibc- and musl-linked binaries run end-to-end |
+| **NT / Win32** | software interrupt `INT 0x2E` (the classic NT syscall gate) | PE32+ images | Loader + a `KUSER_SHARED_DATA`-style stub subsystem |
+| **Native Aether** | software interrupt `INT 0x2E` (Aether dispatch) | AstryxOS-native programs | First-party calls for the shell, demos, and tooling |
+
+The Linux personality is the most developed because it is the one Firefox needs.
+It dispatches **193+ Linux syscalls** through `kernel/src/subsys/linux/`,
+alongside the **50+ native Aether calls** in `kernel/src/subsys/aether/`. The
+two dispatchers share a single entry point in `kernel/src/syscall/` that routes
+on the calling personality.
+
+The most important property of a personality is that it is *honest*: it does not
+emulate behaviour with a workaround, it implements the documented contract. When
+an upstream binary trips, the response is to fix the personality (or the shared
+executive beneath it) so that the documented ABI is satisfied — see
+[Running Upstream Binaries](running-upstream-binaries.md) for the invariant and
+the list of real ABI bugs this discipline has surfaced and fixed.
+
+---
+
+## The executive (shared core)
+
+Below the personalities sits the Aether executive — the OS-agnostic machinery
+that every personality is built on. It mirrors the NT executive's
+responsibilities.
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| Memory manager | `mm/` | Physical memory manager (PMM), virtual memory manager (VMM), slab heap, page tables, ASLR, demand paging, OOM killer |
+| Scheduler | `sched/` | SMP run queue: round-robin + priority (CoreSched), with anti-starvation aging so a runnable thread cannot be starved indefinitely |
+| Process / thread | `proc/` | Process and thread control blocks, the ELF loader (static, PIE, dynamic) and the PE32+ loader |
+| Virtual filesystem | `vfs/` | Mount table and the file/inode abstraction over every filesystem driver |
+| IPC | `ipc/` | Pipes, Unix-domain sockets, SysV shared memory, `timerfd`, `signalfd`, `inotify`, PTYs |
+| Networking | `net/` | The TCP/IP stack (see below) |
+| X11 server | `x11/` | An in-kernel X11 server with seven extensions |
+| Core executive | `ke/` | Spinlocks, DPCs, deferred work, wait/notify primitives |
+| Object manager | `ob/` | Handles and reference counting |
+| Security | `security/` | Capabilities (`capget`/`capset`), rlimits, `prctl`, `PR_SET_NO_NEW_PRIVS` |
+| GUI / GDI | `gui/`, `gdi/`, `wm/` | Window manager, compositor, terminal emulator, desktop shell; the GDI device-context / surface / BitBlt engine |
+
+The executive owns the hard concurrency invariants. Two recurring examples from
+the project's history illustrate the level the code operates at:
+
+- **Futex correctness.** `futex(2)` `FUTEX_WAIT` compares the 32-bit word at the
+  user address against the supplied value. The comparison must be done in 32
+  bits — a 64-bit compare sign-extends a high-bit-set value and breaks the
+  contract. Getting this exactly right is what lets contended musl mutexes park
+  and wake correctly.
+- **Wake delivery under contention.** A scheduler timer that comes due must wake
+  its sleeper even if a lock acquisition loses a race; a due-wake must never be
+  silently dropped. The executive guarantees forward progress here.
+
+---
+
+## Memory management
+
+The memory manager is a conventional two-level design — a physical frame
+allocator under a per-address-space virtual memory manager — extended with the
+features upstream dynamic binaries require:
+
+- **Demand paging** for file- and anonymous-backed mappings, so `mmap(2)`
+  regions are populated lazily on first touch.
+- **ASLR** for both `ET_DYN` ELF images and PE images (`DYNAMIC_BASE`), so load
+  addresses are randomised as on a hardened host.
+- **`mremap(2)`** including in-place grow, which must preserve adjacent mappings
+  rather than clobber them.
+- **`PT_GNU_RELRO`** read-only hardening of the relocated GOT after startup.
+- **A slab heap** for kernel objects and an **OOM killer** for memory pressure.
+
+Page tables follow the x86-64 4-level paging layout described in the Intel SDM.
+
+---
+
+## Scheduling
+
+CoreSched is an SMP scheduler combining round-robin fairness with priority. The
+key correctness property for running real multi-process applications is
+**anti-starvation aging**: a thread's effective priority rises with the time it
+has spent waiting in the Ready queue, so a runnable thread (for example, a
+freshly-spawned content-process child) is guaranteed to be scheduled rather than
+sitting Ready forever behind higher-priority work. Without this, multi-process
+startup can deadlock even though no thread is blocked.
+
+---
+
+## Process model and binary loading
+
+`proc/` owns process and thread control blocks and the loaders. The ELF loader
+honours exactly what the upstream toolchain emitted:
+
+- `PT_LOAD` segments mapped with the correct protections;
+- `PT_INTERP` — the path to the upstream dynamic linker, which is then loaded
+  and run as the program interpreter;
+- `PT_TLS` — thread-local storage, set up so libc's TLS model works unmodified;
+- the relocation tables, including the compact `DT_RELR` form and `DT_GNU_HASH`
+  symbol lookup;
+- `PT_GNU_RELRO` for post-relocation hardening.
+
+The exec path also constructs a variant-aware `LD_LIBRARY_PATH` derived from the
+binary's `PT_INTERP`, so the upstream `ld.so` searches the same directories it
+would on a normal install and resolves a program's bundled `.so` set.
+
+The PE32+ loader parses Windows images natively, sets up the Win32 environment
+block, and provides a `KUSER_SHARED_DATA`-style shared page so the image's CRT
+can initialise.
+
+---
+
+## Filesystems and the VFS
+
+The VFS presents a single mount tree over a set of filesystem drivers:
+
+| Filesystem | Access | Notes |
+|---|---|---|
+| ramfs | read/write | Root VFS, in-memory |
+| FAT32 | read/write | Cluster allocator: create, write, truncate, unlink |
+| ext2 | read | Inode + directory traversal; backs the data disk that carries upstream libraries |
+| NTFS | read | |
+| procfs | read | `/proc/self`, `/proc/<pid>`, `cpuinfo`, `meminfo`, `uptime`, `maps`, `fd/` |
+| tmpfs | read/write | Mounted at `/tmp` via `sys_mount` |
+
+A subtle but load-bearing correctness rule lives here: a device-level read error
+is **not** end-of-file. A failed read must propagate an error and must never
+install a zero-filled page as valid data — otherwise file-backed memory silently
+diverges from the disk, which corrupts code pages of large libraries.
+
+---
+
+## Networking
+
+`net/` is a full TCP/IP stack implemented from scratch:
+
+- **IPv4 and IPv6**, ARP, ICMP.
+- **TCP** with the 3-way handshake, FIN teardown, retransmission, and congestion
+  control, per the relevant RFCs.
+- **UDP**, **DNS**, and **DHCP** for autoconfiguration.
+- Drivers for **e1000** and **virtio-net**.
+
+This is what lets upstream `wget`/`curl`, an `httpd`, and an OpenSSL TLS
+handshake run over real sockets.
+
+---
+
+## Graphics: X11, GDI, and the shell
+
+AstryxOS runs an **in-kernel X11 server** (`x11/`) implementing the core
+protocol plus the RENDER, MIT-SHM, XKB, XFIXES, SYNC, and BIG-REQUESTS
+extensions — enough for real X11 clients to connect and draw. Above it,
+`gui/`, `wm/`, and `gdi/` provide a window manager, a compositor, a terminal
+emulator, a desktop shell, and a GDI engine (device contexts, surfaces, BitBlt,
+text, regions).
+
+---
+
+## Drivers and the HAL
+
+The Hardware Abstraction Layer (`hal/`) isolates the executive from the
+platform. The driver set covers what is needed to boot and run on QEMU and
+comparable hardware:
+
+| Category | Drivers |
+|---|---|
+| Block | ATA PIO, AHCI DMA, virtio-blk, partition table |
+| Network | e1000, virtio-net |
+| Audio | AC97 (`/dev/dsp`) |
+| Input | PS/2 keyboard, PS/2 mouse |
+| Display | Framebuffer, VMware SVGA stub |
+| USB | xHCI enumeration (Tier 1 probe) |
+| Serial | 16550 UART |
+| Timer | PIT, LAPIC, HPET, RTC |
+
+---
+
+## Boot flow
+
+1. **AstryxBoot**, a from-scratch UEFI bootloader (`bootloader/`), runs in the
+   UEFI environment, loads the flat kernel binary, gathers a memory map and
+   framebuffer info, and hands control to the kernel.
+2. The kernel brings up the x86-64 platform: GDT, IDT, LAPIC, SMP AP startup,
+   paging, and the executive subsystems in dependency order.
+3. The personalities register their syscall surfaces, the VFS mounts the root
+   and the data disk, and `init` (or the test runner, in test mode) starts.
+
+---
+
+## Source layout
+
+```
+kernel/src/
+├── arch/       # x86-64: GDT, IDT, LAPIC, SMP, context switch, ISR delivery
+├── mm/         # PMM, VMM, slab heap, page tables, ASLR, OOM killer
+├── sched/      # CoreSched — SMP round-robin + priority, anti-starvation aging
+├── proc/       # Process/thread control blocks, ELF + PE32+ loaders
+├── vfs/        # VFS: ramfs, FAT32, ext2, NTFS, procfs, tmpfs
+├── ipc/        # Pipes, Unix sockets, SysV SHM, timerfd, signalfd, inotify, PTY
+├── net/        # TCP/IP stack, DNS, DHCP, e1000, virtio-net
+├── x11/        # In-kernel X11 server (7 extensions)
+├── gui/ wm/ gdi/   # Window manager, compositor, terminal, desktop, GDI engine
+├── ke/ ob/     # Core executive (locks, DPCs, wait/notify) + object manager
+├── security/   # Capabilities, rlimits, prctl
+├── hal/        # Hardware Abstraction Layer
+├── drivers/    # ATA, AHCI, virtio-blk/net, AC97, PS/2, xHCI, serial
+├── nt/ win32/  # NT personality subsystem (Win32 ABI)
+├── subsys/
+│   ├── linux/  # Linux syscall dispatch (193+ syscalls)
+│   ├── aether/ # Native Aether syscall dispatch (50+ calls)
+│   └── win32/  # Win32 syscall dispatch
+├── syscall/    # Syscall entry point and personality routing
+└── test_runner.rs   # Headless integration test suite
+```
+
+---
+
+## See also
+
+- [Running Upstream Binaries](running-upstream-binaries.md) — the multi-ABI
+  model in practice, the never-patch-the-binary invariant, and the Firefox push.
+- [Getting Started](getting-started.md) — build it and run the tests.
+- [Contributing & Dev Tooling](dev-tooling.md) — the harness, GDB autopsy, and
+  the contribution flow.

--- a/docs/dev-tooling.md
+++ b/docs/dev-tooling.md
@@ -1,0 +1,217 @@
+---
+title: Contributing & Dev Tooling
+nav_order: 5
+---
+
+# Contributing & Dev Tooling
+
+AstryxOS is built and debugged through a small set of purpose-built,
+**non-interactive, structured-output** tools. This page covers the harness you
+will use to boot and debug the kernel, the GDB-autopsy-first discipline for
+investigating faults, and the contribution workflow.
+
+{: .note }
+AstryxOS is also an experiment in agentic development: most of the codebase was
+written by AI agents working in parallel worktrees, with human review at merge
+time. The tooling reflects that — every command is a one-shot invocation that
+prints machine-readable JSON, so a human, a script, or an agent can drive it
+identically.
+
+---
+
+## The QEMU harness
+
+`scripts/qemu-harness.py` is the canonical way to build, boot, and debug the
+kernel. Every subcommand prints JSON to stdout; session state persists on disk
+under `~/.astryx-harness/`, so any number of one-shot queries can run against a
+single live boot.
+
+```bash
+# start a session — prints {"sid": "...", "pid": ..., "serial_log": "..."}
+python3 scripts/qemu-harness.py start [--features FLAGS] [--no-build] \
+                                      [--gdb-port PORT] [--gdb-wait]
+
+python3 scripts/qemu-harness.py wait <sid> <regex> [--ms MS]   # blocking wait on a marker
+python3 scripts/qemu-harness.py grep <sid> <regex> [--tail N]  # search the serial log
+python3 scripts/qemu-harness.py tail <sid>                     # recent serial output
+python3 scripts/qemu-harness.py status <sid>                   # session status JSON
+python3 scripts/qemu-harness.py list                           # all sessions
+python3 scripts/qemu-harness.py stop <sid>                     # tear down
+```
+
+KVM is used automatically when `/dev/kvm` is present (recommended — it reaches
+deeper into long boots and is much faster). Pass `--no-kvm` only to force a TCG
+run.
+
+A typical debug loop runs the QEMU session in the background and issues
+foreground queries against it:
+
+```bash
+# 1. boot in the background
+python3 scripts/qemu-harness.py start --features firefox-test    # backgrounded
+# 2. block until a marker appears
+python3 scripts/qemu-harness.py wait <sid> 'Compositor' --ms 120000
+# 3. query live state as many times as needed (each returns immediately)
+python3 scripts/qemu-harness.py grep <sid> 'content proc|Screenshot' --tail 20
+python3 scripts/qemu-harness.py ff-progress <sid>
+# 4. stop
+python3 scripts/qemu-harness.py stop <sid>
+```
+
+The full subcommand reference is in [docs/HARNESS.md](HARNESS.md).
+
+{: .warning }
+For kernel and Firefox-port work, use the harness — **not** the shell wrappers
+(`run-test.sh`, `run-firefox-test.sh`, etc.). The harness is the supported path:
+it carries session state, an event stream, and the GDB stub. If it is missing a
+subcommand you need, extend the harness rather than working around it.
+
+### Firefox bring-up helpers
+
+The harness ships oracles for the Firefox push:
+
+- **`ff-progress <sid>`** — a pure serial-log scan reporting the headless
+  screenshot **gate ladder** and the deepest gate reached: lib-load → x11-ready →
+  compositor-init → ff-launch → content-proc → screenshot-actors →
+  draw-snapshot → png-write, plus the max syscall count, whether a PNG was
+  written, and the terminal cause. This is the authoritative "how deep did this
+  boot get?" answer. The ladder lives in `scripts/ff_gates.yaml` and is
+  additive.
+- **`kdb <sid> cond-autopsy <pid> <cond_va> [<half>]`** — a one-shot
+  pthread-condition-variable / mutex autopsy: it dumps the live struct, lists
+  every parked waiter near the address (with the delta to the query), shows
+  recent `FUTEX_WAKE` targets, infers the lock holder and whether it ever runs,
+  and emits a `verdict_hint` (`wake-address-mismatch` | `held-lock-deadlock` |
+  `owner-starved` | `true-lost-wakeup` | `benign-empty`). This is the decisive
+  probe for the condvar-livelock gate.
+
+---
+
+## GDB autopsy first
+
+AstryxOS has a GDB stub wired directly into the harness (`start --gdb-port N`).
+The binding rule for fault investigation is:
+
+> **Before adding any new printk-style probe** — a ring buffer, a counter, a
+> diagnostic log line — to investigate a fault, first run a structured GDB
+> autopsy and report what it says.
+
+The autopsy subcommand breaks at a symbol or address, captures a named set of
+registers and memory windows, and prints JSON:
+
+```bash
+python3 scripts/qemu-harness.py start --features <flags> --gdb-port 1234
+python3 scripts/qemu-harness.py wait <sid> '<fault-marker-regex>'
+python3 scripts/qemu-harness.py autopsy <sid> \
+    --break <symbol-or-addr> \
+    --capture <preset> \
+    [--once N] [--continue-after] [--timeout-ms MS] [--output /tmp/autopsy.json]
+```
+
+Presets live in `scripts/autopsy/presets.yaml` and are additive (append a YAML
+entry; no code change). The current set:
+
+| Preset | Use when |
+|---|---|
+| `full-register-dump` | Minimal first probe — GPRs + segments + RFLAGS |
+| `stack-walk-bt-full` | Need to walk frames; captures RSP/RBP windows |
+| `ssp-fail-snapshot` | Stack-canary / `__stack_chk_fail`; canary slot + `fs:0x28` |
+| `vfork-window` | `vfork(2)` gate; pre-clone frame identity |
+| `gp-fault-context` | `#GP` at IRET/SYSRET; IRET frame + code around RIP |
+| `sigsegv-user-gprs` | `SIGSEGV` delivery; the faulting user GPR context |
+| `bugcheck-entry` | `ke_bugcheck` entry; decodes the bugcheck code + parameters |
+
+A technique worth calling out, because it has cracked several gates: **live-RIP
+on the correct build.** Break at the kernel syscall or futex handler and read
+the *saved user RIP* — that names the exact upstream instruction that is stuck,
+which the in-kernel debugger's process view alone may not reveal.
+
+The GDB stub also exposes the lower-level primitives directly: `regs`, `mem`,
+`sym`, `bp add|del|list`, `step`, `cont`, `pause`, `resume`.
+
+The only faults GDB literally cannot reach — concurrent-write races where the
+writer no longer holds the faulting page, freed-frame writers, fire-and-forget
+corruption that completes before the symptom fires — are the documented
+exceptions where a targeted probe is justified. Everything else (page faults,
+`#GP`, `#UD`, canary corruption, bugchecks, kernel asserts) gets an autopsy
+first.
+
+---
+
+## The in-kernel debugger (kdb)
+
+`kdb` is a non-interactive in-kernel debugger surfaced through the harness as
+one-shot argv commands — process listing, per-process detail, memory reads, and
+the `cond-autopsy` probe above. Like everything else, each invocation is a
+single request/response that prints structured output and exits; there is no
+REPL to type into.
+
+---
+
+## Snapshots
+
+The harness supports save/restore so a known-good boot state can be captured and
+restored without redoing the boot:
+
+```bash
+python3 scripts/qemu-harness.py snap <sid> save <name>
+python3 scripts/qemu-harness.py snap <sid> load <name>
+```
+
+This is the force-multiplier for deep gates: reach a hard-to-hit state once,
+snapshot it, and restore it instead of waiting through a long reboot.
+
+---
+
+## Contribution workflow
+
+Process rules that apply to **everyone**, human or agent:
+
+1. **One change per branch.** No drive-by refactors inside a feature branch.
+2. **Kernel changes land via pull request with green CI** — never direct to
+   `master`.
+3. **Tests are required.** Every new syscall or feature ships with at least one
+   headless test in `kernel/src/test_runner.rs`.
+4. **The test suite must pass before merging** — run
+   `python3 scripts/watch-test.py --idle-timeout 60 --hard-timeout 300` and
+   confirm the expected pass count.
+5. **Never patch an upstream binary.** If an upstream binary misbehaves, fix the
+   kernel or the ABI layer — see
+   [Running Upstream Binaries](running-upstream-binaries.md).
+6. **Cite public specifications only.** In commits, comments, PRs, and docs,
+   cite POSIX, the Linux man-pages, RFCs, the Intel SDM, and the ELF/psABI
+   standards — never a private or proprietary source tree.
+
+Routing:
+
+- **Human contributors** — [HUMAN_CONTRIBUTING.md](https://github.com/me1iissa/AstryxOS/blob/master/HUMAN_CONTRIBUTING.md):
+  environment, branch naming, commit format, PR workflow, style, filing bugs.
+- **AI agents** — [AI_CONTRIBUTING.md](https://github.com/me1iissa/AstryxOS/blob/master/AI_CONTRIBUTING.md):
+  worktree isolation, the canonical test command, known pitfalls, and how to
+  extend the test suite autonomously.
+- Vulnerability reports — [SECURITY.md](https://github.com/me1iissa/AstryxOS/blob/master/SECURITY.md).
+
+---
+
+## Tooling principles
+
+Every debug/test tool in AstryxOS follows the same contract, which is what makes
+the workflow scriptable end-to-end:
+
+- **Non-interactive.** Each operation is one argv invocation that reads its
+  arguments, does the work, prints structured output (preferably JSON), and
+  exits. No REPLs, no "press any key", no required persistent stdin.
+- **State lives on disk.** If state must survive between calls (a running QEMU
+  session, a GDB attachment), it is written under a known path so any future
+  caller can resume it.
+- **Additive output.** New JSON fields are fine; field renames break downstream
+  callers, so breaking changes are called out explicitly.
+
+---
+
+## See also
+
+- [Getting Started](getting-started.md) — build and run the test suite first.
+- [Architecture](architecture.md) — what you are debugging.
+- [Running Upstream Binaries](running-upstream-binaries.md) — the find-the-
+  divergence, fix-the-kernel method the harness exists to support.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,253 @@
+---
+title: Getting Started
+nav_order: 3
+---
+
+# Getting Started
+
+This guide takes a fresh checkout to a building kernel and a passing test run by
+the shortest path. It is tested on **Ubuntu 22.04 LTS** and **WSL2 (Ubuntu
+22.04)**; other recent Debian-based distributions should work with minor
+package-name changes.
+
+{: .note }
+For interactive kernel debugging (GDB autopsy, the in-kernel `kdb`, the Firefox
+bring-up harness), continue to [Contributing & Dev Tooling](dev-tooling.md)
+after your first passing test run.
+
+---
+
+## 1. Prerequisites
+
+### System packages
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    gcc \
+    musl-tools \
+    mtools \
+    qemu-system-x86 \
+    ovmf \
+    git \
+    curl \
+    python3
+```
+
+- **`musl-tools`** provides `musl-gcc`, used to build the musl libc that ships
+  on the data disk.
+- **`mtools`** (`mformat`, `mcopy`) is used by `create-data-disk.sh` to populate
+  the FAT32 image.
+- **`ovmf`** installs UEFI firmware under `/usr/share/OVMF/`. The build/test
+  tooling expects `OVMF_CODE_4M.fd` and `OVMF_VARS_4M.fd` there. The package is
+  `ovmf` on Ubuntu and `edk2-ovmf` on Fedora/Arch.
+
+Verify the firmware is present:
+
+```bash
+ls /usr/share/OVMF/OVMF_CODE_4M.fd
+```
+
+If it is missing, see [OVMF path variations](#ovmf-path-variations) below.
+
+### KVM (optional, recommended)
+
+KVM cuts test wall-clock time dramatically (roughly 90 s → 15 s) and the
+harness reaches deeper into long-running boots with it. The harness and
+watchdog detect `/dev/kvm` automatically and enable it when present.
+
+```bash
+ls -la /dev/kvm
+# If permission is denied:
+sudo usermod -aG kvm "$USER"
+# then log out/in, or: newgrp kvm
+```
+
+### Rust nightly
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+```
+
+The repository pins the exact nightly in `rust-toolchain.toml`; cargo downloads
+and uses the correct toolchain automatically. The kernel compiles the Rust
+standard library from source via `-Zbuild-std`, which is why `rust-src` is
+required.
+
+---
+
+## 2. Clone and build
+
+```bash
+git clone <repo-url> AstryxOS
+cd AstryxOS
+./build.sh release
+```
+
+A successful build produces:
+
+```
+build/esp/EFI/BOOT/BOOTX64.EFI    — UEFI bootloader
+build/esp/EFI/astryx/kernel.bin   — flat kernel binary
+```
+
+The first build takes 2–4 minutes (it compiles `std` from source). Incremental
+builds are much faster.
+
+---
+
+## 3. Create the data disk
+
+The data disk is a FAT32 image holding the musl/glibc dynamic linker, shared
+libraries, and `/etc` seed files. It is required for any test that exercises the
+filesystem, the dynamic linker, or glibc/musl binary paths.
+
+```bash
+bash scripts/create-data-disk.sh
+```
+
+This produces `build/data.img`. If you also want the musl libc, the TCC
+compiler, and glibc on the disk (for the disk-dependent test subset), run:
+
+```bash
+bash scripts/build-musl.sh
+bash scripts/build-tcc.sh
+bash scripts/install-glibc.sh
+```
+
+These are optional for a basic test run.
+
+---
+
+## 4. Run the test suite
+
+The kernel ships a headless integration test runner (`kernel/src/test_runner.rs`)
+covering the memory manager, scheduler, VFS, IPC, networking, the syscall ABIs,
+and more.
+
+```bash
+python3 scripts/watch-test.py --idle-timeout 60 --hard-timeout 300
+```
+
+The watchdog rebuilds the kernel in test mode, launches QEMU headless, streams
+the annotated serial log, and exits on a pass/fail result or a timeout. A
+passing run ends with output like:
+
+```
+[PASS] 139/140 tests passed
+[WATCHDOG] QEMU exited cleanly (code 1 = pass)
+```
+
+To iterate without rebuilding:
+
+```bash
+python3 scripts/watch-test.py --no-build --idle-timeout 60 --hard-timeout 300
+```
+
+{: .note }
+`watch-test.py` is the right tool for the **test suite**. For interactive
+debugging and the Firefox bring-up, use `scripts/qemu-harness.py` instead — see
+[Contributing & Dev Tooling](dev-tooling.md).
+
+---
+
+## 5. Boot it interactively
+
+To boot a normal (non-test) kernel and drive it through the structured harness:
+
+```bash
+# start a session (prints JSON with the session id "sid")
+python3 scripts/qemu-harness.py start
+
+# wait for a boot marker, then read recent serial output
+python3 scripts/qemu-harness.py wait <sid> "kernel ready" --ms 15000
+python3 scripts/qemu-harness.py tail <sid>
+
+# tear it down
+python3 scripts/qemu-harness.py stop <sid>
+```
+
+To run the **upstream Firefox bring-up** (once the data disk is staged with the
+Firefox payload), boot with the `firefox-test` feature and watch it advance the
+gate ladder:
+
+```bash
+python3 scripts/qemu-harness.py start --features firefox-test
+python3 scripts/qemu-harness.py ff-progress <sid>   # reports the deepest gate reached
+python3 scripts/qemu-harness.py stop <sid>
+```
+
+See [Running Upstream Binaries](running-upstream-binaries.md) for what each gate
+means and the honest current state of the Firefox screenshot pipeline.
+
+---
+
+## Common problems and fixes
+
+### OVMF path variations
+
+The tooling expects firmware at `/usr/share/OVMF/OVMF_CODE_4M.fd`. If your
+distribution puts it elsewhere, the simplest fix is a symlink:
+
+```bash
+# Fedora / Arch (edk2-ovmf)
+sudo ln -s /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/OVMF/OVMF_CODE_4M.fd
+sudo ln -s /usr/share/edk2/ovmf/OVMF_VARS.fd /usr/share/OVMF/OVMF_VARS_4M.fd
+```
+
+### `mtools` not found
+
+`create-data-disk.sh` calls `mformat`/`mcopy` from the `mtools` package:
+
+```bash
+sudo apt-get install mtools    # Debian/Ubuntu
+sudo dnf install mtools        # Fedora
+```
+
+### KVM permission denied
+
+```bash
+sudo usermod -aG kvm "$USER"
+# then: newgrp kvm   (or log out/in)
+```
+
+### Build fails with `llvm-objcopy not found`
+
+The build script converts the kernel ELF to a flat binary with `llvm-objcopy`
+from the Rust sysroot, falling back to the system copy. If neither is present:
+
+```bash
+sudo apt-get install llvm
+```
+
+### `cargo` uses the wrong toolchain
+
+The nightly date is pinned in `rust-toolchain.toml`. If cargo reports a missing
+component:
+
+```bash
+rustup update nightly
+rustup component add rust-src --toolchain nightly
+```
+
+### QEMU exits immediately
+
+Most common causes: a missing `build/data.img` (run
+`scripts/create-data-disk.sh`), missing OVMF firmware (see above), or an
+unreliable nested-KVM setup under WSL2. The fuller troubleshooting list lives in
+[docs/QUICKSTART.md](QUICKSTART.md).
+
+---
+
+## See also
+
+- [Architecture](architecture.md) — how the kernel is structured.
+- [Running Upstream Binaries](running-upstream-binaries.md) — the multi-ABI
+  model and the Firefox bring-up.
+- [Contributing & Dev Tooling](dev-tooling.md) — the harness, GDB autopsy,
+  `kdb`, and the contribution workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,144 @@
+---
+title: Home
+nav_order: 1
+---
+
+# AstryxOS
+
+{: .fs-9 }
+A hybrid-kernel operating system, written from scratch in Rust, that runs
+**upstream, unmodified binaries** from other operating systems.
+{: .fs-6 .fw-300 }
+
+[Get started](getting-started.md){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Architecture](architecture.md){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+AstryxOS is a UEFI-native x86-64 research operating system (kernel codename
+*Aether*). It takes the NT subsystem model as its architectural inspiration: a
+small executive at the centre, a Hardware Abstraction Layer beneath it, and
+**personality subsystems** layered above that each present one operating
+system's native Application Binary Interface (ABI).
+
+The practical result, and the whole point of the project, is this:
+
+> You take a binary that was built for another operating system. You do not
+> touch it. It runs.
+
+A glibc- or musl-linked Linux ELF makes Linux `syscall`s through the
+`SYSCALL` instruction gate and gets Linux semantics back. A Windows PE32+ image
+makes NT calls through the `INT 0x2E` gate and gets NT semantics back. Same
+kernel, multiple faces — and the binaries are exactly the ones the upstream
+toolchains shipped.
+
+{: .note }
+The headline proof point is **upstream musl-linked Firefox**, driven toward a
+headless `--screenshot`. These docs are honest about where that stands: Firefox
+boots through the dynamic linker, initialises the compositor, spawns content
+processes, and is now running the headless screenshot pipeline — see
+[Running Upstream Binaries](running-upstream-binaries.md) for the exact current
+state. There is no finished PNG yet; we describe the real progress, gate by
+gate, not a finished demo.
+
+---
+
+## Why this matters
+
+Most "compatibility layers" cheat: they recompile the library, ship a patched
+libc, or wrap the program in a shim that rewrites what it does. AstryxOS holds a
+single hard invariant instead:
+
+> **If an upstream binary misbehaves on AstryxOS, the bug is in AstryxOS — not
+> in the binary.** The fix goes in the kernel or the ABI layer, never in the
+> binary, never in the libc, never in a shim.
+
+The justification is the philosophical core of the Firefox work: the *same*
+musl + libxul Firefox runs for millions of people on real Linux. If it runs
+there and stalls here, AstryxOS has diverged from the documented ABI somewhere —
+a syscall returning the wrong errno, a wakeup that never fires, a page served
+with the wrong contents. The job is to find that divergence and close it with a
+real, generally-correct fix that any conformant binary benefits from.
+
+---
+
+## What works today
+
+- **Upstream glibc- and musl-linked Linux ELF binaries run end-to-end** — the
+  upstream dynamic linker (`ld-musl-x86_64.so.1` / `ld-linux-x86-64.so.2`) runs
+  as the program interpreter, processing `PT_INTERP`, `PT_TLS`, `PT_GNU_RELRO`,
+  and the relocation tables (including the compact `DT_RELR` form and
+  `DT_GNU_HASH` lookup) in-kernel.
+- **193+ Linux syscalls** dispatched, plus 50+ native Aether calls. See the
+  [Linux syscall coverage table](LINUX_SYSCALL_COVERAGE.md).
+- **A real userspace** of upstream Linux tools: BusyBox and its 400+ applets,
+  `wget`/`curl`, an `httpd`, `dropbear` sshd, `git`, an OpenSSL TLS handshake,
+  and X11 clients against the in-kernel X server. See
+  [Running Linux utilities](RUNNING_LINUX_UTILITIES.md).
+- **A full TCP/IP stack** — IPv4, IPv6, TCP (3-way handshake, FIN, retransmit,
+  congestion control), UDP, ARP, ICMP, DNS, DHCP.
+- **An in-kernel X11 server** with RENDER, MIT-SHM, XKB, XFIXES, SYNC, and
+  BIG-REQUESTS extensions, a window manager, compositor, and desktop shell.
+- **Multiple filesystems** — FAT32 read/write, ext2, NTFS read-only, procfs,
+  tmpfs, ramfs.
+- **A from-scratch UEFI bootloader** (AstryxBoot) and SMP x86-64 kernel: PMM,
+  VMM, slab heap, ASLR, an SMP round-robin + priority scheduler, capabilities,
+  rlimits, and a broad driver set (ATA/AHCI/virtio-blk, e1000/virtio-net, AC97,
+  PS/2, xHCI, serial).
+
+---
+
+## The shape of the system
+
+```
+        upstream binaries                       upstream binaries
+   (Linux ELF: glibc / musl)                 (Windows PE32+ images)
+              │                                        │
+       SYSCALL instruction                       INT 0x2E gate
+              │                                        │
+   ┌──────────▼───────────┐               ┌────────────▼───────────┐
+   │  Linux personality   │               │   NT / Win32 person.   │
+   │  (subsys/linux)      │               │   (nt/, subsys/win32)  │
+   └──────────┬───────────┘               └────────────┬───────────┘
+              └───────────────┬────────────────────────┘
+                              ▼
+              ┌──────────────────────────────┐
+              │   Aether executive (shared)  │
+              │  mm · sched · proc · vfs ·   │
+              │  ipc · net · x11 · ke · ob   │
+              └──────────────┬───────────────┘
+                             ▼
+              ┌──────────────────────────────┐
+              │  HAL + drivers (x86-64 SMP)  │
+              └──────────────────────────────┘
+```
+
+Read the [Architecture](architecture.md) page for the full executive / HAL /
+personality model and the dual syscall entry surface.
+
+---
+
+## Where to go next
+
+| If you want to… | Read |
+|---|---|
+| Understand the kernel design | [Architecture](architecture.md) |
+| Understand the "run upstream binaries" model and the Firefox push | [Running Upstream Binaries](running-upstream-binaries.md) |
+| Build it and run the test suite | [Getting Started](getting-started.md) |
+| Debug the kernel or contribute | [Contributing & Dev Tooling](dev-tooling.md) |
+
+---
+
+## A note on how AstryxOS is built
+
+AstryxOS is also an experiment in agentic software development: most of its
+~83 KLOC across 170+ Rust source files was written by AI agents working in
+parallel worktrees, with human review at merge time. Kernel changes land via
+reviewed pull requests with green CI — never direct to `master`. See
+[Contributing & Dev Tooling](dev-tooling.md).
+
+---
+
+## License
+
+MIT. Copyright (c) 2026 Melissa and AstryxOS Contributors.

--- a/docs/running-upstream-binaries.md
+++ b/docs/running-upstream-binaries.md
@@ -1,0 +1,235 @@
+---
+title: Running Upstream Binaries
+nav_order: 4
+---
+
+# Running Upstream Binaries
+
+> The whole point of AstryxOS is in this sentence: **you take a binary that was
+> built for another operating system, you do not touch it, and it runs.**
+
+AstryxOS is a UEFI-native x86-64 hybrid kernel written in Rust (codename
+*Aether*). Its architecture borrows the NT subsystem model — a small executive
+at the centre, a Hardware Abstraction Layer beneath it, and **personality
+subsystems** layered above that each present one operating system's native
+Application Binary Interface (ABI). A program does not know it is running on
+AstryxOS. A glibc- or musl-linked Linux ELF makes Linux `syscall`s and gets
+Linux semantics back; a Windows PE32+ image makes NT calls through the
+`INT 0x2E` gate and gets NT semantics back. Same kernel, two faces.
+
+This page explains the multi-personality model, the single invariant that
+keeps it honest, and the flagship stress test that drives the whole project:
+bringing **upstream, unmodified, musl-linked Firefox** to a headless
+`--screenshot`.
+
+{: .note }
+This is an honest progress document. Where a thing works, we say so. Where a
+thing is in progress — and the Firefox screenshot pipeline is very much in
+progress — we say that too, and we say exactly where it stops.
+
+---
+
+## The multi-personality model
+
+A personality subsystem is the thin translation layer that turns one OS's ABI
+into AstryxOS executive primitives. Each personality owns a syscall entry
+surface and a binary loader; everything below the personality (memory manager,
+scheduler, VFS, IPC, networking, drivers) is shared.
+
+| Personality | Entry surface | Binaries | Maturity |
+|---|---|---|---|
+| **Linux x86-64** | the `syscall` instruction (per the x86-64 psABI / `SYSCALL` in the Intel SDM Vol. 2) | static ELF, PIE (`ET_DYN`), and fully dynamic ELF via the system's `ld.so` | Real upstream glibc- and musl-linked binaries run end-to-end |
+| **NT / Win32** | software interrupt `INT 0x2E` (the classic NT syscall gate) | PE32+ images | Loader + `KUSER_SHARED_DATA`-style stub subsystem |
+| **Native Aether** | software interrupt `INT 0x2E` (Aether dispatch) | AstryxOS-native programs | First-party calls for the shell, demos, and tooling |
+
+The Linux personality is the most developed because it is the one Firefox
+needs. It dispatches **193+ Linux syscalls** (see
+[`docs/LINUX_SYSCALL_COVERAGE.md`](LINUX_SYSCALL_COVERAGE.md)) through
+`kernel/src/subsys/linux/syscall.rs`, alongside **50+ native Aether calls** for
+first-party programs.
+
+### What "run upstream binaries unmodified" means in practice
+
+It means the loader consumes exactly what the upstream toolchain emitted:
+
+- **The ELF program is loaded as shipped.** Static, PIE, and dynamically linked
+  layouts are all honoured: `PT_LOAD` segments, `PT_INTERP` (the path to the
+  upstream dynamic linker), `PT_TLS` (thread-local storage), `PT_GNU_RELRO`,
+  and the relocation tables — including the compact `DT_RELR` form and
+  `DT_GNU_HASH` symbol lookup — are processed in-kernel so the upstream
+  `ld-musl-x86_64.so.1` (or glibc's `ld-linux-x86-64.so.2`) runs as the program
+  interpreter.
+- **The upstream libc runs unmodified.** AstryxOS ships *no* patched libc. The
+  exact musl and glibc binaries that ship on a normal Linux distribution
+  execute against the kernel's syscall surface. When something doesn't work,
+  that is information about an AstryxOS ABI gap, never an excuse to recompile
+  the library.
+- **PE32+ images are parsed natively** by the NT loader, which sets up the
+  Win32 environment block and a `KUSER_SHARED_DATA`-style shared page so the
+  image's CRT can initialise.
+
+---
+
+## The invariant: never patch the upstream binary — fix the kernel
+
+This is the single rule the entire project is organised around:
+
+> **If an upstream binary misbehaves on AstryxOS, the bug is in AstryxOS, not in
+> the binary. The fix goes in the kernel or the ABI layer — never in the
+> binary, never in the libc, never in a "shim" that rewrites what the program
+> does.**
+
+The justification is simple and is the philosophical core of the Firefox work:
+**the same musl + libxul Firefox runs for millions of people on real Linux.**
+If it runs there and stalls here, then AstryxOS has diverged from the
+documented ABI somewhere — a syscall returning the wrong errno, a wakeup that
+never fires, a page served with the wrong contents. The job is to find that
+divergence and close it. "It's an upstream bug" is, in this project, almost
+always the wrong answer.
+
+This invariant has teeth: it forbids the easy outs (recompiling the library
+with a workaround, LD_PRELOAD-ing a shim, editing the data disk's copy of a
+`.so`) and forces every fix to be a real, generally-correct ABI fix that any
+conformant binary benefits from.
+
+---
+
+## The Firefox bring-up story (flagship)
+
+Firefox is the forcing function. It is not a synthetic benchmark — it is a
+~100-million-line real-world application (Gecko, SpiderMonkey, WebRender, NSS,
+ICU, Cairo/Skia, the GTK/X11 stack, and the libxul mega-library) that exercises
+nearly every corner of a POSIX kernel: threads and futexes, demand paging and
+`mremap`, epoll/poll readiness, Unix-socket IPC between processes, signal
+delivery, the whole VFS. If AstryxOS can drive upstream Firefox to render a
+page, the Linux personality is real.
+
+**The concrete goal:** run the upstream binary as
+
+```
+firefox --headless --screenshot /tmp/out.png https://…/hello.html
+```
+
+and have it write a non-empty PNG.
+
+### The engineering method
+
+The Firefox push is not guesswork; it is a disciplined, repeatable loop.
+
+1. **Golden reference on a real kernel.** The *same* musl Firefox build is run
+   on a stock Linux host, where it produces `/tmp/out.png` in roughly nine
+   seconds. That run is captured as a full `strace` (the "golden strace"). This
+   is the ground truth: it proves the demo is achievable with this exact binary
+   and gives a syscall-by-syscall reference to diff against.
+
+2. **Run it on AstryxOS under the harness.** Everything goes through
+   [`scripts/qemu-harness.py`](HARNESS.md) — a non-interactive, structured-JSON
+   QEMU session manager. It boots the kernel with the `firefox-test` feature,
+   waits on serial markers, greps the log, and exposes a GDB stub. Sessions
+   persist on disk so any number of one-shot queries can run against a live
+   boot.
+
+3. **Diff against golden, find the first divergence.** Firefox advances
+   "gate by gate": it gets a little further, then stalls at the first place
+   AstryxOS behaves differently from the golden run. The harness reports how
+   far it got (a syscall count and a named gate), and the divergence is the
+   thing to root-cause.
+
+4. **GDB autopsy first — not a printk.** When something faults or hangs, the
+   first diagnostic is a structured GDB autopsy
+   (`qemu-harness.py autopsy …`, presets in
+   [`scripts/autopsy/presets.yaml`](../scripts/autopsy/presets.yaml):
+   `full-register-dump`, `gp-fault-context`, `sigsegv-user-gprs`,
+   `ssp-fail-snapshot`, `vfork-window`, `bugcheck-entry`,
+   `stack-walk-bt-full`), plus the in-kernel debugger `kdb` for live process and
+   memory state. A key technique that broke several gates is *live-RIP on the
+   correct build*: break at the kernel syscall/futex handler and read the saved
+   **user** RIP, which names the exact upstream instruction that is stuck.
+
+5. **Fix the kernel/ABI, re-run, confirm.** Each fix lands as a reviewed PR
+   with green CI, citing only public specifications (POSIX, the relevant
+   man-pages, RFCs, the Intel SDM, the ELF/psABI standards). Then the harness
+   re-runs Firefox and confirms it advances past the gate.
+
+### The real ABI bugs found and fixed
+
+The honesty of the project is in this list: every gate was a genuine, distinct
+kernel/ABI bug that *any* conformant binary could have hit, not a Firefox
+special-case. Each one is described here at a public-specification level.
+
+| # | Symptom in Firefox | The real bug (public-spec framing) |
+|---|---|---|
+| **A. 32-bit `FUTEX_WAIT` value compare** | A contended musl mutex spun forever; the main thread never parked and "stormed" billions of syscalls. Misdiagnosed for *months* as a userspace problem. | `futex(2)` `FUTEX_WAIT` compares the 32-bit word at `uaddr` against the supplied `val`. The kernel was comparing the full 64-bit register. A musl `int` futex value with the high bit set (e.g. `0x80000010`) sign-extended, so the compare never matched, the wait always returned `EAGAIN`, and the waiter never slept. Fixed by comparing as a 32-bit value, per the `futex(2)` contract. This single fix retired the long-running "futex storm" saga. |
+| **B. `mremap` clobbered the argv page** | Process started, then took a `SIGSEGV` because `argv[1]` had become `NULL` — the command line was corrupted before `main` ran. | An in-place `mremap(2)` grow was implemented with a destructive `MAP_FIXED`-style mapping that could overwrite an *adjacent* existing mapping (here, the page holding the process's argument vector). `mremap` must not clobber unrelated mappings; the grow path was corrected so adjacent pages are preserved. |
+| **C. ext2 read-error treated as EOF** | A code page of `libxul` would intermittently read back as all-zeros, yielding `Exec format error` / spurious `ENOENT` and a corrupt main loop. | A device-level read error is **not** end-of-file. The page cache was zero-filling a *failed* covering read and installing it as valid data, silently corrupting file contents. A failed read now propagates an error and never installs a zero page, so file-backed memory matches the disk. |
+| **D. Scheduler starved Ready threads** | A content-process child was created but **never scheduled** — it sat Ready forever while other threads ran, so the multi-process startup deadlocked. | A fair run queue must not let a runnable thread starve indefinitely behind higher-priority work. The scheduler gained anti-starvation aging: a thread's effective priority rises with its time spent waiting in the Ready queue, guaranteeing forward progress. |
+| **E. Timer due-wake dropped under contention** | Timed waits (`FUTEX_WAIT` with timeout, `poll` timeouts) occasionally never woke, so threads slept past their deadline. | A scheduler timer that comes due must wake its sleeper. The due-wake was being silently dropped when a `try_lock` on the thread table lost a race; it now never drops a due wake on lock contention. |
+| **F. Dynamic-linker search path** | The upstream dynamic linker couldn't find Firefox's bundled `.so` files, failing to resolve `libxul` and friends. | The exec environment now builds a variant-aware `LD_LIBRARY_PATH` derived from the binary's `PT_INTERP`, so the upstream `ld.so` searches the same directories it would on a normal install and resolves the bundled libraries (dozens of them) from `/usr/lib`. |
+
+(These six sit on top of a longer tail of earlier ABI fixes from the same push:
+the `pipe(2)` buffer ABI, `PT_TLS` page refcounting, `epoll`/`poll` `HUP`
+delivery on peer close, `CLONE_CHILD_CLEARTID` exit semantics, AF_UNIX
+readiness/`POLLOUT` gating, a VFS mount-lock SMP deadlock, ext2 directory and
+read-coalescing correctness, and futex requeue/wake-op handling.)
+
+### Honest current state
+
+With those fixes in place, upstream Firefox no longer wedges early. It now:
+
+- boots through the dynamic linker, resolves `libxul` and the full bundled
+  library set, and initialises;
+- reaches **Compositor initialisation**;
+- spawns **two content processes**;
+- loads the **HeadlessShell screenshot actors** (the IPC machinery that, on a
+  working run, captures the page and encodes the PNG);
+- and runs into the hundreds of thousands of syscalls deep into the
+  screenshot pipeline.
+
+**Where it stops, honestly:** the run currently stalls at a **screenshot-IPC
+condition-variable lost-wakeup**. Deep in startup, a thread parks on a musl
+condition variable (a `futex(2)` `FUTEX_WAIT`) waiting for the screenshot IPC to
+hand it work; the wake that should release it either never arrives or targets a
+`uaddr` offset from where the waiter is parked, so the thread only ever escapes
+via timeout and the run livelocks instead of proceeding to `drawSnapshot` and
+writing the PNG.
+
+**So: there is no rendered `out.png` yet.** Firefox is *running the headless
+screenshot pipeline* — Compositor up, content processes up, screenshot actors
+loaded — and is blocked on this one condvar-wakeup gate. That gate is the next
+thing to root-cause, and the standing discipline is to characterise it with the
+`cond-autopsy` tool (which dumps the condition variable's struct, every parked
+waiter, recent wake targets, the inferred lock-holder, and a verdict hint)
+*before* writing any speculative fix — exactly the same find-the-divergence,
+fix-the-kernel method that carried Firefox this far.
+
+---
+
+## Try it yourself
+
+The full setup is in [Getting Started](getting-started.md); the short version,
+once the data disk is staged with the Firefox payload, is:
+
+```bash
+# boot the kernel with the Firefox bring-up feature and watch it advance
+python3 scripts/qemu-harness.py start --features firefox-test
+python3 scripts/qemu-harness.py ff-progress <sid>     # report the gate ladder reached
+python3 scripts/qemu-harness.py grep <sid> 'Compositor|content proc|Screenshot'
+python3 scripts/qemu-harness.py stop  <sid>
+```
+
+For other upstream Linux programs that *do* complete today — busybox and its
+400+ applets, `wget`/`curl`, an `httpd`, `dropbear` sshd, `git`, an OpenSSL
+TLS handshake, and X11 clients against the in-kernel X server — see
+[Running Linux utilities on AstryxOS](RUNNING_LINUX_UTILITIES.md).
+
+---
+
+## See also
+
+- [Architecture](architecture.md) — the executive / HAL / personality model
+  (Linux vs NT vs Win32) and the dual syscall entry surface.
+- [Getting Started](getting-started.md) — build the kernel, run the test suite,
+  and boot the Firefox bring-up under the harness.
+- [Contributing & Dev Tooling](dev-tooling.md) — `qemu-harness.py`, the
+  `ff-progress` gate ladder, `cond-autopsy`, GDB autopsy, `kdb`, and the
+  contribution flow.


### PR DESCRIPTION
## What

A clean, shippable **v1 documentation site** for AstryxOS under `docs/`, served by GitHub Pages with **no custom build pipeline** beyond the just-the-docs remote theme. Client-side search, the left-hand nav sidebar, mobile-responsive layout, code-block syntax highlighting, and note/warning callouts all ship out of the box.

### Authored pages (`nav_order` 1–5)

| Page | Covers |
|---|---|
| `docs/index.md` — **Home** | The multi-personality model, the never-patch-the-binary invariant, what works today, and an **honest** framing of the Firefox headless-screenshot push (in progress — no finished PNG yet). |
| `docs/architecture.md` — **Architecture** | Executive / HAL / personality layering, the dual syscall entry surface (`SYSCALL` vs `INT 0x2E`), `mm`/`sched`/`proc`/`vfs`/`ipc`/`net`/`x11`, drivers, and the boot flow. |
| `docs/running-upstream-binaries.md` — **Running Upstream Binaries** | The run-upstream-unmodified model, the invariant, and the gate-by-gate Firefox bring-up with the real ABI bugs fixed and described at a public-spec level. |
| `docs/getting-started.md` — **Getting Started** | Build, data disk, test suite, first harness boot, and common build problems. |
| `docs/dev-tooling.md` — **Contributing & Dev Tooling** | `qemu-harness.py`, the `ff-progress` gate ladder, `cond-autopsy`, GDB-autopsy-first discipline, `kdb`, snapshots, and the contribution workflow. |

### Site config

- `docs/_config.yml` — `remote_theme: just-the-docs/just-the-docs`, client-side search, dark scheme, `note`/`warning` callouts, nav scoped to the five guides (dated investigation/audit docs are excluded from the sidebar but still served + linked).
- `docs/Gemfile` — `github-pages` + `jekyll-remote-theme` for local `bundle exec jekyll build`.
- `.github/workflows/pages.yml` — official Pages flow (`configure-pages` → `jekyll-build-pages` → `deploy-pages`), triggered on `docs/**` changes; **PRs build for validation but do not publish**.

## Accuracy & sourcing

All content is grounded in the repo (README, `kernel/src/` tree, `scripts/qemu-harness.py`, existing `docs/`) and the session milestone narrative. It **cites public specifications only** — POSIX, the Linux man-pages, RFCs, the Intel SDM, and the ELF/psABI. The Firefox demo is described as *running the headless screenshot pipeline, in progress* (Compositor up, two content processes, screenshot actors loaded, blocked on a condvar-wakeup gate) — **not** as a finished screenshot.

## Verification

No Ruby/Jekyll toolchain is present on the authoring host, so the site builds in CI (this workflow). Locally verified:
- `_config.yml` and `pages.yml` parse as valid YAML.
- Every page has valid front-matter (`title` + `nav_order`, clean 1–5 ordering).
- All internal `*.md` links resolve to files that exist in `docs/`.
- All code fences are balanced.

## ▶️ How to enable (one step, repo Settings)

**Settings → Pages → Build and deployment → Source: "GitHub Actions".** After this PR merges to `master`, the `Deploy docs (GitHub Pages)` workflow builds `docs/` and publishes the site automatically. (No `gh-pages` branch needed — deployment is artifact-based via `actions/deploy-pages`.)

> Do **not** merge automatically — this is a v1 for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)