### PR TITLE
net/e1000: drop RX_CUR before handle_rx_packet to end SMP poll_rx deadlock

### DIFF
--- a/kernel/src/net/e1000.rs
+++ b/kernel/src/net/e1000.rs
@@ -660,52 +660,92 @@ pub fn poll_rx() {
 
     let desc_base_phys = *RX_DESCS.lock();
     let bufs_base_phys = *RX_BUFS.lock();
-    let mut cur = RX_CUR.lock();
 
     let mut drained_any = false;
+
+    // Drain the RX ring one descriptor at a time.  Each iteration holds
+    // RX_CUR only for the descriptor-ring mutation (read DD/length, copy
+    // out the frame, clear status, advance the cursor, write RDT) and
+    // DROPS it before delivering the frame to the network stack.  Holding
+    // RX_CUR across handle_rx_packet() is unsafe for two reasons:
+    //
+    //  1. Lock inversion / re-entry — the stack may reply (ARP, ICMP, TCP
+    //     send_frame -> send_packet), which re-enters the e1000 flush
+    //     nudge and try_lock()s RX_CUR; a blocking hold here would stall
+    //     that nudge needlessly.
+    //  2. SMP cross-core starvation — on smp>1 a second core entering
+    //     poll_rx() would block on RX_CUR's spin lock for the entire,
+    //     unbounded duration of handle_rx_packet() (which itself contends
+    //     downstream spin locks).  A Ring-0 spinner is not timer-preempted,
+    //     so that core can stall indefinitely.  Bounding the critical
+    //     section to the ring mutation keeps the cross-core wait short.
+    //
+    // This mirrors the virtio_net::poll_rx() pattern (copy-under-lock,
+    // deliver-after-drop) and the snapshot-then-drop discipline used on
+    // other held-across-dispatch locks in this tree.
     loop {
-        let idx = *cur as usize;
-        // Kernel-side descriptor pointer = direct-map virtual.
-        let desc_ptr = (phys_to_virt(desc_base_phys) + (idx as u64) * 16) as *const RxDesc;
+        // Stack buffer for the frame, captured while RX_CUR is held so the
+        // descriptor's RX buffer can be safely reused by hardware once we
+        // clear the status and release the lock.
+        let mut frame_buf = [0u8; RX_BUF_SIZE];
+        let mut frame_len = 0usize;
 
-        // Volatile reads — hardware writes these fields via DMA.
-        let status = unsafe { core::ptr::read_volatile(&(*desc_ptr).status) };
-        let length = unsafe { core::ptr::read_volatile(&(*desc_ptr).length) };
+        {
+            let mut cur = RX_CUR.lock();
+            let idx = *cur as usize;
+            // Kernel-side descriptor pointer = direct-map virtual.
+            let desc_ptr = (phys_to_virt(desc_base_phys) + (idx as u64) * 16) as *const RxDesc;
 
-        // Check if this descriptor has been filled by hardware
-        if status & RDESC_STA_DD == 0 {
-            break; // No more packets
+            // Volatile reads — hardware writes these fields via DMA.
+            let status = unsafe { core::ptr::read_volatile(&(*desc_ptr).status) };
+            let length = unsafe { core::ptr::read_volatile(&(*desc_ptr).length) };
+
+            // Check if this descriptor has been filled by hardware
+            if status & RDESC_STA_DD == 0 {
+                break; // No more packets — RX_CUR released by the block scope
+            }
+            drained_any = true;
+
+            if status & RDESC_STA_EOP != 0 && length > 0 {
+                let buf_phys = bufs_base_phys + (idx as u64) * RX_BUF_SIZE as u64;
+                // Bound the copy by the RX buffer size — hardware should
+                // never report a length larger than the buffer it DMA'd
+                // into, but clamp defensively.
+                let len = core::cmp::min(length as usize, RX_BUF_SIZE);
+
+                // Safety: copying from the RX buffer that hardware wrote
+                // into, via the kernel direct-map (PHYS_OFFSET + buf_phys).
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        phys_to_virt(buf_phys) as *const u8,
+                        frame_buf.as_mut_ptr(),
+                        len,
+                    );
+                }
+                frame_len = len;
+            }
+
+            // Volatile write: clear status so hardware can reuse this descriptor
+            let desc_ptr_mut = desc_ptr as *mut RxDesc;
+            unsafe {
+                core::ptr::write_volatile(&mut (*desc_ptr_mut).status, 0);
+            }
+
+            // Advance and update tail
+            let next = ((idx + 1) % NUM_RX_DESC) as u16;
+            *cur = next;
+
+            // Tell hardware it can use this descriptor again
+            mmio_write(REG_RDT, idx as u32);
+        } // RX_CUR released here — deliver the frame lock-free below.
+
+        // Hand the captured frame to the network stack with NO lock held,
+        // so a reply path (or a second core's poll_rx) can re-acquire
+        // RX_CUR without spinning behind us.
+        if frame_len > 0 {
+            super::handle_rx_packet(&frame_buf[..frame_len]);
         }
-        drained_any = true;
-
-        if status & RDESC_STA_EOP != 0 && length > 0 {
-            let buf_phys = bufs_base_phys + (idx as u64) * RX_BUF_SIZE as u64;
-            let len = length as usize;
-
-            // Safety: reading from the RX buffer that hardware wrote into,
-            // via the kernel direct-map (PHYS_OFFSET + buf_phys).
-            let packet = unsafe {
-                core::slice::from_raw_parts(phys_to_virt(buf_phys) as *const u8, len)
-            };
-
-            // Hand to the network stack
-            super::handle_rx_packet(packet);
-        }
-
-        // Volatile write: clear status so hardware can reuse this descriptor
-        let desc_ptr_mut = desc_ptr as *mut RxDesc;
-        unsafe {
-            core::ptr::write_volatile(&mut (*desc_ptr_mut).status, 0);
-        }
-
-        // Advance and update tail
-        let next = ((idx + 1) % NUM_RX_DESC) as u16;
-        *cur = next;
-
-        // Tell hardware it can use this descriptor again
-        mmio_write(REG_RDT, idx as u32);
     }
-    drop(cur);
 
     // If the ring was empty, nudge the emulator to flush any packets
     // its backend (SLIRP for user-mode netdev) is holding for us.


### PR DESCRIPTION
## Summary

`e1000::poll_rx()` held the `RX_CUR` spin lock across the entire RX drain loop — including each `super::handle_rx_packet()` delivery — releasing it only after the ring drained empty. Packet delivery re-enters arbitrary network-stack code (ARP / ICMP / TCP), which takes other spin locks and can do unbounded work per frame.

On `smp>1` this is a cross-core deadlock. `net::poll()` is pumped from many syscall hot-path sites with no single-CPU gate, so a second core entering `poll_rx()` blocks on `RX_CUR`'s spin lock for the *full* duration of the first core's `handle_rx_packet()`. A Ring-0 spinner is not timer-preempted (the timer ISR never reschedules a kernel-mode `CS`), so that core stalls indefinitely. With both cores stuck the scheduler never runs again and the machine freezes — which is exactly the render-init wedge in the Firefox headless-screenshot path: the parent ↔ content `drawSnapshot` IPDL handshake can never complete because no core can make progress, and the parent's condvar waiter (faithfully) times out forever.

## Fix

Restructure the drain loop to mirror the `virtio_net::poll_rx()` discipline (copy-under-lock, deliver-after-drop). Each iteration now:

1. acquires `RX_CUR`,
2. under the lock reads the descriptor's DD/length, copies the frame into a stack buffer bounded by `RX_BUF_SIZE`, clears the descriptor status, advances the cursor, and writes `REG_RDT`,
3. **drops `RX_CUR`**,
4. delivers the captured frame via `handle_rx_packet()` with **no lock held**,
5. loops to re-acquire for the next descriptor.

The ring-cursor mutation stays serialized under `RX_CUR` (short, bounded critical section — no two cores corrupt the cursor) while delivery is lock-free, so a second core blocks only momentarily on the drain section and any reply TX re-enters with `RX_CUR` free. The copy-before-deliver is required because the descriptor status is cleared inside the lock and hardware may then reuse the buffer.

The `virtio_net` twin was audited and is already correct (it drops its queue lock before `handle_rx_packet`); no change needed there.

## Scope

- 1 file, +77 / −37 LOC (`kernel/src/net/e1000.rs`).
- No behavioural change to delivery semantics: a frame is still delivered only when `EOP` is set and `length > 0`; the drain-to-empty-per-poll guarantee is preserved.

## Test

Built clean and booted a fresh `firefox-test,kdb` session via the harness to drive the headless-screenshot pipeline past the render-init wedge.

Cites POSIX / Intel SDM / the device datasheet semantics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
