### PR TITLE
docs: fix GitHub Pages CSS/JS 404 (set baseurl to /AstryxOS)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,11 +11,15 @@ description: >-
   upstream unmodified binaries from other operating systems.
 remote_theme: just-the-docs/just-the-docs
 
-# Site URL config is set by GitHub Pages at build time; baseurl is left blank so
-# the site works for both a user/repo page and a custom domain. If this deploys
-# to https://<user>.github.io/AstryxOS/, set baseurl to "/AstryxOS".
-url: ""
-baseurl: ""
+# This is a GitHub Pages *project* site served from a subpath
+# (https://<user>.github.io/AstryxOS/). Jekyll resolves every theme asset
+# (CSS/JS) through the `relative_url` filter, which prepends `site.baseurl`;
+# with an empty baseurl those links resolve to the domain root (/assets/...)
+# and 404. `actions/configure-pages` only auto-injects a baseurl for the JS
+# generators it supports (Next/Nuxt/Gatsby/SvelteKit), NOT for Jekyll, so the
+# baseurl must be set here explicitly to the repository subpath.
+url: "https://me1iissa.github.io"
+baseurl: "/AstryxOS"
 
 # --- just-the-docs options ---------------------------------------------------
 


### PR DESCRIPTION
## Problem
The published docs site (https://me1iissa.github.io/AstryxOS/) loaded with **no styling** — every CSS and JS asset returned **404**.

## Root cause
It's a GitHub Pages **project** site (served from the `/AstryxOS/` subpath). just-the-docs links all theme assets via Jekyll's `relative_url` filter, which prepends `site.baseurl`. Our `_config.yml` had `baseurl: ""`, so asset URLs resolved to the **domain root** (`https://me1iissa.github.io/assets/css/…`) instead of the project subpath (`…/AstryxOS/assets/css/…`) → 404.

`actions/configure-pages@v5` only auto-injects a baseurl for the JS generators in its `static_site_generator` input (Next / Nuxt / Gatsby / SvelteKit) — **Jekyll is not supported** — so the baseurl must be declared in config.

## Fix
- `baseurl: "/AstryxOS"` — the repository subpath, so `relative_url` produces correct asset paths.
- `url: "https://me1iissa.github.io"` — the Pages origin, for absolute URLs (jekyll-seo-tag / sitemap).

Audited the authored pages: they use theme-nav front-matter and relative links only, and there are no hardcoded `/assets/` references, so no in-page links need to change.

## Verification
PR build validates the Jekyll build; after merge, the deploy job publishes and the stylesheet/JS load from `/AstryxOS/assets/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)