### PR TITLE
harness/snap-gate: pin data overlay to a lower PCI slot than the boot ESP

### DIFF
--- a/scripts/astryx_qemu.py
+++ b/scripts/astryx_qemu.py
@@ -211,6 +211,18 @@ def _firmware_args(ovmf_code: str, ovmf_vars: str,
     ]
 
 
+# Pinned PCI slots on the i440fx (`-machine pc`) root bus for the two
+# virtio-blk-pci devices that only the --snapshottable topology presents
+# (the default path has a single virtio-blk data disk and pins nothing).
+# The kernel's virtio-blk driver is a singleton that binds the FIRST
+# virtio-blk device in ascending-slot order, so the DATA overlay MUST sit at
+# a lower slot than the boot ESP.  Slots 0x00..0x02 are the i440fx host
+# bridge / PIIX3 / VGA and the e1000 NIC auto-assigns above them; 0x04/0x05
+# are clear of those defaults.  Lower number = enumerated first by the guest.
+_DATA_DISK_PCI_ADDR = 0x04   # ext2 data overlay — bound by the kernel
+_BOOT_DISK_PCI_ADDR = 0x05   # read-only vvfat boot ESP — must NOT be bound
+
+
 def _boot_disk_args(esp_dir: str, snapshottable: bool = False) -> list[str]:
     """Boot disk: FAT-formatted ESP directory exposed as a raw image.
 
@@ -228,12 +240,26 @@ def _boot_disk_args(esp_dir: str, snapshottable: bool = False) -> list[str]:
     read-only").  So under --snapshottable we attach it via `if=none` + a
     `virtio-blk-pci,read-only=on` frontend, which OVMF enumerates and boots
     from exactly like the IDE path.
+
+    DATA-DISK BINDING (snap-gate data-overlay fix): the snapshottable boot
+    disk is itself a virtio-blk-pci device, so the topology now presents TWO
+    virtio-blk devices (this boot ESP + the data overlay).  The kernel's
+    virtio-blk driver is a singleton that binds the FIRST virtio-blk device in
+    PCI bus-scan (ascending slot) order.  If the boot ESP enumerates first the
+    kernel binds the ~504 MiB read-only vvfat ESP instead of the ext2 data
+    overlay and the data mount fails ("neither FAT32 nor ext2").  We therefore
+    PIN explicit PCI slots so the data overlay always lands at a LOWER slot
+    than this boot disk — see `_BOOT_DISK_PCI_ADDR` / `_DATA_DISK_PCI_ADDR`.
+    The default (non-snapshottable) path keeps a single virtio-blk data disk
+    and is left byte-for-byte unchanged.  QEMU `-device ...,addr=N` fixes the
+    device's slot on the i440fx root bus (QEMU `-device` PCI addressing).
     """
     if not snapshottable:
         return ["-drive", f"format=raw,file=fat:rw:{esp_dir}"]
     return [
         "-drive", f"format=raw,file=fat:ro:{esp_dir},if=none,id=boot0,readonly=on",
-        "-device", "virtio-blk-pci,drive=boot0,bootindex=0",
+        "-device",
+        f"virtio-blk-pci,drive=boot0,bootindex=0,addr={_BOOT_DISK_PCI_ADDR:#x}",
     ]
 
 
@@ -277,10 +303,15 @@ def _data_disk_args(data_img: str, warn_on_missing: bool = False,
         # `snapshot=on` temp-overlay used by the default path is deleted on
         # QEMU exit and would lose that snapshot.  The overlay file itself
         # is created by the caller via `qemu-img create -b <data_img>`.
+        # Pin the data overlay to a LOWER PCI slot than the snapshottable boot
+        # disk so the kernel's singleton virtio-blk driver (binds the first
+        # virtio-blk device in ascending-slot order) selects the ext2 data
+        # overlay, not the read-only vvfat boot ESP.  See `_boot_disk_args`.
         return [
             "-drive",
             f"file={data_overlay},format=qcow2,if=none,id=data0",
-            "-device", "virtio-blk-pci,drive=data0",
+            "-device",
+            f"virtio-blk-pci,drive=data0,addr={_DATA_DISK_PCI_ADDR:#x}",
         ]
     return [
         "-drive", f"file={data_img},format=raw,if=none,id=data0,snapshot=on",

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -483,6 +483,32 @@ def run_snapgate_argv_check():
     check("snap data disk is the qcow2 overlay",
           any("file=/x/ov.qcow2,format=qcow2,if=none,id=data0" in x for x in s),
           "data overlay missing")
+    # Data-overlay binding (snap-gate data-overlay fix): the snapshottable
+    # topology presents TWO virtio-blk devices (boot ESP + data overlay).  The
+    # kernel's singleton virtio-blk driver binds the FIRST device in
+    # ascending-PCI-slot order, so the ext2 data overlay MUST be pinned to a
+    # LOWER slot than the boot ESP — otherwise the guest binds the ~504 MiB
+    # vvfat boot disk and the data mount fails ("neither FAT32 nor ext2").
+    try:
+        boot_dev = next(x for x in s if "virtio-blk-pci,drive=boot0" in x)
+        data_dev = next(x for x in s if "virtio-blk-pci,drive=data0" in x)
+
+        def _addr(dev):
+            for tok in dev.split(","):
+                if tok.startswith("addr="):
+                    return int(tok.split("=", 1)[1], 0)
+            return None
+
+        a_boot, a_data = _addr(boot_dev), _addr(data_dev)
+        check("snap data overlay + boot ESP both have pinned PCI addr",
+              a_boot is not None and a_data is not None,
+              f"boot_addr={a_boot} data_addr={a_data}")
+        check("snap data overlay pinned to LOWER PCI slot than boot ESP",
+              a_data is not None and a_boot is not None and a_data < a_boot,
+              f"data@{a_data} boot@{a_boot} (data must be < boot)")
+    except StopIteration:
+        check("snap data overlay + boot ESP both have pinned PCI addr", False,
+              "could not locate both virtio-blk -device lines")
     # vmstate must precede the data overlay so bdrv_all_find_vmstate_bs picks it.
     try:
         i_vm = next(i for i, x in enumerate(s) if "id=vmstate0" in x)


### PR DESCRIPTION
## Summary

Fixes a confirmed bug in the snap-gate `--snapshottable` device topology (introduced by #496): the **data disk presented as unreadable**, so Firefox could not mount its rootfs and wedged at `sc=0/pf=0`. The default (non-snapshottable) path was never affected.

Before the fix, a `start --features firefox-test,kdb --snapshottable` boot showed:

```
[VFS] Probing virtio-blk device (1032192 sectors) for partitions...
[VFS] Virtio-blk disk is neither FAT32 nor ext2
```

(1032192 sectors ≈ 504 MiB = the read-only vvfat boot ESP — **not** the 2 GiB ext2 data image.)

## Root cause

A device-enumeration collision unique to the snapshottable topology. To make the boot disk `savevm`-compatible, the snapshottable path attaches the read-only vvfat boot ESP through a `virtio-blk-pci` frontend (a writable vvfat disk aborts QEMU `savevm`). That makes the boot ESP a **second** `virtio-blk` device alongside the data overlay.

The kernel's virtio-blk driver is a **singleton** (`find_virtio_blk_pci()` returns the first match) that binds the **first** virtio-blk device in ascending-PCI-slot order. With QEMU auto-assigning slots in `-device` command-line order, the boot ESP (emitted first) landed at the lower slot, so the kernel bound the ~504 MiB read-only vvfat ESP instead of the ext2 data overlay.

The default path has only one virtio-blk device (its boot disk is plain `fat:rw` on the implicit IDE bus), so it was never affected.

## Fix

Pin explicit PCI slots on the two snapshottable virtio-blk devices via `-device virtio-blk-pci,...,addr=N`, with the **data overlay at a lower slot (0x04)** than the **boot ESP (0x05)**. The kernel's first-by-slot binding then selects the ext2 data overlay. The default path emits no `addr=` and is **byte-for-byte unchanged**. Both `start --snapshottable` and `snap-gate load` build the device line through the same `build_qemu_cmd`, so both paths are covered.

`scripts/astryx_qemu.py`: `_DATA_DISK_PCI_ADDR=0x04` / `_BOOT_DISK_PCI_ADDR=0x05`, applied in `_data_disk_args` (overlay branch) and `_boot_disk_args` (snapshottable branch).

## Verification (real boot via `scripts/qemu-harness.py` — not just the host-argv check)

This bug passed the host-only CI argv check once, so verification was done with a real boot.

**Gate 1 — data disk readable under `--snapshottable`:**
- Guest now reports the virtio-blk device as **4194304 sectors (2 GiB)** and `[VFS] ext2 whole-disk mounted at /disk (virtio-blk)` — the "neither FAT32 nor ext2" line is **gone**. Confirmed under both TCG and KVM.
- PCI table after the fix: `e1000 @ 00:03.0`, **data overlay @ 00:04.0 (bound)**, boot ESP @ 00:05.0 (not bound) — no slot collision.
- Firefox boots and makes syscalls (`sc` climbs `0 → 738+`), actively reading the ext2 overlay (`disk=R12.6MB across 3090 reqs`), advancing past `ff-launch`.

**Gate 2 — deep-FF save/load round-trip (the thing #496 never confirmed):**
- `snap-gate <sid> save` at a live FF guest (sc=625) → `stop` → `snap-gate load`.
- Restored session resumed a **live** FF guest: heartbeat advanced `tick 14000 → 16500`, sc **continued climbing 625 → 738** post-load, and FF kept reading the ext2 data overlay after the load (`disk=R12.6MB`). The data overlay round-trips through `savevm`/`loadvm` and stays readable.

## Additive smoke assertion

`scripts/qemu-harness-smoke.py` Tier 1.5: the snapshottable data overlay must carry a pinned PCI `addr` strictly **lower** than the boot ESP's. Locks the invariant so a future topology refactor cannot silently regress data-disk binding at the host-argv level.

## Notes

- Additive only: no field/subcommand renames; default (non-snapshottable) argv unchanged.
- Refs: QEMU `qemu-img` backing files (qcow2 `-b`/`-F`), QEMU `-device` PCI addressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)