### PR TITLE
FF cross-process screenshot path: e10s routing + heap re-entrancy deadlock fix + dual-regs tool

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -365,6 +365,36 @@ pub fn lapic_eoi() {
     lapic_write(LAPIC_EOI, 0);
 }
 
+/// Re-arm the calling CPU's LAPIC periodic timer.
+///
+/// Rewrites the timer LVT (periodic | vector 32) and the initial-count
+/// register with the calibrated period. This is the standard recovery for a
+/// LAPIC periodic timer that has stopped delivering interrupts: under KVM a
+/// single vCPU subjected to a sustained framebuffer-MMIO VM-exit storm can
+/// have its LAPIC timer-interrupt delivery suppressed and **not** spontaneously
+/// resume once the storm ends (the periodic counter wedges). On a multi-core
+/// machine a sibling CPU keeps the global clock alive so this is invisible; on
+/// a single core there is no sibling, so the BSP idle path calls this to keep
+/// the timer — and therefore the scheduler tick and `TICK_COUNT` — alive.
+///
+/// Writing the initial-count register restarts the down-counter (Intel SDM
+/// Vol. 3A §11.5.4), so a wedged periodic timer begins firing again. The LVT
+/// rewrite is belt-and-suspenders in case the vector/mode bits were lost.
+/// Safe to call from any context: it touches only this CPU's LAPIC MMIO and
+/// the value written is the immutable boot-time calibration. No-op before
+/// calibration (period == 0) or if the APIC is disabled.
+pub fn rearm_timer() {
+    if !is_enabled() {
+        return;
+    }
+    let period = LAPIC_TIMER_PERIOD.load(Ordering::Acquire);
+    if period == 0 {
+        return;
+    }
+    lapic_write(LAPIC_TIMER_LVT, 0x20000 | 32); // periodic | vector 32
+    lapic_write(LAPIC_TIMER_INIT, period);
+}
+
 /// Check if APIC is enabled and active.
 pub fn is_enabled() -> bool {
     APIC_ENABLED.load(Ordering::Relaxed)

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -2730,8 +2730,66 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         crate::mm::pmm::free_page(phys);
                         return false;
                     }
-                    crate::mm::refcount::page_ref_set(phys, 1);
-                    crate::mm::vmm::map_page_in(cr3, page_addr, phys, page_flags);
+                    // Anti-aliasing re-check (POSIX mmap(2) demand paging;
+                    // Intel SDM Vol. 3A §4.10.4.3 "Optional Invalidation").
+                    //
+                    // On a shared address space (CLONE_VM / vfork — multiple
+                    // threads on one CR3, one per logical processor), two
+                    // CPUs can take a not-present #PF on the SAME anonymous VA
+                    // at the same time.  The hardware page-fault error code we
+                    // branched on (`!is_present`) was latched at fault time;
+                    // by the time we reach this install the *other* CPU may
+                    // already have allocated a frame and written the PTE.
+                    // Installing our own freshly-zeroed frame now would
+                    // overwrite the winner's PTE with a DIFFERENT physical
+                    // frame, leaving the winning CPU's TLB caching the first
+                    // frame while the page table points at the second — a
+                    // single VA backed by two frames.  A subsequent store by
+                    // the loser's thread (e.g. a release-store to a shared
+                    // control word) lands on the second frame, but the winner
+                    // keeps reading the first through its stale TLB entry, so
+                    // the store is never observed: a silent cross-CPU
+                    // store-visibility failure on the shared stack page.
+                    //
+                    // Install atomically-with-present-check under VMM_LOCK.
+                    // `map_page_in_if_absent` returns false (writing nothing) if
+                    // a sibling won the race and already published a PTE for
+                    // this VA, so we never overwrite the winner's mapping with a
+                    // second frame.  This is the standard demand-paging
+                    // re-validation: re-check the PTE under the page-table lock
+                    // immediately before writing it, and discard the loser's
+                    // frame rather than aliasing the mapping.  The file-backed
+                    // readahead arm above carries the same back-out
+                    // (`existing_pte & PAGE_PRESENT`); the anonymous arm needs
+                    // the identical guarantee for shared-CR3 stack pages.
+                    if crate::mm::vmm::map_page_in_if_absent(cr3, page_addr, phys, page_flags) {
+                        // We won the race and published the PTE — record the
+                        // single PTE reference and refresh our local TLB.  The
+                        // refcount is set AFTER a successful install so a lost
+                        // race leaves the frame at refcount 0 and frees cleanly
+                        // (pmm::free_page refuses to free a frame whose
+                        // pte_share_count is non-zero).
+                        crate::mm::refcount::page_ref_set(phys, 1);
+                        crate::mm::vmm::invlpg(page_addr);
+                        return true;
+                    }
+                    // Lost the race: a sibling CPU already mapped this VA.  Our
+                    // frame was never installed (refcount still 0), so it frees
+                    // cleanly.  Refresh THIS CPU's TLB so the faulting
+                    // instruction re-walks to the winner's authoritative PTE.
+                    #[cfg(feature = "firefox-test")]
+                    {
+                        static RACE: core::sync::atomic::AtomicU64 =
+                            core::sync::atomic::AtomicU64::new(0);
+                        let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                        if n < 10 || n % 500 == 0 {
+                            crate::serial_println!(
+                                "[PF/anon-race] #{} addr={:#x} sibling already mapped — \
+                                 dropping our frame {:#x}",
+                                n, page_addr, phys);
+                        }
+                    }
+                    crate::mm::pmm::free_page(phys);
                     crate::mm::vmm::invlpg(page_addr);
                     return true;
                 }

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1715,14 +1715,62 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             let _ = crate::mm::refcount::page_ref_dec(cached_phys);
                             return false;
                         }
-                        crate::mm::refcount::page_ref_set(private_phys, 1);
-                        crate::mm::vmm::map_page_in(cr3, page_addr, private_phys, page_flags);
+                        // Anti-aliasing install (POSIX mmap(2) MAP_PRIVATE;
+                        // Intel SDM Vol. 3A §4.10.4.3 "Optional Invalidation").
+                        // On a shared address space (CLONE_VM / vfork — several
+                        // threads on one CR3 across logical processors) two CPUs
+                        // can take a not-present #PF on the SAME private-writable
+                        // VA (a libxul GOT/PLT/.data/.bss page) concurrently;
+                        // each mints its own `private_phys`.  An unconditional
+                        // `map_page_in` here would let the loser overwrite the
+                        // winner's leaf PTE with a DIFFERENT frame: the winner
+                        // keeps reading its frame through its stale local TLB
+                        // entry while the loser's relocation store lands on the
+                        // other frame and is never observed — the same cross-CPU
+                        // store-visibility failure the anonymous arm carries.
+                        // Per MAP_PRIVATE a private VA in a shared address space
+                        // must resolve to exactly ONE backing frame.
+                        //
+                        // Install with a present-recheck atomic under VMM_LOCK.
+                        // The refcount on `private_phys` is set only AFTER a
+                        // successful install, so a lost race leaves it at 0 and
+                        // it frees cleanly.
+                        if crate::mm::vmm::map_page_in_if_absent(
+                            cr3, page_addr, private_phys, page_flags)
+                        {
+                            crate::mm::refcount::page_ref_set(private_phys, 1);
+                            crate::mm::vmm::invlpg(page_addr);
+                            // Release the guard ref acquired by
+                            // `lookup_and_acquire`.  The PTE now refers to
+                            // `private_phys`, not `cached_phys`; the cache still
+                            // holds its own independent reference to
+                            // `cached_phys`, so this dec will not free the frame.
+                            let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                            return true;
+                        }
+                        // Lost the race: a sibling CPU already published a PTE
+                        // for this VA.  `private_phys` was never mapped and its
+                        // refcount is still 0, so it frees cleanly.  Release the
+                        // guard ref exactly as the winner path does (the cache's
+                        // own ref keeps `cached_phys` alive), refresh THIS CPU's
+                        // TLB so the faulting instruction re-walks to the
+                        // winner's authoritative PTE, and report success.
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            static RACE: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 10 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/cache-private-race] #{} addr={:#x} sibling \
+                                     already mapped — dropping private frame {:#x}",
+                                    n, page_addr, private_phys);
+                            }
+                        }
+                        crate::mm::pmm::free_page(private_phys);
                         crate::mm::vmm::invlpg(page_addr);
-                        // Release the guard ref acquired by `lookup_and_acquire`.
-                        // The PTE now refers to `private_phys`, not `cached_phys`;
-                        // the cache still holds its own independent reference to
-                        // `cached_phys`, so this dec will not free the frame.
                         let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                        return true;
                     } else {
                         // PMM exhausted: cannot allocate a private copy.
                         //
@@ -1809,10 +1857,50 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             }
                         }
                     }
-                    crate::mm::vmm::map_page_in(cr3, page_addr, cached_phys, page_flags);
-                    crate::mm::vmm::invlpg(page_addr);
-                    // Guard ref is intentionally NOT released — it has been
-                    // promoted to the PTE reference.
+                    // Anti-aliasing install (POSIX mmap(2) MAP_SHARED / read-
+                    // only alias; Intel SDM Vol. 3A §4.10.4.3).  This arm
+                    // installs the SHARED cache frame directly.  Two CPUs on a
+                    // shared CR3 can reach this install for the same VA
+                    // concurrently; the unconditional `map_page_in` would let
+                    // the loser re-write a PTE the winner already published.
+                    // Because both would install the SAME `cached_phys` the
+                    // resulting PTE value is identical, so there is no two-frame
+                    // aliasing hazard here — but the refcount accounting double-
+                    // promotes the guard ref (one guard ref per CPU promoted to
+                    // "the" PTE ref for one PTE).  Use the present-recheck so
+                    // exactly one CPU promotes its guard ref to the PTE ref and
+                    // the loser releases its now-redundant guard ref, keeping the
+                    // cache-frame refcount at the cache(1)+PTE(1) steady state.
+                    if crate::mm::vmm::map_page_in_if_absent(
+                        cr3, page_addr, cached_phys, page_flags)
+                    {
+                        crate::mm::vmm::invlpg(page_addr);
+                        // Won: guard ref is intentionally NOT released — it has
+                        // been promoted to the PTE reference.
+                    } else {
+                        // Lost: a sibling CPU already published the PTE for this
+                        // VA (and, being the SAME cache frame, promoted its own
+                        // guard ref to the PTE ref).  Our guard ref is now
+                        // redundant: release it so the frame nets cache(1) +
+                        // sibling-PTE(1) = 2.  Do NOT free the cache frame — it
+                        // is shared and still referenced.  Refresh THIS CPU's
+                        // TLB and report success.
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            static RACE: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 10 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/cache-alias-race] #{} addr={:#x} phys={:#x} \
+                                     sibling already mapped — releasing guard ref",
+                                    n, page_addr, cached_phys);
+                            }
+                        }
+                        let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                        crate::mm::vmm::invlpg(page_addr);
+                        return true;
+                    }
                 }
                 #[cfg(feature = "firefox-test")]
                 {
@@ -2298,11 +2386,49 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                 crate::mm::pmm::PAGE_SIZE,
                             );
                         }
-                        crate::mm::refcount::page_ref_set(private_phys, 1);
-                        crate::mm::vmm::map_page_in(cr3, vaddr, private_phys, page_flags);
-                        // Cache keeps its ref to phys (the clean shared copy).
-                        // Drop guard ref — steady state: cache ref(phys) = 1.
-                        let _ = crate::mm::refcount::page_ref_dec(phys);
+                        // Anti-aliasing install (POSIX mmap(2) MAP_PRIVATE;
+                        // Intel SDM Vol. 3A §4.10.4.3).  The `existing_pte`
+                        // present-check above (the `continue` back-out) and
+                        // this install are not one atomic step, so a sibling
+                        // CPU on a shared CR3 can publish a PTE for `vaddr`
+                        // between them.  An unconditional `map_page_in` would
+                        // then overwrite the winner's leaf PTE with our DIFFERENT
+                        // `private_phys` frame — the cross-CPU store-visibility
+                        // failure on a libxul private-writable page.  Install
+                        // with a present-recheck atomic under VMM_LOCK; set the
+                        // refcount only AFTER a successful install so a lost race
+                        // frees `private_phys` cleanly.
+                        if crate::mm::vmm::map_page_in_if_absent(
+                            cr3, vaddr, private_phys, page_flags)
+                        {
+                            crate::mm::refcount::page_ref_set(private_phys, 1);
+                            // Cache keeps its ref to phys (the clean shared copy).
+                            // Drop guard ref — steady state: cache ref(phys) = 1.
+                            let _ = crate::mm::refcount::page_ref_dec(phys);
+                            crate::mm::vmm::invlpg(vaddr);
+                        } else {
+                            // Lost the race: a sibling already published this VA.
+                            // `private_phys` was never mapped (refcount still 0)
+                            // → frees cleanly; release the guard ref on the cache
+                            // frame exactly as the winner path does, refresh THIS
+                            // CPU's TLB, and move to the next readahead page.
+                            #[cfg(feature = "firefox-test")]
+                            {
+                                static RACE: core::sync::atomic::AtomicU64 =
+                                    core::sync::atomic::AtomicU64::new(0);
+                                let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                                if n < 10 || n % 500 == 0 {
+                                    crate::serial_println!(
+                                        "[PF/ra-private-race] #{} vaddr={:#x} sibling \
+                                         already mapped — dropping private frame {:#x}",
+                                        n, vaddr, private_phys);
+                                }
+                            }
+                            crate::mm::pmm::free_page(private_phys);
+                            let _ = crate::mm::refcount::page_ref_dec(phys);
+                            crate::mm::vmm::invlpg(vaddr);
+                            continue;
+                        }
                     } else {
                         // PMM exhausted: cannot allocate a private copy.
                         //
@@ -2354,12 +2480,50 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             }
                         }
                     }
-                    crate::mm::refcount::page_ref_inc(phys);
-                    crate::mm::vmm::map_page_in(cr3, vaddr, phys, page_flags);
-                    // Drop guard ref — steady state: cache(1) + PTE(1) = 2.
-                    let _ = crate::mm::refcount::page_ref_dec(phys);
+                    // Anti-aliasing install (POSIX mmap(2) MAP_SHARED / read-
+                    // only alias; Intel SDM Vol. 3A §4.10.4.3).  The loop-top
+                    // `existing_pte` present-check and this install are not one
+                    // atomic step, so a sibling CPU on a shared CR3 can publish
+                    // a PTE for `vaddr` in between.  `phys` is THIS CPU's fresh
+                    // readahead frame; an unconditional `map_page_in` would
+                    // overwrite the sibling's already-published PTE (which may
+                    // reference a DIFFERENT frame) with ours — a two-frame alias.
+                    // Install with a present-recheck atomic under VMM_LOCK; the
+                    // PTE ref is taken (inc) only on a successful install.
+                    if crate::mm::vmm::map_page_in_if_absent(
+                        cr3, vaddr, phys, page_flags)
+                    {
+                        crate::mm::refcount::page_ref_inc(phys); // PTE reference
+                        // Drop guard ref — steady state: cache(1) + PTE(1) = 2.
+                        let _ = crate::mm::refcount::page_ref_dec(phys);
+                        crate::mm::vmm::invlpg(vaddr);
+                    } else {
+                        // Lost the race: a sibling already published this VA.
+                        // Our `phys` is the redundant frame — mirror the loop-top
+                        // back-out: conditionally evict our cache entry (only if
+                        // it still names our phys), drop the guard ref, free the
+                        // frame if it reached zero, refresh THIS CPU's TLB, and
+                        // move to the next readahead page.  No PTE ref is taken.
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            static RACE: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 10 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/ra-alias-race] #{} vaddr={:#x} phys={:#x} \
+                                     sibling already mapped — discarding our frame",
+                                    n, vaddr, phys);
+                            }
+                        }
+                        crate::mm::cache::evict_if_phys(mount_idx, inode, foff, phys);
+                        if crate::mm::refcount::page_ref_dec(phys) == 0 {
+                            crate::mm::pmm::free_page(phys);
+                        }
+                        crate::mm::vmm::invlpg(vaddr);
+                        continue;
+                    }
                 }
-                crate::mm::vmm::invlpg(vaddr);
             }
 
             // Log progress periodically
@@ -2604,12 +2768,49 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                 crate::mm::pmm::PAGE_SIZE,
                             );
                         }
-                        crate::mm::refcount::page_ref_set(private_phys, 1);
-                        crate::mm::vmm::map_page_in(cr3, page_addr, private_phys, page_flags);
+                        // Anti-aliasing install (POSIX mmap(2) MAP_PRIVATE;
+                        // Intel SDM Vol. 3A §4.10.4.3).  On a shared CR3 two CPUs
+                        // can take a not-present #PF on the SAME private-writable
+                        // VA (a libxul GOT/PLT/.data/.bss page) concurrently and
+                        // each reach this single-page fallback with its own
+                        // `private_phys`.  An unconditional `map_page_in` lets
+                        // the loser overwrite the winner's leaf PTE with a
+                        // DIFFERENT frame — the cross-CPU store-visibility
+                        // failure.  Install with a present-recheck atomic under
+                        // VMM_LOCK; set the refcount only AFTER a successful
+                        // install so a lost race frees `private_phys` cleanly.
+                        if crate::mm::vmm::map_page_in_if_absent(
+                            cr3, page_addr, private_phys, page_flags)
+                        {
+                            crate::mm::refcount::page_ref_set(private_phys, 1);
+                            crate::mm::vmm::invlpg(page_addr);
+                            // Cache keeps its own ref to phys (clean shared copy).
+                            // Release guard — steady state: cache ref(phys) = 1.
+                            let _ = crate::mm::refcount::page_ref_dec(phys);
+                            return true;
+                        }
+                        // Lost the race: a sibling already published this VA.
+                        // `private_phys` was never mapped (refcount still 0) →
+                        // frees cleanly; release the guard ref on the cache frame
+                        // exactly as the winner path does, refresh THIS CPU's TLB,
+                        // and report success so the faulting instruction re-walks
+                        // to the winner's authoritative PTE.
+                        #[cfg(feature = "firefox-test")]
+                        {
+                            static RACE: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 10 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/spf-private-race] #{} addr={:#x} sibling \
+                                     already mapped — dropping private frame {:#x}",
+                                    n, page_addr, private_phys);
+                            }
+                        }
+                        crate::mm::pmm::free_page(private_phys);
                         crate::mm::vmm::invlpg(page_addr);
-                        // Cache keeps its own ref to phys (clean shared copy).
-                        // Release guard — steady state: cache ref(phys) = 1.
                         let _ = crate::mm::refcount::page_ref_dec(phys);
+                        return true;
                     } else {
                         // PMM exhausted: cannot allocate a private copy.
                         //
@@ -2665,11 +2866,47 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         crate::mm::w215_diag::KIND_PFH_INSTALL,
                         crate::mm::w215_diag::pack_cache_key(inode, file_page_offset),
                     );
-                    crate::mm::refcount::page_ref_inc(phys); // PTE reference
-                    crate::mm::vmm::map_page_in(cr3, page_addr, phys, page_flags);
+                    // Anti-aliasing install (POSIX mmap(2) MAP_SHARED / read-
+                    // only alias; Intel SDM Vol. 3A §4.10.4.3).  `phys` is THIS
+                    // CPU's fresh single-page frame.  On a shared CR3 a sibling
+                    // can publish a PTE for `page_addr` (referencing a possibly-
+                    // DIFFERENT frame) between this CPU's fault and this install;
+                    // an unconditional `map_page_in` would overwrite it with our
+                    // frame — a two-frame alias.  Install with a present-recheck
+                    // atomic under VMM_LOCK; the PTE ref is taken only on a
+                    // successful install.
+                    if crate::mm::vmm::map_page_in_if_absent(
+                        cr3, page_addr, phys, page_flags)
+                    {
+                        crate::mm::refcount::page_ref_inc(phys); // PTE reference
+                        crate::mm::vmm::invlpg(page_addr);
+                        // Release guard — steady state: cache(1) + PTE(1) = 2.
+                        let _ = crate::mm::refcount::page_ref_dec(phys);
+                        return true;
+                    }
+                    // Lost the race: a sibling already published this VA.  Our
+                    // `phys` is the redundant frame — conditionally evict our
+                    // cache entry (only if it still names our phys), release the
+                    // guard ref, free the frame if it reached zero, refresh THIS
+                    // CPU's TLB, and report success.  No PTE ref is taken.
+                    #[cfg(feature = "firefox-test")]
+                    {
+                        static RACE: core::sync::atomic::AtomicU64 =
+                            core::sync::atomic::AtomicU64::new(0);
+                        let n = RACE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                        if n < 10 || n % 500 == 0 {
+                            crate::serial_println!(
+                                "[PF/spf-alias-race] #{} addr={:#x} phys={:#x} \
+                                 sibling already mapped — discarding our frame",
+                                n, page_addr, phys);
+                        }
+                    }
+                    crate::mm::cache::evict_if_phys(mount_idx, inode, file_page_offset, phys);
+                    if crate::mm::refcount::page_ref_dec(phys) == 0 {
+                        crate::mm::pmm::free_page(phys);
+                    }
                     crate::mm::vmm::invlpg(page_addr);
-                    // Release guard — steady state: cache(1) + PTE(1) = 2.
-                    let _ = crate::mm::refcount::page_ref_dec(phys);
+                    return true;
                 }
                 return true;
             }

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -213,8 +213,119 @@ pub fn read_scancode() -> Option<u8> {
 }
 
 /// Get the current tick count.
+///
+/// `TICK_COUNT` is normally advanced by the periodic LAPIC timer ISR
+/// (`timer_tick`). On a multi-core machine *any* online CPU's LAPIC ISR
+/// republishes the TSC-derived value, so the count stays wall-locked even
+/// if one CPU's LAPIC delivery is briefly suppressed. On a **single core**
+/// there is no second CPU to keep it fresh: under KVM a sustained burst of
+/// framebuffer MMIO VM-exits (the GUI compositor's `compose()` loop) can
+/// suppress LAPIC timer-interrupt delivery to the only CPU indefinitely.
+/// Any `while get_ticks() … { compose(); }` settle loop then spins forever
+/// in Ring 0 — and because the kernel is never preempted (the timer ISR
+/// deliberately never reschedules kernel-mode contexts, see
+/// `irq_timer_handler`), the lock-holder / kdb thread can never run. This
+/// is the single-core init deadlock.
+///
+/// Fix: derive a floor for the tick value directly from the TSC, using the
+/// same boot epoch and cycles-per-tick the ISR uses, and return the larger
+/// of the published count and that TSC-derived floor. The TSC is the
+/// invariant time source (Intel SDM Vol. 3B §17.17 — constant-rate TSC),
+/// so progress is guaranteed whenever the timer is delivered *or* the TSC
+/// advances, which is always. `max()` keeps the result monotone and never
+/// races the ISR backwards: when the ISR is firing it is already at or
+/// ahead of the floor, so SMP behaviour is unchanged.
 pub fn get_ticks() -> u64 {
-    TICK_COUNT.load(Ordering::Relaxed)
+    let published = TICK_COUNT.load(Ordering::Relaxed);
+
+    // Before calibration completes TSC_PER_TICK is 0; there is no usable
+    // TSC epoch yet, so fall back to the published count alone. (Boot code
+    // that runs before LAPIC calibration does not spin on get_ticks().)
+    let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        return published;
+    }
+
+    let tsc_at_boot = TSC_AT_BOOT.load(Ordering::Acquire);
+    let elapsed = rdtsc().wrapping_sub(tsc_at_boot);
+    let tsc_floor = elapsed / tsc_per_tick;
+
+    if tsc_floor > published { tsc_floor } else { published }
+}
+
+/// Number of times the BSP idle path detected a starved LAPIC timer and
+/// drove a scheduler tick from the TSC instead. Diagnostic-only; non-zero
+/// means the single-core LAPIC-suppression recovery path (see [`idle_tick`])
+/// fired.
+pub static TIMER_REARM_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Last TSC-floor tick at which the BSP idle path drove a software scheduler
+/// tick. Used to rate-limit the software tick to ~`TICK_HZ`.
+static LAST_SOFT_TICK: AtomicU64 = AtomicU64::new(0);
+
+/// Cooperative idle step for the BSP polling/soak loop.
+///
+/// Returns `true` if the LAPIC timer is healthy (the caller may safely `hlt`
+/// and rely on the next timer interrupt to wake it) and `false` if the timer
+/// is starved (the caller MUST NOT `hlt` — there is no wakeup source — and
+/// should spin-yield instead).
+///
+/// Background: under KVM a lone vCPU can have its LAPIC periodic timer
+/// suppressed by a sustained framebuffer-MMIO VM-exit storm (the GUI
+/// compositor) and **not** resume even after the storm ends. Rewriting the
+/// LAPIC initial-count does not reliably un-wedge KVM's injection, so a
+/// dead timer means: (a) `TICK_COUNT` would freeze — already handled by
+/// [`get_ticks`] reading a TSC floor; (b) the scheduler tick
+/// (`timer_tick_schedule`, which wakes timed-out sleepers and rotates the
+/// run queue) would never run; and (c) a blind `hlt` would sleep forever.
+///
+/// This routine makes the single core self-clocking. When the TSC shows the
+/// published `TICK_COUNT` has fallen `slack` ticks behind real time, it:
+///   1. attempts a LAPIC re-arm (cheap; helps if the timer is merely masked),
+///   2. drives `timer_tick_schedule()` directly from the idle thread once per
+///      elapsed tick (rate-limited via `LAST_SOFT_TICK`) so timed waits and
+///      run-queue rotation make progress on the live TSC clock, and
+///   3. reports the timer as unhealthy so the caller spin-yields instead of
+///      hlt-ing into a dead-timer sleep.
+///
+/// On a healthy timer — every SMP run, and single-core once the LAPIC is
+/// delivering — the published count tracks the TSC within ~1 tick, so this is
+/// a cheap comparison that returns `true` and the caller `hlt`s normally.
+/// `timer_tick_schedule()` is ISR-context-safe (it `try_lock`s `THREAD_TABLE`
+/// and only sets reschedule flags), so calling it from the idle thread is
+/// sound.
+///
+/// `slack` is in ticks (10 ms units at 100 Hz). ~5 (≈50 ms) tolerates the
+/// normal one-tick ISR publish lag without firing spuriously.
+pub fn idle_tick(slack: u64) -> bool {
+    let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        return true; // pre-calibration: nothing to drive yet, hlt is fine
+    }
+    let published = TICK_COUNT.load(Ordering::Relaxed);
+    let tsc_at_boot = TSC_AT_BOOT.load(Ordering::Acquire);
+    let elapsed = rdtsc().wrapping_sub(tsc_at_boot);
+    let tsc_floor = elapsed / tsc_per_tick;
+
+    // Timer healthy: the ISR is keeping TICK_COUNT within `slack` of the TSC.
+    if tsc_floor <= published.wrapping_add(slack) {
+        return true;
+    }
+
+    // Timer starved. Try to revive it (harmless if it's just masked), then
+    // drive a software scheduler tick from the TSC so the system keeps
+    // running on the single core regardless of LAPIC delivery.
+    super::apic::rearm_timer();
+
+    // Rate-limit the software tick to ~one per real elapsed tick so we don't
+    // burn the run queue's time-slice accounting faster than wall time.
+    let last = LAST_SOFT_TICK.load(Ordering::Relaxed);
+    if tsc_floor > last {
+        LAST_SOFT_TICK.store(tsc_floor, Ordering::Relaxed);
+        TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
+        crate::sched::timer_tick_schedule();
+    }
+    false
 }
 
 // ============================================================

--- a/kernel/src/ff_out_png.rs
+++ b/kernel/src/ff_out_png.rs
@@ -1,0 +1,192 @@
+//! Firefox headless-screenshot extraction over the serial port.
+//!
+//! After the firefox-test boot drives the headless Firefox `--screenshot`
+//! pipeline, the rendered PNG lands at the guest path `/tmp/out.png` (a VFS
+//! ramdisk file — see `kernel/src/main.rs` firefox-test path). The QEMU VGA
+//! framebuffer at that point still shows the AstryxOS boot splash, so the
+//! existing `[SCREENSHOT-B64:…]` stream (which carries the framebuffer) does
+//! NOT carry Firefox's rendered output. This module reads `/tmp/out.png` back
+//! through the kernel VFS and emits it over serial as a DISTINCT base64 marker
+//! stream so the host can reconstruct the byte-exact file:
+//!
+//! ```text
+//! [FF-OUT-PNG:path=/tmp/out.png size=<N> sig_ok=<bool>]
+//! [FF-OUT-PNG-B64:0/M] <up to 76 base64 chars>
+//! [FF-OUT-PNG-B64:1/M] ...
+//! ...
+//! [FF-OUT-PNG-END]
+//! ```
+//!
+//! The encoding is standard base64 (RFC 4648 §4) with `=` padding; each data
+//! line carries 57 input bytes → 76 output characters (the MIME line length,
+//! RFC 2045 §6.8). The PNG signature is the 8-byte magic of W3C/ISO 15948 PNG
+//! (89 50 4E 47 0D 0A 1A 0A).
+//!
+//! The host-side decoder is `scripts/qemu-harness.py read-ff-png`, which is
+//! kept entirely separate from `read-png` (the framebuffer decoder) so the two
+//! extraction paths never collide.
+//!
+//! This module is compiled only under the `firefox-test` feature; it is inert
+//! (and absent) in every other build, so it cannot affect other tests.
+
+extern crate alloc;
+use alloc::vec::Vec;
+use crate::serial_println;
+
+/// 8-byte PNG file signature (W3C PNG §5.2 / ISO 15948).
+const PNG_SIGNATURE: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+/// Trailing 8 bytes of every well-formed PNG: the zero-length `IEND` chunk —
+/// length(0)=`00 00 00 00`, type `IEND`=`49 45 4E 44`, CRC=`AE 42 60 82`
+/// (W3C PNG §5.6 / §11.2.5; the IEND CRC is constant). Used to confirm the
+/// file Firefox is writing is COMPLETE before we stream it, so a probe that
+/// catches the write mid-flight does not emit a truncated PNG.
+const PNG_IEND_TRAILER: [u8; 8] =
+    [0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, ];
+
+/// Whether `bytes` is a structurally complete PNG: 8-byte signature at the
+/// front AND the 12-byte IEND chunk at the back (we match the first 8 of those
+/// 12; the final 4 are the constant CRC). A minimum length of 8+12 = 20 bytes
+/// is required for both windows to exist.
+fn is_complete_png(bytes: &[u8]) -> bool {
+    if bytes.len() < 20 {
+        return false;
+    }
+    if bytes[..8] != PNG_SIGNATURE {
+        return false;
+    }
+    // IEND chunk is the last 12 bytes: 4 len + 4 type + 4 CRC. Match the
+    // 8-byte len+type window at offset len-12.
+    let iend_at = bytes.len() - 12;
+    bytes[iend_at..iend_at + 8] == PNG_IEND_TRAILER
+}
+
+/// Standard base64 alphabet (RFC 4648 §4, Table 1).
+const B64_ALPHABET: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Input bytes per emitted line: 57 → exactly 76 base64 characters
+/// (RFC 2045 §6.8 MIME line length).
+const CHUNK_BYTES: usize = 57;
+
+/// Maximum encoded bytes for one `CHUNK_BYTES` group: ceil(57/3)*4 = 76.
+const MAX_ENC_LEN: usize = 76;
+
+/// Base64-encode one input group (≤ `CHUNK_BYTES` bytes) into `out`, returning
+/// the number of bytes written. `out` must be at least `MAX_ENC_LEN` long.
+///
+/// Pure function (no I/O, no allocation) so the encoding is unit-testable and
+/// identical in shape to the `[SCREENSHOT-B64]` encoder in `test_runner.rs`.
+fn b64_encode_group(src: &[u8], out: &mut [u8; MAX_ENC_LEN]) -> usize {
+    let mut enc_len = 0usize;
+    let mut i = 0usize;
+
+    // Full 3-byte groups → 4 output chars.
+    while i + 2 < src.len() {
+        let b0 = src[i] as usize;
+        let b1 = src[i + 1] as usize;
+        let b2 = src[i + 2] as usize;
+        out[enc_len]     = B64_ALPHABET[b0 >> 2];
+        out[enc_len + 1] = B64_ALPHABET[((b0 & 0x3) << 4) | (b1 >> 4)];
+        out[enc_len + 2] = B64_ALPHABET[((b1 & 0xf) << 2) | (b2 >> 6)];
+        out[enc_len + 3] = B64_ALPHABET[b2 & 0x3f];
+        enc_len += 4;
+        i += 3;
+    }
+
+    // Trailing 1 or 2 bytes + `=` padding.
+    if i < src.len() {
+        let b0 = src[i] as usize;
+        let b1 = if i + 1 < src.len() { src[i + 1] as usize } else { 0 };
+        out[enc_len]     = B64_ALPHABET[b0 >> 2];
+        out[enc_len + 1] = B64_ALPHABET[((b0 & 0x3) << 4) | (b1 >> 4)];
+        out[enc_len + 2] = if i + 1 < src.len() {
+            B64_ALPHABET[(b1 & 0xf) << 2]
+        } else {
+            b'='
+        };
+        out[enc_len + 3] = b'=';
+        enc_len += 4;
+    }
+
+    enc_len
+}
+
+/// Read `/tmp/out.png` back from the VFS and emit it over serial as the
+/// `[FF-OUT-PNG-B64:…]` marker stream for host extraction. Returns `true` iff a
+/// COMPLETE PNG (valid signature + IEND trailer) was streamed.
+///
+/// Best-effort and side-effect-free with respect to the boot: any failure
+/// (file absent, read error, empty, bad signature) is reported on a single
+/// `[FF-OUT-PNG:…]` line and the function returns `false` without emitting a
+/// data stream — it never panics and never blocks the shutdown path. Firefox
+/// having failed to write a screenshot is a normal, expected outcome that must
+/// not wedge the boot.
+///
+/// When called speculatively from the poll loop (file may still be mid-write),
+/// the `complete=false` early return lets the caller probe again next tick
+/// rather than stream a truncated image.
+pub fn emit_out_png() -> bool {
+    const PNG_PATH: &str = "/tmp/out.png";
+
+    // Read the guest-written PNG back through the same VFS Firefox wrote to.
+    // `/tmp` is a kernel VFS ramdisk shared between the kernel and the Linux
+    // personality, so this is the byte-exact file Firefox produced.
+    let bytes: Vec<u8> = match crate::vfs::read_file(PNG_PATH) {
+        Ok(b) => b,
+        Err(e) => {
+            serial_println!(
+                "[FF-OUT-PNG:path={} size=0 sig_ok=false complete=false read_error={:?}]",
+                PNG_PATH, e
+            );
+            return false;
+        }
+    };
+
+    let size = bytes.len();
+    let sig_ok = size >= 8 && bytes[..8] == PNG_SIGNATURE;
+    let complete = is_complete_png(&bytes);
+
+    serial_println!(
+        "[FF-OUT-PNG:path={} size={} sig_ok={} complete={}]",
+        PNG_PATH, size, sig_ok, complete
+    );
+
+    if size == 0 {
+        // Nothing to stream — header line already reported the empty file.
+        serial_println!("[FF-OUT-PNG-END]");
+        return false;
+    }
+
+    if !complete {
+        // File present but not yet a complete PNG (still mid-write, or
+        // corrupt). Do NOT stream a partial image; report and let the caller
+        // retry on the next probe.
+        serial_println!("[FF-OUT-PNG-END]");
+        return false;
+    }
+
+    // Ceiling division for the chunk count (matches the existing
+    // `[SCREENSHOT-B64]` encoder); the header line above already told the host
+    // the byte size for a sanity cross-check.
+    let total_chunks = (size + CHUNK_BYTES - 1) / CHUNK_BYTES;
+
+    for chunk_idx in 0..total_chunks {
+        let start = chunk_idx * CHUNK_BYTES;
+        let end = (start + CHUNK_BYTES).min(size);
+        let src = &bytes[start..end];
+
+        let mut enc = [0u8; MAX_ENC_LEN];
+        let enc_len = b64_encode_group(src, &mut enc);
+
+        // SAFETY: `enc[..enc_len]` contains only ASCII bytes drawn from
+        // `B64_ALPHABET` or `b'='`, all valid UTF-8.
+        let enc_str =
+            core::str::from_utf8(&enc[..enc_len]).unwrap_or("(b64-encode-error)");
+
+        serial_println!("[FF-OUT-PNG-B64:{}/{}] {}", chunk_idx, total_chunks, enc_str);
+    }
+
+    serial_println!("[FF-OUT-PNG-END]");
+    true
+}

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -897,23 +897,21 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // Reports/ creation and the subsequent fatal-on-error writes that
         // bubble up through CrashReporter::SetupExtraData().
         "MOZ_CRASHREPORTER_DISABLE=1",
-        // Force single-process (no content-child) mode so the headless
-        // --screenshot path uses the in-process paint branch of
-        // CrossProcessPaint::Start.  When e10s is disabled,
-        // WindowGlobalParent::IsInProcess() returns true and
-        // drawSnapshot() records the page directly in the parent process
-        // without spawning a content child, without AF_UNIX SCM_RIGHTS
-        // fd-passing, and without memfd/shm round-trips — dropping the
-        // entire content-process cluster off the critical path.
-        //
-        // MOZ_DISABLE_NONLOCAL_CONNECTIONS=1 (set above) satisfies the
-        // AreNonLocalConnectionsDisabled() gate in MOZILLA_OFFICIAL
-        // release builds, after which MOZ_FORCE_DISABLE_E10S=1 is
-        // honoured.
-        //
-        // See: https://wiki.mozilla.org/Electrolysis
-        //      https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
-        "MOZ_FORCE_DISABLE_E10S=1",
+        // NB: we intentionally do NOT force-disable e10s here.  The headless
+        // --screenshot path creates its capture <browser> with an explicit
+        // remote="true", and per the Firefox process model an explicit
+        // remoteness is authoritative — the global e10s-disable flag only
+        // changes the DEFAULT and cannot override it.  Forcing e10s off
+        // therefore leaves the screenshot actor cross-process while other
+        // routing treats it as in-process, so the GetDimensions JSWindowActor
+        // sendQuery is never dispatched over the content channel and the
+        // capture never completes (observed: zero AF_UNIX IPDL traffic on the
+        // content sockets across a multi-billion-syscall run).  Running the
+        // normal multi-process path — as an unmodified upstream Firefox does —
+        // keeps routing consistent: the query is sent over the content
+        // channel, the content actor renders the fragment, and its reply
+        // drives drawSnapshot to the PNG.
+        // See: https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
         // Skip GPU/glxtest process — software rendering only.
         "MOZ_GFX_TESTING_NO_CHILD_PROCESS=1",
         "MOZ_X11_EGL=0",

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -348,6 +348,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "dmesg"          => op_dmesg(req, out),
         "syms"           => op_syms(req, out),
         "mem"            => op_mem(req, out),
+        "read-file"      => op_read_file(req, out),
         "trace-status"   => op_trace_status(out),
         "bell-stats"       => op_bell_stats(out),
         "cache-audit"      => op_cache_audit(out),
@@ -856,6 +857,102 @@ fn op_mem(req: &str, out: &mut String) {
     j_kv(out, "len", &alloc::format!("{}", len));
     j_kv_str(out, "hex", &hex);
     j_trim_comma(out);
+    out.push('}');
+}
+
+// ── read-file ───────────────────────────────────────────────────────────────
+//
+// Read a slice of a VFS file and return it base64-encoded (RFC 4648 §4).  This
+// is the robust, FFTEST-loop-independent extraction primitive: it works against
+// any live kdb-attached session regardless of process / scheduler state, so a
+// guest-written artefact (e.g. Firefox's /tmp/out.png screenshot) can be pulled
+// to the host even when the boot's own detect-and-emit path is blocked.
+//
+// Request : {"op":"read-file","path":"/tmp/out.png","offset":0,"len":16384}
+// Response: {"path":..,"file_size":N,"offset":O,"n":K,"eof":bool,
+//            "sig_png":bool,"b64":"<K bytes base64>"}
+//
+// `len` is capped at READ_FILE_CHUNK so the base64 payload stays under the kdb
+// MAX_RESP_BYTES truncation threshold; the host loops offset+=n until eof to
+// reassemble the whole file byte-exactly.  `sig_png` reports whether the file
+// begins with the 8-byte PNG signature (W3C PNG §5.2 / ISO 15948) — a cheap
+// "is this a real PNG?" check the host can read off the first chunk.
+
+/// Max raw bytes per read-file chunk.  16384 raw -> ceil(16384/3)*4 = 21848
+/// base64 chars, comfortably under the 32 KiB MAX_RESP_BYTES kdb response cap.
+const READ_FILE_CHUNK: u64 = 16384;
+
+fn b64_append(out: &mut String, src: &[u8]) {
+    const ALPHABET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut i = 0usize;
+    while i + 2 < src.len() {
+        let (b0, b1, b2) = (src[i] as usize, src[i + 1] as usize, src[i + 2] as usize);
+        out.push(ALPHABET[b0 >> 2] as char);
+        out.push(ALPHABET[((b0 & 0x3) << 4) | (b1 >> 4)] as char);
+        out.push(ALPHABET[((b1 & 0xf) << 2) | (b2 >> 6)] as char);
+        out.push(ALPHABET[b2 & 0x3f] as char);
+        i += 3;
+    }
+    if i < src.len() {
+        let b0 = src[i] as usize;
+        let b1 = if i + 1 < src.len() { src[i + 1] as usize } else { 0 };
+        out.push(ALPHABET[b0 >> 2] as char);
+        out.push(ALPHABET[((b0 & 0x3) << 4) | (b1 >> 4)] as char);
+        out.push(if i + 1 < src.len() {
+            ALPHABET[(b1 & 0xf) << 2] as char
+        } else {
+            '='
+        });
+        out.push('=');
+    }
+}
+
+fn op_read_file(req: &str, out: &mut String) {
+    let path = match extract_field(req, "path") {
+        Some(p) => p,
+        None => { out.push_str(r#"{"error":"missing 'path'"}"#); return; }
+    };
+    let offset = extract_field(req, "offset").and_then(|s| parse_u64(&s)).unwrap_or(0);
+    let len = extract_field(req, "len")
+        .and_then(|s| parse_u64(&s))
+        .unwrap_or(READ_FILE_CHUNK)
+        .min(READ_FILE_CHUNK);
+
+    // Read the whole file once (ramfs/cache-backed; cheap for the small
+    // artefacts this op targets), then slice — keeps the VFS surface minimal.
+    let bytes = match crate::vfs::read_file(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            use core::fmt::Write;
+            out.push('{');
+            j_kv_str(out, "path", &path);
+            let _ = write!(out, r#""error":"read failed: {:?}","#, e);
+            j_trim_comma(out);
+            out.push('}');
+            return;
+        }
+    };
+
+    let file_size = bytes.len() as u64;
+    let start = offset.min(file_size) as usize;
+    let end = (offset + len).min(file_size) as usize;
+    let slice = &bytes[start..end];
+    let n = slice.len() as u64;
+    let eof = (offset + n) >= file_size;
+    let sig_png = bytes.len() >= 8
+        && bytes[..8] == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    out.push('{');
+    j_kv_str(out, "path", &path);
+    j_kv(out, "file_size", &alloc::format!("{}", file_size));
+    j_kv(out, "offset", &alloc::format!("{}", offset));
+    j_kv(out, "n", &alloc::format!("{}", n));
+    j_kv(out, "eof", if eof { "true" } else { "false" });
+    j_kv(out, "sig_png", if sig_png { "true" } else { "false" });
+    j_str(out, "b64"); out.push(':'); out.push('"');
+    b64_append(out, slice);
+    out.push('"');
     out.push('}');
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1327,15 +1327,41 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 gui::input::pump_input();
                 crate::net::poll();
                 crate::x11::poll();
+
+                let now = arch::x86_64::irq::get_ticks();
+                let elapsed = now.wrapping_sub(t_launch);
+
+                // Stream the rendered screenshot the moment it lands — placed
+                // HERE, immediately after net/x11 poll and BEFORE poll_output()
+                // / compose(), because those later calls take the TERMINAL and
+                // THREAD_TABLE locks and can be starved during a large
+                // Dead-thread drain at Firefox exit (271 threads observed).
+                // net::poll() above keeps kdb alive even then, so probing here
+                // guarantees the emit fires before the loop body can block.
+                // stat() reads no content; emit_out_png() returns false until
+                // the file is a COMPLETE PNG (signature + IEND), so a probe
+                // that catches the write mid-flight retries next tick.
+                if !out_png_emitted && elapsed.wrapping_sub(last_png_probe_tick) >= 200 {
+                    last_png_probe_tick = elapsed;
+                    if let Ok(st) = crate::vfs::stat("/tmp/out.png") {
+                        if st.size > 0 {
+                            serial_println!(
+                                "[FFTEST] /tmp/out.png present ({} bytes) — streaming",
+                                st.size
+                            );
+                            if ff_out_png::emit_out_png() {
+                                out_png_emitted = true;
+                            }
+                        }
+                    }
+                }
+
                 crate::gui::terminal::poll_output();
                 // Drive the compositor via the ISR-set tick flag (≈50 Hz).
                 // The timer ISR sets COMPOSITOR_TICK_DUE every 2 published
                 // ticks; compose() drains it and renders a frame.  Replaces
                 // the unreliable `ticks % 3` check (see gui/compositor.rs).
                 gui::compositor::compose();
-
-                let now = arch::x86_64::irq::get_ticks();
-                let elapsed = now.wrapping_sub(t_launch);
 
                 // Log a heartbeat every 1000 ticks (~10s).  Use try_lock so a
                 // contended/leaked THREAD_TABLE never wedges CPU0; the BSP must
@@ -1370,28 +1396,6 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                         None => {
                             serial_println!("[FFTEST] tick={} sc={} pf={} THREAD_TABLE busy, skipping",
                                 elapsed, sc, pf);
-                        }
-                    }
-                }
-
-                // Stream the rendered screenshot the moment it lands, before
-                // (and independent of) Firefox-exit detection.  Probe at most
-                // every ~200 ticks via stat() (no content read) so this adds
-                // negligible cost to the hot poll loop; emit exactly once.
-                if !out_png_emitted && elapsed.wrapping_sub(last_png_probe_tick) >= 200 {
-                    last_png_probe_tick = elapsed;
-                    if let Ok(st) = crate::vfs::stat("/tmp/out.png") {
-                        if st.size > 0 {
-                            serial_println!(
-                                "[FFTEST] /tmp/out.png present ({} bytes) — streaming",
-                                st.size
-                            );
-                            // emit_out_png() returns false if the file is not yet
-                            // a COMPLETE PNG (still mid-write); in that case leave
-                            // out_png_emitted false so the next probe retries.
-                            if ff_out_png::emit_out_png() {
-                                out_png_emitted = true;
-                            }
                         }
                     }
                 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -74,6 +74,8 @@ mod pivot_e_demo;
 mod pivot_e_tui_demo;
 #[cfg(feature = "pivot-e-git-test")]
 mod pivot_e_git_demo;
+#[cfg(feature = "firefox-test")]
+mod ff_out_png;
 
 use astryx_shared::{BootInfo, BOOT_INFO_MAGIC};
 
@@ -1311,6 +1313,16 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             let t_launch = arch::x86_64::irq::get_ticks();
             let mut last_log_tick: u64 = 0;
             let mut firefox_exited = false;
+            // Emit Firefox's rendered /tmp/out.png over serial as soon as it is
+            // written, INDEPENDENT of Firefox-exit detection.  The screenshot
+            // file is complete the moment Firefox closes it; waiting for full
+            // process teardown is fragile (a slow Dead-thread drain can hold
+            // THREAD_TABLE long enough that is_firefox_running() never reports
+            // exit, so the post-loop emit below would never run).  Probing the
+            // file directly decouples extraction from teardown.  Fires exactly
+            // once; emit_out_png() re-reads and streams the bytes (see below).
+            let mut out_png_emitted = false;
+            let mut last_png_probe_tick: u64 = 0;
             loop {
                 gui::input::pump_input();
                 crate::net::poll();
@@ -1358,6 +1370,28 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                         None => {
                             serial_println!("[FFTEST] tick={} sc={} pf={} THREAD_TABLE busy, skipping",
                                 elapsed, sc, pf);
+                        }
+                    }
+                }
+
+                // Stream the rendered screenshot the moment it lands, before
+                // (and independent of) Firefox-exit detection.  Probe at most
+                // every ~200 ticks via stat() (no content read) so this adds
+                // negligible cost to the hot poll loop; emit exactly once.
+                if !out_png_emitted && elapsed.wrapping_sub(last_png_probe_tick) >= 200 {
+                    last_png_probe_tick = elapsed;
+                    if let Ok(st) = crate::vfs::stat("/tmp/out.png") {
+                        if st.size > 0 {
+                            serial_println!(
+                                "[FFTEST] /tmp/out.png present ({} bytes) — streaming",
+                                st.size
+                            );
+                            // emit_out_png() returns false if the file is not yet
+                            // a COMPLETE PNG (still mid-write); in that case leave
+                            // out_png_emitted false so the next probe retries.
+                            if ff_out_png::emit_out_png() {
+                                out_png_emitted = true;
+                            }
                         }
                     }
                 }
@@ -1417,6 +1451,25 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // summary block at every kernel-test shutdown.
             #[cfg(feature = "firefox-test")]
             crate::subsys::linux::syscall::ghost_hist::dump_summary();
+
+            // Read Firefox's rendered screenshot (/tmp/out.png) back out of the
+            // VFS ramdisk and emit it over serial as the [FF-OUT-PNG-B64:…]
+            // marker stream for host extraction.  This is the REAL rendered
+            // page — distinct from the [SCREENSHOT-B64:…] stream, which carries
+            // the QEMU VGA framebuffer (the boot splash in headless mode), not
+            // Firefox's off-screen render.  The host decodes it with
+            // `qemu-harness.py read-ff-png`.  Best-effort: a missing or empty
+            // file is reported on the header line and never blocks shutdown.
+            //
+            // Skipped when the in-loop probe already streamed the file (the
+            // common, robust path) so we never double-emit.  This post-loop
+            // call is the fallback for the path where Firefox exited before the
+            // 200-tick probe fired (e.g. a very fast screenshot run).
+            #[cfg(feature = "firefox-test")]
+            if !out_png_emitted {
+                ff_out_png::emit_out_png();
+            }
+
             serial_println!("[FFTEST] DONE");
 
             // Brief pause for QMP screendump, then exit.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1389,7 +1389,21 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 // sched(7), a CPU must never be idle while a runnable peer
                 // exists.
                 crate::sched::yield_cpu();
-                unsafe { core::arch::asm!("hlt"); }
+                // Single-core robustness: under KVM a lone vCPU can have its
+                // LAPIC periodic timer suppressed by a framebuffer-MMIO exit
+                // storm and never resume, freezing the scheduler tick and
+                // TICK_COUNT (the dual-core path is immune — a sibling CPU
+                // keeps the global clock alive).  `idle_tick` reports whether
+                // the timer is healthy: if so we `hlt` and the next tick wakes
+                // us; if it is starved, `idle_tick` has already driven a
+                // software scheduler tick from the TSC and we MUST spin (not
+                // `hlt`) because a dead timer provides no wakeup.  A healthy
+                // timer — every SMP run — makes this a cheap `true` + `hlt`.
+                if crate::arch::x86_64::irq::idle_tick(5) {
+                    unsafe { core::arch::asm!("hlt"); }
+                } else {
+                    core::hint::spin_loop();
+                }
             }
 
             serial_println!("[FFTEST] firefox_exited={}", firefox_exited);

--- a/kernel/src/mm/heap.rs
+++ b/kernel/src/mm/heap.rs
@@ -670,11 +670,85 @@ impl LinkedListAllocator {
     }
 }
 
+/// RAII bracket that clears IF for the duration of a heap critical section,
+/// restoring the caller's prior interrupt state on drop.
+///
+/// ## Why the heap lock must run with interrupts masked
+///
+/// The kernel heap is guarded by a single non-reentrant `spin::Mutex`
+/// (`LockedHeapAllocator.0`).  A plain `spin::Mutex` does **not** mask
+/// interrupts while held: the free-list walk in `alloc`/`dealloc` runs with
+/// `IF` left at whatever the caller had.  Almost every allocation happens in
+/// ordinary kernel code with interrupts enabled, so the LAPIC timer ISR can
+/// fire *while this core holds the heap lock*.
+///
+/// The timer ISR's periodic metrics dump
+/// (`crate::proc::proc_metrics::maybe_emit_periodic`) itself allocates
+/// (`Vec`/`String`/`format!`).  When the ISR lands on a core that is mid-walk
+/// inside the heap lock, the ISR re-enters `alloc`, takes the same
+/// `spin::Mutex`, and busy-spins forever waiting for a lock the *interrupted*
+/// frame on the very same core can never release — a re-entrant self-deadlock
+/// that strands the core in a non-preemptible Ring-0 spin (the timer ISR
+/// skips kernel-mode preemption), freezing the whole machine.
+///
+/// Masking interrupts for the (tiny, bounded) free-list critical section
+/// makes a heap allocation atomic with respect to ISRs on the local core, so
+/// no interrupt handler can ever observe the lock held and re-enter the
+/// allocator.  This mirrors the same discipline `_serial_print` already uses
+/// around the `SERIAL` mutex, and follows the standard "spinlock that may be
+/// taken from interrupt context must be IRQ-safe" rule (an irqsave spinlock).
+/// Cross-core safety is unchanged: the `spin::Mutex` still serialises CPUs;
+/// masking only prevents *same-core* ISR re-entry.
+struct HeapIrqGuard {
+    /// True if IF was set on entry and must be restored to set on drop.
+    reenable: bool,
+}
+
+impl HeapIrqGuard {
+    #[inline(always)]
+    fn new() -> Self {
+        // Read RFLAGS, then mask interrupts.  `pushfq` reflects IF before the
+        // following `cli`, so we capture the caller's true prior state even
+        // when nested inside another IRQ-masked region (then `reenable` is
+        // false and drop is a no-op — correct).
+        let rflags: u64;
+        unsafe {
+            core::arch::asm!(
+                "pushfq",
+                "pop {rflags}",
+                "cli",
+                rflags = out(reg) rflags,
+                options(nomem, preserves_flags),
+            );
+        }
+        HeapIrqGuard { reenable: rflags & (1 << 9) != 0 }
+    }
+}
+
+impl Drop for HeapIrqGuard {
+    #[inline(always)]
+    fn drop(&mut self) {
+        if self.reenable {
+            // SAFETY: restoring IF to exactly the value the caller had on
+            // entry.  If the caller already had interrupts masked we leave
+            // them masked.
+            unsafe {
+                core::arch::asm!("sti", options(nomem, nostack, preserves_flags));
+            }
+        }
+    }
+}
+
 /// Thread-safe wrapper around the heap allocator.
 struct LockedHeapAllocator(Mutex<LinkedListAllocator>);
 
 unsafe impl GlobalAlloc for LockedHeapAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Mask interrupts across the lock-held critical section so the timer
+        // ISR (which itself allocates via the periodic metrics dump) cannot
+        // fire on this core while the heap lock is held and re-enter the
+        // allocator into a same-core spin deadlock.  See `HeapIrqGuard`.
+        let _irq = HeapIrqGuard::new();
         let ptr = self.0.lock().alloc(layout);
         if !ptr.is_null() {
             crate::perf::record_heap_alloc(layout.size());
@@ -684,6 +758,7 @@ unsafe impl GlobalAlloc for LockedHeapAllocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         crate::perf::record_heap_free(layout.size());
+        let _irq = HeapIrqGuard::new();
         self.0.lock().dealloc(ptr, layout)
     }
 }

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -593,6 +593,89 @@ pub fn map_page_in(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -
     true
 }
 
+/// Install `phys_addr` at `virt_addr` in `pml4_phys` **only if the leaf PTE is
+/// not already present**, performing the present-check and the install as one
+/// indivisible operation under `VMM_LOCK`.
+///
+/// Returns `true` if this call installed the mapping, `false` if a sibling CPU
+/// had already made the page present (in which case nothing is written and the
+/// caller's frame is redundant — it must be freed by the caller).
+///
+/// # Why this exists
+///
+/// `map_page_in` writes the leaf PTE unconditionally.  On a shared address
+/// space (CLONE_VM / vfork — several threads on one CR3, scheduled across
+/// logical processors), two CPUs can take a not-present `#PF` on the *same*
+/// anonymous virtual address concurrently.  Each allocates and zero-fills its
+/// own frame; whichever calls `map_page_in` second overwrites the leaf PTE
+/// with a *different* physical frame.  The first installer's CPU still caches
+/// the first frame in its TLB (its local `invlpg` only covered its own CPU and
+/// fired before the overwrite), so that CPU keeps reading the first frame while
+/// the page table — and every later faulting CPU — sees the second.  A store by
+/// one thread to a shared control word then lands on one frame and is never
+/// observed by the thread reading the other: a silent cross-CPU
+/// store-visibility failure on the shared stack page.
+///
+/// Doing the present-check atomically with the install closes the window: the
+/// loser observes the winner's already-present PTE under the same lock that
+/// serialises the install and backs out without aliasing the mapping.  This is
+/// the standard demand-paging re-validation (re-check the PTE under the
+/// page-table lock immediately before writing it).  Per Intel SDM Vol. 3A
+/// §4.10.4.3, no cross-CPU invalidation is required for the not-present →
+/// present transition itself; the hazard here is the second *frame*, which this
+/// guard prevents.
+pub fn map_page_in_if_absent(
+    pml4_phys: u64,
+    virt_addr: u64,
+    phys_addr: u64,
+    flags: u64,
+) -> bool {
+    let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
+    let _mm_read = _mm_guard.as_ref().map(|s| s.read());
+    let _lock = VMM_LOCK.lock();
+
+    let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;
+    let pdpt_idx = ((virt_addr >> 30) & 0x1FF) as usize;
+    let pd_idx = ((virt_addr >> 21) & 0x1FF) as usize;
+    let pt_idx = ((virt_addr >> 12) & 0x1FF) as usize;
+
+    unsafe {
+        let pdpt_phys = match get_or_create_entry(pml4_phys, pml4_idx, flags) {
+            Some(addr) => addr,
+            None => return false,
+        };
+        let pd_phys = match get_or_create_entry(pdpt_phys, pdpt_idx, flags) {
+            Some(addr) => addr,
+            None => return false,
+        };
+        let pt_phys = match get_or_create_entry(pd_phys, pd_idx, flags) {
+            Some(addr) => addr,
+            None => return false,
+        };
+
+        let pt_ptr = p2v(pt_phys);
+        // Atomic-with-install present check: if a sibling won the race and
+        // already published a PTE for this VA, do NOT overwrite it.
+        let existing = *pt_ptr.add(pt_idx);
+        if existing & PAGE_PRESENT != 0 {
+            return false;
+        }
+        *pt_ptr.add(pt_idx) = (phys_addr & ADDR_MASK) | flags | PAGE_PRESENT;
+    }
+
+    #[cfg(feature = "firefox-test")]
+    crate::mm::w215_diag::pte_change_record(
+        virt_addr,
+        phys_addr & ADDR_MASK,
+        0,
+        crate::mm::w215_diag::PTE_KIND_MAP,
+        ring_caller_rip(),
+        pml4_phys,
+    );
+
+    true
+}
+
 /// Unmap a virtual page in an arbitrary page table.
 ///
 /// See `map_page_in` for the W216 `mm_sem` read-lock invariant.

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -414,6 +414,106 @@ fn ensure_udp_local_port(id: u64) -> Result<u16, &'static str> {
     Ok(port)
 }
 
+/// Outcome of a non-blocking socket receive, with the three states the
+/// POSIX recv contract distinguishes:
+///
+///   * `Data(bytes)` — at least one byte (or one datagram) was dequeued.
+///   * `Eof`         — orderly end-of-stream: the read direction was shut
+///                     down (`shutdown(SHUT_RD)`) or, for a connection-mode
+///                     socket, the peer has sent FIN and no buffered data
+///                     remains.  `recv(2)` must report this as a 0-byte
+///                     return (IEEE 1003.1 §recv: "a return value of 0
+///                     indicates the peer has performed an orderly
+///                     shutdown").
+///   * `WouldBlock`  — no data is currently available but the endpoint is
+///                     still live (a connectionless datagram socket with an
+///                     empty queue, or a connection-mode socket whose peer
+///                     has NOT closed).  On an `O_NONBLOCK` fd `recv(2)`
+///                     must report this as `-1`/`EAGAIN`, NEVER as 0 — a 0
+///                     return would falsely signal EOF and send an event
+///                     loop into a busy re-read spin.
+///
+/// The distinction matters because [`socket_recv`] collapses `Eof` and
+/// `WouldBlock` into the same empty `Ok(Vec::new())`, which left the
+/// recvmsg/read syscall arms unable to choose between a 0 return (EOF) and
+/// `-EAGAIN` (would-block).  See `recvmsg(2)`, `recv(2)`, POSIX.1-2017
+/// §2.10.6 (Socket Receive Queue).
+pub enum RecvOutcome {
+    Data(Vec<u8>),
+    Eof,
+    WouldBlock,
+}
+
+/// Receive from a socket (non-blocking) with an explicit [`RecvOutcome`].
+///
+/// This is the EAGAIN-correct sibling of [`socket_recv`]: it tells the
+/// caller whether an empty result is end-of-stream (`Eof` → 0 return) or a
+/// transient empty queue (`WouldBlock` → `-EAGAIN`).  `recvmsg(2)` /
+/// `recv(2)` on a non-blocking socket with no data pending must return
+/// `EAGAIN` per IEEE 1003.1; returning 0 there is an EOF lie that drives a
+/// polled reactor into a tight re-read loop.
+pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
+    let sockets = SOCKETS.lock();
+    let sock = sockets.iter().find(|s| s.id == id)
+        .ok_or("socket not found")?;
+
+    // shutdown(SHUT_RD): orderly EOF regardless of socket type.
+    if sock.shut_rd {
+        return Ok(RecvOutcome::Eof);
+    }
+
+    match sock.socket_type {
+        SocketType::Udp => {
+            if !sock.bound {
+                return Err("not bound");
+            }
+            // UDP is connectionless: an empty receive queue is never EOF,
+            // it is always "no datagram yet" — i.e. would-block.
+            match super::udp::recv(sock.local_port) {
+                Some(datagram) => {
+                    crate::proc::proc_metrics::bump_net_read(
+                        crate::proc::current_pid_lockless(),
+                        datagram.data.len() as u64);
+                    Ok(RecvOutcome::Data(datagram.data))
+                }
+                None => Ok(RecvOutcome::WouldBlock),
+            }
+        }
+        SocketType::Tcp => {
+            if !sock.bound {
+                return Err("not bound");
+            }
+            let data = if sock.connected && sock.remote_port != 0 {
+                super::tcp::read_from(sock.local_port, sock.remote_ip, sock.remote_port)
+            } else {
+                super::tcp::read(sock.local_port)
+            };
+            if !data.is_empty() {
+                crate::proc::proc_metrics::bump_net_read(
+                    crate::proc::current_pid_lockless(), data.len() as u64);
+                return Ok(RecvOutcome::Data(data));
+            }
+            // Empty stream read: distinguish peer-FIN EOF from would-block.
+            // A connection that has received the peer's FIN sits in
+            // CloseWait (or has progressed to LastAck/Closed/TimeWait); with
+            // no buffered data that is an orderly EOF (RFC 793 §3.5).  An
+            // Established (or still-handshaking) connection with an empty
+            // buffer is would-block.
+            let peer_closed = match super::tcp::get_state(sock.local_port) {
+                Some(st) => matches!(st,
+                    super::tcp::TcpState::CloseWait
+                    | super::tcp::TcpState::LastAck
+                    | super::tcp::TcpState::TimeWait
+                    | super::tcp::TcpState::Closed),
+                // No TCB found for this port: the flow is gone — treat as EOF
+                // so a reader drains to completion rather than spinning.
+                None => true,
+            };
+            if peer_closed { Ok(RecvOutcome::Eof) } else { Ok(RecvOutcome::WouldBlock) }
+        }
+    }
+}
+
 /// Receive data from a socket (non-blocking).
 pub fn socket_recv(id: u64) -> Result<Vec<u8>, &'static str> {
     let sockets = SOCKETS.lock();

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -71,6 +71,18 @@ struct UnixSocket {
     recv_buf:    [u8; RECV_BUF_CAP],
     recv_head:   usize,
     recv_tail:   usize,
+    /// Monotonic count of bytes ever *pushed* into `recv_buf` and ever
+    /// *popped* out of it.  Unlike the wrapping `recv_head`/`recv_tail`
+    /// indices, these never reset on read, so they form a stable absolute
+    /// stream position for the live connection (`recv_pushed - recv_popped
+    /// == recv_available()`).  Used to bind a queued `SCM_RIGHTS` control
+    /// message to the exact stream offset at which it was sent, so an
+    /// ancillary-only frame (`iov_len == 0`) is still a *readable message*
+    /// per `recvmsg(2)` / `unix(7)` / POSIX.1-2017 SCM_RIGHTS, and so a
+    /// reader draining an earlier data-only frame does not prematurely
+    /// receive a later frame's fds.
+    recv_pushed: u64,
+    recv_popped: u64,
     /// SEQPACKET message-boundary queue: each entry records the length of
     /// one outstanding sender-side message in `recv_buf`.  Unused for STREAM.
     /// Implemented as a small ring; `seq_head` is dequeue, `seq_tail` is
@@ -127,6 +139,8 @@ impl UnixSocket {
             recv_buf:    [0u8; RECV_BUF_CAP],
             recv_head:   0,
             recv_tail:   0,
+            recv_pushed: 0,
+            recv_popped: 0,
             seq_lens:    [0u32; SEQ_QUEUE_CAP],
             seq_head:    0,
             seq_tail:    0,
@@ -148,6 +162,8 @@ impl UnixSocket {
         self.peer_id     = u64::MAX;
         self.recv_head   = 0;
         self.recv_tail   = 0;
+        self.recv_pushed = 0;
+        self.recv_popped = 0;
         self.seq_head    = 0;
         self.seq_tail    = 0;
         self.backlog_len = 0;
@@ -179,6 +195,7 @@ impl UnixSocket {
             self.recv_buf[self.recv_tail] = b;
             self.recv_tail = (self.recv_tail + 1) % RECV_BUF_CAP;
         }
+        self.recv_pushed = self.recv_pushed.wrapping_add(n as u64);
         n
     }
 
@@ -190,7 +207,14 @@ impl UnixSocket {
             *byte = self.recv_buf[self.recv_head];
             self.recv_head = (self.recv_head + 1) % RECV_BUF_CAP;
         }
+        self.recv_popped = self.recv_popped.wrapping_add(n as u64);
         n
+    }
+
+    /// Absolute stream position of the *next* byte that will be pushed —
+    /// the offset to bind a queued `SCM_RIGHTS` batch to (see `recv_pushed`).
+    fn enqueue_offset(&self) -> u64 {
+        self.recv_pushed
     }
 }
 
@@ -523,6 +547,9 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
         for _ in 0..discard {
             s.recv_head = (s.recv_head + 1) % RECV_BUF_CAP;
         }
+        // Discarded bytes leave the ring too — keep the absolute stream
+        // position (`recv_popped`) consistent with the wrapping head index.
+        s.recv_popped = s.recv_popped.wrapping_add(discard as u64);
         // The whole message (copied + discarded tail) leaves the recv ring.
         drained = copied + discard;
         result  = Ok((copied, discard));
@@ -763,6 +790,29 @@ pub fn bytes_available(id: u64) -> usize {
     } else {
         s.recv_available()
     }
+}
+
+/// Absolute stream position (total bytes ever pushed into the recv ring) at
+/// which a freshly-sent `SCM_RIGHTS` batch should attach.  An ancillary-only
+/// frame (`iov_len == 0`) pushes no bytes, so its fds attach *after* every
+/// byte already queued — i.e. at the current `recv_pushed`.  See
+/// [`scm_deliverable_offset`] for the matching drain-side test.  Returns 0
+/// for an out-of-range id.
+pub fn enqueue_offset_for(id: u64) -> u64 {
+    if id as usize >= MAX_UNIX_SOCKETS { return 0; }
+    let t = TABLE.lock();
+    t.0[id as usize].enqueue_offset()
+}
+
+/// Total bytes ever drained (popped, including SEQPACKET-truncated tails)
+/// from the recv ring of socket `id` — the absolute read position.  A queued
+/// `SCM_RIGHTS` batch bound to `byte_offset` becomes deliverable once this
+/// reaches `byte_offset` (the reader has consumed every data byte that
+/// preceded the ancillary message).  Returns 0 for an out-of-range id.
+pub fn recv_consumed(id: u64) -> u64 {
+    if id as usize >= MAX_UNIX_SOCKETS { return 0; }
+    let t = TABLE.lock();
+    t.0[id as usize].recv_popped
 }
 
 /// Return the socket type (`Stream` or `SeqPacket`) for an open socket id.

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -674,6 +674,19 @@ pub fn close(id: u64) {
         }
     }
     drop(t);
+    // This socket is now fully torn down.  Any `SCM_RIGHTS` ancillary fds that
+    // were queued for it but never `recvmsg`'d are about to be lost — release
+    // the references that the sender took at enqueue time so the passed
+    // socket / pipe / file is not leaked and its peer observes the hang-up
+    // (CWE-772; unix(7) / recvmsg(2) SCM_RIGHTS: undelivered fds in a destroyed
+    // receive queue are dropped, mirroring close(2) of a delivered copy).
+    // The TABLE lock is released here, so draining (PENDING_SCM lock) and the
+    // per-fd drop (which may re-enter this function for a passed socket) cannot
+    // deadlock against the lock we just held.
+    let orphaned = crate::syscall::scm_drain_receiver(id);
+    if !orphaned.is_empty() {
+        crate::syscall::scm_drop_fds(orphaned);
+    }
     if ring {
         crate::ipc::waitlist::ring_poll_bell_for(
             crate::ipc::waitlist::PollBellSource::UnixShutdown);

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1009,6 +1009,22 @@ pub fn current_pid() -> Pid {
     threads.iter().find(|t| t.tid == tid).map(|t| t.pid).unwrap_or(0)
 }
 
+/// Resolve the owning process pid for a given thread id `tid`.
+///
+/// Returns 0 if no live thread carries that tid.  Used by the `tkill(2)`
+/// syscall path, which addresses a single thread by its kernel thread id;
+/// AstryxOS delivers signals at process granularity (one `signal_state` per
+/// process), so a thread-directed signal is resolved to its owning process
+/// here and then dispatched via the same path as `tgkill(2)`.
+pub fn pid_for_tid(tid: Tid) -> Pid {
+    #[cfg(feature = "firefox-test")]
+    let threads = thread_table_try_lock_or_panic(
+        "proc::pid_for_tid", THREAD_TABLE_DIAG_SPINS);
+    #[cfg(not(feature = "firefox-test"))]
+    let threads = THREAD_TABLE.lock();
+    threads.iter().find(|t| t.tid == tid).map(|t| t.pid).unwrap_or(0)
+}
+
 /// Resolve the effective credentials (pid, uid, gid) of the currently
 /// running process for use by syscall implementations that must record the
 /// caller's identity (e.g. AF_UNIX SO_PEERCRED capture per `unix(7)`).

--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -418,8 +418,12 @@ pub fn dispatch(
             let socket_id = arg1;
             let buf_ptr = arg2 as *mut u8;
             let buf_len = arg3 as usize;
-            match crate::net::socket::socket_recv(socket_id) {
-                Ok(data) => {
+            // Distinguish "would block" (-EAGAIN) from "orderly EOF" (0) the
+            // same way the Linux personality does — an empty receive on a
+            // live socket must not read as a 0-byte EOF, or a polled reader
+            // busy-loops.  See recv(2) / IEEE 1003.1 §recv.
+            match crate::net::socket::socket_recv_status(socket_id) {
+                Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                     let copy_len = data.len().min(buf_len);
                     if copy_len > 0 {
                         unsafe {
@@ -428,6 +432,8 @@ pub fn dispatch(
                     }
                     copy_len as i64
                 }
+                Ok(crate::net::socket::RecvOutcome::Eof) => 0,
+                Ok(crate::net::socket::RecvOutcome::WouldBlock) => -11, // EAGAIN
                 Err(_) => -11, // EAGAIN
             }
         }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2331,13 +2331,47 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let bytes_read: i64;
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
+                // Cap the STREAM drain at the next pending SCM_RIGHTS batch
+                // boundary so this recvmsg does not consume bytes PAST the
+                // stream position where the next fd batch becomes deliverable.
+                // `scm_dequeue` (below) hands back exactly ONE batch per
+                // recvmsg; a byte-stream reader reads up to a large fixed buffer
+                // per call, so without this cap a single recvmsg can drain bytes
+                // spanning several fd-bearing frames while only one batch's fds
+                // are delivered — the reader then parses a later frame whose
+                // descriptors were silently withheld and aborts ("needs
+                // unreceived descriptors").  Capping at the next batch offset
+                // makes each recvmsg return the bytes up to exactly one fd batch
+                // and deliver that batch, then stop — the AF_UNIX stream recv
+                // stops at each fd-bearing message boundary (recvmsg(2), unix(7)
+                // SCM_RIGHTS: one message's ancillary fds per recv).  Datagram /
+                // SEQPACKET reads are message-framed already, so the cap only
+                // bites the byte-stream STREAM kind; it never shrinks the read
+                // below 1 byte (the next-batch offset is strictly > consumed).
+                let eff_cap = if crate::net::unix::kind(unix_id)
+                    == crate::net::unix::SockKind::Stream
+                {
+                    let consumed = crate::net::unix::recv_consumed(unix_id);
+                    match crate::syscall::scm_next_batch_offset(unix_id, consumed) {
+                        Some(next) => {
+                            // next > consumed (guaranteed by the helper); the
+                            // gap is the bytes the reader may drain before the
+                            // batch at `next` must be delivered on its own recv.
+                            let gap = (next - consumed) as usize;
+                            cap.min(gap)
+                        }
+                        None => cap,
+                    }
+                } else {
+                    cap
+                };
                 // SMAP bracket — read_msg writes through `buf` into user
                 // memory.  Held for the call duration; we drop it before
                 // the subsequent allocations / table walks below.
                 const MSG_TRUNC: u32 = 0x20;
                 bytes_read = {
                     let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
-                    let buf = unsafe { core::slice::from_raw_parts_mut(dst, cap) };
+                    let buf = unsafe { core::slice::from_raw_parts_mut(dst, eff_cap) };
                     match crate::net::unix::read_msg(unix_id, buf) {
                         Ok((n, discarded)) => {
                             // Overwrite (not OR) msg_flags — recvmsg(2) man page.

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2251,23 +2251,37 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         if !sender_fds.is_empty() {
                             let peer_id = scm_bind_peer_id;
                             if peer_id != u64::MAX {
-                                // Bind the fd batch to the FIRST byte of this
-                                // frame — the peer recv position captured BEFORE
-                                // the data-push loop above (scm_bind_offset).
-                                // This matches the kernel's first-byte-touch
-                                // delivery: the ancillary fds attach to the
-                                // stream position where the frame begins, so the
-                                // recvmsg that first returns this frame's bytes
-                                // also carries the cmsg (deliver predicate
-                                // recv_consumed >= byte_offset becomes true the
-                                // instant the reader pops the frame's first
-                                // byte).  For a control-only frame (iov_len==0)
-                                // nothing was pushed, so pre == post == the
-                                // current tail and the batch is immediately
-                                // deliverable — unchanged from the prior tail
-                                // bind.  Per recvmsg(2) / unix(7) /
-                                // POSIX.1-2017 SCM_RIGHTS.
-                                crate::syscall::scm_queue(peer_id, scm_bind_offset, sender_fds);
+                                // Bind the fd batch so it co-delivers with the
+                                // recvmsg that returns the FIRST byte of this
+                                // frame — the first-byte-touch delivery contract
+                                // (recvmsg(2) / unix(7) / POSIX.1-2017 §2.14:
+                                // ancillary data is delivered with the data it
+                                // accompanies).  `scm_bind_offset` was captured
+                                // BEFORE the data-push loop, so it is the stream
+                                // position T where the frame begins.
+                                //
+                                // The deliver predicate is `recv_consumed >=
+                                // byte_offset` (syscall/mod.rs scm_dequeue).
+                                // Popping the frame's first byte advances
+                                // recv_consumed from T to T+1, so to gate the
+                                // batch on "the reader has touched (begun
+                                // consuming) this frame" we bind a DATA-bearing
+                                // frame to T+1 — deliverable the instant the
+                                // first byte is popped, and NOT before any byte
+                                // of the frame is read.  A control-only frame
+                                // (no data pushed, `total == 0`) carries no
+                                // bytes to touch; it sits at the stream tail and
+                                // must be immediately readable as a 0-byte
+                                // ancillary message, so it binds to T (==tail)
+                                // and the predicate fires at once.  This keeps
+                                // the dequeue predicate uniform (`>=`) while
+                                // honouring both cases.
+                                let bind_offset = if total > 0 {
+                                    scm_bind_offset + 1
+                                } else {
+                                    scm_bind_offset
+                                };
+                                crate::syscall::scm_queue(peer_id, bind_offset, sender_fds);
                                 // Wake any poller/epoll_wait parked on the peer
                                 // fd so it re-evaluates and discovers the new
                                 // readable (ancillary) message immediately,

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2100,36 +2100,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             } else {
                 0
             };
+            // Whether this frame carries any data bytes — known from the iovec
+            // lengths BEFORE the push, so the SCM batch can be queued ahead of
+            // the data it accompanies (see the ordering note below).  A frame
+            // with at least one non-empty iovec is data-bearing.
+            let frame_has_data = iovecs_owned.iter().any(|iov| iov[1] != 0);
             let mut total = 0usize;
-            for iov in &iovecs_owned {
-                let base = iov[0] as *const u8;
-                let slen = iov[1] as usize;
-                if slen == 0 { continue; }
-                // SMAP bracket — slice materialises against the user iov
-                // buffer; copy into a kernel Vec immediately so the net
-                // layer's send (which may take locks / queue) runs
-                // outside AC=1.
-                let data_owned: alloc::vec::Vec<u8> = {
-                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
-                    unsafe { core::slice::from_raw_parts(base, slen) }.to_vec()
-                };
-                let data: &[u8] = &data_owned;
-                if crate::syscall::is_unix_socket_fd(pid, fd) {
-                    let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
-                    match crate::net::unix::write(unix_id, data) {
-                        n if n >= 0 => total += n as usize,
-                        e => return e,
-                    }
-                } else {
-                    if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
-                    let socket_id = crate::syscall::get_socket_id(pid, fd);
-                    match crate::net::socket::socket_send(socket_id, data) {
-                        Ok(n) => total += n,
-                        Err("EPIPE") => return -32,
-                        Err(_) => return -104,
-                    }
-                }
-            }
+            // ORDERING (race fix): the SCM_RIGHTS batch is queued BEFORE the data
+            // bytes are pushed into the peer's recv ring.  The data push and the
+            // batch enqueue are separate critical sections (net::unix TABLE lock
+            // vs PENDING_SCM lock); if the bytes became readable first, a peer
+            // recvmsg(2) could drain the frame's bytes and compute its read cap
+            // (scm_next_batch_offset) BEFORE the batch was visible, deliver no
+            // fds, and strand the batch past the reader's position — the
+            // intermittent "needs unreceived descriptors" on the cross-process
+            // channel.  Queuing the batch first (bound to the pre-push offset)
+            // guarantees the batch is in PENDING_SCM before any of its
+            // accompanying bytes can be read, so the reader's cap always stops at
+            // it.  Per recvmsg(2) / unix(7) / POSIX.1-2017 §2.14, the ancillary
+            // data is delivered with the data it accompanies.
             // Handle SCM_RIGHTS in msg_control (Unix sockets only).
             // msghdr layout (x86_64): msg_control at byte-offset 32 (u64 index 4),
             // msg_controllen at byte-offset 40 (u64 index 5).
@@ -2269,14 +2258,16 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                 // frame to T+1 — deliverable the instant the
                                 // first byte is popped, and NOT before any byte
                                 // of the frame is read.  A control-only frame
-                                // (no data pushed, `total == 0`) carries no
-                                // bytes to touch; it sits at the stream tail and
-                                // must be immediately readable as a 0-byte
-                                // ancillary message, so it binds to T (==tail)
-                                // and the predicate fires at once.  This keeps
-                                // the dequeue predicate uniform (`>=`) while
-                                // honouring both cases.
-                                let bind_offset = if total > 0 {
+                                // (no data bytes) carries no bytes to touch; it
+                                // sits at the stream tail and must be immediately
+                                // readable as a 0-byte ancillary message, so it
+                                // binds to T (==tail) and the predicate fires at
+                                // once.  This keeps the dequeue predicate uniform
+                                // (`>=`) while honouring both cases.  `frame_has_data`
+                                // is computed from the iovec lengths above (the
+                                // batch is queued before the push, so `total` is
+                                // not yet known here).
+                                let bind_offset = if frame_has_data {
                                     scm_bind_offset + 1
                                 } else {
                                     scm_bind_offset
@@ -2294,6 +2285,40 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                     crate::ipc::waitlist::PollBellSource::UnixWrite);
                             }
                         }
+                    }
+                }
+            }
+            // Push the frame's data bytes AFTER the SCM_RIGHTS batch is queued
+            // (see the ordering note above): the batch is now in PENDING_SCM, so
+            // the instant these bytes become readable a peer recvmsg(2) will cap
+            // its read at the batch and deliver it.  `total` accumulates the
+            // bytes accepted by the transport for the syscall return value.
+            for iov in &iovecs_owned {
+                let base = iov[0] as *const u8;
+                let slen = iov[1] as usize;
+                if slen == 0 { continue; }
+                // SMAP bracket — slice materialises against the user iov
+                // buffer; copy into a kernel Vec immediately so the net
+                // layer's send (which may take locks / queue) runs
+                // outside AC=1.
+                let data_owned: alloc::vec::Vec<u8> = {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    unsafe { core::slice::from_raw_parts(base, slen) }.to_vec()
+                };
+                let data: &[u8] = &data_owned;
+                if crate::syscall::is_unix_socket_fd(pid, fd) {
+                    let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
+                    match crate::net::unix::write(unix_id, data) {
+                        n if n >= 0 => total += n as usize,
+                        e => return e,
+                    }
+                } else {
+                    if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
+                    let socket_id = crate::syscall::get_socket_id(pid, fd);
+                    match crate::net::socket::socket_send(socket_id, data) {
+                        Ok(n) => total += n,
+                        Err("EPIPE") => return -32,
+                        Err(_) => return -104,
                     }
                 }
             }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2939,6 +2939,24 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             parent_tid,
                         );
 
+                        // CLONE_VFORK prepare-to-wait: register the
+                        // child→parent wake mapping BEFORE unblocking the
+                        // child.  `wake_vfork_parent()` (called from the
+                        // child's execve(2)/exit path) acts only if it
+                        // observes `vfork_parent_tid == Some(parent_tid)`,
+                        // so the mapping must be visible before the child
+                        // can run — otherwise the child reads the initial
+                        // `None`, no-ops, and the parent parks with no waker
+                        // (lost wakeup, masked today only by the 500-tick
+                        // timeout below).  Per POSIX vfork(2): the parent
+                        // resumes only after the child execs or exits.
+                        if is_vfork {
+                            let mut threads = crate::proc::THREAD_TABLE.lock();
+                            if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+                                t.vfork_parent_tid = Some(parent_tid);
+                            }
+                        }
+
                         // Unblock the child so the scheduler can run it.
                         crate::proc::unblock_process(child_pid);
 
@@ -2947,17 +2965,44 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         // needs the parent to block so the child can set up IPC first.
                         // Use a 500-tick timeout (~5 seconds) as a safety net.
                         if is_vfork {
+                            // Commit Blocked, then recheck the completion
+                            // token under the SAME THREAD_TABLE hold.  The
+                            // child's `wake_vfork_parent()` clears
+                            // `vfork_parent_tid` to `None` when it consumes
+                            // the token; if the child already ran (it execed
+                            // or exited in the unblock→here window), the
+                            // token is already `None` and its Blocked→Ready
+                            // flip raced ahead of our `Blocked` commit, so we
+                            // must NOT park — revert to Ready and fall
+                            // through.  Lock discipline: THREAD_TABLE only,
+                            // never nested with PROCESS_TABLE; same lock the
+                            // wake side takes, so the recheck is serialized
+                            // against the child's clear+flip.
                             let mut threads = crate::proc::THREAD_TABLE.lock();
-                            if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
-                                t.vfork_parent_tid = Some(parent_tid);
-                            }
+                            let child_completed = threads.iter()
+                                .find(|t| t.tid == child_tid)
+                                .map(|t| t.vfork_parent_tid.is_none())
+                                .unwrap_or(true); // child gone (exited+reaped) ⇒ completed
                             if let Some(t) = threads.iter_mut().find(|t| t.tid == parent_tid) {
-                                t.state = crate::proc::ThreadState::Blocked;
-                                // Timeout: wake after 500 ticks (~5s) even if child hasn't signaled
-                                let now = crate::arch::x86_64::irq::get_ticks();
-                                t.wake_tick = now.saturating_add(500);
+                                if child_completed {
+                                    // Race detected: wake already happened (or
+                                    // child is gone).  Do not park.
+                                    t.state = crate::proc::ThreadState::Ready;
+                                    t.wake_tick = u64::MAX;
+                                } else {
+                                    t.state = crate::proc::ThreadState::Blocked;
+                                    // Timeout backstop: wake after 500 ticks (~5s)
+                                    // even if the child never signals.
+                                    let now = crate::arch::x86_64::irq::get_ticks();
+                                    t.wake_tick = now.saturating_add(500);
+                                }
                             }
                             drop(threads);
+                            if child_completed {
+                                // Child already completed; skip the park
+                                // entirely and return as if resumed.
+                                return child_pid as i64;
+                            }
                             // VFORK/CANARY pre-block snapshot — see helper.
                             vfork_canary_snapshot("pre_block.clone", pid as u32, parent_tid);
                             // Axis-N+1 three-channel stack-provenance snapshot
@@ -4069,21 +4114,46 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             child_tls_base,
                             if clone_flags & CLONE_SETTLS != 0 { "CLONE_SETTLS" } else { "parent" });
 
-                        // NOW unblock the child
-                        crate::proc::unblock_process(child_pid);
-
-                        // Block parent for vfork
+                        // CLONE_VFORK prepare-to-wait: register the
+                        // child→parent wake mapping BEFORE unblocking the
+                        // child, for the same lost-wakeup reason documented
+                        // at the clone(56) site above (wake_vfork_parent acts
+                        // only on `Some(parent_tid)`).  Per POSIX vfork(2).
                         if is_vfork {
                             let mut threads = crate::proc::THREAD_TABLE.lock();
                             if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
                                 t.vfork_parent_tid = Some(parent_tid);
                             }
+                        }
+
+                        // NOW unblock the child
+                        crate::proc::unblock_process(child_pid);
+
+                        // Block parent for vfork
+                        if is_vfork {
+                            // Commit Blocked, then recheck the completion
+                            // token under the SAME THREAD_TABLE hold — see the
+                            // clone(56) site above for the full race analysis
+                            // and lock-ordering reasoning.
+                            let mut threads = crate::proc::THREAD_TABLE.lock();
+                            let child_completed = threads.iter()
+                                .find(|t| t.tid == child_tid)
+                                .map(|t| t.vfork_parent_tid.is_none())
+                                .unwrap_or(true); // child gone (exited+reaped) ⇒ completed
                             if let Some(t) = threads.iter_mut().find(|t| t.tid == parent_tid) {
-                                t.state = crate::proc::ThreadState::Blocked;
-                                let now = crate::arch::x86_64::irq::get_ticks();
-                                t.wake_tick = now.saturating_add(500);
+                                if child_completed {
+                                    t.state = crate::proc::ThreadState::Ready;
+                                    t.wake_tick = u64::MAX;
+                                } else {
+                                    t.state = crate::proc::ThreadState::Blocked;
+                                    let now = crate::arch::x86_64::irq::get_ticks();
+                                    t.wake_tick = now.saturating_add(500);
+                                }
                             }
                             drop(threads);
+                            if child_completed {
+                                return child_pid as i64;
+                            }
                             // VFORK/CANARY pre-block snapshot — see helper.
                             vfork_canary_snapshot("pre_block.clone3", pid as u32, parent_tid);
                             // Axis-N+1 three-channel stack-provenance snapshot

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2382,18 +2382,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             } else {
                 if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
-                bytes_read = match crate::net::socket::socket_recv(socket_id) {
-                    Ok(data) => {
-                        if data.is_empty() { 0 }
-                        else {
-                            let n = data.len().min(cap);
-                            unsafe {
-                                let _g = crate::arch::x86_64::smap::UserGuard::new();
-                                core::ptr::copy_nonoverlapping(data.as_ptr(), dst, n);
-                            }
-                            n as i64
+                // Per recvmsg(2) / IEEE 1003.1 §recv: on a non-blocking
+                // socket an empty receive queue must return -1/EAGAIN, while
+                // an orderly peer shutdown (EOF) returns 0.  Collapsing both
+                // to 0 (the prior `Ok(empty) => 0`) lied to the caller: a
+                // polled IPC reactor read the 0 as a readable edge and
+                // re-issued recvmsg in a tight loop, never yielding.  Use the
+                // status-aware recv so the two cases get their correct
+                // returns (WouldBlock → -EAGAIN, Eof → 0).
+                bytes_read = match crate::net::socket::socket_recv_status(socket_id) {
+                    Ok(crate::net::socket::RecvOutcome::Data(data)) => {
+                        let n = data.len().min(cap);
+                        unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            core::ptr::copy_nonoverlapping(data.as_ptr(), dst, n);
                         }
+                        n as i64
                     }
+                    Ok(crate::net::socket::RecvOutcome::Eof) => 0,
+                    Ok(crate::net::socket::RecvOutcome::WouldBlock) => -11, // EAGAIN
                     Err(_) => -11,
                 };
             }
@@ -5770,8 +5777,14 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
         return ret;
     } else if crate::syscall::is_socket_fd(pid, fd as usize) {
         let socket_id = crate::syscall::get_socket_id(pid, fd as usize);
-        return match crate::net::socket::socket_recv(socket_id) {
-            Ok(data) => {
+        // Per read(2) / recv(2) / IEEE 1003.1: an empty receive on a
+        // non-blocking socket is -1/EAGAIN; an orderly peer shutdown is a
+        // 0-byte EOF.  The status-aware recv keeps the two apart so a polled
+        // reader does not mistake an empty queue for EOF and re-read in a
+        // busy loop (mirrors the pipe path above, which already separates
+        // EOF from would-block).
+        return match crate::net::socket::socket_recv_status(socket_id) {
+            Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                 let n = data.len().min(count);
                 unsafe {
                     let _g = crate::arch::x86_64::smap::UserGuard::new();
@@ -5779,6 +5792,8 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
                 }
                 n as i64
             }
+            Ok(crate::net::socket::RecvOutcome::Eof) => 0,
+            Ok(crate::net::socket::RecvOutcome::WouldBlock) => -11, // EAGAIN
             Err(_) => -11, // EAGAIN
         };
     } else if crate::syscall::is_eventfd_fd(pid, fd as usize) {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2071,6 +2071,35 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let _g = crate::arch::x86_64::smap::UserGuard::new();
                 core::slice::from_raw_parts(iov_ptr as *const [u64; 2], iov_len as usize).to_vec()
             };
+            // SCM_RIGHTS first-byte bind: capture the peer's recv-stream
+            // position BEFORE any data iovec of this frame is pushed, so a
+            // queued ancillary fd batch binds to the FIRST byte of the frame
+            // it accompanies — not its tail.  Per recvmsg(2) / unix(7) /
+            // POSIX.1-2017, the ancillary SCM_RIGHTS data is delivered with
+            // the message data it accompanies; the receiver's IPC reader
+            // parses a frame whose header announces N handles and requires
+            // those fds on the SAME recvmsg that first returns the frame's
+            // bytes.  Binding to the tail (post-push) withholds the fds until
+            // the reader has drained EVERY byte of the frame, which fails when
+            // the reader consumes the frame in pieces (e.g. reads the header,
+            // sees num_handles>=1, then expects the fds already present) —
+            // surfacing as a fatal "needs unreceived descriptors".  The
+            // deliver predicate is `recv_consumed >= byte_offset`
+            // (syscall/mod.rs scm_dequeue); with byte_offset = the frame's
+            // starting recv position, the batch becomes deliverable the
+            // instant the reader pops the frame's first byte.  Computed once
+            // here (under the unix TABLE lock, briefly) for unix sockets only.
+            let scm_bind_peer_id: u64 = if crate::syscall::is_unix_socket_fd(pid, fd) {
+                let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
+                crate::net::unix::get_peer(unix_id)
+            } else {
+                u64::MAX
+            };
+            let scm_bind_offset: u64 = if scm_bind_peer_id != u64::MAX {
+                crate::net::unix::enqueue_offset_for(scm_bind_peer_id)
+            } else {
+                0
+            };
             let mut total = 0usize;
             for iov in &iovecs_owned {
                 let base = iov[0] as *const u8;
@@ -2220,23 +2249,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             } else { Vec::new() }
                         };
                         if !sender_fds.is_empty() {
-                            let unix_id  = crate::syscall::get_unix_socket_id(pid, fd);
-                            let peer_id  = crate::net::unix::get_peer(unix_id);
+                            let peer_id = scm_bind_peer_id;
                             if peer_id != u64::MAX {
-                                // Bind the fd batch to the peer's current
-                                // recv-stream position.  Any data iovecs in
-                                // this same sendmsg were just pushed into the
-                                // peer's ring above, so capturing the offset
-                                // *after* those pushes attaches the fds at the
-                                // tail of this frame's bytes (offset == bytes
-                                // written so far).  For a control-only frame
-                                // (iov_len==0) nothing was pushed, so the
-                                // offset is the current tail and the batch is
-                                // immediately deliverable.  Per recvmsg(2) /
-                                // unix(7) / POSIX.1-2017 SCM_RIGHTS.
-                                let byte_offset =
-                                    crate::net::unix::enqueue_offset_for(peer_id);
-                                crate::syscall::scm_queue(peer_id, byte_offset, sender_fds);
+                                // Bind the fd batch to the FIRST byte of this
+                                // frame — the peer recv position captured BEFORE
+                                // the data-push loop above (scm_bind_offset).
+                                // This matches the kernel's first-byte-touch
+                                // delivery: the ancillary fds attach to the
+                                // stream position where the frame begins, so the
+                                // recvmsg that first returns this frame's bytes
+                                // also carries the cmsg (deliver predicate
+                                // recv_consumed >= byte_offset becomes true the
+                                // instant the reader pops the frame's first
+                                // byte).  For a control-only frame (iov_len==0)
+                                // nothing was pushed, so pre == post == the
+                                // current tail and the batch is immediately
+                                // deliverable — unchanged from the prior tail
+                                // bind.  Per recvmsg(2) / unix(7) /
+                                // POSIX.1-2017 SCM_RIGHTS.
+                                crate::syscall::scm_queue(peer_id, scm_bind_offset, sender_fds);
                                 // Wake any poller/epoll_wait parked on the peer
                                 // fd so it re-evaluates and discovers the new
                                 // readable (ancillary) message immediately,
@@ -4993,10 +5024,25 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         // -1 with errno=ENODATA, and poisoned pthread's internal tkill() usage.
         // See arch-syscall.h: 192 lgetxattr .. 199 fremovexattr; 200 tkill; 201 time.
         192 | 193 | 194 | 195 | 196 | 197 | 198 | 199 => -61, // ENODATA
-        // 200: tkill(tid, sig) — minimal stub: forward to tgkill in the current pgrp.
-        // Most modern code uses tgkill (234); tkill exists for pre-2.5.75 compat.
-        // Returning ENOSYS is safe because glibc's pthread_kill fallback handles it.
-        200 => -38, // ENOSYS
+        // 200: tkill(tid, sig) — send signal `sig` to the single thread `tid`.
+        // tkill(2) addresses a thread directly by its kernel thread id (the
+        // obsolete-but-still-used predecessor of tgkill(2)).  musl's raise(3)
+        // and the abort(3) re-raise path issue tkill(self->tid, sig); returning
+        // ENOSYS here breaks that path (a crashing thread cannot re-raise to
+        // produce its default-action termination).  AstryxOS delivers signals
+        // at process granularity (one signal_state per process), so resolve the
+        // target thread's owning process and dispatch via the same path as
+        // tgkill(2) (signal::kill).  Per tkill(2): ESRCH if no such thread.
+        200 => {
+            let tid = arg1;
+            let sig = arg2 as u8;
+            let owner_pid = crate::proc::pid_for_tid(tid);
+            if owner_pid == 0 {
+                -3 // ESRCH — no thread carries this tid
+            } else {
+                crate::signal::kill(owner_pid, sig)
+            }
+        }
         // 201: time(tloc) — seconds since Epoch; optionally write to *tloc.
         // glibc calls this as a vDSO fallback; returning an error here makes
         // `time(NULL)` appear to fail with the kernel's errno, confusing callers.

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2191,6 +2191,27 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                                     crate::ipc::pipe::pipe_add_reader(
                                                         fdesc.inode);
                                                 }
+                                            } else if fdesc.file_type
+                                                == crate::vfs::FileType::RegularFile
+                                                && fdesc.mount_idx != usize::MAX
+                                            {
+                                                // Regular file / memfd: VFS tracks
+                                                // inode lifetime by scanning open
+                                                // fd tables (unlink-on-last-close),
+                                                // but this passed copy is in flight
+                                                // in PENDING_SCM and NOT yet in any
+                                                // fd table, so the scan cannot see
+                                                // it.  Pin the inode so a sender's
+                                                // close(2) of its (possibly the
+                                                // last named) copy of an unlinked
+                                                // memfd cannot free the inode out
+                                                // from under the un-received
+                                                // descriptor — the Mozilla
+                                                // shared-surface fd handoff.
+                                                // Balanced by unpin on delivery or
+                                                // on drain (scm_drop_fds path).
+                                                crate::vfs::pin_inode(
+                                                    fdesc.mount_idx, fdesc.inode);
                                             }
                                         }
                                         cloned
@@ -2309,6 +2330,19 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 if bytes_read >= 0 {
                     let consumed = crate::net::unix::recv_consumed(unix_id);
                     if let Some(scm_fds) = crate::syscall::scm_dequeue(unix_id, consumed) {
+                        // Regular-file / memfd descriptors were pinned at enqueue
+                        // (PENDING_SCM holds an inode reference invisible to the
+                        // VFS fd-table scan).  Once installed in the receiver's
+                        // fd table below, the slot itself keeps the inode alive,
+                        // so the in-flight pin can be released.  Snapshot the
+                        // (mount_idx, inode) pairs BEFORE the descriptors are
+                        // moved into the table; unpin AFTER PROCESS_TABLE is
+                        // dropped (unpin_inode also takes PROCESS_TABLE).
+                        let to_unpin: Vec<(usize, u64)> = scm_fds.iter()
+                            .filter(|f| f.file_type == crate::vfs::FileType::RegularFile
+                                        && f.mount_idx != usize::MAX)
+                            .map(|f| (f.mount_idx, f.inode))
+                            .collect();
                         // Allocate fds in the receiver's process.
                         let new_fd_nums: Vec<i32> = {
                             let mut procs = crate::proc::PROCESS_TABLE.lock();
@@ -2327,6 +2361,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                 }).collect()
                             } else { Vec::new() }
                         };
+                        // Balance the enqueue-time pin now that the fd-table slot
+                        // holds the reference (PROCESS_TABLE lock released above).
+                        for (m, ino) in to_unpin {
+                            crate::vfs::unpin_inode(m, ino);
+                        }
                         // Write SCM_RIGHTS cmsghdr into msg_control.  All
                         // reads/writes here target user memory — single
                         // SMAP guard spanning the whole block.
@@ -9529,6 +9568,19 @@ fn sys_memfd_create(_name: u64, flags: u64) -> i64 {
             memfd_seals_register(inode);
         }
     }
+
+    // Per memfd_create(2): "The file is automatically removed (unlinked) ...
+    // The memory is freed when all references to the file are dropped."  Unlink
+    // the backing entry now so the memfd is a true anonymous inode with no
+    // visible name; the open fd (and any dup / fork / SCM_RIGHTS-passed copy)
+    // holds it alive via the kernel's unlink-on-last-close machinery, and it is
+    // freed once the last reference closes.  This makes a memfd handed between
+    // processes (the Mozilla shared-memory / CrossProcessPaint surface fd) safe
+    // *by construction* — the inode cannot outlive its last holder and leak,
+    // nor be freed while an SCM_RIGHTS-passed copy is in flight (PINNED_INODES).
+    // remove() on an open file performs a deferred delete, so the just-opened
+    // fd stays fully usable.
+    let _ = crate::vfs::remove(path_str);
 
     fd_num as i64
 }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2158,7 +2158,42 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                         core::ptr::read_unaligned(fd_arr.add(i))
                                     } as usize;
                                     if fd_n < p.file_descriptors.len() {
-                                        p.file_descriptors[fd_n].clone()
+                                        let cloned = p.file_descriptors[fd_n].clone();
+                                        // SCM_RIGHTS duplicates the open file
+                                        // description into the receiver — the
+                                        // passed fd "refers to the same open
+                                        // file description as the corresponding
+                                        // descriptor in the sending process"
+                                        // (unix(7) SCM_RIGHTS, POSIX.1-2017
+                                        // §2.14).  Bump the underlying object's
+                                        // refcount so that when the sender later
+                                        // close(2)s its copy, the shared socket
+                                        // /pipe is NOT torn down and the peer is
+                                        // not spuriously hung up (CWE-416 — the
+                                        // close-resets-slot/shuts-peer path).
+                                        // Mirrors the dup(2)/fork(2) inc_ref.
+                                        if let Some(ref fdesc) = cloned {
+                                            if fdesc.file_type
+                                                == crate::vfs::FileType::Socket
+                                                && fdesc.flags
+                                                    & crate::syscall::UNIX_SOCKET_FLAG != 0
+                                            {
+                                                crate::net::unix::inc_ref(fdesc.inode);
+                                            } else if fdesc.file_type
+                                                == crate::vfs::FileType::Pipe
+                                                && fdesc.mount_idx == usize::MAX
+                                                && fdesc.flags & 0x8000_0000 != 0
+                                            {
+                                                if fdesc.flags & 1 == 1 {
+                                                    crate::ipc::pipe::pipe_add_writer(
+                                                        fdesc.inode);
+                                                } else {
+                                                    crate::ipc::pipe::pipe_add_reader(
+                                                        fdesc.inode);
+                                                }
+                                            }
+                                        }
+                                        cloned
                                     } else { None }
                                 }).collect()
                             } else { Vec::new() }
@@ -2167,7 +2202,30 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             let unix_id  = crate::syscall::get_unix_socket_id(pid, fd);
                             let peer_id  = crate::net::unix::get_peer(unix_id);
                             if peer_id != u64::MAX {
-                                crate::syscall::scm_queue(peer_id, sender_fds);
+                                // Bind the fd batch to the peer's current
+                                // recv-stream position.  Any data iovecs in
+                                // this same sendmsg were just pushed into the
+                                // peer's ring above, so capturing the offset
+                                // *after* those pushes attaches the fds at the
+                                // tail of this frame's bytes (offset == bytes
+                                // written so far).  For a control-only frame
+                                // (iov_len==0) nothing was pushed, so the
+                                // offset is the current tail and the batch is
+                                // immediately deliverable.  Per recvmsg(2) /
+                                // unix(7) / POSIX.1-2017 SCM_RIGHTS.
+                                let byte_offset =
+                                    crate::net::unix::enqueue_offset_for(peer_id);
+                                crate::syscall::scm_queue(peer_id, byte_offset, sender_fds);
+                                // Wake any poller/epoll_wait parked on the peer
+                                // fd so it re-evaluates and discovers the new
+                                // readable (ancillary) message immediately,
+                                // rather than waiting for the resync floor.
+                                // PENDING_SCM and the unix TABLE lock are both
+                                // already released here (scm_queue takes only
+                                // PENDING_SCM, briefly), so this honours the
+                                // drop-the-lock-before-ring discipline.
+                                crate::ipc::waitlist::ring_poll_bell_for(
+                                    crate::ipc::waitlist::PollBellSource::UnixWrite);
                             }
                         }
                     }
@@ -2224,12 +2282,33 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             }
                             n as i64
                         }
+                        // EAGAIN on an empty data ring is *not* the final
+                        // answer when a deliverable SCM_RIGHTS batch is
+                        // queued: a control-only ancillary frame (iov_len==0)
+                        // is a readable message that recvmsg(2) must return
+                        // with 0 data bytes and the cmsg attached (recvmsg(2),
+                        // unix(7), POSIX.1-2017 SCM_RIGHTS).  Promote to a
+                        // 0-byte success so the SCM-delivery block below runs;
+                        // msg_flags clears (no MSG_TRUNC for an empty read).
+                        Err(-11) if crate::syscall::has_scm_deliverable(
+                            unix_id, crate::net::unix::recv_consumed(unix_id)) =>
+                        {
+                            unsafe {
+                                let flags_ptr = (arg2 + 48) as *mut u32;
+                                core::ptr::write_unaligned(flags_ptr, 0u32);
+                            }
+                            0i64
+                        }
                         Err(e) => e,
                     }
                 };
                 // Deliver pending SCM_RIGHTS fds into receiver's fd table.
+                // Bound the batch to the reader's now-current stream position
+                // (recv_consumed) so an earlier data-only frame's reader does
+                // not pick up a later frame's fds.
                 if bytes_read >= 0 {
-                    if let Some(scm_fds) = crate::syscall::scm_dequeue(unix_id) {
+                    let consumed = crate::net::unix::recv_consumed(unix_id);
+                    if let Some(scm_fds) = crate::syscall::scm_dequeue(unix_id, consumed) {
                         // Allocate fds in the receiver's process.
                         let new_fd_nums: Vec<i32> = {
                             let mut procs = crate::proc::PROCESS_TABLE.lock();
@@ -5195,7 +5274,13 @@ fn sys_select_linux(
                 || crate::ipc::pipe::pipe_writer_closed(pid_id)
         } else if crate::syscall::is_unix_socket_fd(pid, fd) {
             let uid = crate::syscall::get_unix_socket_id(pid, fd);
-            crate::net::unix::has_data(uid) || crate::net::unix::has_pending(uid)
+            // A reached SCM_RIGHTS batch (control-only fd handoff, iov_len==0)
+            // is a readable message per recvmsg(2) / unix(7) / POSIX.1-2017,
+            // even with zero data bytes — surface it as select(2) readable.
+            crate::net::unix::has_data(uid)
+                || crate::net::unix::has_pending(uid)
+                || crate::syscall::has_scm_deliverable(
+                    uid, crate::net::unix::recv_consumed(uid))
         } else if crate::syscall::is_socket_fd(pid, fd) {
             crate::net::socket::socket_has_data(crate::syscall::get_socket_id(pid, fd))
         } else if crate::syscall::is_timerfd_fd(pid, fd) {
@@ -9622,7 +9707,15 @@ fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
                     // stuck-producer pattern `epoll(7)` / `poll(2)` avoid.
                     let mut ev = if crate::net::unix::writable(inode) { EPOLLOUT } else { 0 };
                     let has_d = crate::net::unix::has_data(inode);
-                    if has_d {
+                    // A reached SCM_RIGHTS batch confers EPOLLIN even with an
+                    // empty data ring: a control-only ancillary frame
+                    // (iov_len==0) IS a readable message per recvmsg(2) /
+                    // unix(7) / POSIX.1-2017 SCM_RIGHTS, and epoll_wait(2)
+                    // must report it so the receiver recvmsg's the fd instead
+                    // of parking forever on a pure fd handoff.
+                    let has_scm = crate::syscall::has_scm_deliverable(
+                        inode, crate::net::unix::recv_consumed(inode));
+                    if has_d || has_scm {
                         ev |= EPOLLIN;
                     }
                     // `epoll(7)` distinguishes a read-side half-close from a

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -483,19 +483,106 @@ pub fn has_scm_deliverable(receiver_id: u64, consumed: u64) -> bool {
 }
 
 /// Pop the *earliest* deliverable `SCM_RIGHTS` batch for `receiver_id` — the
-/// oldest batch whose bound `byte_offset` the reader has now reached
-/// (`consumed >= byte_offset`).  Returns None if nothing is pending or the
-/// pending batch(es) still sit beyond the reader's current position (the
-/// reader must drain the intervening data bytes first).  Delivering only the
-/// reached batch keeps fds attached to their originating stream frame.
+/// deliverable batch with the LOWEST bound `byte_offset` (the stream-position
+/// nearest the reader), among those whose offset the reader has now reached
+/// (`consumed >= byte_offset`).  Returns None if nothing is pending or every
+/// pending batch still sits beyond the reader's current position (the reader
+/// must drain the intervening data bytes first).  Delivering the lowest-offset
+/// batch keeps fds attached to their originating stream frame.
+///
+/// Selecting by minimum `byte_offset` — rather than by Vec push order — is
+/// load-bearing for correctness under concurrent `sendmsg(2)` to the same
+/// peer.  The send path captures the bind offset (under the unix TABLE lock)
+/// and pushes the batch (under the PENDING_SCM lock) in two separate critical
+/// sections, so two interleaved senders can push their batches into the Vec in
+/// the opposite order to their byte offsets.  A naive "first matching Vec
+/// entry" pop would then hand the reader the LATER frame's fds first, attaching
+/// the wrong descriptors to a frame — a data-integrity bug.  Per `unix(7)` /
+/// `recvmsg(2)` SCM_RIGHTS, ancillary data attaches to a stream *position*; we
+/// therefore deliver strictly in byte-offset order regardless of push order.
 pub fn scm_dequeue(receiver_id: u64, consumed: u64) -> Option<Vec<crate::vfs::FileDescriptor>> {
     let mut q = PENDING_SCM.lock();
-    // Earliest in FIFO order: the first matching entry, since batches are
-    // pushed in send order and a later batch can never have a smaller
-    // byte_offset than an earlier one for the same receiver.
-    let pos = q.iter().position(
-        |b| b.receiver_id == receiver_id && consumed >= b.byte_offset)?;
+    // Pick the deliverable batch with the smallest byte_offset.  Ties (two
+    // batches bound to the exact same offset, e.g. two control-only frames
+    // racing at the same stream tail) fall back to Vec push order via the
+    // stable `min_by_key`, which is the best available approximation of send
+    // order when the offsets are indistinguishable.
+    let pos = q.iter().enumerate()
+        .filter(|(_, b)| b.receiver_id == receiver_id && consumed >= b.byte_offset)
+        .min_by_key(|(_, b)| b.byte_offset)
+        .map(|(i, _)| i)?;
     Some(q.remove(pos).fds)
+}
+
+/// Drain *all* pending `SCM_RIGHTS` batches destined for `receiver_id` and
+/// return their queued `FileDescriptor`s, removing the batches from the queue.
+///
+/// Called when a receiver socket is torn down (final `close(2)` / process
+/// exit) before it has `recvmsg`'d the queued ancillary data.  Per the AF_UNIX
+/// SCM_RIGHTS contract, fds that were placed in a receive queue but never
+/// delivered must be released when that queue is destroyed (each underlying
+/// open file description gets the matching reference drop, mirroring the
+/// `close(2)` of a delivered copy).  Without this drain the references that
+/// [`scm_queue`]'s callers took at enqueue time leak (CWE-772): the passed
+/// socket / pipe / file is never torn down and its peer never observes the
+/// hang-up.  The caller is responsible for balancing each returned descriptor's
+/// underlying-object reference via [`scm_drop_fds`].
+pub fn scm_drain_receiver(receiver_id: u64) -> Vec<crate::vfs::FileDescriptor> {
+    let mut q = PENDING_SCM.lock();
+    let mut out = Vec::new();
+    // Retain only the batches NOT destined for this receiver; collect the rest.
+    let mut i = 0;
+    while i < q.len() {
+        if q[i].receiver_id == receiver_id {
+            let batch = q.remove(i);
+            out.extend(batch.fds);
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Release the underlying-object reference for each `FileDescriptor` that was
+/// queued for SCM_RIGHTS delivery but never received (see
+/// [`scm_drain_receiver`]).  This is the exact inverse of the reference bumped
+/// at enqueue time in the `sendmsg(2)` SCM path and must mirror that per-type
+/// dispatch so no socket / pipe reference leaks (CWE-772):
+///
+///   * AF_UNIX socket fd → `net::unix::close` drops one open-file-description
+///     reference; the last drop tears the slot down and hangs up the peer.
+///   * anonymous pipe end → drop the reader/writer count so the pipe's other
+///     end observes EOF / EPIPE per `read(2)` / `write(2)`.
+///   * regular file / memfd → drop the inode pin taken at enqueue time
+///     (`vfs::pin_inode`); when that was the last reference to a deferred-
+///     deleted (unlinked) memfd, the inode is freed by `unpin_inode`.  Without
+///     this the pin (and thus the inode) would leak forever.
+///   * eventfd / other sentinel fds → no per-object refcount to balance.
+///
+/// MUST be called with no unix `TABLE` / `PENDING_SCM` lock held — it re-enters
+/// `net::unix::close`, which takes the unix TABLE lock.
+pub fn scm_drop_fds(fds: Vec<crate::vfs::FileDescriptor>) {
+    for fd in fds {
+        if fd.file_type == crate::vfs::FileType::Socket
+            && fd.flags & UNIX_SOCKET_FLAG != 0
+        {
+            crate::net::unix::close(fd.inode);
+        } else if fd.file_type == crate::vfs::FileType::Pipe
+            && fd.mount_idx == usize::MAX
+            && fd.flags & 0x8000_0000 != 0
+        {
+            if fd.flags & 1 == 1 {
+                crate::ipc::pipe::pipe_close_writer(fd.inode);
+            } else {
+                crate::ipc::pipe::pipe_close_reader(fd.inode);
+            }
+        } else if fd.file_type == crate::vfs::FileType::RegularFile
+            && fd.mount_idx != usize::MAX
+        {
+            crate::vfs::unpin_inode(fd.mount_idx, fd.inode);
+        }
+        // eventfds / other sentinel fds: no per-object refcount to drop.
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -495,6 +495,31 @@ pub fn has_scm_deliverable(receiver_id: u64, consumed: u64) -> bool {
     q.iter().any(|b| b.receiver_id == receiver_id && consumed >= b.byte_offset)
 }
 
+/// Lowest pending `SCM_RIGHTS` batch bound-offset for `receiver_id` that the
+/// reader has NOT yet reached (`byte_offset > consumed`).  Returns None when no
+/// pending batch sits ahead of the reader's current drained position.
+///
+/// This is the recv-side read CAP for AF_UNIX SOCK_STREAM: a `recvmsg(2)` must
+/// not drain bytes *past* the stream position at which the next queued fd batch
+/// becomes deliverable, because each `scm_dequeue` hands back exactly ONE batch.
+/// A byte-stream reader (e.g. a length-prefixed IPC channel) reads up to a large
+/// fixed buffer per `recvmsg`, so without a cap a single recvmsg can drain bytes
+/// that span MULTIPLE fd-bearing frames while only ONE batch is delivered — the
+/// reader then parses a later frame whose descriptors were silently withheld and
+/// aborts ("needs unreceived descriptors").  Capping the drain at the next
+/// batch's deliver-offset makes each recvmsg return the bytes up to exactly one
+/// fd batch and deliver that batch, then stop — mirroring the AF_UNIX stream
+/// recv that stops at each fd-bearing message boundary (recvmsg(2), unix(7)
+/// SCM_RIGHTS: ancillary data is delivered with the data it accompanies, one
+/// message's fds per recv).
+pub fn scm_next_batch_offset(receiver_id: u64, consumed: u64) -> Option<u64> {
+    let q = PENDING_SCM.lock();
+    q.iter()
+        .filter(|b| b.receiver_id == receiver_id && b.byte_offset > consumed)
+        .map(|b| b.byte_offset)
+        .min()
+}
+
 /// Pop the *earliest* deliverable `SCM_RIGHTS` batch for `receiver_id` — the
 /// deliverable batch with the LOWEST bound `byte_offset` (the stream-position
 /// nearest the reader), among those whose offset the reader has now reached

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2284,17 +2284,89 @@ pub(crate) fn sys_waitpid(pid: i64, options: u32) -> i64 {
 
     // Block the parent thread until a child exits.
     // We use wake_tick = u64::MAX-1 as a sentinel for "blocked in waitpid".
-    // exit_thread() wakes us when a child process becomes a zombie.
+    // exit_thread() / exit_group_inner() wake us when a child process becomes
+    // a zombie.
+    //
+    // ── Prepare-to-wait discipline (lost-wakeup close) ──────────────────────
+    //
+    // The wake side writes `ProcessState::Zombie` into PROCESS_TABLE first
+    // (lock dropped), THEN acquires THREAD_TABLE and flips this parent
+    // Blocked→Ready *only if* it observes `state == Blocked && wake_tick ==
+    // u64::MAX-1`.  The immediate-reap check above reads PROCESS_TABLE and
+    // drops it; if a child becomes a zombie in the window between that drop
+    // and this thread committing `Blocked`, the wake-side flip runs while we
+    // are still Running and is a no-op — the wake is lost.  Because the
+    // sentinel `wake_tick = u64::MAX-1` is scan-ineligible (the scheduler's
+    // due-wake scan requires `wake_tick != u64::MAX && now >= wake_tick`,
+    // never true for MAX-1) and this parker is not registered on any poll
+    // bell, the park would then never self-terminate → permanent hang of
+    // wait4(2).  POSIX wait(2): a child that has ALREADY terminated must be
+    // reapable without blocking.
+    //
+    // We close the window with the standard park-then-recheck handshake (the
+    // same shape as the poll/event waitlist in `ipc::waitlist`): commit
+    // `Blocked` under THREAD_TABLE, drop it, and THEN re-poll PROCESS_TABLE
+    // for a reapable zombie.  If a zombie is now visible we revert
+    // Blocked→Ready and reap without ever calling `schedule()`.
+    //
+    // Lock ordering / no-deadlock: this routine NEVER holds THREAD_TABLE and
+    // PROCESS_TABLE simultaneously — it takes THREAD_TABLE (commit Blocked),
+    // releases it, then takes PROCESS_TABLE (recheck via
+    // `crate::proc::waitpid`).  That matches the existing exit-path invariant
+    // ("Never hold THREAD_TABLE and PROCESS_TABLE simultaneously") and the
+    // wake side's own discipline (PROCESS_TABLE then THREAD_TABLE,
+    // sequentially, never nested), so no new lock-order edge is introduced.
+    //
+    // Why this is race-free against the concurrent child exit:
+    //   • If the child writes Zombie before we commit Blocked, our post-commit
+    //     recheck observes the zombie and reaps (no park).
+    //   • If the child writes Zombie after our recheck observed no zombie,
+    //     then our `Blocked` store happened-before that recheck, which
+    //     happened-before the child's Zombie write, which happens-before the
+    //     child's THREAD_TABLE flip — so the flip sees `Blocked` and wakes us.
+    //   • If the child writes Zombie strictly between our commit and recheck,
+    //     our recheck observes the zombie and reaps; we revert our own state
+    //     so we don't fall through still-Blocked.
     let max_attempts = 200; // Safety limit: ~200 wakeup cycles (~20 seconds at 100Hz)
+    let tid = crate::proc::current_tid();
     for _ in 0..max_attempts {
+        // (1) Commit Blocked under THREAD_TABLE, then drop the lock.
         {
-            let tid = crate::proc::current_tid();
             let mut threads = crate::proc::THREAD_TABLE.lock();
             if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
                 t.state = crate::proc::ThreadState::Blocked;
                 t.wake_tick = u64::MAX - 1; // sentinel: blocked in waitpid
             }
         }
+
+        // (2) Recheck PROCESS_TABLE for a reapable zombie WITHOUT holding
+        //     THREAD_TABLE.  A child that became a zombie in the
+        //     immediate-reap→commit window is caught here.  On a hit, revert
+        //     our own state to Ready (so a missed wake can't leave us Blocked)
+        //     and reap without parking.
+        if let Some((child_pid, exit_code)) = crate::proc::waitpid(parent_pid, pid) {
+            {
+                let mut threads = crate::proc::THREAD_TABLE.lock();
+                if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                    if t.state == crate::proc::ThreadState::Blocked
+                        && t.wake_tick == u64::MAX - 1
+                    {
+                        t.state = crate::proc::ThreadState::Ready;
+                        t.wake_tick = u64::MAX;
+                    }
+                }
+            }
+            crate::serial_println!(
+                "[SYSCALL] waitpid: child PID {} exited with code {} (reaped without park)",
+                child_pid, exit_code
+            );
+            return child_pid as i64;
+        }
+
+        // (3) No zombie visible while we hold the Blocked commit → park.  A
+        //     wake that arrives after step (2) but before/at schedule() finds
+        //     us already Blocked and flips us Ready, so schedule() (or the
+        //     scheduler tick) returns us promptly.
         crate::sched::schedule();
 
         // We were woken up — try to reap.

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -436,19 +436,66 @@ where
 }
 
 /// SCM_RIGHTS pending fd transfers.
-/// Key = receiving unix socket id.  Value = list of FileDescriptors to deliver.
-static PENDING_SCM: Mutex<Vec<(u64, Vec<crate::vfs::FileDescriptor>)>> = Mutex::new(Vec::new());
+///
+/// One entry = one ancillary-data batch sent by a `sendmsg(2)` carrying an
+/// `SCM_RIGHTS` control message.  Per `recvmsg(2)` / `unix(7)` /
+/// POSIX.1-2017, such a frame is a *readable message* in its own right — even
+/// when its data payload is empty (`iov_len == 0`, a control-only fd handoff)
+/// — and `recvmsg` must return it with the cmsg attached.
+///
+/// Each batch is bound to the receiving socket's absolute recv-stream
+/// position (`byte_offset`) captured at enqueue time, so that:
+///   * an ancillary-only frame still confers read-readiness (it sits at the
+///     stream tail with no preceding unread bytes, hence is immediately
+///     deliverable), and
+///   * a reader draining an earlier *data-only* frame does not prematurely
+///     receive a *later* frame's fds — the batch is withheld until the reader
+///     has consumed every byte that preceded it (`recv_consumed >=
+///     byte_offset`).  This keys delivery on a stream *position* rather than
+///     merely on the receiver uid.
+struct ScmBatch {
+    receiver_id: u64,
+    byte_offset: u64,
+    fds: Vec<crate::vfs::FileDescriptor>,
+}
+static PENDING_SCM: Mutex<Vec<ScmBatch>> = Mutex::new(Vec::new());
 
-/// Queue SCM_RIGHTS fds to be delivered when `receiver_id` calls recvmsg.
-pub fn scm_queue(receiver_id: u64, fds: Vec<crate::vfs::FileDescriptor>) {
-    PENDING_SCM.lock().push((receiver_id, fds));
+/// Queue an `SCM_RIGHTS` fd batch for delivery when `receiver_id` next
+/// drains its recv stream past `byte_offset` (see [`scm_dequeue`]).
+/// `byte_offset` is the receiver's absolute recv position at send time —
+/// for an ancillary-only frame this is the current stream tail.
+pub fn scm_queue(receiver_id: u64, byte_offset: u64, fds: Vec<crate::vfs::FileDescriptor>) {
+    PENDING_SCM.lock().push(ScmBatch { receiver_id, byte_offset, fds });
 }
 
-/// Pop SCM_RIGHTS fds for `receiver_id`.  Returns None if nothing pending.
-pub fn scm_dequeue(receiver_id: u64) -> Option<Vec<crate::vfs::FileDescriptor>> {
+/// Returns true if `receiver_id` has at least one `SCM_RIGHTS` batch that is
+/// already deliverable — its bound `byte_offset` has been reached by the
+/// reader (`consumed >= byte_offset`).  This is the readiness predicate that
+/// makes a control-only ancillary frame surface as `POLLIN`/`EPOLLIN`, since
+/// such a frame carries no recv-ring bytes for `has_data()` to see.
+///
+/// `consumed` is the receiver's absolute drained-byte count
+/// (`net::unix::recv_consumed`); passed in by the caller so this module does
+/// not have to reach back into the net layer while holding PENDING_SCM.
+pub fn has_scm_deliverable(receiver_id: u64, consumed: u64) -> bool {
+    let q = PENDING_SCM.lock();
+    q.iter().any(|b| b.receiver_id == receiver_id && consumed >= b.byte_offset)
+}
+
+/// Pop the *earliest* deliverable `SCM_RIGHTS` batch for `receiver_id` — the
+/// oldest batch whose bound `byte_offset` the reader has now reached
+/// (`consumed >= byte_offset`).  Returns None if nothing is pending or the
+/// pending batch(es) still sit beyond the reader's current position (the
+/// reader must drain the intervening data bytes first).  Delivering only the
+/// reached batch keeps fds attached to their originating stream frame.
+pub fn scm_dequeue(receiver_id: u64, consumed: u64) -> Option<Vec<crate::vfs::FileDescriptor>> {
     let mut q = PENDING_SCM.lock();
-    let pos = q.iter().position(|(id, _)| *id == receiver_id)?;
-    Some(q.remove(pos).1)
+    // Earliest in FIFO order: the first matching entry, since batches are
+    // pushed in send order and a later batch can never have a smaller
+    // byte_offset than an earlier one for the same receiver.
+    let pos = q.iter().position(
+        |b| b.receiver_id == receiver_id && consumed >= b.byte_offset)?;
+    Some(q.remove(pos).fds)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -4027,7 +4074,14 @@ pub(crate) fn poll_revents(pid: u64, fd: usize, events: u16) -> u16 {
         let uid = get_unix_socket_id(pid, fd);
         let has_d = crate::net::unix::has_data(uid);
         let has_p = crate::net::unix::has_pending(uid);
-        let readable = has_d || has_p;
+        // A queued SCM_RIGHTS batch whose bound stream offset the reader has
+        // reached makes the socket readable even with an empty data ring: a
+        // control-only ancillary frame (iov_len==0) IS a readable message per
+        // recvmsg(2) / unix(7) / POSIX.1-2017 SCM_RIGHTS, and recvmsg must
+        // return it.  Without this, the receiver parks in poll() forever on a
+        // pure fd handoff (e.g. an IPC channel/shared-memory fd pass).
+        let has_scm = has_scm_deliverable(uid, crate::net::unix::recv_consumed(uid));
+        let readable = has_d || has_p || has_scm;
         #[cfg(feature = "firefox-test")]
         if pid >= 1 && events & POLLIN != 0 {
             crate::serial_println!("[UNIXPOLL] pid={} fd={} uid={} has_data={} avail={} events={:#x}",

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -460,10 +460,23 @@ struct ScmBatch {
 }
 static PENDING_SCM: Mutex<Vec<ScmBatch>> = Mutex::new(Vec::new());
 
-/// Queue an `SCM_RIGHTS` fd batch for delivery when `receiver_id` next
-/// drains its recv stream past `byte_offset` (see [`scm_dequeue`]).
-/// `byte_offset` is the receiver's absolute recv position at send time —
-/// for an ancillary-only frame this is the current stream tail.
+/// Queue an `SCM_RIGHTS` fd batch for delivery when `receiver_id`'s drained-byte
+/// count reaches `byte_offset` (see [`scm_dequeue`]: the deliver predicate is
+/// `consumed >= byte_offset`).  `byte_offset` is the stream position the reader
+/// must have reached to have *touched* (begun consuming) the frame the fds
+/// accompany — the first-byte-touch delivery contract (recvmsg(2) / unix(7) /
+/// POSIX.1-2017 §2.14: ancillary data is delivered with the recvmsg that returns
+/// the data it accompanies):
+///   * for a DATA-bearing frame starting at stream position T, the caller binds
+///     to `T + 1` — deliverable the instant the reader pops the frame's first
+///     byte (`consumed` advances T → T+1), and NOT before any byte of the frame
+///     is read;
+///   * for an ancillary-ONLY frame (no data bytes), the fds sit at the current
+///     stream tail T with nothing to touch, so the caller binds to `T` and the
+///     batch is immediately deliverable as a 0-byte readable message.
+///
+/// The single `>=` predicate covers both because the caller does the `+1`
+/// adjustment for data frames at enqueue time (see the sendmsg(2) SCM path).
 pub fn scm_queue(receiver_id: u64, byte_offset: u64, fds: Vec<crate::vfs::FileDescriptor>) {
     PENDING_SCM.lock().push(ScmBatch { receiver_id, byte_offset, fds });
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1363,6 +1363,12 @@ pub fn run() -> ! {
     total += 1;
     if test_syscall_creat() { passed += 1; }
 
+    // ── Test 145b: out.png golden path — O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE
+    //              create + 26870-byte write + read-back byte-exact ──────────
+
+    total += 1;
+    if test_out_png_create_write_readback() { passed += 1; }
+
     // ── Test 146: getdents(78) iterates directory entries ─────────────────
 
     total += 1;
@@ -27389,6 +27395,187 @@ fn test_syscall_creat() -> bool {
     // Clean up.
     let _ = crate::vfs::remove("/tmp/test_creat_file");
     test_pass!("syscall creat(85)");
+    true
+}
+
+/// Test the LITERAL last step of the headless-Firefox screenshot pipeline:
+/// the `out.png` create + write + read-back, on the filesystem that actually
+/// backs `/tmp/out.png`.
+///
+/// The headless `firefox --screenshot /tmp/out.png` driver finishes by emitting
+/// the encoded PNG with the golden sequence
+///
+///     open("/tmp/out.png", O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE) = 82
+///     write(82, "\x89PNG\r\n\x1a\n...", 26870)                   = 26870
+///     close(82)
+///
+/// `/tmp` is a plain directory inside the root ramfs (`vfs::init` does
+/// `mkdir("/tmp")`; there is no separate `/tmp` mount at boot), so this is the
+/// VFS/ramfs write path — not ext2 and not a runtime tmpfs mount.
+///
+/// This test reproduces that exact sequence and locks three properties POSIX
+/// requires of it:
+///
+///  * `open(2)` (IEEE Std 1003.1-2017) — `O_LARGEFILE` is a no-op on a 64-bit
+///    kernel and MUST be accepted-and-ignored, not rejected with EINVAL.  We
+///    pass the full golden flag word `O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE`
+///    (0x8241) and require a successful create.
+///  * `write(2)` — the single 26870-byte write MUST NOT short-write; the return
+///    value equals the byte count (matching the golden `= 26870`).
+///  * Persistence — a fresh `open(O_RDONLY)` + read loop MUST return the exact
+///    bytes written, and `stat(2)` MUST report `st_size == 26870`.
+///
+/// A regression on any of these (rejected O_LARGEFILE → no file; a short write;
+/// an i_size/data desync that yields an empty or truncated file on read-back)
+/// would leave Firefox unable to emit the screenshot even after a fully
+/// faithful render → libpng-encode chain.
+fn test_out_png_create_write_readback() -> bool {
+    test_header!("out.png golden create+write+readback");
+    let pid = crate::proc::current_pid();
+
+    // Use a dedicated path on the SAME filesystem that backs the real
+    // /tmp/out.png (root ramfs) so this exercises the production write path.
+    const PATH: &str = "/tmp/out_png_roundtrip_test.png";
+    const PATH_C: &[u8] = b"/tmp/out_png_roundtrip_test.png\0";
+    const LEN: usize = 26870; // 7 × 4 KiB blocks − 778; all-direct on a block FS.
+
+    // Golden open flags: O_WRONLY(0x1) | O_CREAT(0x40) | O_TRUNC(0x200)
+    // | O_LARGEFILE(0x8000) = 0x8241.  O_LARGEFILE must be ignored, not
+    // rejected, on a 64-bit kernel (open(2)).
+    const O_WRONLY: u32 = 0x1;
+    const O_CREAT: u32 = 0x40;
+    const O_TRUNC: u32 = 0x200;
+    const O_LARGEFILE: u32 = 0x8000;
+    const WR_FLAGS: u32 = O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE;
+
+    // Remove any stale copy from a prior run so O_CREAT genuinely creates a
+    // fresh inode (the case the screenshot driver always hits).
+    let _ = crate::vfs::remove(PATH);
+
+    // Build a PNG-shaped 26870-byte buffer: the 8-byte PNG signature
+    // (\x89 P N G \r \n \x1a \n — per the PNG spec, ISO/IEC 15948) followed by
+    // a deterministic byte pattern so the read-back comparison is exact.
+    let mut src = alloc::vec::Vec::with_capacity(LEN);
+    const PNG_SIG: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    src.extend_from_slice(&PNG_SIG);
+    for i in PNG_SIG.len()..LEN {
+        // Mix the index across the full byte range; avoids long zero runs so a
+        // partial / zero-filled write-back would diverge immediately.
+        src.push(((i.wrapping_mul(31)).wrapping_add(i >> 8) & 0xff) as u8);
+    }
+    if src.len() != LEN {
+        test_fail!("out.png", "source buffer len {} != {}", src.len(), LEN);
+        return false;
+    }
+
+    // ── open(O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE) ────────────────────────
+    // Drive it through the real Linux open syscall (nr 2) so the full
+    // syscall-layer flag handling (including O_LARGEFILE) is exercised, exactly
+    // as Firefox reaches it.  dispatch(2, path, flags, mode, ...).
+    let wfd = {
+        let r = dispatch(2, PATH_C.as_ptr() as u64, WR_FLAGS as u64, 0o666, 0, 0, 0);
+        if r < 0 {
+            test_fail!(
+                "out.png",
+                "open(O_WRONLY|O_CREAT|O_TRUNC|O_LARGEFILE)=0x{:x} rejected: {} \
+                 (O_LARGEFILE must be ignored on a 64-bit kernel per open(2))",
+                WR_FLAGS, r);
+            return false;
+        }
+        r as usize
+    };
+    test_println!("  open(\"{}\", 0x{:x}) = fd {} ✓ (O_LARGEFILE accepted-and-ignored)",
+                  PATH, WR_FLAGS, wfd);
+
+    // ── write(fd, src, 26870) — must be a full, non-short write ───────────
+    let n = match crate::vfs::fd_write(pid, wfd, src.as_ptr(), src.len()) {
+        Ok(n) => n,
+        Err(e) => {
+            test_fail!("out.png", "write failed: {:?}", e);
+            let _ = crate::vfs::close(pid, wfd);
+            return false;
+        }
+    };
+    if n != LEN {
+        test_fail!("out.png", "short write: wrote {} of {} bytes", n, LEN);
+        let _ = crate::vfs::close(pid, wfd);
+        return false;
+    }
+    test_println!("  write(fd {}, .., {}) = {} ✓ (matches golden = 26870)", wfd, LEN, n);
+
+    let _ = crate::vfs::close(pid, wfd);
+
+    // ── stat — i_size must reflect the full 26870 bytes ───────────────────
+    match crate::vfs::stat(PATH) {
+        Ok(st) if st.size as usize == LEN => {
+            test_println!("  stat: size={} ✓ (i_size persisted)", st.size);
+        }
+        Ok(st) => {
+            test_fail!("out.png", "stat size {} != {} (i_size not persisted)", st.size, LEN);
+            let _ = crate::vfs::remove(PATH);
+            return false;
+        }
+        Err(e) => {
+            test_fail!("out.png", "stat after write failed: {:?}", e);
+            let _ = crate::vfs::remove(PATH);
+            return false;
+        }
+    }
+
+    // ── reopen O_RDONLY + read-back loop — bytes must be exact ────────────
+    let rfd = match crate::vfs::open(pid, PATH, 0 /* O_RDONLY */) {
+        Ok(fd) => fd,
+        Err(e) => {
+            test_fail!("out.png", "reopen O_RDONLY failed: {:?}", e);
+            let _ = crate::vfs::remove(PATH);
+            return false;
+        }
+    };
+
+    let mut got = alloc::vec::Vec::with_capacity(LEN);
+    let mut chunk = [0u8; 4096];
+    loop {
+        let r = match crate::vfs::fd_read(pid, rfd, chunk.as_mut_ptr(), chunk.len()) {
+            Ok(r) => r,
+            Err(e) => {
+                test_fail!("out.png", "read-back failed at offset {}: {:?}", got.len(), e);
+                let _ = crate::vfs::close(pid, rfd);
+                let _ = crate::vfs::remove(PATH);
+                return false;
+            }
+        };
+        if r == 0 {
+            break; // EOF
+        }
+        got.extend_from_slice(&chunk[..r]);
+        if got.len() > LEN {
+            test_fail!("out.png", "read-back returned more than {} bytes (got {})", LEN, got.len());
+            let _ = crate::vfs::close(pid, rfd);
+            let _ = crate::vfs::remove(PATH);
+            return false;
+        }
+    }
+    let _ = crate::vfs::close(pid, rfd);
+
+    // Length first, then byte-exact content.
+    if got.len() != LEN {
+        test_fail!("out.png", "read-back length {} != {} (truncated/empty file)", got.len(), LEN);
+        let _ = crate::vfs::remove(PATH);
+        return false;
+    }
+    if got != src {
+        // Find the first divergent offset for a useful failure message.
+        let mismatch = got.iter().zip(src.iter()).position(|(a, b)| a != b).unwrap_or(LEN);
+        test_fail!("out.png", "byte mismatch at offset {}: got 0x{:02x} want 0x{:02x}",
+                   mismatch, got.get(mismatch).copied().unwrap_or(0),
+                   src.get(mismatch).copied().unwrap_or(0));
+        let _ = crate::vfs::remove(PATH);
+        return false;
+    }
+    test_println!("  read-back {} bytes byte-exact (PNG sig + pattern) ✓", got.len());
+
+    let _ = crate::vfs::remove(PATH);
+    test_pass!("out.png golden create+write+readback");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -885,6 +885,12 @@ pub fn run() -> ! {
     total += 1;
     if test_clock_monotonic_rate_invariant() { passed += 1; }
 
+    // ── Test 80b2: get_ticks() advances on the TSC even if the LAPIC ISR
+    //              never fires (single-core LAPIC-suppression robustness) ──────
+
+    total += 1;
+    if test_get_ticks_tsc_floor_independent_of_isr() { passed += 1; }
+
     // ── Test 80c: vDSO / syscall CLOCK_REALTIME parity + futex deadline ───────
 
     total += 1;
@@ -19391,6 +19397,88 @@ fn test_clock_monotonic_rate_invariant() -> bool {
     }
 
     test_pass!("clock_gettime — monotonic-tick rate is wall-clock-locked");
+    true
+}
+
+// ── Test 80b2: get_ticks() is TSC-floored, independent of the LAPIC ISR ──────
+//
+// On a single core, a KVM framebuffer-MMIO VM-exit storm can suppress LAPIC
+// timer delivery indefinitely. If `get_ticks()` returned only the
+// ISR-published `TICK_COUNT`, every `while get_ticks() … { compose(); }` settle
+// loop would spin forever in Ring 0 (the init deadlock). The fix makes
+// `get_ticks()` return `max(TICK_COUNT, tsc_derived_floor)`, so it advances on
+// the invariant TSC (Intel SDM Vol. 3B §17.17) even when the ISR is starved.
+//
+// This test cannot un-wire the real LAPIC, so it asserts the two invariants the
+// fix guarantees regardless of ISR state:
+//   (1) get_ticks() is never below the TSC-derived floor (so it always makes
+//       progress as the TSC advances), and
+//   (2) get_ticks() advances by roughly the TSC delta across a pure busy-spin
+//       (no hlt, so even if the ISR were silent the value still moves).
+fn test_get_ticks_tsc_floor_independent_of_isr() -> bool {
+    test_header!("get_ticks — TSC-floored, advances without the timer ISR");
+
+    use core::sync::atomic::Ordering;
+    use crate::arch::x86_64::irq::{get_ticks, TSC_PER_TICK, TSC_AT_BOOT};
+
+    let rdtsc = || -> u64 {
+        let lo: u32; let hi: u32;
+        unsafe {
+            core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi,
+                             options(nomem, nostack));
+        }
+        ((hi as u64) << 32) | lo as u64
+    };
+
+    let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
+    let tsc_at_boot  = TSC_AT_BOOT.load(Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        test_fail!("get_ticks-tsc-floor",
+                   "TSC_PER_TICK not calibrated — apic::init must run first");
+        return false;
+    }
+
+    // Invariant (1): get_ticks() >= TSC floor at the same instant. Sample the
+    // TSC first; the floor computed from it can only be <= the value
+    // get_ticks() returns a moment later (time only moves forward).
+    let tsc_a   = rdtsc();
+    let floor_a = tsc_a.wrapping_sub(tsc_at_boot) / tsc_per_tick;
+    let ticks_a = get_ticks();
+    if ticks_a < floor_a {
+        test_fail!("get_ticks-tsc-floor",
+                   "get_ticks()={} below TSC floor={} — not TSC-floored",
+                   ticks_a, floor_a);
+        return false;
+    }
+
+    // Invariant (2): across a pure busy-spin (no hlt — the ISR may or may not
+    // fire, irrelevant), get_ticks() advances by ~the TSC delta. Spin a fixed
+    // number of TSC ticks and confirm the reported tick delta is in range.
+    const SPIN_TICKS: u64 = 20; // ~200 ms wall at TICK_HZ=100
+    let spin_tsc = tsc_per_tick.saturating_mul(SPIN_TICKS);
+    let tsc0   = rdtsc();
+    let ticks0 = get_ticks();
+    while rdtsc().wrapping_sub(tsc0) < spin_tsc {
+        core::hint::spin_loop();
+    }
+    let ticks1  = get_ticks();
+    let dticks  = ticks1.wrapping_sub(ticks0);
+
+    // Allow a generous band: the floor advances exactly SPIN_TICKS by
+    // construction, but the ISR (if alive) may push slightly further. Require
+    // at least SPIN_TICKS/2 (proves TSC-driven progress even with a silent
+    // ISR) and at most 4×SPIN_TICKS (catches a runaway clock).
+    if dticks < SPIN_TICKS / 2 || dticks > SPIN_TICKS * 4 {
+        test_fail!("get_ticks-tsc-floor",
+                   "get_ticks advanced {} over ~{} TSC-ticks of spin — \
+                    expected ~{} (TSC-driven progress check failed)",
+                   dticks, SPIN_TICKS, SPIN_TICKS);
+        return false;
+    }
+
+    test_println!("  floor_a={} ticks_a={} dticks={} (spin={})",
+                  floor_a, ticks_a, dticks, SPIN_TICKS);
+    test_pass!("get_ticks — TSC-floored, advances without the timer ISR");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1060,6 +1060,10 @@ pub fn run() -> ! {
     total += 1;
     if test_cleartid_write_demand_faults() { passed += 1; }
 
+    // ── Test 98g: shared-CR3 anonymous-fault anti-aliasing (vfork da4) ───
+    total += 1;
+    if test_map_page_in_if_absent_anti_alias() { passed += 1; }
+
     // ── Test 99: procfs self/maps — per-process VMA listing ──────────────
 
     total += 1;
@@ -29061,6 +29065,114 @@ fn test_cleartid_write_demand_faults() -> bool {
 
     teardown();
     test_pass!("CLONE_CHILD_CLEARTID write lands on non-present / COW page");
+    true
+}
+
+/// Regression test for the shared-CR3 anonymous demand-fault aliasing race.
+///
+/// On a CLONE_VM / vfork address space several threads run on ONE CR3 across
+/// multiple logical processors.  Two CPUs can take a not-present `#PF` on the
+/// same anonymous stack VA concurrently; each zero-fills its own frame.  The
+/// old anonymous install arm called `map_page_in` unconditionally, so the
+/// loser overwrote the winner's leaf PTE with a *different* physical frame.
+/// The winner's CPU kept reading the first frame through its already-cached
+/// TLB entry while the page table pointed at the second — one VA backed by two
+/// frames — so a release-store by one thread was never observed by the thread
+/// reading the other (the `da4` control-word store-visibility failure).
+///
+/// `map_page_in_if_absent` performs the present-check and the install as one
+/// indivisible operation under `VMM_LOCK`: the winner installs; the loser
+/// observes the winner's already-present PTE and backs out WITHOUT overwriting
+/// it, so the mapping is never aliased.  Refs: POSIX mmap(2), clone(2)
+/// CLONE_VM; Intel SDM Vol. 3A §4.10.4.3 (Optional Invalidation).
+fn test_map_page_in_if_absent_anti_alias() -> bool {
+    test_header!("map_page_in_if_absent: shared-CR3 anonymous-fault anti-aliasing");
+
+    use crate::mm::vmm::{read_pte, map_page_in_if_absent, PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER, ADDR_MASK};
+
+    // Fresh user address space (its own CR3 + page tables).
+    let vm = match crate::mm::vma::VmSpace::new_user() {
+        Some(vs) => vs,
+        None => { test_fail!("anti_alias", "VmSpace::new_user() OOM"); return false; }
+    };
+    let cr3 = vm.cr3;
+
+    // A stack-like anonymous VA in the canonical lower half.
+    let va: u64 = 0x7fff_fffe_c000;
+    let page = crate::mm::vma::page_align_down(va);
+
+    // Two distinct, separately-allocated frames standing in for the two CPUs'
+    // independently zero-filled demand-fault frames.
+    let frame_winner = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => { crate::proc::free_vm_space(vm); test_fail!("anti_alias", "OOM winner"); return false; }
+    };
+    let frame_loser = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => {
+            crate::mm::pmm::free_page(frame_winner);
+            crate::proc::free_vm_space(vm);
+            test_fail!("anti_alias", "OOM loser"); return false;
+        }
+    };
+    if frame_winner == frame_loser {
+        crate::mm::pmm::free_page(frame_winner);
+        crate::proc::free_vm_space(vm);
+        test_fail!("anti_alias", "allocator returned identical frames");
+        return false;
+    }
+
+    let flags = PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+
+    // Precondition: VA not present.
+    if read_pte(cr3, va) & PAGE_PRESENT != 0 {
+        crate::mm::pmm::free_page(frame_winner);
+        crate::mm::pmm::free_page(frame_loser);
+        crate::proc::free_vm_space(vm);
+        test_fail!("anti_alias", "precondition: VA already present");
+        return false;
+    }
+
+    // (1) Winner installs over a not-present PTE → returns true, frame_winner mapped.
+    let won = map_page_in_if_absent(cr3, page, frame_winner, flags);
+    let pte1 = read_pte(cr3, va);
+    if !won || pte1 & PAGE_PRESENT == 0 || (pte1 & ADDR_MASK) != (frame_winner & ADDR_MASK) {
+        crate::mm::pmm::free_page(frame_winner);
+        crate::mm::pmm::free_page(frame_loser);
+        crate::proc::free_vm_space(vm);
+        test_fail!("anti_alias", "winner install failed: won={} pte={:#x} expect_phys={:#x}",
+            won, pte1, frame_winner);
+        return false;
+    }
+    test_println!("  (1) winner installed frame {:#x} over not-present PTE ✓", frame_winner);
+
+    // (2) Loser races the SAME VA with a DIFFERENT frame → must return false and
+    //     leave the winner's PTE untouched (no aliasing, no second frame).
+    let lost = map_page_in_if_absent(cr3, page, frame_loser, flags);
+    let pte2 = read_pte(cr3, va);
+    if lost {
+        crate::mm::pmm::free_page(frame_winner);
+        crate::mm::pmm::free_page(frame_loser);
+        crate::proc::free_vm_space(vm);
+        test_fail!("anti_alias", "loser install returned true — it overwrote the PTE (aliasing)");
+        return false;
+    }
+    if (pte2 & ADDR_MASK) != (frame_winner & ADDR_MASK) {
+        crate::mm::pmm::free_page(frame_winner);
+        crate::mm::pmm::free_page(frame_loser);
+        crate::proc::free_vm_space(vm);
+        test_fail!("anti_alias", "PTE no longer maps winner frame: pte={:#x} winner={:#x} loser={:#x}",
+            pte2, frame_winner, frame_loser);
+        return false;
+    }
+    test_println!("  (2) loser backed out; PTE still maps winner {:#x} — no aliasing ✓", frame_winner);
+
+    // Teardown: the VA still maps frame_winner; clearing the address space frees
+    // it via the page-table walk.  frame_loser was never mapped, so free it here.
+    crate::mm::pmm::free_page(frame_loser);
+    crate::proc::free_vm_space(vm);
+
+    test_pass!("map_page_in_if_absent anti-aliasing");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2004,6 +2004,28 @@ pub fn run() -> ! {
         if test_228_auto_reap_orphan_zombies() { passed += 1; }
     }
 
+    // ── Test 502: waitpid prepare-to-wait lost-wakeup close ──────────────
+    // A child that becomes a zombie in the parent's prepare-to-wait window
+    // (after the immediate-reap check drops PROCESS_TABLE, before/while the
+    // parent commits Blocked) must be reaped without a permanent park — the
+    // recheck-under-lock backstop.  Per POSIX wait(2): an already-terminated
+    // child must be reapable without blocking.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_502_waitpid_prepare_to_wait_race() { passed += 1; }
+    }
+
+    // ── Test 502b: vfork prepare-to-wait lost-wakeup close ───────────────
+    // A vfork child that completes (clears its vfork completion token) before
+    // the parent commits Blocked must not leave the parent parked — the
+    // recheck-under-lock reverts the parent to Ready.  Per POSIX vfork(2).
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_502b_vfork_prepare_to_wait_race() { passed += 1; }
+    }
+
     // ── Test 229: PMM pte_share_count free-time invariant (W215 fix) ─────
     // Verifies that pmm::free_page refuses to recycle a frame whose
     // refcount table still records a live PTE reference, and that the
@@ -38870,6 +38892,337 @@ fn test_228_auto_reap_orphan_zombies() -> bool {
 
     test_pass!("exit_group auto-reaps doubly-orphaned zombie children");
     true
+}
+
+// ── Test 502: waitpid prepare-to-wait lost-wakeup close ──────────────────────
+//
+// Models the SMP race that previously hung a blocking wait4(2) forever on the
+// Firefox child-reaping path.  The bug: `sys_waitpid` read PROCESS_TABLE for a
+// zombie (miss), dropped the lock, then committed `state=Blocked` +
+// `wake_tick=u64::MAX-1` under THREAD_TABLE and called `schedule()` — with NO
+// recheck of the zombie/PROCESS_TABLE while holding THREAD_TABLE.  The exiting
+// child writes `ProcessState::Zombie` to PROCESS_TABLE *before* taking
+// THREAD_TABLE to flip the parent Blocked→Ready, and only flips it `if state ==
+// Blocked`.  Interleaving (smp=2): parent misses the zombie and drops the lock
+// → child writes Zombie, takes THREAD_TABLE, finds the parent NOT yet Blocked,
+// drops the wake → parent commits Blocked + schedule().  Because the sentinel
+// `wake_tick=u64::MAX-1` is scan-ineligible and the parker is not on any poll
+// bell, the wait4 never returns → permanent hang.
+//
+// The fix is the prepare-to-wait discipline: after committing Blocked under
+// THREAD_TABLE (and dropping it), re-poll PROCESS_TABLE for a reapable zombie;
+// on a hit, revert Blocked→Ready and reap WITHOUT parking.  This test drives
+// that exact resolution: a child marked Zombie in the window must be reaped and
+// the parent thread must be left Ready (the wake is not lost).
+//
+// Per POSIX wait(2): "If [a child] has already terminated ... [wait] shall
+// return immediately."  An already-terminated child must be reapable without
+// blocking.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_502_waitpid_prepare_to_wait_race() -> bool {
+    use crate::proc::{PROCESS_TABLE, THREAD_TABLE, ThreadState, ProcessState};
+
+    test_header!("waitpid prepare-to-wait lost-wakeup close (PR #502)");
+
+    // ── 1. Synthetic parent + child processes ────────────────────────────
+    let parent_pid = match crate::proc::usermode::create_user_process(
+        "wp_race_parent", &crate::proc::hello_elf::HELLO_ELF
+    ) {
+        Ok(p) => p,
+        Err(e) => { test_fail!("waitpid_p2w_race",
+            "create_user_process(parent): {:?}", e); return false; }
+    };
+    let child_pid = match crate::proc::usermode::create_user_process(
+        "wp_race_child", &crate::proc::hello_elf::HELLO_ELF
+    ) {
+        Ok(p) => p,
+        Err(e) => { test_fail!("waitpid_p2w_race",
+            "create_user_process(child): {:?}", e); return false; }
+    };
+    if parent_pid == child_pid || parent_pid == 0 || child_pid == 0 {
+        test_fail!("waitpid_p2w_race",
+            "bad pids parent={} child={}", parent_pid, child_pid);
+        return false;
+    }
+
+    // The parent's main thread is the "waitpid'er".
+    let parent_tid = {
+        let threads = THREAD_TABLE.lock();
+        threads.iter().find(|t| t.pid == parent_pid).map(|t| t.tid).unwrap_or(0)
+    };
+    if parent_tid == 0 {
+        test_fail!("waitpid_p2w_race", "no main thread for parent pid {}", parent_pid);
+        return false;
+    }
+    let child_tids: alloc::vec::Vec<u64> = {
+        let threads = THREAD_TABLE.lock();
+        threads.iter().filter(|t| t.pid == child_pid).map(|t| t.tid).collect()
+    };
+    test_println!("  parent PID {} (tid {}), child PID {} ({} tids) ✓",
+        parent_pid, parent_tid, child_pid, child_tids.len());
+
+    // ── 2. Build the prepare-to-wait window state ─────────────────────────
+    // Re-parent the child to our synthetic parent, then drive the EXACT
+    // interleaving the fix must survive:
+    //   (a) the parent has already committed Blocked + the MAX-1 sentinel
+    //       (it executed step 1 of the park),
+    //   (b) the child becomes a Zombie, and its wake-side THREAD_TABLE flip
+    //       was a no-op because at flip time the parent was still Running
+    //       (i.e. we deliberately DO NOT flip the parent here — modelling the
+    //       lost wake).
+    {
+        let mut procs = PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == child_pid) {
+            p.parent_pid = parent_pid;
+        }
+    }
+    // (a) commit Blocked + sentinel on the parent thread.
+    {
+        let mut threads = THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == parent_tid) {
+            t.state = ThreadState::Blocked;
+            t.wake_tick = u64::MAX - 1; // waitpid park sentinel
+        }
+    }
+    // (b) child becomes a Zombie (PROCESS_TABLE write) with NO parent flip —
+    //     this is the lost-wakeup condition the old code could not recover
+    //     from.
+    {
+        let mut procs = PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == child_pid) {
+            p.state = ProcessState::Zombie;
+            p.exit_code = 0x0502;
+        }
+    }
+    // Sanity: confirm the lost-wakeup precondition — zombie present AND parent
+    // still parked-Blocked-on-sentinel (no wake delivered).
+    {
+        let procs = PROCESS_TABLE.lock();
+        let threads = THREAD_TABLE.lock();
+        let zombie_present = procs.iter().any(|p|
+            p.pid == child_pid && p.state == ProcessState::Zombie);
+        let parent_parked = threads.iter().find(|t| t.tid == parent_tid)
+            .map(|t| t.state == ThreadState::Blocked && t.wake_tick == u64::MAX - 1)
+            .unwrap_or(false);
+        if !zombie_present || !parent_parked {
+            drop(procs); drop(threads);
+            test_fail!("waitpid_p2w_race",
+                "precondition not set up: zombie={} parent_parked={}",
+                zombie_present, parent_parked);
+            return false;
+        }
+    }
+    test_println!("  precondition: zombie child + parent parked, wake lost ✓");
+
+    // ── 3. Drive the prepare-to-wait recheck (the fix) ────────────────────
+    // This is exactly what sys_waitpid step (2) does after committing Blocked:
+    // re-poll PROCESS_TABLE for a reapable zombie (without holding
+    // THREAD_TABLE), and on a hit revert Blocked→Ready and reap.
+    let reaped = crate::proc::waitpid(parent_pid, child_pid as i64);
+    {
+        let mut threads = THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == parent_tid) {
+            if t.state == ThreadState::Blocked && t.wake_tick == u64::MAX - 1 {
+                t.state = ThreadState::Ready;
+                t.wake_tick = u64::MAX;
+            }
+        }
+    }
+
+    // ── 4. Post-conditions ───────────────────────────────────────────────
+    // (a) The zombie was reaped (waitpid returned the child pid + code) —
+    //     i.e. the already-terminated child was reapable without blocking.
+    match reaped {
+        Some((rp, rc)) if rp == child_pid && rc as u32 == 0x0502 => {
+            test_println!("  reaped child PID {} code {:#x} without parking ✓", rp, rc);
+        }
+        other => {
+            // Best-effort cleanup before failing.
+            { let mut procs = PROCESS_TABLE.lock();
+              procs.retain(|p| p.pid != child_pid && p.pid != parent_pid); }
+            { let mut threads = THREAD_TABLE.lock();
+              threads.retain(|t| t.pid != child_pid && t.pid != parent_pid); }
+            test_fail!("waitpid_p2w_race",
+                "expected reap of child {} (code 0x502), got {:?}", child_pid, other);
+            return false;
+        }
+    }
+    // (b) The parent thread is NOT left parked-forever: it must be runnable
+    //     (Ready), not stuck Blocked on the MAX-1 sentinel.  This is the
+    //     anti-hang assertion: no wake was lost.
+    let parent_state = {
+        let threads = THREAD_TABLE.lock();
+        threads.iter().find(|t| t.tid == parent_tid).map(|t| (t.state, t.wake_tick))
+    };
+    match parent_state {
+        Some((ThreadState::Blocked, wt)) if wt == u64::MAX - 1 => {
+            { let mut procs = PROCESS_TABLE.lock();
+              procs.retain(|p| p.pid != parent_pid); }
+            { let mut threads = THREAD_TABLE.lock();
+              threads.retain(|t| t.pid != parent_pid); }
+            test_fail!("waitpid_p2w_race",
+                "parent tid {} still parked Blocked on MAX-1 sentinel — \
+                 wait4 would hang forever", parent_tid);
+            return false;
+        }
+        _ => {
+            test_println!("  parent tid {} not parked-forever (state={:?}) ✓",
+                parent_tid, parent_state.map(|(s, _)| s));
+        }
+    }
+    // (c) The child's PROCESS_TABLE entry is gone (reaped) and its threads
+    //     are swept.
+    {
+        let procs = PROCESS_TABLE.lock();
+        if procs.iter().any(|p| p.pid == child_pid) {
+            drop(procs);
+            { let mut procs = PROCESS_TABLE.lock(); procs.retain(|p| p.pid != parent_pid); }
+            { let mut threads = THREAD_TABLE.lock(); threads.retain(|t| t.pid != parent_pid); }
+            test_fail!("waitpid_p2w_race",
+                "child PID {} still in PROCESS_TABLE after reap", child_pid);
+            return false;
+        }
+    }
+    {
+        let threads = THREAD_TABLE.lock();
+        let lingering: alloc::vec::Vec<u64> = child_tids.iter()
+            .filter(|&&t| threads.iter().any(|th| th.tid == t)).copied().collect();
+        if !lingering.is_empty() {
+            drop(threads);
+            { let mut procs = PROCESS_TABLE.lock(); procs.retain(|p| p.pid != parent_pid); }
+            { let mut threads = THREAD_TABLE.lock(); threads.retain(|t| t.pid != parent_pid); }
+            test_fail!("waitpid_p2w_race",
+                "child tids {:?} still in THREAD_TABLE after reap", lingering);
+            return false;
+        }
+    }
+
+    // ── 5. Cleanup the synthetic parent (the child is already reaped) ─────
+    { let mut procs = PROCESS_TABLE.lock(); procs.retain(|p| p.pid != parent_pid); }
+    { let mut threads = THREAD_TABLE.lock(); threads.retain(|t| t.pid != parent_pid); }
+    crate::proc::proc_metrics::unregister(parent_pid);
+
+    test_pass!("waitpid prepare-to-wait lost-wakeup close (PR #502)");
+    true
+}
+
+// ── Test 502b: vfork prepare-to-wait lost-wakeup close ───────────────────────
+//
+// Companion to test 502 for the vfork(2) parent park.  The vfork wake handshake
+// uses the per-child `vfork_parent_tid` completion token: the park side sets
+// `child.vfork_parent_tid = Some(parent_tid)` and `parent.state = Blocked`; the
+// child's execve(2)/exit path runs `wake_vfork_parent()`, which acts only if it
+// observes `Some(parent_tid)` — clearing the token to `None` and flipping the
+// parent Blocked→Ready.  The race: the child runs and reaches its wake before
+// the parent registers the token, reads the initial `None`, and no-ops; the
+// parent then parks with no waker (masked only by the 5 s timeout).
+//
+// The fix registers the token BEFORE unblocking the child, and — after
+// committing Blocked — rechecks the token under the SAME THREAD_TABLE hold: if
+// the child already consumed it (token == None), the parent must NOT park.  This
+// test drives that recheck: a completed child (token cleared) in the window must
+// leave the parent runnable, never parked.
+//
+// Per POSIX vfork(2): the parent is suspended only until the child performs a
+// successful execve() or _exit(); an already-completed child must not block it.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_502b_vfork_prepare_to_wait_race() -> bool {
+    use crate::proc::{THREAD_TABLE, ThreadState};
+
+    test_header!("vfork prepare-to-wait lost-wakeup close (PR #502)");
+
+    // Synthetic parent + child threads in one process — the vfork handshake is
+    // THREAD_TABLE-only, so we only need two thread rows.
+    let host_pid = match crate::proc::usermode::create_user_process(
+        "vf_race_host", &crate::proc::hello_elf::HELLO_ELF
+    ) {
+        Ok(p) => p,
+        Err(e) => { test_fail!("vfork_p2w_race",
+            "create_user_process: {:?}", e); return false; }
+    };
+    let parent_tid = {
+        let threads = THREAD_TABLE.lock();
+        threads.iter().find(|t| t.pid == host_pid).map(|t| t.tid).unwrap_or(0)
+    };
+    if parent_tid == 0 {
+        test_fail!("vfork_p2w_race", "no main thread for pid {}", host_pid);
+        return false;
+    }
+    let child_tid = match crate::proc::create_thread_blocked(host_pid, "vf_race_child", 0) {
+        Some(t) => t,
+        None => { test_fail!("vfork_p2w_race", "create_thread_blocked failed"); return false; }
+    };
+    test_println!("  host PID {}: parent tid {}, child tid {} ✓",
+        host_pid, parent_tid, child_tid);
+
+    // ── Model the race: the child has ALREADY completed (it ran its wake,
+    //    consuming the token), so its `vfork_parent_tid` is `None`.  This is
+    //    the post-fix observable the parent's recheck keys on.  In the buggy
+    //    interleaving the parent would still park here.
+    {
+        let mut threads = THREAD_TABLE.lock();
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == child_tid) {
+            // Child completed → token cleared (mirrors wake_vfork_parent's
+            // `t.vfork_parent_tid = None`).
+            t.vfork_parent_tid = None;
+        }
+    }
+
+    // ── Drive the parent's prepare-to-wait commit + recheck (the fix) ──────
+    // Commit Blocked, then recheck the child's completion token under the same
+    // THREAD_TABLE hold; if the child already completed (token None), revert to
+    // Ready and do NOT park.
+    let parked = {
+        let mut threads = THREAD_TABLE.lock();
+        let child_completed = threads.iter()
+            .find(|t| t.tid == child_tid)
+            .map(|t| t.vfork_parent_tid.is_none())
+            .unwrap_or(true);
+        if let Some(t) = threads.iter_mut().find(|t| t.tid == parent_tid) {
+            if child_completed {
+                t.state = ThreadState::Ready;
+                t.wake_tick = u64::MAX;
+            } else {
+                t.state = ThreadState::Blocked;
+                t.wake_tick = crate::arch::x86_64::irq::get_ticks().saturating_add(500);
+            }
+        }
+        !child_completed
+    };
+
+    // ── Post-condition: the parent must NOT have parked. ──────────────────
+    let mut ok = true;
+    if parked {
+        test_fail!("vfork_p2w_race",
+            "parent parked despite child already completed — would rely on \
+             the 5 s timeout (lost wake)");
+        ok = false;
+    } else {
+        let parent_state = {
+            let threads = THREAD_TABLE.lock();
+            threads.iter().find(|t| t.tid == parent_tid).map(|t| t.state)
+        };
+        if matches!(parent_state, Some(ThreadState::Blocked)) {
+            test_fail!("vfork_p2w_race",
+                "parent tid {} left Blocked after recheck (state={:?})",
+                parent_tid, parent_state);
+            ok = false;
+        } else {
+            test_println!("  parent tid {} not parked; child completion observed ✓",
+                parent_tid);
+        }
+    }
+
+    // ── Cleanup synthetic rows. ───────────────────────────────────────────
+    { let mut threads = THREAD_TABLE.lock(); threads.retain(|t| t.tid != child_tid); }
+    { let mut procs = crate::proc::PROCESS_TABLE.lock(); procs.retain(|p| p.pid != host_pid); }
+    { let mut threads = THREAD_TABLE.lock(); threads.retain(|t| t.pid != host_pid); }
+    crate::proc::proc_metrics::unregister(host_pid);
+
+    if ok {
+        test_pass!("vfork prepare-to-wait lost-wakeup close (PR #502)");
+    }
+    ok
 }
 
 // ── Test 232: VFS write-path page-cache coherency (POSIX mmap+write) ──────

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2525,6 +2525,29 @@ pub fn run() -> ! {
     total += 1;
     if test_281_socket_recv_eagain_vs_eof() { passed += 1; }
 
+    // ── Test 286: concurrent SCM_RIGHTS deliver in byte-offset order (N1) ──
+    // Two SCM batches whose enqueue-offset capture and PENDING_SCM push
+    // interleave so the Vec order inverts vs byte order must still be
+    // delivered lowest-offset-first.  Refs: unix(7)/recvmsg(2) SCM_RIGHTS.
+    total += 1;
+    if test_286_scm_dequeue_byte_order() { passed += 1; }
+
+    // ── Test 287: PENDING_SCM drained on receiver teardown (N2, CWE-772) ──
+    // Closing a receiver socket with an undelivered SCM batch must release
+    // the per-fd reference taken at enqueue so the passed socket is not
+    // leaked and its peer observes the hang-up.  Refs: unix(7) SCM_RIGHTS,
+    // CWE-772.
+    total += 1;
+    if test_287_scm_drain_on_close_no_leak() { passed += 1; }
+
+    // ── Test 288: SCM-passed memfd inode survives sender close (N4) ────────
+    // A memfd (unlinked anonymous inode per memfd_create(2)) passed via
+    // SCM_RIGHTS must stay readable after the sender closes its copy — the
+    // in-flight pin keeps the inode alive, and it is freed only once both
+    // sides close.  Refs: memfd_create(2), unix(7) SCM_RIGHTS.
+    total += 1;
+    if test_288_scm_memfd_inode_lifecycle() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -44961,5 +44984,317 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
     // Cleanup: release the bound port so a re-run does not collide.
     socket::socket_close(sid);
     test_pass!("non-blocking socket recv: EAGAIN on empty, 0 only on EOF (Test 281)");
+    true
+}
+
+// ── Test 286: concurrent SCM_RIGHTS delivered in byte-offset order (N1) ──────
+//
+// The sendmsg(2) SCM path captures the enqueue byte-offset (under the unix
+// TABLE lock) and pushes the ScmBatch (under the PENDING_SCM lock) in two
+// separate critical sections.  Two concurrent sendmsg(2)s to the SAME peer can
+// therefore push their batches into the PENDING_SCM Vec in the OPPOSITE order
+// to their byte offsets.  scm_dequeue must deliver the LOWEST-offset deliverable
+// batch first (byte order), not the first Vec entry (push order) — otherwise the
+// later frame's fds attach to the earlier frame, a data-integrity bug.
+//
+// This test reproduces the inverted-push order directly: enqueue an
+// offset==4 batch BEFORE an offset==0 batch (the order two interleaved senders
+// could produce), then assert delivery is offset 0 then offset 4.
+// Refs: unix(7) / recvmsg(2) / sendmsg(2) SCM_RIGHTS.
+fn test_286_scm_dequeue_byte_order() -> bool {
+    use crate::net::unix;
+    test_header!("concurrent SCM_RIGHTS delivered in byte-offset order (Test 286)");
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("scm_order", "socketpair returned MAX");
+        return false;
+    }
+
+    // Two distinguishable throw-away descriptors.  We tag identity via `inode`.
+    let mk_fd = |ino: u64| crate::vfs::FileDescriptor {
+        inode: ino, mount_idx: 0, offset: 0, flags: 0,
+        file_type: crate::vfs::FileType::RegularFile,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+
+    // Place 4 bytes in B's recv ring so an offset-4 batch is a valid "later
+    // frame" position; the reader has NOT drained them yet (consumed==0), so
+    // only the offset-0 batch is deliverable first.
+    if unix::write(a, b"DATA") != 4 {
+        test_fail!("scm_order", "write(DATA) != 4");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // INVERTED push order: the offset-4 (later-frame) batch is pushed FIRST,
+    // the offset-0 (earlier-frame) batch SECOND — exactly the Vec inversion a
+    // non-atomic offset-capture-then-push race can produce.
+    crate::syscall::scm_queue(b, 4, alloc::vec![mk_fd(0xAAAA)]); // later frame
+    crate::syscall::scm_queue(b, 0, alloc::vec![mk_fd(0xBBBB)]); // earlier frame
+
+    // Reader at consumed==0: only the offset-0 batch is deliverable, and it must
+    // be the 0xBBBB one regardless of it being pushed second.
+    let first = crate::syscall::scm_dequeue(b, unix::recv_consumed(b));
+    match first.as_deref() {
+        Some([fd]) if fd.inode == 0xBBBB => {
+            test_println!("  consumed=0 → delivered offset-0 batch (0xBBBB) first ✓");
+        }
+        other => {
+            test_fail!("scm_order",
+                "consumed=0 delivered {:?} (expected the offset-0 batch 0xBBBB)",
+                other.map(|s| s.iter().map(|f| f.inode).collect::<alloc::vec::Vec<_>>()));
+            unix::close(a); unix::close(b);
+            return false;
+        }
+    }
+
+    // The offset-4 batch must still be WITHHELD (its data is undrained).
+    if crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).is_some() {
+        test_fail!("scm_order", "offset-4 batch delivered before its data drained");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // Drain the 4 data bytes; now the offset-4 batch (0xAAAA) is reachable.
+    let mut rbuf = [0u8; 4];
+    let _ = unix::read_msg(b, &mut rbuf);
+    match crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).as_deref() {
+        Some([fd]) if fd.inode == 0xAAAA => {
+            test_println!("  consumed=4 → delivered offset-4 batch (0xAAAA) second ✓");
+        }
+        other => {
+            test_fail!("scm_order",
+                "post-drain delivered {:?} (expected the offset-4 batch 0xAAAA)",
+                other.map(|s| s.iter().map(|f| f.inode).collect::<alloc::vec::Vec<_>>()));
+            unix::close(a); unix::close(b);
+            return false;
+        }
+    }
+
+    unix::close(a);
+    unix::close(b);
+    test_pass!("concurrent SCM_RIGHTS delivered in byte-offset order (Test 286)");
+    true
+}
+
+// ── Test 287: PENDING_SCM drained on receiver teardown — no ref leak (N2) ────
+//
+// 9c09fc8 inc_ref's an AF_UNIX socket passed via SCM_RIGHTS so the sender's
+// later close(2) does not tear down the shared socket.  But if the receiver is
+// torn down before it recvmsg's the batch, that reference must be released —
+// otherwise the passed socket leaks (CWE-772) and its peer never sees the
+// hang-up.  This test queues a passed socket for a receiver, closes the
+// receiver (which must drain PENDING_SCM and balance the inc_ref), then closes
+// the sender's own copy and asserts the passed socket's PEER now sees a full
+// hang-up — proving the refcount returned to zero (no leak).
+// Refs: unix(7) SCM_RIGHTS, CWE-772.
+fn test_287_scm_drain_on_close_no_leak() -> bool {
+    use crate::net::unix;
+    test_header!("PENDING_SCM drained on receiver close — no socket leak (Test 287)");
+
+    // Transport pair (sender end `ta`, receiver end `tb`).
+    let (ta, tb) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    // Payload pair: `pc` is the fd we "pass" via SCM; `pd` is its peer, which
+    // must observe the hang-up once `pc` is finally torn down.
+    let (pc, pd) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if ta == u64::MAX || tb == u64::MAX || pc == u64::MAX || pd == u64::MAX {
+        test_fail!("scm_leak", "socketpair returned MAX");
+        return false;
+    }
+
+    // Baseline: pd is connected and NOT hung up.
+    if unix::fully_hung_up(pd) {
+        test_fail!("scm_leak", "pd unexpectedly hung up at start");
+        unix::close(ta); unix::close(tb); unix::close(pc); unix::close(pd);
+        return false;
+    }
+
+    // Model the sendmsg(2) SCM enqueue: inc_ref the passed socket (pc.ref_count
+    // 1→2, mirroring the kernel's inc_ref on fd-pass) and queue the batch for
+    // receiver tb at its current stream tail.
+    unix::inc_ref(pc);
+    let off = unix::enqueue_offset_for(tb);
+    let passed_fd = crate::vfs::FileDescriptor {
+        inode: pc, mount_idx: 0, offset: 0,
+        flags: crate::syscall::UNIX_SOCKET_FLAG,
+        file_type: crate::vfs::FileType::Socket,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+    crate::syscall::scm_queue(tb, off, alloc::vec![passed_fd]);
+
+    // Sanity: the batch is queued and deliverable.
+    if !crate::syscall::has_scm_deliverable(tb, unix::recv_consumed(tb)) {
+        test_fail!("scm_leak", "queued batch not deliverable");
+        unix::close(ta); unix::close(tb); unix::close(pc); unix::close(pd);
+        return false;
+    }
+
+    // Receiver is torn down WITHOUT ever recvmsg'ing the batch.  close(tb) must
+    // drain PENDING_SCM and run scm_drop_fds, which net::unix::close(pc)'s the
+    // passed socket — balancing the inc_ref above (pc.ref_count 2→1).
+    unix::close(tb);
+
+    // The batch must be gone from PENDING_SCM (no leak of the Vec entry).
+    if crate::syscall::has_scm_deliverable(tb, 0) {
+        test_fail!("scm_leak", "batch still queued after receiver close (drain leaked)");
+        unix::close(ta); unix::close(pc); unix::close(pd);
+        return false;
+    }
+
+    // pd must NOT yet be hung up — pc still has one live reference (the
+    // sender's own copy), so the drain correctly did NOT over-decrement.
+    if unix::fully_hung_up(pd) {
+        test_fail!("scm_leak",
+            "pd hung up after receiver close — drain OVER-decremented (double free)");
+        unix::close(ta); unix::close(pc); unix::close(pd);
+        return false;
+    }
+    test_println!("  receiver close drained the batch + balanced one ref ✓");
+
+    // Now close the sender's own copy of the passed socket (pc.ref_count 1→0).
+    // This is the LAST reference: if the drain had leaked (not decremented),
+    // pc.ref_count would be 2 here and this close would leave it at 1 — pd would
+    // NOT hang up.  A correct drain leaves exactly one ref, so this tears pc down
+    // and pd observes the full hang-up.
+    unix::close(pc);
+    if !unix::fully_hung_up(pd) {
+        test_fail!("scm_leak",
+            "pd NOT hung up after final close — passed-socket ref LEAKED (CWE-772)");
+        unix::close(ta); unix::close(pd);
+        return false;
+    }
+    test_println!("  final close tore down the passed socket → peer sees HUP ✓");
+
+    unix::close(ta);
+    unix::close(pd);
+    test_pass!("PENDING_SCM drained on receiver close — no socket leak (Test 287)");
+    true
+}
+
+// ── Test 288: SCM-passed memfd inode survives sender close (N4) ──────────────
+//
+// memfd_create(2) now unlinks the backing file immediately (anonymous inode),
+// so its lifetime is governed by the unlink-on-last-close machinery — which
+// frees the inode once no open fd references it.  A memfd handed to another
+// process via SCM_RIGHTS that is still IN FLIGHT (queued in PENDING_SCM, not yet
+// in any fd table) is invisible to that fd-table scan, so the enqueue path pins
+// the inode (vfs::pin_inode).  This test proves: while pinned, the sender's
+// close(2) of its copy must NOT free the inode (the in-flight passed copy still
+// needs it — the Mozilla shared-surface fd handoff); once the pin is balanced
+// (delivery) and the delivered copy is the last reference, the inode is freed.
+// Refs: memfd_create(2), unix(7) SCM_RIGHTS.
+fn test_288_scm_memfd_inode_lifecycle() -> bool {
+    test_header!("SCM-passed memfd inode survives sender close (Test 288)");
+    const MFD_CLOEXEC: u64 = 0x0001;
+
+    // Create a memfd (now an unlinked anonymous inode) and write a surface byte.
+    let fd = crate::subsys::linux::syscall::sys_memfd_create_test(0, MFD_CLOEXEC);
+    if fd < 0 {
+        test_fail!("scm_memfd", "memfd_create returned {}", fd);
+        return false;
+    }
+    let mut surf = [0xC0u8, 0xFF, 0xEE, 0x42];
+    let wn = crate::syscall::sys_write_test(fd as usize, surf.as_ptr(), surf.len());
+    if wn != surf.len() as i64 {
+        test_fail!("scm_memfd", "write to memfd = {} (want {})", wn, surf.len());
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+
+    // Snapshot (mount_idx, inode) of the memfd from the current fd table.
+    let pid = crate::proc::current_pid_lockless();
+    let (mnt, ino) = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter().find(|p| p.pid == pid)
+            .and_then(|p| p.file_descriptors.get(fd as usize))
+            .and_then(|f| f.as_ref())
+            .map(|f| (f.mount_idx, f.inode))
+        {
+            Some(v) => v,
+            None => {
+                test_fail!("scm_memfd", "could not resolve memfd inode");
+                crate::subsys::linux::syscall::sys_close_test(fd as u64);
+                return false;
+            }
+        }
+    };
+    if mnt == usize::MAX {
+        test_fail!("scm_memfd", "memfd has sentinel mount_idx (not a real inode)");
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+    test_println!("  memfd inode {} on mount {} ✓", ino, mnt);
+
+    // Model the SCM enqueue: pin the inode (the in-flight passed copy) and also
+    // install a second fd-table slot that references the same inode (the copy
+    // that will be DELIVERED to the receiver).  We do this in-process: a second
+    // fd is the cleanest stand-in for the receiver's installed descriptor.
+    crate::vfs::pin_inode(mnt, ino);
+    let recv_fd = {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter_mut().find(|p| p.pid == pid) {
+            Some(p) => {
+                let mut dup = p.file_descriptors[fd as usize].clone();
+                // The writer advanced the offset to 4; reset the receiver copy to
+                // 0 so this test's read(2) reads the surface from the start (real
+                // surface access is via mmap, where the offset is irrelevant).
+                if let Some(d) = dup.as_mut() { d.offset = 0; }
+                let slot = p.file_descriptors.iter().position(|e| e.is_none())
+                    .unwrap_or(p.file_descriptors.len());
+                if slot == p.file_descriptors.len() {
+                    p.file_descriptors.push(dup);
+                } else {
+                    p.file_descriptors[slot] = dup;
+                }
+                slot
+            }
+            None => { test_fail!("scm_memfd", "process gone"); return false; }
+        }
+    };
+
+    // SENDER close: drop the original fd while the batch is "in flight" (pinned).
+    // The inode MUST survive — the pin holds it even though, with the receiver
+    // copy modelled below, the fd-table scan also would; pin is the load-bearing
+    // guard for the true in-flight (pre-delivery) window.
+    crate::subsys::linux::syscall::sys_close_test(fd as u64);
+
+    // The delivered/receiver copy must STILL read the surface bytes — the inode
+    // was not freed out from under it.
+    let mut rbuf = [0u8; 4];
+    let rn = crate::syscall::sys_read_test(recv_fd, rbuf.as_mut_ptr(), rbuf.len());
+    if rn != 4 || rbuf != surf {
+        test_fail!("scm_memfd",
+            "receiver read after sender close = {} bytes {:?} (want {:?}) — inode freed early",
+            rn, rbuf, surf);
+        crate::vfs::unpin_inode(mnt, ino);
+        crate::subsys::linux::syscall::sys_close_test(recv_fd as u64);
+        return false;
+    }
+    test_println!("  receiver copy still reads the surface after sender close ✓");
+
+    // DELIVERY balance: drop the in-flight pin.  The receiver fd-table slot now
+    // keeps the inode alive on its own, so it must remain readable.
+    crate::vfs::unpin_inode(mnt, ino);
+    surf[0] = 0xC0; // (rbuf already validated; re-read to confirm liveness)
+    let rn2 = crate::syscall::sys_read_test(recv_fd, rbuf.as_mut_ptr(), 1);
+    // After the prior 4-byte read the offset is at EOF, so a further read returns
+    // 0 — that is liveness (a freed inode would not even resolve the fd).  Accept
+    // rn2 >= 0 (0 = EOF at end of file, the expected steady state).
+    if rn2 < 0 {
+        test_fail!("scm_memfd", "post-unpin read errored ({}) — inode freed while fd open", rn2);
+        crate::subsys::linux::syscall::sys_close_test(recv_fd as u64);
+        return false;
+    }
+    test_println!("  inode stays alive via the delivered fd-table slot after unpin ✓");
+
+    // Final close of the last reference frees the (unlinked) inode.
+    crate::subsys::linux::syscall::sys_close_test(recv_fd as u64);
+    test_pass!("SCM-passed memfd inode survives sender close (Test 288)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1064,6 +1064,10 @@ pub fn run() -> ! {
     total += 1;
     if test_map_page_in_if_absent_anti_alias() { passed += 1; }
 
+    // ── Test 98h: file-backed install-arm anti-aliasing back-out ─────────
+    total += 1;
+    if test_pfh_install_arm_anti_alias_backout() { passed += 1; }
+
     // ── Test 99: procfs self/maps — per-process VMA listing ──────────────
 
     total += 1;
@@ -29173,6 +29177,164 @@ fn test_map_page_in_if_absent_anti_alias() -> bool {
     crate::proc::free_vm_space(vm);
 
     test_pass!("map_page_in_if_absent anti-aliasing");
+    true
+}
+
+/// Regression test for the file-backed page-fault install-arm anti-aliasing
+/// back-out (the libxul GOT/PLT/.data/.bss private-writable segment race).
+///
+/// The cache-hit / readahead / single-page install arms in `handle_page_fault`
+/// mint a backing frame and publish a leaf PTE for a file-backed
+/// MAP_PRIVATE-writable VA.  On a shared address space (CLONE_VM / vfork) two
+/// CPUs can reach the SAME VA's install concurrently.  The arms were converted
+/// from an unconditional `map_page_in` to `map_page_in_if_absent` so the loser
+/// backs out instead of overwriting the winner's PTE with a second frame (the
+/// cross-CPU store-visibility failure).  This test models the two back-out
+/// shapes used by those arms and proves the refcount accounting nets correctly:
+///
+///   (A) PRIVATE-COPY shape — the loser's freshly-allocated private frame was
+///       never mapped (refcount left at 0 until a successful install), so the
+///       arm must `free_page` it with NO leak and NO refcount drift, while the
+///       winner's private frame stays mapped at refcount 1.
+///   (B) ALIAS shape — the installed frame is the SHARED cache frame; the loser
+///       must NOT free it but must release its redundant guard ref so the frame
+///       nets cache(1) + winner-PTE(1) = 2 with no drift.
+///
+/// Refs: POSIX mmap(2) MAP_PRIVATE (a private VA in a shared address space must
+/// resolve to one backing frame); Intel SDM Vol. 3A §4.10.4.3 (present-recheck
+/// before leaf install; per-logical-processor invalidation).
+fn test_pfh_install_arm_anti_alias_backout() -> bool {
+    test_header!("PFH install-arm anti-aliasing back-out (private-copy + alias)");
+
+    use crate::mm::vmm::{read_pte, map_page_in_if_absent, PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER, ADDR_MASK};
+    use crate::mm::refcount::{page_ref_set, page_ref_inc, page_ref_dec, page_ref_count,
+        page_ref_dec_underflow_count};
+
+    let vm = match crate::mm::vma::VmSpace::new_user() {
+        Some(vs) => vs,
+        None => { test_fail!("backout", "VmSpace::new_user() OOM"); return false; }
+    };
+    let cr3 = vm.cr3;
+    let va: u64 = 0x5555_0001_0000;            // file-backed-style lower-half VA
+    let page = crate::mm::vma::page_align_down(va);
+    let flags = PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+
+    let underflow_before = page_ref_dec_underflow_count();
+
+    // Helper: free up to three frames + the address space, then fail.
+    macro_rules! bail {
+        ($($f:expr),* ; $($arg:tt)*) => {{
+            $( crate::mm::pmm::free_page($f); )*
+            crate::proc::free_vm_space(vm);
+            test_fail!("backout", $($arg)*);
+            return false;
+        }};
+    }
+
+    // ── (A) PRIVATE-COPY shape ────────────────────────────────────────────
+    // Winner: alloc private frame, install, THEN set refcount 1 (mirrors the
+    // arm order: refcount is set only after a successful install).
+    let priv_winner = match crate::mm::pmm::alloc_page() {
+        Some(p) => p, None => bail!( ; "OOM priv_winner"),
+    };
+    if !map_page_in_if_absent(cr3, page, priv_winner, flags) {
+        bail!(priv_winner ; "priv winner install returned false on not-present PTE");
+    }
+    page_ref_set(priv_winner, 1);
+
+    // Loser: alloc a DIFFERENT private frame (refcount stays 0 — never set),
+    // race the SAME VA → must lose, and the arm frees it WITHOUT a refcount
+    // touch (frame at 0 frees cleanly; no underflow).
+    let priv_loser = match crate::mm::pmm::alloc_page() {
+        Some(p) => p, None => bail!(priv_winner ; "OOM priv_loser"),
+    };
+    if priv_loser == priv_winner {
+        bail!(priv_winner, priv_loser ; "allocator returned identical frames");
+    }
+    let lost_a = map_page_in_if_absent(cr3, page, priv_loser, flags);
+    if lost_a {
+        bail!(priv_winner, priv_loser ; "priv loser returned true — overwrote winner PTE (aliasing)");
+    }
+    // PTE must still map the winner's private frame.
+    let pte_a = read_pte(cr3, va);
+    if (pte_a & ADDR_MASK) != (priv_winner & ADDR_MASK) {
+        bail!(priv_winner, priv_loser ; "PTE no longer maps priv_winner: pte={:#x} winner={:#x}",
+            pte_a, priv_winner);
+    }
+    // The loser frame was never mapped and its refcount is 0 → the arm frees it.
+    // We model that free here and confirm no refcount drift / underflow.
+    if page_ref_count(priv_loser) != 0 {
+        bail!(priv_winner, priv_loser ; "priv_loser refcount drifted to {} (expected 0)",
+            page_ref_count(priv_loser));
+    }
+    crate::mm::pmm::free_page(priv_loser);   // loser-frees path — no leak
+    if page_ref_count(priv_winner) != 1 {
+        bail!(priv_winner ; "priv_winner refcount drifted to {} (expected 1)",
+            page_ref_count(priv_winner));
+    }
+    test_println!("  (A) private-copy loser freed its unmapped frame; winner intact (rc=1) ✓");
+
+    // ── (B) ALIAS shape ───────────────────────────────────────────────────
+    // A shared cache frame: cache holds one ref, plus a guard ref per faulting
+    // CPU.  Winner promotes its guard ref to the PTE ref (no dec); loser must
+    // release its redundant guard ref so the frame nets cache(1)+PTE(1)=2.
+    let va2: u64 = 0x5555_0002_0000;
+    let page2 = crate::mm::vma::page_align_down(va2);
+    let cache_phys = match crate::mm::pmm::alloc_page() {
+        Some(p) => p, None => bail!(priv_winner ; "OOM cache_phys"),
+    };
+    page_ref_set(cache_phys, 1);             // cache's own reference
+    page_ref_inc(cache_phys);                // winner's guard ref
+    page_ref_inc(cache_phys);                // loser's guard ref  → rc = 3
+
+    // Winner installs the SHARED frame, promoting its guard ref to the PTE ref
+    // (does NOT dec).  rc stays 3 (cache + winner-PTE + loser-guard).
+    if !map_page_in_if_absent(cr3, page2, cache_phys, flags) {
+        page_ref_set(cache_phys, 0);
+        bail!(priv_winner, cache_phys ; "alias winner install returned false on not-present PTE");
+    }
+    // Loser races the SAME VA → must lose and release ONLY its guard ref
+    // (do NOT free the shared frame).  Model that release: dec once.
+    let lost_b = map_page_in_if_absent(cr3, page2, cache_phys, flags);
+    if lost_b {
+        page_ref_set(cache_phys, 0);
+        bail!(priv_winner, cache_phys ; "alias loser returned true — re-published shared PTE");
+    }
+    let rc_after_loss = page_ref_dec(cache_phys);   // loser releases guard ref
+    if rc_after_loss != 2 {
+        page_ref_set(cache_phys, 0);
+        bail!(priv_winner, cache_phys ; "alias frame refcount after loser back-out = {} (expected 2: cache+PTE)",
+            rc_after_loss);
+    }
+    // PTE still maps the shared frame (winner's mapping survived).
+    let pte_b = read_pte(cr3, va2);
+    if (pte_b & ADDR_MASK) != (cache_phys & ADDR_MASK) {
+        page_ref_set(cache_phys, 0);
+        bail!(priv_winner, cache_phys ; "alias PTE no longer maps cache_phys: pte={:#x} phys={:#x}",
+            pte_b, cache_phys);
+    }
+    test_println!("  (B) alias loser released guard ref; frame intact (rc=2), not freed ✓");
+
+    // No refcount-dec underflow may have been triggered by either back-out.
+    let underflow_after = page_ref_dec_underflow_count();
+    if underflow_after != underflow_before {
+        page_ref_set(cache_phys, 0);
+        bail!(priv_winner, cache_phys ; "refcount-dec underflow fired {} time(s) during back-out",
+            underflow_after - underflow_before);
+    }
+
+    // Teardown.  `free_vm_space` frees backing frames only for VMAs in
+    // `vm_space.areas`; this test installs PTEs directly (no VMAs), so it
+    // explicitly releases the two mapped frames here, then frees the page-table
+    // structures via `free_vm_space`.  Reset both frames to refcount 0 and
+    // return them to the PMM with no leak.
+    page_ref_set(priv_winner, 0);
+    crate::mm::pmm::free_page(priv_winner);
+    page_ref_set(cache_phys, 0);
+    crate::mm::pmm::free_page(cache_phys);
+    crate::proc::free_vm_space(vm);
+
+    test_pass!("PFH install-arm anti-aliasing back-out");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -45254,7 +45254,11 @@ fn test_288_scm_memfd_inode_lifecycle() -> bool {
                 }
                 slot
             }
-            None => { test_fail!("scm_memfd", "process gone"); return false; }
+            None => {
+                test_fail!("scm_memfd", "process gone");
+                crate::vfs::unpin_inode(mnt, ino); // balance the pin taken above
+                return false;
+            }
         }
     };
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2492,6 +2492,17 @@ pub fn run() -> ! {
     total += 1;
     if test_280_scm_control_only_readiness() { passed += 1; }
 
+    // ── Test 281: non-blocking socket recv reports EAGAIN, not 0, on an
+    // empty queue (and 0 only on orderly EOF) ───────────────────────────
+    // recvmsg(2)/recv(2) on a non-blocking AF_INET socket with no datagram
+    // pending must surface "would block" as -EAGAIN, never as a 0-byte
+    // return: a 0 falsely signals EOF and drives a polled event loop into a
+    // busy re-read spin (the FF content-process screenshot-IPC gate).  An
+    // orderly read-shutdown must still return 0.  Refs: recvmsg(2), recv(2),
+    // IEEE 1003.1 §recv, POSIX.1-2017 §2.10.6.
+    total += 1;
+    if test_281_socket_recv_eagain_vs_eof() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -44473,5 +44484,129 @@ fn test_280_scm_control_only_readiness() -> bool {
     unix::close(a);
     unix::close(b);
     test_pass!("control-only SCM_RIGHTS readiness + byte-offset binding (Test 280)");
+    true
+}
+
+// ── Test 281: non-blocking socket recv — EAGAIN on empty queue, 0 only on EOF
+//
+// recvmsg(2)/recv(2) on a non-blocking AF_INET socket distinguishes three
+// outcomes that the syscall layer must translate correctly:
+//
+//   * data pending      → return the byte count
+//   * empty, peer live  → -1 / EAGAIN  (would-block)
+//   * orderly shutdown  →  0           (EOF)
+//
+// The bug this guards: the recvmsg/read arms previously collapsed "empty,
+// peer live" into a 0-byte return (the same value as EOF).  A polled IPC
+// reactor reads the spurious 0 as a readable edge and re-issues recvmsg in a
+// tight loop — the exact busy-spin observed on the Firefox content-process
+// screenshot-IPC channel, where one process pegged ~680k recvmsg/s while the
+// peer it should have serviced stayed frozen.
+//
+// This drives `socket_recv_status` (the EAGAIN-correct primitive the syscall
+// arms now call) directly, asserting the WouldBlock / Data / Eof mapping.
+//
+// Refs: recvmsg(2), recv(2), IEEE 1003.1 §recv ("a return value of 0
+// indicates the peer has performed an orderly shutdown"), POSIX.1-2017
+// §2.10.6 (Socket Receive Queue).
+fn test_281_socket_recv_eagain_vs_eof() -> bool {
+    use crate::net::socket::{self, RecvOutcome, SocketType};
+    test_header!("non-blocking socket recv: EAGAIN on empty, 0 only on EOF (Test 281)");
+
+    const PORT: u16 = 0xB281; // arbitrary unused test port
+
+    let sid = socket::socket_create(SocketType::Udp);
+    if sid == u64::MAX {
+        test_fail!("recv_eagain", "socket_create returned MAX");
+        return false;
+    }
+    if let Err(e) = socket::socket_bind(sid, PORT) {
+        test_fail!("recv_eagain", "socket_bind failed: {}", e);
+        return false;
+    }
+
+    // (1) Empty queue, socket live → MUST be WouldBlock (the storm-fix case).
+    match socket::socket_recv_status(sid) {
+        Ok(RecvOutcome::WouldBlock) => {
+            test_println!("  empty bound UDP socket → WouldBlock ✓");
+        }
+        other => {
+            let tag = match other {
+                Ok(RecvOutcome::Data(d)) => {
+                    test_fail!("recv_eagain",
+                        "empty socket returned Data({} bytes), expected WouldBlock",
+                        d.len());
+                    return false;
+                }
+                Ok(RecvOutcome::Eof) => "Eof",
+                Ok(RecvOutcome::WouldBlock) => unreachable!(),
+                Err(_) => "Err",
+            };
+            test_fail!("recv_eagain",
+                "empty socket returned {}, expected WouldBlock (EAGAIN)", tag);
+            return false;
+        }
+    }
+
+    // (2) Inject a datagram via the wire path → MUST be Data with the bytes.
+    //     checksum=0 skips verification (RFC 1071 identity), so the datagram
+    //     is delivered straight to the bound port's queue.
+    const PAYLOAD: &[u8] = b"px";
+    {
+        let mut pkt = alloc::vec::Vec::with_capacity(8 + PAYLOAD.len());
+        pkt.extend_from_slice(&0x1234u16.to_be_bytes());          // src_port
+        pkt.extend_from_slice(&PORT.to_be_bytes());               // dst_port
+        pkt.extend_from_slice(&((8 + PAYLOAD.len()) as u16).to_be_bytes()); // length
+        pkt.extend_from_slice(&0u16.to_be_bytes());               // checksum=0 → skip
+        pkt.extend_from_slice(PAYLOAD);
+        crate::net::udp::handle_udp([10, 0, 2, 2], [10, 0, 2, 15], &pkt);
+    }
+    match socket::socket_recv_status(sid) {
+        Ok(RecvOutcome::Data(d)) if d == PAYLOAD => {
+            test_println!("  injected datagram → Data({} bytes) ✓", d.len());
+        }
+        Ok(RecvOutcome::Data(d)) => {
+            test_fail!("recv_eagain",
+                "datagram recv returned {} bytes, expected {}", d.len(), PAYLOAD.len());
+            return false;
+        }
+        _ => {
+            test_fail!("recv_eagain", "datagram recv did not return Data");
+            return false;
+        }
+    }
+
+    // (3) After draining, the queue is empty again → WouldBlock, NOT Eof.
+    //     This is the regression's heart: an empty-but-live socket must never
+    //     read as EOF.
+    match socket::socket_recv_status(sid) {
+        Ok(RecvOutcome::WouldBlock) => {
+            test_println!("  drained socket → WouldBlock (not EOF) ✓");
+        }
+        _ => {
+            test_fail!("recv_eagain", "drained live socket did not return WouldBlock");
+            return false;
+        }
+    }
+
+    // (4) shutdown(SHUT_RD) → orderly EOF → MUST be Eof (0-byte return).
+    const SHUT_RD: i32 = 0;
+    if socket::socket_shutdown(sid, SHUT_RD) != 0 {
+        test_fail!("recv_eagain", "socket_shutdown(SHUT_RD) failed");
+        return false;
+    }
+    match socket::socket_recv_status(sid) {
+        Ok(RecvOutcome::Eof) => {
+            test_println!("  after SHUT_RD → Eof ✓");
+        }
+        _ => {
+            test_fail!("recv_eagain", "post-SHUT_RD recv did not return Eof");
+            return false;
+        }
+    }
+
+    // Cleanup: release the bound port so a re-run does not collide.
+    socket::socket_close(sid);
+    test_pass!("non-blocking socket recv: EAGAIN on empty, 0 only on EOF (Test 281)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2482,6 +2482,16 @@ pub fn run() -> ! {
     total += 1;
     if test_278_mounts_lock_not_held_across_fs_dispatch() { passed += 1; }
 
+    // ── Test 280: control-only SCM_RIGHTS confers read-readiness ─────────
+    // A sendmsg(2) carrying SCM_RIGHTS with an empty data payload
+    // (iov_len==0, a pure fd handoff) is still a readable message:
+    // poll/epoll must report POLLIN and recvmsg must return it with 0 data
+    // bytes + the cmsg.  Also verifies the byte-offset binding that keeps
+    // fds attached to their originating stream frame.
+    // Refs: recvmsg(2)/sendmsg(2), poll(2), epoll(7), unix(7) SCM_RIGHTS.
+    total += 1;
+    if test_280_scm_control_only_readiness() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -21183,11 +21193,20 @@ fn test_scm_rights() -> bool {
     };
     test_println!("  File inode={} prepared ✓", inode);
 
-    // Queue the fd from A→B: scm_queue(receiver=B, fds).
-    crate::syscall::scm_queue(id_b, alloc::vec![fd_to_pass]);
+    // Queue the fd from A→B at B's current recv-stream position.  B has read
+    // nothing, so this batch (offset 0) is immediately deliverable
+    // (consumed 0 >= offset 0).
+    let off_b = crate::net::unix::enqueue_offset_for(id_b);
+    crate::syscall::scm_queue(id_b, off_b, alloc::vec![fd_to_pass]);
 
-    // Dequeue from B.
-    let received = crate::syscall::scm_dequeue(id_b);
+    // The batch must register as deliverable — the POLLIN readiness predicate.
+    if !crate::syscall::has_scm_deliverable(id_b, crate::net::unix::recv_consumed(id_b)) {
+        test_fail!("scm_rights", "queued SCM batch not reported deliverable");
+        return false;
+    }
+
+    // Dequeue from B at B's current consumed position.
+    let received = crate::syscall::scm_dequeue(id_b, crate::net::unix::recv_consumed(id_b));
     if received.is_none() {
         test_fail!("scm_rights", "scm_dequeue(B) returned None");
         return false;
@@ -21216,7 +21235,7 @@ fn test_scm_rights() -> bool {
     test_println!("  File content via path: {:?} ✓", core::str::from_utf8(&content).unwrap_or("?"));
 
     // Second dequeue should return None (only one batch queued).
-    if crate::syscall::scm_dequeue(id_b).is_some() {
+    if crate::syscall::scm_dequeue(id_b, crate::net::unix::recv_consumed(id_b)).is_some() {
         test_fail!("scm_rights", "Second dequeue should return None");
         return false;
     }
@@ -44292,5 +44311,167 @@ fn test_278_mounts_lock_not_held_across_fs_dispatch() -> bool {
     test_println!("  cleaned up test mount");
 
     test_pass!("VFS MOUNTS-lock not held across FS dispatch (deadlock regression)");
+    true
+}
+
+// ── Test 280: control-only SCM_RIGHTS confers read-readiness + byte-offset bind
+//
+// A `sendmsg(2)` that carries an `SCM_RIGHTS` control message with an empty
+// data payload (`iov_len == 0`, a pure fd handoff) is still a *readable
+// message*: `poll(2)`/`epoll(7)` must report `POLLIN`/`EPOLLIN` and
+// `recvmsg(2)` must return it with 0 data bytes and the cmsg attached
+// (recvmsg(2), unix(7), POSIX.1-2017 SCM_RIGHTS).  Without this the receiver
+// parks in poll() forever on a control-only frame.
+//
+// This test drives the exact predicates the syscall layer uses:
+//   * `has_scm_deliverable(uid, consumed)` — the readiness predicate ORed
+//     into POLLIN/EPOLLIN in poll_revents / epoll_poll_events / select.
+//   * `scm_dequeue(uid, consumed)` — the byte-offset-gated delivery used by
+//     recvmsg after read_msg returns EAGAIN on an empty ring.
+//   * the byte-offset binding: a batch sent *after* a data frame is withheld
+//     until the reader drains past it, so an earlier reader does not pick up
+//     a later frame's fds.
+//
+// Refs: recvmsg(2)/sendmsg(2), poll(2), epoll(7), unix(7) SCM_RIGHTS,
+// POSIX.1-2017 §2.10.10 (Socket Receive Queue), §2.14 (File Descriptors).
+fn test_280_scm_control_only_readiness() -> bool {
+    use crate::net::unix;
+    use crate::ipc::waitlist::{BELL_RINGS_BY_SOURCE, PollBellSource};
+    test_header!("control-only SCM_RIGHTS readiness + byte-offset binding (Test 280)");
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("scm_ctrl_only", "socketpair returned MAX");
+        return false;
+    }
+
+    // A throw-away fd to pass.  Its identity is irrelevant — we assert on the
+    // readiness/binding, not the file behind it.
+    let mk_fd = || crate::vfs::FileDescriptor {
+        inode: 0xBEEF, mount_idx: 0, offset: 0, flags: 0,
+        file_type: crate::vfs::FileType::RegularFile,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+
+    // ── Part 1: a control-only batch (no data) on an empty stream is
+    // immediately readable — has_data() is false, has_scm_deliverable() true.
+    if unix::has_data(b) {
+        test_fail!("scm_ctrl_only", "fresh socket b unexpectedly has data");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    // Sender enqueues fds bound to B's current stream tail (offset 0, since B
+    // has received nothing) — exactly what sendmsg does for an iov_len==0 frame.
+    let off0 = unix::enqueue_offset_for(b);
+    if off0 != 0 {
+        test_fail!("scm_ctrl_only", "fresh enqueue_offset = {} (want 0)", off0);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    let bell_before = BELL_RINGS_BY_SOURCE[PollBellSource::UnixWrite as usize]
+        .load(core::sync::atomic::Ordering::Relaxed);
+    crate::syscall::scm_queue(b, off0, alloc::vec![mk_fd()]);
+    // The send-side bell ring is exercised by the sendmsg arm; emulate it so
+    // the test also covers the wake discipline (drop-lock-then-ring).
+    crate::ipc::waitlist::ring_poll_bell_for(PollBellSource::UnixWrite);
+    let bell_after = BELL_RINGS_BY_SOURCE[PollBellSource::UnixWrite as usize]
+        .load(core::sync::atomic::Ordering::Relaxed);
+    if bell_after <= bell_before {
+        test_fail!("scm_ctrl_only", "UnixWrite poll bell did not advance");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // Readiness predicate (the OR added to POLLIN) must now fire for B even
+    // though the data ring is empty.
+    let consumed_b = unix::recv_consumed(b);
+    if !crate::syscall::has_scm_deliverable(b, consumed_b) {
+        test_fail!("scm_ctrl_only", "control-only batch NOT reported readable");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    // read_msg on the empty ring returns EAGAIN — recvmsg promotes this to a
+    // 0-byte success because a deliverable batch is queued.  Verify the
+    // dequeue succeeds at B's current consumed position.
+    let mut scratch = [0u8; 8];
+    match unix::read_msg(b, &mut scratch) {
+        Err(-11) => { /* expected: empty ring, recvmsg would promote to 0 */ }
+        other => {
+            test_fail!("scm_ctrl_only", "read_msg on empty ring = {:?} (want EAGAIN)", other);
+            unix::close(a); unix::close(b);
+            return false;
+        }
+    }
+    let got = crate::syscall::scm_dequeue(b, unix::recv_consumed(b));
+    if got.map(|v| v.len()) != Some(1) {
+        test_fail!("scm_ctrl_only", "control-only scm_dequeue did not return the fd");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    // Batch consumed: no longer deliverable.
+    if crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
+        test_fail!("scm_ctrl_only", "batch still deliverable after dequeue");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  control-only SCM batch: readable + delivered with 0 data bytes ✓");
+
+    // ── Part 2: byte-offset binding.  Send a 4-byte data frame, THEN an
+    // fd batch bound to the post-data offset.  A reader that has not yet
+    // drained the 4 bytes must NOT receive the later batch.
+    let n = unix::write(a, b"DATA");          // lands in B's recv ring
+    if n != 4 {
+        test_fail!("scm_ctrl_only", "write(DATA) = {} (want 4)", n);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    let off_after_data = unix::enqueue_offset_for(b);   // == 4
+    if off_after_data != 4 {
+        test_fail!("scm_ctrl_only", "offset after 4-byte write = {} (want 4)", off_after_data);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    crate::syscall::scm_queue(b, off_after_data, alloc::vec![mk_fd()]);
+
+    // Reader is still at consumed==0 (the 4 data bytes are undrained): the
+    // batch bound to offset 4 must be WITHHELD.
+    if crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
+        test_fail!("scm_ctrl_only", "later batch deliverable before its data drained");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    if crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).is_some() {
+        test_fail!("scm_ctrl_only", "dequeued a not-yet-reached batch (ordering bug)");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  fds bound to a later stream offset are withheld until drained ✓");
+
+    // Drain the 4 data bytes — now the batch's offset is reached.
+    let mut rbuf = [0u8; 4];
+    let rn = unix::read_msg(b, &mut rbuf).map(|(c, _)| c).unwrap_or(-1isize as usize);
+    if rn != 4 || &rbuf != b"DATA" {
+        test_fail!("scm_ctrl_only", "drain read = {} / {:?}", rn, rbuf);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    if !crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
+        test_fail!("scm_ctrl_only", "batch not deliverable after its data drained");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    let got2 = crate::syscall::scm_dequeue(b, unix::recv_consumed(b));
+    if got2.map(|v| v.len()) != Some(1) {
+        test_fail!("scm_ctrl_only", "post-drain dequeue did not return the fd");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  fds delivered once the reader drains past their bound offset ✓");
+
+    unix::close(a);
+    unix::close(b);
+    test_pass!("control-only SCM_RIGHTS readiness + byte-offset binding (Test 280)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2565,6 +2565,17 @@ pub fn run() -> ! {
     total += 1;
     if test_289_scm_first_byte_bind() { passed += 1; }
 
+    // ── Test 290: a multi-fd SCM_RIGHTS message delivers ALL its fds ───────
+    // A single sendmsg(2) that attaches N>1 file descriptors in one SCM_RIGHTS
+    // control message forms ONE batch carrying all N fds; the recvmsg(2) that
+    // first returns the frame's bytes must co-deliver EVERY one of those fds
+    // (not a partial subset).  A reader whose message header announces
+    // num_handles==N and receives fewer than N descriptors aborts with "needs
+    // unreceived descriptors".  Refs: recvmsg(2), unix(7) SCM_RIGHTS,
+    // POSIX.1-2017 §2.14.
+    total += 1;
+    if test_290_scm_multi_fd_delivery() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -45541,9 +45552,10 @@ fn test_289_scm_first_byte_bind() -> bool {
         open_path: alloc::string::String::new(),
     };
 
-    // Capture B's recv position BEFORE pushing this frame's data — exactly the
-    // pre-push offset the sendmsg path now binds to (scm_bind_offset).
-    let first_byte_off = unix::enqueue_offset_for(b);
+    // Capture B's recv position T BEFORE pushing this frame's data — the stream
+    // position where the frame begins (the sendmsg path captures this as
+    // scm_bind_offset, also before its data-push loop).
+    let frame_start = unix::enqueue_offset_for(b);
 
     // Push an 8-byte data frame into B's recv ring (the "message").
     let n = unix::write(a, b"HDRBODY!");
@@ -45553,19 +45565,27 @@ fn test_289_scm_first_byte_bind() -> bool {
         return false;
     }
 
-    // Bind the fd batch to the FIRST byte of the frame (the fix).  The pre-fix
-    // tail bind would have used enqueue_offset_for(b) AFTER the write (== 8).
+    // The DATA-bearing sendmsg binds its fd batch to the position the reader
+    // reaches after popping the frame's FIRST byte (frame_start + 1) — the
+    // first-byte-touch contract (recvmsg(2) / unix(7) / POSIX.1-2017 §2.14:
+    // ancillary data is delivered with the recvmsg that returns the data it
+    // accompanies, i.e. once the reader begins consuming the frame, and NOT
+    // before any of its bytes are read).  The pre-fix tail bind would have used
+    // enqueue_offset_for(b) AFTER the write (== frame_start + 8), withholding
+    // the fds until EVERY byte was drained.
     let tail_off = unix::enqueue_offset_for(b);
-    if tail_off != first_byte_off + 8 {
+    if tail_off != frame_start + 8 {
         test_fail!("scm_firstbyte",
-            "tail offset {} != first {} + 8", tail_off, first_byte_off);
+            "tail offset {} != first {} + 8", tail_off, frame_start);
         unix::close(a); unix::close(b);
         return false;
     }
-    crate::syscall::scm_queue(b, first_byte_off, alloc::vec![mk_fd()]);
+    let bind_off = frame_start + 1; // data frame → first-byte-touched position
+    crate::syscall::scm_queue(b, bind_off, alloc::vec![mk_fd()]);
 
-    // Reader has consumed nothing yet — batch must be WITHHELD (it binds to the
-    // first byte, which the reader has not reached).
+    // Reader has consumed nothing yet (recv_consumed == frame_start) — the batch
+    // must be WITHHELD: its bound position frame_start+1 has not been reached, so
+    // the reader has not yet touched (begun consuming) the frame.
     if crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
         test_fail!("scm_firstbyte", "batch deliverable before any byte read");
         unix::close(a); unix::close(b);
@@ -45573,7 +45593,8 @@ fn test_289_scm_first_byte_bind() -> bool {
     }
 
     // Read ONLY the first byte of the 8-byte frame (a partial / header-first
-    // read).  recv_consumed advances by 1 — now >= first_byte_off.
+    // read).  recv_consumed advances from frame_start to frame_start+1 — exactly
+    // the bound position bind_off, so the batch now becomes deliverable.
     let mut one = [0u8; 1];
     let rn = unix::read_msg(b, &mut one).map(|(c, _)| c).unwrap_or(0xFFFF);
     if rn != 1 || one[0] != b'H' {
@@ -45614,5 +45635,122 @@ fn test_289_scm_first_byte_bind() -> bool {
     unix::close(a);
     unix::close(b);
     test_pass!("SCM_RIGHTS fds bound to the first byte of their frame (Test 289)");
+    true
+}
+
+// ── Test 290: a multi-fd SCM_RIGHTS message delivers ALL its fds ─────────────
+//
+// The sendmsg(2) SCM path collects every fd named in a single SCM_RIGHTS
+// control message into ONE batch and binds it to the frame's first-byte-touched
+// stream position; the recvmsg(2) that first returns the frame's bytes pops that
+// batch and installs ALL of its descriptors, writing one cmsg whose payload is
+// the full set of receiver-side fd numbers.  A 2-fd batch must therefore deliver
+// BOTH fds with the same recvmsg as a 1-fd batch delivers its one fd — a
+// short-delivery (fewer fds than the message header announced) makes a
+// length-prefixed IPC reader abort with "needs unreceived descriptors".  This
+// directly exercises the batch+dequeue layer with a 2-fd batch and an
+// interleaved 1-fd frame to confirm the multi-fd batch is neither split,
+// truncated, nor lost.  Refs: recvmsg(2)/sendmsg(2), unix(7) SCM_RIGHTS,
+// POSIX.1-2017 §2.14.
+fn test_290_scm_multi_fd_delivery() -> bool {
+    use crate::net::unix;
+    test_header!("multi-fd SCM_RIGHTS message delivers ALL its fds (Test 290)");
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("scm_multifd", "socketpair returned MAX");
+        return false;
+    }
+
+    // Distinguishable throw-away descriptors, tagged by `inode`.
+    let mk_fd = |ino: u64| crate::vfs::FileDescriptor {
+        inode: ino, mount_idx: 0, offset: 0, flags: 0,
+        file_type: crate::vfs::FileType::RegularFile,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+
+    // ── Part 1: a single 2-fd batch on a data frame delivers BOTH fds ────────
+    // Model the data-bearing 2-fd sendmsg: capture the frame start, push the
+    // data, then queue ONE batch of two fds bound to the first-byte-touched
+    // position (frame_start + 1), exactly as the sendmsg(2) SCM path does.
+    let frame_start = unix::enqueue_offset_for(b);
+    if unix::write(a, b"HDR") != 3 {
+        test_fail!("scm_multifd", "write(HDR) != 3");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    crate::syscall::scm_queue(b, frame_start + 1,
+        alloc::vec![mk_fd(0xF1), mk_fd(0xF2)]);
+
+    // Before any byte of the frame is read, the batch is withheld (first-byte
+    // bind): recv_consumed == frame_start < frame_start + 1.
+    if crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
+        test_fail!("scm_multifd", "2-fd batch deliverable before any byte read");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // Pop the first byte → recv_consumed reaches frame_start + 1 → the WHOLE
+    // 2-fd batch becomes deliverable on this recvmsg.
+    let mut one = [0u8; 1];
+    if unix::read_msg(b, &mut one).map(|(c, _)| c).unwrap_or(0xFFFF) != 1 {
+        test_fail!("scm_multifd", "partial read of frame failed");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    let got = crate::syscall::scm_dequeue(b, unix::recv_consumed(b));
+    match got.as_deref() {
+        Some([f1, f2]) if (f1.inode, f2.inode) == (0xF1, 0xF2) => {
+            test_println!("  2-fd batch delivered BOTH fds in one dequeue ✓");
+        }
+        other => {
+            test_fail!("scm_multifd",
+                "2-fd dequeue returned {:?} (expected exactly [0xF1, 0xF2])",
+                other.map(|s| s.iter().map(|f| f.inode).collect::<alloc::vec::Vec<_>>()));
+            unix::close(a); unix::close(b);
+            return false;
+        }
+    }
+    // Drain the rest of the frame so the stream position is clean for Part 2.
+    let mut rest = [0u8; 2];
+    let _ = unix::read_msg(b, &mut rest);
+
+    // ── Part 2: a 1-fd frame after a 2-fd frame keeps its single fd ──────────
+    // Cross-check the N1 ordering interaction: when one message carries 2 fds
+    // and a following message carries 1 fd, each batch is bound to its own
+    // first-byte position and dequeued in byte order — the 2-fd batch is not
+    // merged into, nor does it steal a descriptor from, the 1-fd batch.
+    let f2_start = unix::enqueue_offset_for(b);
+    if unix::write(a, b"X") != 1 {
+        test_fail!("scm_multifd", "write(X) != 1");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    crate::syscall::scm_queue(b, f2_start + 1, alloc::vec![mk_fd(0xAB)]);
+    let _ = unix::read_msg(b, &mut one); // pop the single byte
+    match crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).as_deref() {
+        Some([f]) if f.inode == 0xAB => {
+            test_println!("  following 1-fd frame delivered exactly its one fd ✓");
+        }
+        other => {
+            test_fail!("scm_multifd",
+                "1-fd frame dequeue returned {:?} (expected exactly [0xAB])",
+                other.map(|s| s.iter().map(|f| f.inode).collect::<alloc::vec::Vec<_>>()));
+            unix::close(a); unix::close(b);
+            return false;
+        }
+    }
+    // Nothing should remain queued.
+    if crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).is_some() {
+        test_fail!("scm_multifd", "unexpected extra batch after both frames drained");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    unix::close(a);
+    unix::close(b);
+    test_pass!("multi-fd SCM_RIGHTS message delivers ALL its fds (Test 290)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2554,6 +2554,17 @@ pub fn run() -> ! {
     total += 1;
     if test_288_scm_memfd_inode_lifecycle() { passed += 1; }
 
+    // ── Test 289: SCM_RIGHTS fds bound to the FIRST byte of their frame ────
+    // A data-bearing sendmsg(2) that also carries SCM_RIGHTS must deliver the
+    // passed fds with the SAME recvmsg(2) that first returns the frame's
+    // bytes — even on a partial (header-first) read.  Binding the fd batch to
+    // the frame TAIL withholds the fds until every byte is drained, which
+    // breaks a reader that parses a message header announcing N handles and
+    // then expects those fds already present ("needs unreceived
+    // descriptors").  Refs: recvmsg(2), unix(7) SCM_RIGHTS, POSIX.1-2017.
+    total += 1;
+    if test_289_scm_first_byte_bind() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -45487,5 +45498,121 @@ fn test_288_scm_memfd_inode_lifecycle() -> bool {
     // Final close of the last reference frees the (unlinked) inode.
     crate::subsys::linux::syscall::sys_close_test(recv_fd as u64);
     test_pass!("SCM-passed memfd inode survives sender close (Test 288)");
+    true
+}
+
+// ── Test 289: SCM_RIGHTS fds bind to the FIRST byte of their frame ───────────
+//
+// sendmsg(2) on an AF_UNIX SOCK_STREAM that carries BOTH data and SCM_RIGHTS
+// must deliver the passed fds with the SAME recvmsg(2) that first returns that
+// frame's bytes — including the common case where the receiver reads the frame
+// in pieces (a length-prefixed IPC reader reads the small fixed header first,
+// sees that the message announces N handles, and expects those descriptors
+// already attached).  The kernel binds an SCM batch to a recv-stream byte
+// position and makes it deliverable once `recv_consumed >= byte_offset`
+// (scm_dequeue).  Binding to the frame TAIL (the position AFTER the data bytes
+// are pushed) withholds the fds until the reader drains EVERY byte of the
+// frame; a header-first reader then gets the bytes with NO cmsg and aborts with
+// the fatal "needs unreceived descriptors".  The fix binds to the FIRST byte
+// (the position captured BEFORE the data push), so the batch becomes
+// deliverable the instant the reader pops the frame's first byte.
+//
+// This test reproduces the partial-read scenario at the primitive layer: push
+// a multi-byte data frame, bind an fd batch to the frame's FIRST byte, then
+// read only the first byte and assert the batch is ALREADY deliverable (the
+// pre-fix tail bind would withhold it until all bytes were drained).
+//
+// Refs: recvmsg(2), sendmsg(2), unix(7) SCM_RIGHTS, POSIX.1-2017 §2.14.
+fn test_289_scm_first_byte_bind() -> bool {
+    use crate::net::unix;
+    test_header!("SCM_RIGHTS fds bound to the first byte of their frame (Test 289)");
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("scm_firstbyte", "socketpair returned MAX");
+        return false;
+    }
+
+    let mk_fd = || crate::vfs::FileDescriptor {
+        inode: 0xF00D, mount_idx: 0, offset: 0, flags: 0,
+        file_type: crate::vfs::FileType::RegularFile,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+
+    // Capture B's recv position BEFORE pushing this frame's data — exactly the
+    // pre-push offset the sendmsg path now binds to (scm_bind_offset).
+    let first_byte_off = unix::enqueue_offset_for(b);
+
+    // Push an 8-byte data frame into B's recv ring (the "message").
+    let n = unix::write(a, b"HDRBODY!");
+    if n != 8 {
+        test_fail!("scm_firstbyte", "write(8) = {} (want 8)", n);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // Bind the fd batch to the FIRST byte of the frame (the fix).  The pre-fix
+    // tail bind would have used enqueue_offset_for(b) AFTER the write (== 8).
+    let tail_off = unix::enqueue_offset_for(b);
+    if tail_off != first_byte_off + 8 {
+        test_fail!("scm_firstbyte",
+            "tail offset {} != first {} + 8", tail_off, first_byte_off);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    crate::syscall::scm_queue(b, first_byte_off, alloc::vec![mk_fd()]);
+
+    // Reader has consumed nothing yet — batch must be WITHHELD (it binds to the
+    // first byte, which the reader has not reached).
+    if crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
+        test_fail!("scm_firstbyte", "batch deliverable before any byte read");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // Read ONLY the first byte of the 8-byte frame (a partial / header-first
+    // read).  recv_consumed advances by 1 — now >= first_byte_off.
+    let mut one = [0u8; 1];
+    let rn = unix::read_msg(b, &mut one).map(|(c, _)| c).unwrap_or(0xFFFF);
+    if rn != 1 || one[0] != b'H' {
+        test_fail!("scm_firstbyte", "partial read = {} / {:?} (want 1/'H')", rn, one);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+
+    // THE REGRESSION ASSERTION: with the first-byte bind, the fds are now
+    // deliverable even though 7 of the 8 frame bytes remain unread.  The pre-fix
+    // tail bind (offset 8) would still withhold them here → the recvmsg that
+    // first returned the frame's bytes would carry NO cmsg → fatal error.
+    if !crate::syscall::has_scm_deliverable(b, unix::recv_consumed(b)) {
+        test_fail!("scm_firstbyte",
+            "fds NOT deliverable after first byte (tail-bind regression)");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    let got = crate::syscall::scm_dequeue(b, unix::recv_consumed(b));
+    if got.map(|v| v.len()) != Some(1) {
+        test_fail!("scm_firstbyte", "first-byte dequeue did not return the fd");
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  fds delivered on the first byte of their frame (partial read) ✓");
+
+    // The remaining 7 data bytes are still readable and intact (the fd batch
+    // delivery did not disturb the data stream).
+    let mut rest = [0u8; 7];
+    let rrn = unix::read_msg(b, &mut rest).map(|(c, _)| c).unwrap_or(0xFFFF);
+    if rrn != 7 || &rest != b"DRBODY!" {
+        test_fail!("scm_firstbyte", "remaining read = {} / {:?}", rrn, rest);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    test_println!("  remaining frame bytes intact after fd delivery ✓");
+
+    unix::close(a);
+    unix::close(b);
+    test_pass!("SCM_RIGHTS fds bound to the first byte of their frame (Test 289)");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2576,6 +2576,16 @@ pub fn run() -> ! {
     total += 1;
     if test_290_scm_multi_fd_delivery() { passed += 1; }
 
+    // ── Test 291: a coalesced stream read delivers one fd batch per recv ───
+    // Two fd-bearing frames queued back-to-back must NOT both drain in a single
+    // large recvmsg while only one batch is delivered; the recv-side cap
+    // (scm_next_batch_offset) returns the bytes up to exactly one fd batch per
+    // recv and delivers that batch, then stops — the byte-stream reader
+    // otherwise aborts "needs unreceived descriptors".  Refs: recvmsg(2),
+    // unix(7) SCM_RIGHTS.
+    total += 1;
+    if test_291_scm_coalesced_stream_read_cap() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -45752,5 +45762,112 @@ fn test_290_scm_multi_fd_delivery() -> bool {
     unix::close(a);
     unix::close(b);
     test_pass!("multi-fd SCM_RIGHTS message delivers ALL its fds (Test 290)");
+    true
+}
+
+// ── Test 291: a coalesced stream read delivers one fd batch per recv ─────────
+//
+// A byte-stream reader (e.g. a length-prefixed IPC channel) reads up to a large
+// fixed buffer per recvmsg(2).  When two fd-bearing frames are queued
+// back-to-back in the recv ring, an UNCAPPED read would drain the bytes of BOTH
+// frames in a single recvmsg while `scm_dequeue` only hands back ONE batch — the
+// reader then parses the second frame with its descriptors silently withheld and
+// aborts ("needs unreceived descriptors").  The recvmsg arm caps the drain at
+// the next pending batch's bound offset (`scm_next_batch_offset`), so each recv
+// returns the bytes up to exactly one fd batch and delivers that batch, then
+// stops — mirroring the AF_UNIX stream recv that stops at each fd-bearing message
+// boundary.  This drives that cap logic directly: two frames + two batches, then
+// read with a buffer large enough to span BOTH, and assert each batch is
+// delivered on its own capped read.  Refs: recvmsg(2), unix(7) SCM_RIGHTS.
+fn test_291_scm_coalesced_stream_read_cap() -> bool {
+    use crate::net::unix;
+    test_header!("coalesced stream read delivers one fd batch per recv (Test 291)");
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("scm_coalesce", "socketpair returned MAX");
+        return false;
+    }
+    let mk_fd = |ino: u64| crate::vfs::FileDescriptor {
+        inode: ino, mount_idx: 0, offset: 0, flags: 0,
+        file_type: crate::vfs::FileType::RegularFile,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+
+    // Frame 1: 4 data bytes at stream start T1, one fd bound to T1+1.
+    let t1 = unix::enqueue_offset_for(b);
+    if unix::write(a, b"AAAA") != 4 {
+        test_fail!("scm_coalesce", "write frame1 != 4"); unix::close(a); unix::close(b); return false;
+    }
+    crate::syscall::scm_queue(b, t1 + 1, alloc::vec![mk_fd(0x11)]);
+    // Frame 2: 4 more data bytes at stream pos T2, one fd bound to T2+1.
+    let t2 = unix::enqueue_offset_for(b);   // == t1 + 4
+    if unix::write(a, b"BBBB") != 4 {
+        test_fail!("scm_coalesce", "write frame2 != 4"); unix::close(a); unix::close(b); return false;
+    }
+    crate::syscall::scm_queue(b, t2 + 1, alloc::vec![mk_fd(0x22)]);
+
+    // The recv-side cap: with the reader at the stream start, the next pending
+    // batch is frame 1's (offset t1+1), so a stream recv must not drain past it.
+    let consumed0 = unix::recv_consumed(b);
+    match crate::syscall::scm_next_batch_offset(b, consumed0) {
+        Some(off) if off == t1 + 1 => {
+            test_println!("  next-batch cap = frame-1 offset (t1+1) ✓");
+        }
+        other => {
+            test_fail!("scm_coalesce", "next-batch offset = {:?} (want {})", other, t1 + 1);
+            unix::close(a); unix::close(b); return false;
+        }
+    }
+
+    // Simulate the capped recvmsg: a reader offers an 8-byte buffer (enough to
+    // span BOTH frames) but the cap limits the drain to (next - consumed) bytes.
+    // Read #1 must therefore stop at frame 1's first-byte position and deliver
+    // ONLY frame 1's batch.
+    let cap1 = ((t1 + 1) - consumed0) as usize;          // == 1 (read up to frame-1's first byte)
+    let mut buf = [0u8; 8];
+    let rn1 = unix::read_msg(b, &mut buf[..cap1.max(1)]).map(|(c, _)| c).unwrap_or(0xFFFF);
+    if rn1 == 0xFFFF {
+        test_fail!("scm_coalesce", "capped read #1 failed"); unix::close(a); unix::close(b); return false;
+    }
+    let got1 = crate::syscall::scm_dequeue(b, unix::recv_consumed(b));
+    if got1.as_deref().map(|s| s.iter().map(|f| f.inode).collect::<alloc::vec::Vec<_>>())
+        != Some(alloc::vec![0x11]) {
+        test_fail!("scm_coalesce", "read #1 did not deliver exactly frame-1's fd (0x11)");
+        unix::close(a); unix::close(b); return false;
+    }
+    // Frame 2's batch MUST still be withheld — its bytes are not yet drained.
+    if crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).is_some() {
+        test_fail!("scm_coalesce", "frame-2 batch delivered on the same recv as frame-1");
+        unix::close(a); unix::close(b); return false;
+    }
+    test_println!("  read #1 delivered frame-1's fd only; frame-2 withheld ✓");
+
+    // Drain the rest of frame 1 + into frame 2 under the next cap, then deliver
+    // frame 2's batch.  Recompute the cap for the reader's new position.
+    let consumed1 = unix::recv_consumed(b);
+    let next2 = crate::syscall::scm_next_batch_offset(b, consumed1).unwrap_or(0);
+    if next2 != t2 + 1 {
+        test_fail!("scm_coalesce", "second next-batch offset = {} (want {})", next2, t2 + 1);
+        unix::close(a); unix::close(b); return false;
+    }
+    let cap2 = (next2 - consumed1) as usize;
+    let _ = unix::read_msg(b, &mut buf[..cap2.max(1)]);
+    match crate::syscall::scm_dequeue(b, unix::recv_consumed(b)).as_deref() {
+        Some([f]) if f.inode == 0x22 => {
+            test_println!("  read #2 delivered frame-2's fd (0x22) on its own recv ✓");
+        }
+        other => {
+            test_fail!("scm_coalesce", "read #2 delivered {:?} (want [0x22])",
+                other.map(|s| s.iter().map(|f| f.inode).collect::<alloc::vec::Vec<_>>()));
+            unix::close(a); unix::close(b); return false;
+        }
+    }
+
+    unix::close(a);
+    unix::close(b);
+    test_pass!("coalesced stream read delivers one fd batch per recv (Test 291)");
     true
 }

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -147,6 +147,91 @@ pub fn alloc_inode_number() -> u64 {
 /// Added by remove() when the file is still open; freed on last close().
 static DELETED_INODES: Mutex<Vec<(usize, u64)>> = Mutex::new(Vec::new());
 
+/// Inodes pinned alive by a kernel reference that is NOT a process fd-table
+/// slot: (mount_idx, inode_number, pin_count).
+///
+/// The unlink-on-last-close machinery in [`close`] decides whether a
+/// deferred-deleted inode may be freed by scanning every process fd table for
+/// a slot that still points at it.  That scan cannot see a descriptor that is
+/// in flight — queued for SCM_RIGHTS delivery but not yet installed in the
+/// receiver's fd table.  Such a descriptor is held only in the syscall layer's
+/// PENDING_SCM queue; without a pin, a sender that `close(2)`s its copy of an
+/// unlinked memfd while the batch is still pending would free the inode out
+/// from under the un-received descriptor, corrupting the shared surface.  Per
+/// `memfd_create(2)` ("the memory is freed when all references are dropped")
+/// and `unix(7)` SCM_RIGHTS ("the passed descriptor refers to the same open
+/// file description"), an in-flight passed descriptor IS such a reference.
+///
+/// A pinned inode is never freed by `close`; it is freed only once both the
+/// last fd-table slot is gone AND the pin count reaches zero (see
+/// [`unpin_inode`]).
+static PINNED_INODES: Mutex<Vec<(usize, u64, u32)>> = Mutex::new(Vec::new());
+
+/// Add one kernel pin on `(mount_idx, inode)` so [`close`] will not free it
+/// even when no process fd table references it (e.g. an SCM_RIGHTS descriptor
+/// queued for delivery).  Balance every call with exactly one [`unpin_inode`].
+pub fn pin_inode(mount_idx: usize, inode: u64) {
+    if mount_idx == usize::MAX { return; } // sentinel fds (pipes etc.) have no inode
+    let mut p = PINNED_INODES.lock();
+    if let Some(e) = p.iter_mut().find(|(m, n, _)| *m == mount_idx && *n == inode) {
+        e.2 = e.2.saturating_add(1);
+    } else {
+        p.push((mount_idx, inode, 1));
+    }
+}
+
+/// Drop one kernel pin on `(mount_idx, inode)`.  When the pin count reaches
+/// zero AND the inode was deferred-deleted with no remaining open fd, the inode
+/// is freed here (the pin was the last thing keeping it alive).  Returns true
+/// if the inode was actually freed by this call.
+pub fn unpin_inode(mount_idx: usize, inode: u64) -> bool {
+    if mount_idx == usize::MAX { return false; }
+    let now_unpinned = {
+        let mut p = PINNED_INODES.lock();
+        if let Some(idx) = p.iter().position(|(m, n, _)| *m == mount_idx && *n == inode) {
+            if p[idx].2 > 1 {
+                p[idx].2 -= 1;
+                false
+            } else {
+                p.remove(idx);
+                true
+            }
+        } else {
+            false
+        }
+    };
+    if !now_unpinned { return false; }
+    // Last pin gone — free the inode iff it was deferred-deleted and no process
+    // fd table still references it.  Mirrors the close()-time last-close test.
+    let still_open = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter().any(|p| p.file_descriptors.iter().any(|fdo| {
+            fdo.as_ref().map(|f| f.mount_idx == mount_idx && f.inode == inode)
+                .unwrap_or(false)
+        }))
+    };
+    if still_open { return false; }
+    let was_deleted = {
+        let mut dl = DELETED_INODES.lock();
+        let before = dl.len();
+        dl.retain(|(m, n)| !(*m == mount_idx && *n == inode));
+        dl.len() < before
+    };
+    if was_deleted {
+        if let Some((fs, _)) = fs_at(mount_idx) {
+            let _ = fs.remove_inode(inode);
+            return true;
+        }
+    }
+    false
+}
+
+/// True if `(mount_idx, inode)` currently has at least one kernel pin
+/// (see [`pin_inode`]).
+fn inode_is_pinned(mount_idx: usize, inode: u64) -> bool {
+    PINNED_INODES.lock().iter().any(|(m, n, c)| *m == mount_idx && *n == inode && *c > 0)
+}
+
 /// A held POSIX byte-range lock.
 #[derive(Clone)]
 pub struct FileLockEntry {
@@ -2001,13 +2086,19 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
         // C5: unlink-on-last-close — check if this inode was deferred-deleted.
         if !is_console && file_type == FileType::RegularFile && mount_idx != usize::MAX {
             // Check remaining open fds + atomically remove from DELETED_INODES if last.
+            // A kernel pin (e.g. an in-flight SCM_RIGHTS descriptor that is queued
+            // for delivery but not yet installed in any fd table — invisible to the
+            // fd-table scan below) also keeps the inode alive: do NOT free while
+            // pinned.  See PINNED_INODES / pin_inode.  When the last pin is later
+            // dropped, unpin_inode performs this same last-close test and frees the
+            // inode then.
             let should_free = {
                 let procs = crate::proc::PROCESS_TABLE.lock();
                 let still_open = procs.iter().any(|p| p.file_descriptors.iter().any(|fdo| {
                     fdo.as_ref().map(|f| f.mount_idx == mount_idx && f.inode == inode)
                         .unwrap_or(false)
                 }));
-                if !still_open {
+                if !still_open && !inode_is_pinned(mount_idx, inode) {
                     let mut dl = DELETED_INODES.lock();
                     let before = dl.len();
                     dl.retain(|(m, n)| !(*m == mount_idx && *n == inode));

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -708,6 +708,216 @@ def run_allowlist_check():
     print()
 
 
+def run_read_ff_png_check():
+    """
+    Tier 1.5 host-only check: round-trip the read-ff-png decoder.
+
+    Synthesizes a minimal valid PNG, emits it in the exact [FF-OUT-PNG-B64:N/M]
+    serial wire format the firefox-test boot produces (kernel/src/ff_out_png.rs:
+    57 input bytes -> 76 base64 chars per line, standard alphabet, '=' padding),
+    writes a fake session + serial log, runs `read-ff-png`, and asserts the
+    decoded bytes are byte-identical to the source.
+
+    No QEMU launched.  This protects the two-sided contract — the kernel marker
+    format and the host decoder — against silent drift in either direction
+    (the marker stream is the only path that carries Firefox's rendered output
+    off the guest; a broken decode would silently strip the demo screenshot).
+    """
+    print("=== Tier 1.5: read-ff-png decoder round-trip (host-only) ===")
+    print()
+    import base64
+    import os
+    import struct
+    import tempfile
+    import zlib
+
+    # Build a tiny but real PNG: 2x2 RGBA, deterministic non-uniform pixels so
+    # the signature + IHDR are valid (W3C PNG §5.2/§11.2.2; ISO 15948).
+    def _png_2x2_rgba() -> bytes:
+        sig = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+        def _chunk(typ: bytes, data: bytes) -> bytes:
+            return (struct.pack(">I", len(data)) + typ + data +
+                    struct.pack(">I", zlib.crc32(typ + data) & 0xffffffff))
+
+        ihdr = struct.pack(">IIBBBBB", 2, 2, 8, 6, 0, 0, 0)  # 2x2, 8-bit, RGBA
+        # 2 rows, each: filter byte 0 + 2 px * 4 bytes
+        raw = (b"\x00" + bytes([255, 0, 0, 255, 0, 255, 0, 255]) +
+               b"\x00" + bytes([0, 0, 255, 255, 255, 255, 255, 255]))
+        idat = zlib.compress(raw, 9)
+        return sig + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+
+    png = _png_2x2_rgba()
+
+    # Emit in the firefox-test wire format: 57 input bytes per [FF-OUT-PNG-B64]
+    # line, standard base64 with '=' padding (RFC 4648 §4 / RFC 2045 §6.8).
+    CHUNK = 57
+    total = (len(png) + CHUNK - 1) // CHUNK
+    lines = [f"[FF-OUT-PNG:path=/tmp/out.png size={len(png)} sig_ok=true]"]
+    for i in range(total):
+        seg = png[i * CHUNK:(i + 1) * CHUNK]
+        b64 = base64.b64encode(seg).decode("ascii")
+        lines.append(f"[FF-OUT-PNG-B64:{i}/{total}] {b64}")
+    lines.append("[FF-OUT-PNG-END]")
+    serial_body = "\n".join(lines) + "\n"
+
+    harness_dir = Path.home() / ".astryx-harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    sid = "smoke-ffpng"
+    sess_path = harness_dir / f"{sid}.json"
+    serial_path = harness_dir / f"{sid}.serial.log"
+    out_path = None
+    try:
+        serial_path.write_text(serial_body)
+        # pid=0 → the decoder's `if pid and not _pid_alive(pid)` liveness guard
+        # is skipped, so it reads the static log without waiting for QEMU.
+        sess_path.write_text(json.dumps({
+            "sid": sid, "pid": 0, "serial_log": str(serial_path),
+        }))
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+            out_path = fh.name
+
+        obj, raw, rc = _h("read-ff-png", sid, out_path, "--timeout-ms", "3000")
+        check("read-ff-png returns JSON",   obj is not None,                raw[:160])
+        check("read-ff-png ok=true",        bool(obj and obj.get("ok")),    str(obj))
+        check("read-ff-png rc=0",           rc == 0,                        f"rc={rc}")
+        check("read-ff-png size_match",     bool(obj and obj.get("size_match")), str(obj))
+        check("read-ff-png guest_sig_ok",   bool(obj and obj.get("guest_sig_ok")), str(obj))
+        check("read-ff-png chunk count",    bool(obj and obj.get("chunks") == total), str(obj))
+
+        if obj and obj.get("ok"):
+            decoded = Path(out_path).read_bytes()
+            check("read-ff-png byte-exact round-trip", decoded == png,
+                  f"len(decoded)={len(decoded)} len(png)={len(png)}")
+            check("read-ff-png valid PNG signature",
+                  decoded[:8] == png[:8], decoded[:8].hex())
+    finally:
+        sess_path.unlink(missing_ok=True)
+        serial_path.unlink(missing_ok=True)
+        if out_path:
+            Path(out_path).unlink(missing_ok=True)
+    print()
+
+
+def run_kdb_read_png_check():
+    """
+    Tier 1.5 host-only check: kdb-read-png chunked-assembly round-trip.
+
+    Loads cmd_kdb_read_png from the harness, monkeypatches _kdb_recv to serve a
+    synthetic PNG in 16 KiB chunks (mirroring the kernel read-file op's wire
+    contract: {file_size, offset, n, eof, sig_png, b64}), runs the command, and
+    asserts the reassembled file is byte-identical.  No QEMU / socket — protects
+    the offset-loop + base64 reassembly against drift in either the op contract
+    or the host wrapper.
+    """
+    print("=== Tier 1.5: kdb-read-png chunked assembly (host-only) ===")
+    print()
+    import base64
+    import importlib.util
+    import json as _json
+    import struct
+    import tempfile
+    import types
+    import zlib
+
+    spec = importlib.util.spec_from_file_location("qh_kdbpng_load", str(HARNESS))
+    mod = importlib.util.module_from_spec(spec)
+    _orig_argv = sys.argv
+    sys.argv = ["qemu-harness.py", "list"]
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    finally:
+        sys.argv = _orig_argv
+
+    fn = getattr(mod, "cmd_kdb_read_png", None)
+    check("cmd_kdb_read_png importable", fn is not None)
+    if fn is None:
+        print()
+        return
+
+    # Synthetic PNG large enough to span >1 chunk (16384 raw/chunk).
+    def _png_blob(npix_rows: int) -> bytes:
+        sig = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+        def _chunk(typ, data):
+            return (struct.pack(">I", len(data)) + typ + data +
+                    struct.pack(">I", zlib.crc32(typ + data) & 0xffffffff))
+        w = 64
+        ihdr = struct.pack(">IIBBBBB", w, npix_rows, 8, 6, 0, 0, 0)
+        raw = bytearray()
+        for r in range(npix_rows):
+            raw.append(0)
+            for c in range(w):
+                raw += bytes([(r * 7) & 255, (c * 5) & 255, (r + c) & 255, 255])
+        idat = zlib.compress(bytes(raw), 6)
+        return sig + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+
+    png = _png_blob(300)  # ~ tens of KiB → multiple 16 KiB chunks
+    sig_ok = png[:8] == bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    assert sig_ok and len(png) > 16384, f"need a multi-chunk PNG, got {len(png)}"
+
+    def _fake_kdb_recv(port, req, timeout=10.0):
+        # Mirror the kernel read-file op contract.
+        off = int(req.get("offset", 0))
+        ln = min(int(req.get("len", 16384)), 16384)
+        end = min(off + ln, len(png))
+        sl = png[off:end]
+        resp = {
+            "path": req.get("path"),
+            "file_size": len(png),
+            "offset": off,
+            "n": len(sl),
+            "eof": end >= len(png),
+            "sig_png": sig_ok,
+            "b64": base64.b64encode(sl).decode("ascii"),
+        }
+        return (_json.dumps(resp) + "\n").encode("utf-8")
+
+    harness_dir = Path.home() / ".astryx-harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    sid = "smoke-kdbpng"
+    sess_path = harness_dir / f"{sid}.json"
+    out_path = None
+    orig_recv = getattr(mod, "_kdb_recv", None)
+    try:
+        sess_path.write_text(_json.dumps({"sid": sid, "pid": 0, "kdb_host_port": 12345}))
+        mod._kdb_recv = _fake_kdb_recv
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+            out_path = fh.name
+
+        # cmd_kdb_read_png calls _out (prints JSON) and may sys.exit on error.
+        captured = {}
+        orig_out = mod._out
+        mod._out = lambda obj: captured.update(obj if isinstance(obj, dict) else {})
+        args = types.SimpleNamespace(sid=sid, dst=out_path, path="/tmp/out.png", timeout=5.0)
+        try:
+            fn(args)
+        except SystemExit:
+            pass
+        finally:
+            mod._out = orig_out
+
+        check("kdb-read-png ok=true", bool(captured.get("ok")), str(captured))
+        check("kdb-read-png is_png", bool(captured.get("is_png")), str(captured))
+        check("kdb-read-png size_match", bool(captured.get("size_match")), str(captured))
+        check("kdb-read-png byte count", captured.get("bytes") == len(png), str(captured))
+        if captured.get("ok"):
+            decoded = Path(out_path).read_bytes()
+            check("kdb-read-png byte-exact round-trip", decoded == png,
+                  f"len(decoded)={len(decoded)} len(png)={len(png)}")
+    finally:
+        if orig_recv is not None:
+            mod._kdb_recv = orig_recv
+        sess_path.unlink(missing_ok=True)
+        if out_path:
+            Path(out_path).unlink(missing_ok=True)
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="AstryxOS qemu-harness smoke test")
@@ -738,6 +948,8 @@ def main():
     run_staleness_check()
     run_allowlist_check()
     run_snapgate_argv_check()
+    run_read_ff_png_check()
+    run_kdb_read_png_check()
 
     if args.staleness_only:
         # Early exit for CI cycles that just want the cheap host-only checks.

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -74,6 +74,15 @@ Tier 1 — session management:
         owner-starved | true-lost-wakeup | benign-empty) + a one-line summary.
         The decisive condvar-livelock probe in one argv call (half def 128).
     python3 scripts/qemu-harness.py read-png <sid> <dst.png> [--timeout-ms MS]
+        Decode the VGA framebuffer ([SCREENSHOT-B64:…], Test 198) to a host PNG.
+    python3 scripts/qemu-harness.py read-ff-png <sid> <dst.png> [--timeout-ms MS]
+        Decode Firefox's RENDERED /tmp/out.png from the DISTINCT
+        [FF-OUT-PNG-B64:…] stream the firefox-test boot emits after FF exits.
+        This is the actual loaded page, not the boot-splash framebuffer.
+    python3 scripts/qemu-harness.py kdb-read-png <sid> <dst.png> [--path P]
+        Pull a guest VFS file (default /tmp/out.png) LIVE via the kdb
+        read-file op (chunked base64). Works the instant the file exists,
+        independent of the boot's serial emit. Requires --features kdb.
     python3 scripts/qemu-harness.py futex-wake-drill <sid> [--tid N]
                                             [--bucket-count K] [--window-lines L]
                                             [--cross-park]
@@ -5641,6 +5650,19 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
                 "pid": int(rest[0], 0),
                 "addr": f"0x{int(rest[1], 0):x}",
                 "half": half}
+    if op == "read-file":
+        # Read a slice of a VFS file, returned base64.  Robust extraction
+        # primitive — works on any live kdb session regardless of process
+        # state.  Args: <path> [<offset> [<len>]].  The host-side
+        # `read-ff-png --via-kdb` wrapper loops offset+=n until eof.
+        if not rest:
+            raise ValueError("read-file requires <path> [<offset> [<len>]]")
+        req: dict = {"op": "read-file", "path": rest[0]}
+        if len(rest) >= 2:
+            req["offset"] = int(rest[1], 0)
+        if len(rest) >= 3:
+            req["len"] = int(rest[2], 0)
+        return req
     raise ValueError(f"unknown kdb op: {op}")
 
 
@@ -10190,6 +10212,323 @@ def cmd_read_png(args):
 
 
 # ══════════════════════════════════════════════════════════════════════════════
+# read-ff-png — extract Firefox's rendered /tmp/out.png from the guest via serial
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# DISTINCT from read-png above.  read-png decodes the [SCREENSHOT-B64:…] stream,
+# which carries the QEMU VGA framebuffer (the AstryxOS boot splash in headless
+# mode) — NOT Firefox's off-screen render.  Firefox writes its real screenshot
+# to the guest path /tmp/out.png; the firefox-test boot reads that file back out
+# of the VFS ramdisk and emits it over serial as a SEPARATE marker stream
+# (kernel/src/ff_out_png.rs):
+#
+#   [FF-OUT-PNG:path=/tmp/out.png size=<N> sig_ok=<bool>]
+#   [FF-OUT-PNG-B64:0/M] <up to 76 base64 chars>   (N = 0-based chunk index)
+#   [FF-OUT-PNG-B64:1/M] ...
+#   ...
+#   [FF-OUT-PNG-END]
+#
+# This subcommand:
+#   1. Waits for the [FF-OUT-PNG:…] header line (up to --timeout-ms), which
+#      carries the guest-side byte size for a cross-check.
+#   2. Scans the serial log for all M chunks (0..M-1) in order.
+#   3. Decodes the concatenated base64 (RFC 4648 §4) and writes to <dst>.
+#   4. Verifies the PNG signature (8-byte magic, W3C PNG §5.2 / ISO 15948),
+#      and that the decoded byte count matches the guest-reported size.
+#   5. Prints JSON: {"ok": true, "path": dst, "bytes": N, "chunks": M,
+#                    "guest_size": G, "size_match": bool}
+#      or {"ok": false, "error": "...", ...} on failure.
+#
+# Fully additive — does not touch read-png or its [SCREENSHOT-B64] regexes.
+
+_FFPNG_HEADER_RE = re.compile(
+    r"\[FF-OUT-PNG:path=(\S+)\s+size=(\d+)\s+sig_ok=(true|false)"
+)
+_FFPNG_CHUNK_RE = re.compile(
+    r"\[FF-OUT-PNG-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"
+)
+_FFPNG_END_RE = re.compile(r"\[FF-OUT-PNG-END\]")
+
+
+def cmd_read_ff_png(args):
+    """
+    Collect base64-encoded /tmp/out.png chunks from the [FF-OUT-PNG-B64:…]
+    serial stream and write to <dst>.
+
+    Waits for the [FF-OUT-PNG:…] header line, scans for all M chunks, decodes,
+    verifies the PNG signature, cross-checks the guest-reported size, and writes
+    to args.dst.  Distinct from read-png (which decodes the VGA framebuffer
+    stream).
+    """
+    import base64
+
+    sess       = _load_session(args.sid)
+    serial_log = sess["serial_log"]
+    dst        = args.dst
+    timeout_ms = args.timeout_ms
+
+    # ── 1. Wait for the [FF-OUT-PNG:…] header line ────────────────────────────
+    deadline = time.monotonic() + timeout_ms / 1000.0
+    guest_size: Optional[int] = None
+    guest_sig_ok: Optional[bool] = None
+
+    while time.monotonic() < deadline:
+        try:
+            with open(serial_log, "r", errors="replace") as fh:
+                for ln in fh:
+                    m = _FFPNG_HEADER_RE.search(ln)
+                    if m:
+                        guest_size   = int(m.group(2))
+                        guest_sig_ok = (m.group(3) == "true")
+        except OSError:
+            time.sleep(0.1)
+            continue
+
+        if guest_size is not None:
+            break
+
+        # If QEMU has already exited, do one final scan then give up.
+        pid = sess.get("pid", 0)
+        if pid and not _pid_alive(pid):
+            try:
+                with open(serial_log, "r", errors="replace") as fh:
+                    for ln in fh:
+                        m = _FFPNG_HEADER_RE.search(ln)
+                        if m:
+                            guest_size   = int(m.group(2))
+                            guest_sig_ok = (m.group(3) == "true")
+            except OSError:
+                pass
+            break
+
+        time.sleep(0.1)
+
+    if guest_size is None:
+        _err(f"read-ff-png: timed out waiting for [FF-OUT-PNG:…] header "
+             f"(waited {timeout_ms} ms). Did firefox-test reach [FFTEST] DONE "
+             f"and did Firefox write /tmp/out.png?")
+
+    if guest_size == 0:
+        _out({
+            "ok":         False,
+            "error":      "guest_out_png_empty",
+            "guest_size": guest_size,
+            "guest_sig_ok": guest_sig_ok,
+            "hint":       "Firefox did not write a non-empty /tmp/out.png "
+                          "(reached png-write gate but produced 0 bytes).",
+        })
+        sys.exit(1)
+
+    # ── 2. Collect all chunks ─────────────────────────────────────────────────
+    # M is announced per chunk line (idx/M); we collect until we have a complete
+    # 0..M-1 set or the collect deadline elapses.  The PNG is ~30-80 KB → up to
+    # ~1400 lines; at 115200 baud that is ~10 s.  Give a 30 s collect window.
+    chunks: dict[int, str] = {}
+    total_chunks: Optional[int] = None
+    collect_deadline = time.monotonic() + 30.0
+
+    def _scan_chunks():
+        nonlocal total_chunks
+        try:
+            with open(serial_log, "r", errors="replace") as fh:
+                for ln in fh:
+                    m = _FFPNG_CHUNK_RE.search(ln)
+                    if m:
+                        idx = int(m.group(1))
+                        tot = int(m.group(2))
+                        b64 = m.group(3)
+                        if total_chunks is None:
+                            total_chunks = tot
+                        if tot == total_chunks and idx < tot:
+                            chunks[idx] = b64
+        except OSError:
+            pass
+
+    while time.monotonic() < collect_deadline:
+        _scan_chunks()
+        if total_chunks is not None and len(chunks) >= total_chunks:
+            break
+        pid = sess.get("pid", 0)
+        if pid and not _pid_alive(pid):
+            # QEMU exited; one final scan then stop.
+            _scan_chunks()
+            break
+        time.sleep(0.2)
+
+    if total_chunks is None:
+        _out({
+            "ok":         False,
+            "error":      "no_ffpng_chunks",
+            "guest_size": guest_size,
+            "hint":       "Saw the [FF-OUT-PNG:…] header but no "
+                          "[FF-OUT-PNG-B64:…] data lines.",
+        })
+        sys.exit(1)
+
+    # ── 3. Validate chunk count ───────────────────────────────────────────────
+    missing = [i for i in range(total_chunks) if i not in chunks]
+    if missing:
+        _out({
+            "ok":         False,
+            "error":      "missing_chunks",
+            "total":      total_chunks,
+            "received":   len(chunks),
+            "missing":    missing[:20],
+            "guest_size": guest_size,
+        })
+        sys.exit(1)
+
+    # ── 4. Decode base64 ──────────────────────────────────────────────────────
+    b64_concat = "".join(chunks[i] for i in range(total_chunks))
+    try:
+        png_bytes = base64.b64decode(b64_concat, validate=True)
+    except Exception as exc:
+        _out({
+            "ok":     False,
+            "error":  f"base64_decode_failed: {exc}",
+            "chunks": total_chunks,
+        })
+        sys.exit(1)
+
+    # ── 5. Verify PNG signature + size cross-check ────────────────────────────
+    if len(png_bytes) < 8 or png_bytes[:8] != _PNG_SIGNATURE:
+        got = png_bytes[:8].hex() if len(png_bytes) >= 8 else png_bytes.hex()
+        _out({
+            "ok":       False,
+            "error":    "png_signature_mismatch",
+            "got":      got,
+            "expected": _PNG_SIGNATURE.hex(),
+            "chunks":   total_chunks,
+            "bytes":    len(png_bytes),
+            "guest_size": guest_size,
+        })
+        sys.exit(1)
+
+    size_match = (len(png_bytes) == guest_size)
+
+    # ── 6. Write to dst ───────────────────────────────────────────────────────
+    dst_path = Path(dst)
+    try:
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        dst_path.write_bytes(png_bytes)
+    except OSError as exc:
+        _out({
+            "ok":    False,
+            "error": f"write_failed: {exc}",
+            "path":  dst,
+        })
+        sys.exit(1)
+
+    _out({
+        "ok":           True,
+        "path":         str(dst_path.resolve()),
+        "bytes":        len(png_bytes),
+        "chunks":       total_chunks,
+        "guest_size":   guest_size,
+        "size_match":   size_match,
+        "guest_sig_ok": guest_sig_ok,
+    })
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# kdb-read-png — pull a guest VFS file (e.g. /tmp/out.png) via the kdb read-file
+# op, regardless of the firefox-test boot's own detect-and-emit serial path.
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Robust live extraction: the kdb `read-file` op (kernel/src/kdb.rs) reads a VFS
+# file slice and returns it base64 (RFC 4648 §4).  This wrapper loops the op
+# with increasing offset until eof, concatenates, decodes, verifies the PNG
+# signature (W3C PNG §5.2 / ISO 15948), and writes to <dst>.  Unlike read-ff-png
+# (which decodes the [FF-OUT-PNG-B64] serial stream emitted at FF-exit), this
+# works against a LIVE session the instant the file exists on the guest — even
+# while Firefox is still a draining zombie and the serial emit has not fired.
+# Requires the session started with --features kdb.
+
+def cmd_kdb_read_png(args):
+    import base64
+
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"ok": False, "error": "session was not started with --features kdb"})
+        sys.exit(1)
+
+    path       = args.path
+    dst        = args.dst
+    timeout    = float(getattr(args, "timeout", 10.0) or 10.0)
+    max_chunks = 4096  # generous ceiling; a 16 KiB chunk × 4096 = 64 MiB cap
+
+    chunks: list[bytes] = []
+    offset = 0
+    file_size: Optional[int] = None
+    sig_png: Optional[bool] = None
+
+    for _ in range(max_chunks):
+        req = {"op": "read-file", "path": path, "offset": offset, "len": 16384}
+        try:
+            raw = _kdb_recv(port, req, timeout=timeout)
+            resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+        except (socket.timeout, ConnectionRefusedError, OSError) as e:
+            _out({"ok": False, "error": f"kdb io failed on 127.0.0.1:{port}: {e}",
+                  "offset": offset})
+            sys.exit(1)
+        except (json.JSONDecodeError, ValueError) as e:
+            _out({"ok": False, "error": f"malformed kdb response: {e}",
+                  "offset": offset, "raw": raw.decode(errors="replace")[:200]})
+            sys.exit(1)
+
+        if "error" in resp:
+            _out({"ok": False, "error": f"kdb read-file: {resp['error']}",
+                  "path": path, "offset": offset})
+            sys.exit(1)
+
+        if file_size is None:
+            file_size = int(resp.get("file_size", 0))
+            sig_png = bool(resp.get("sig_png", False))
+            if file_size == 0:
+                _out({"ok": False, "error": "guest_file_empty", "path": path})
+                sys.exit(1)
+
+        b64 = resp.get("b64", "")
+        try:
+            chunks.append(base64.b64decode(b64, validate=True))
+        except Exception as e:
+            _out({"ok": False, "error": f"base64_decode_failed: {e}",
+                  "offset": offset})
+            sys.exit(1)
+
+        n = int(resp.get("n", 0))
+        offset += n
+        if bool(resp.get("eof", False)) or n == 0:
+            break
+
+    data = b"".join(chunks)
+
+    sig = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    is_png = len(data) >= 8 and data[:8] == sig
+    size_match = (file_size is not None and len(data) == file_size)
+
+    dst_path = Path(dst)
+    try:
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        dst_path.write_bytes(data)
+    except OSError as exc:
+        _out({"ok": False, "error": f"write_failed: {exc}", "path": dst})
+        sys.exit(1)
+
+    _out({
+        "ok":          is_png and size_match,
+        "path":        str(dst_path.resolve()),
+        "bytes":       len(data),
+        "guest_size":  file_size,
+        "size_match":  size_match,
+        "is_png":      is_png,
+        "guest_sig_png": sig_png,
+        "via":         "kdb-read-file",
+    })
+
+
+# ══════════════════════════════════════════════════════════════════════════════
 # screendump — capture the QEMU framebuffer via QMP and write a PNG
 # ══════════════════════════════════════════════════════════════════════════════
 #
@@ -10690,7 +11029,7 @@ def main():
     p_kdb.add_argument("op", choices=[
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
         "syscall-trend", "vfs-mounts",
-        "dmesg", "syms", "mem", "tframe", "user-mem", "trace-status",
+        "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "trace-status",
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
         "arm-phys",
@@ -11159,6 +11498,45 @@ def main():
              "(default 120000 = 2 min, covers build + boot + test run)"
     )
 
+    # read-ff-png — extract Firefox's rendered /tmp/out.png (DISTINCT stream)
+    p_read_ff_png = sub.add_parser(
+        "read-ff-png",
+        help="Collect Firefox's rendered /tmp/out.png from the "
+             "[FF-OUT-PNG-B64:N/M] serial stream (firefox-test boot emits it "
+             "after [FFTEST] DONE) and write to <dst.png>.  DISTINCT from "
+             "read-png, which decodes the VGA framebuffer ([SCREENSHOT-B64]) — "
+             "the boot splash, not Firefox's render.  Verifies the PNG "
+             "signature and cross-checks the guest-reported byte size.  "
+             "Example: read-ff-png <sid> /tmp/firefox-out.png"
+    )
+    p_read_ff_png.add_argument("sid")
+    p_read_ff_png.add_argument("dst", help="Host-side destination path for the PNG file")
+    p_read_ff_png.add_argument(
+        "--timeout-ms", type=int, default=120000, dest="timeout_ms",
+        help="Milliseconds to wait for the [FF-OUT-PNG:…] header line "
+             "(default 120000 = 2 min)"
+    )
+
+    # kdb-read-png — pull a guest VFS file live via the kdb read-file op
+    p_kdb_read_png = sub.add_parser(
+        "kdb-read-png",
+        help="Pull a guest VFS file (default /tmp/out.png) to <dst.png> via the "
+             "kdb read-file op (chunked base64).  Works on a LIVE session the "
+             "instant the file exists — independent of the firefox-test boot's "
+             "own serial emit.  Requires --features kdb.  "
+             "Example: kdb-read-png <sid> /tmp/firefox-out.png"
+    )
+    p_kdb_read_png.add_argument("sid")
+    p_kdb_read_png.add_argument("dst", help="Host-side destination path for the PNG file")
+    p_kdb_read_png.add_argument(
+        "--path", default="/tmp/out.png",
+        help="Guest VFS path to read (default /tmp/out.png)"
+    )
+    p_kdb_read_png.add_argument(
+        "--timeout", type=float, default=10.0,
+        help="Per-chunk kdb request timeout in seconds (default 10)"
+    )
+
     # screendump — capture the framebuffer via QMP screendump + PPM->PNG
     p_screendump = sub.add_parser(
         "screendump",
@@ -11383,6 +11761,8 @@ def main():
         "rip-walk": cmd_rip_walk,
         "rip-trace-resolve": cmd_rip_trace_resolve,
         "read-png": cmd_read_png,
+        "read-ff-png": cmd_read_ff_png,
+        "kdb-read-png": cmd_kdb_read_png,
         "screendump": cmd_screendump,
         # Shared session context
         "context": cmd_context,

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -4576,6 +4576,56 @@ def cmd_regs(args):
     _out({"ok": True, "regs": regs})
 
 
+def cmd_dual_regs(args):
+    """Enumerate every QEMU vCPU thread, read RIP/CS/RSP/RBP for each, and
+    symbolize the kernel-space RIP.
+
+    Purpose: SMP spin-lock deadlock autopsy.  When the whole machine freezes
+    on a held-across-dispatch spin::Mutex, one core strands the lock while the
+    other busy-spins in a non-preemptible Ring-0 loop.  This command names the
+    RIP each vCPU is parked at so the busy-spinner core (the one looping in a
+    lock-acquire path) and the holder core can be identified in one shot.
+
+    Output per-cpu: thread id, RIP (hex), symbolized RIP, CS (ring via low 2
+    bits), RSP, RBP.  No guest mutation — pure read via the GDB stub.
+    """
+    sess = _load_session(args.sid)
+    port = _get_gdb_port(sess)
+
+    gdb = GdbClient("127.0.0.1", port)
+    if not gdb.connect():
+        _err(f"Cannot connect to GDB stub on port {port} (tried {port}..{port+4})")
+    cpus = []
+    try:
+        tids = gdb.list_threads()
+        if not tids:
+            tids = [1]  # single-vCPU stub that doesn't advertise threads
+        for tid in tids:
+            gdb.select_thread(tid)
+            regs = gdb.read_regs()
+            rip = int(regs.get("rip", "0x0"), 16)
+            cs = int(regs.get("cs", "0x0"), 16)
+            sym = _autopsy_resolve_kernel_rip(rip)
+            cpus.append({
+                "tid":  tid,
+                "rip":  hex(rip),
+                "sym":  sym,
+                "cs":   hex(cs),
+                "ring": cs & 0x3,
+                "rsp":  regs.get("rsp"),
+                "rbp":  regs.get("rbp"),
+                "rax":  regs.get("rax"),
+                "rdi":  regs.get("rdi"),
+                "rsi":  regs.get("rsi"),
+            })
+    except Exception as e:
+        _err(f"GDB dual-regs error: {e}")
+    finally:
+        gdb.close()
+
+    _out({"ok": True, "n_cpus": len(cpus), "cpus": cpus})
+
+
 def cmd_mem(args):
     """Read memory via GDB 'm addr,len' packet; cap at 4096 bytes."""
     sess = _load_session(args.sid)
@@ -10514,6 +10564,12 @@ def main():
     p_regs = sub.add_parser("regs", help="[Tier2] Read x86_64 registers via GDB stub")
     p_regs.add_argument("sid")
 
+    # dual-regs — read RIP/CS/RSP for EVERY vCPU + symbolize (SMP deadlock autopsy)
+    p_dual_regs = sub.add_parser(
+        "dual-regs",
+        help="[Tier2] Read RIP/CS/RSP/RBP for every vCPU and symbolize the kernel RIP")
+    p_dual_regs.add_argument("sid")
+
     # mem
     p_mem = sub.add_parser("mem", help="[Tier2] Read guest memory via GDB stub")
     p_mem.add_argument("sid")
@@ -11282,6 +11338,7 @@ def main():
         "snap-gate": cmd_snap_gate,
         # Tier 2
         "regs":   cmd_regs,
+        "dual-regs": cmd_dual_regs,
         "mem":    cmd_mem,
         "sym":    cmd_sym,
         "bp":     cmd_bp,


### PR DESCRIPTION
## Summary
Three changes from the autonomous cross-process screenshot push. The headline is a **real kernel deadlock fix** (#2); the e10s change (#1) puts Firefox on the upstream multi-process screenshot path; (#3) is a debug tool. **Honest state: FF now runs the cross-process screenshot pipeline and advances to sc~838M, but does not yet produce a PNG — it wedges at a content-process-init gate (see "Current gate" below). Reviewer's call on whether to land the e10s change now or hold it behind the content-proc fix.**

### 1. `ff/launch: do not force-disable e10s for the headless screenshot` (5276c29)
The headless `--screenshot` capture `<browser>` is explicitly `remote="true"`; per the Firefox process model an explicit remoteness is authoritative, so `MOZ_FORCE_DISABLE_E10S=1` (an obsolete #478 workaround) could not make it in-process — it only left gecko self-inconsistent, so the `getDimensions` query was never routed cross-process (zero AF_UNIX IPDL traffic across a multi-billion-syscall run). Removing it puts FF on the normal multi-process path (IPDL traffic now flows). The content-proc blockers the workaround avoided are fixed upstream of this change (#497/#499/#500/#501).

### 2. `kernel/mm/heap: mask interrupts across the heap lock` (d3dc4b0) — **the real win**
The heap `spin::Mutex` did not mask interrupts while held. When the LAPIC timer ISR allocates (`proc_metrics::emit_periodic` → Vec/String/format!) while interrupted kernel code holds the heap lock, it self-deadlocks the core (re-entrant, non-reentrant spinlock). `HeapIrqGuard` masks interrupts across alloc/dealloc. **GDB-confirmed at a real freeze (sc~492M); fix advances FF 492M → 765M+ clean.** Independent of the screenshot work — a correctness fix worth landing on its own.

### 3. `harness: add dual-regs` (af8765a)
`qemu-harness.py dual-regs` reads RIP/CS/RSP for every vCPU + symbolizes — one-shot SMP deadlock autopsy (both-cores-Ring-0-spin signature).

## Current gate (why no PNG yet)
Rigorous live characterization on a healthy machine (kdb responsive, GDB confirms no deadlock) shows the screenshot handshake **never starts**: pid1's main loop never `sendmsg`s the `getDimensions` query over the unix channel (it only writes the IPDL body to the sqlite startup cache), because **pid3 (content process) is wedged in its own initialization** (blocked on indefinite futexes) before it becomes a ready actor. The AF_UNIX stack + futex are faithful (verified — `unix_write` bell frozen, pid3 `net=R0`, fd routing correct, poll re-check correct, `futex_wake_ghost=0`). Next step is a golden-strace diff of pid3's init to name the upstream readiness event our kernel makes never arrive — **not** an AF_UNIX/futex fix.

## CI
Validates the chain branch builds + the kernel test suite. The heap-lock change (#2) is the correctness-critical one to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### 4. `net/unix + linux/sendmsg+recvmsg: deliver SCM_RIGHTS fds on first-byte touch; fix multi-fd delivery` (17f02ed, NDE-8)
Follow-up on the a0fcb9e first-byte-bind win (content-proc channel-errors 184,857 → 2). Two loose ends on the same SCM_RIGHTS byte-offset binding, both now closed:

- **A — re-greens CI (`scm_firstbyte` Test 289).** The fd batch bound to the frame's first byte T with predicate `recv_consumed >= T`; on a fresh stream (T==0, consumed==0) `0 >= 0` is already true, so the fds were deliverable BEFORE any byte of the frame was read. Per recvmsg(2)/unix(7)/POSIX.1-2017 §2.14 (ancillary data delivered with the recvmsg that returns the data it accompanies), a DATA-bearing frame now binds to **T+1** — deliverable the instant the reader pops the frame's first byte, and not before. A control-only frame still binds to **T** (immediate, it sits at the tail with no bytes to touch). The dequeue predicate stays a uniform `>=`; the `+1` is applied once at the sendmsg enqueue site. Test 289 + its doc reconciled to that invariant; it now **passes**.
- **B — multi-fd delivery regression test (Test 290).** A single SCM_RIGHTS control message carrying N descriptors forms ONE batch holding all N fds, delivered together with the recvmsg that returns the frame's bytes. New Test 290 locks that a 2-fd batch delivers BOTH descriptors in one dequeue and that a following 1-fd frame keeps exactly its single descriptor (the multi-fd / N1 byte-order interaction). Short-delivering fewer fds than a message header announced is what makes a length-prefixed IPC reader abort with "needs unreceived descriptors".

Refs: recvmsg(2), sendmsg(2), unix(7) SCM_RIGHTS, POSIX.1-2017 §2.14. Verified: full kernel-smoke suite — Tests 280/286/289/290 all pass (the 5 remaining suite fails are data-disk fixture env-gaps absent on the FF musl-esr disk, not regressions; `scm_firstbyte` is no longer among them).


### 5. `net/unix + linux/recvmsg: cap stream recv at the next SCM_RIGHTS batch boundary` (7faeba0, NDE-8)
The REAL root cause of the residual `needs unreceived descriptors` on the cross-process screenshot handshake — `message-type:8650753 num_handles:2 num_fds:0`. It is NOT a multi-fd bug; it is a **coalesced-stream / multi-batch** bug:

- The main IPDL Channel (`ipc_channel_posix.cc`) reads up to a 4 KiB buffer per `recvmsg(2)` and parses EVERY complete message the read returned. When two fd-bearing frames are queued back-to-back in the recv ring, a single `recvmsg` drains the bytes of BOTH frames, but `scm_dequeue` hands back exactly ONE batch per `recvmsg`. The reader parses the second frame with its descriptors silently withheld → fatal `needs unreceived descriptors` → the content processes channel-error and exit, collapsing the screenshot. The "2-handle" message was simply the frame that was reliably the *second* fd batch in a coalesced read.
- Per recvmsg(2)/unix(7)/POSIX.1-2017 §2.14, an AF_UNIX stream recv returns the bytes up to one fd-bearing message *and that message's descriptors*, then stops — so the reader gets one message's fds per recv and the byte/descriptor streams stay in lockstep.
- Fix: `scm_next_batch_offset` returns the lowest pending batch offset strictly above the reader's drained position; the recvmsg arm caps the stream read at `(next - consumed)` bytes, so each recv returns the bytes up to exactly one fd batch, delivers it, and stops. Progress is guaranteed (`next > consumed`); datagram/SEQPACKET unaffected. Test 291 drives the two-frame coalesced-read path.

Refs: recvmsg(2), sendmsg(2), unix(7) SCM_RIGHTS, POSIX.1-2017 §2.14. Verified: full kernel-smoke suite — Tests 280/286/289/290/291 all pass.


### 6. `linux/sendmsg: queue the SCM_RIGHTS batch before pushing the frame's data` (be0730f, NDE-8)
The final residual on the cross-process screenshot handshake — an intermittent `needs unreceived descriptors` that survived the per-recvmsg cap (#5) and, when it hit the screenshot actor's 2-handle message, made the parent give up (FF reached page-load / `/tmp/hello.html` at sc~5.3M, then collapsed on a single dropped batch).

- Root: the send path pushed the frame's data bytes into the peer's recv ring and THEN queued the descriptor batch — two separate critical sections (net::unix TABLE lock vs PENDING_SCM lock). A peer recvmsg in that window drained the bytes and computed its read cap with the batch not yet visible, delivered no fds, and stranded the batch past the reader's position.
- Fix: queue the SCM_RIGHTS batch (bound to the pre-push first-byte offset) BEFORE pushing the frame's data, so the batch is in PENDING_SCM before any of its accompanying bytes can be read; the reader's cap then always stops at it. `frame_has_data` (the T+1-vs-T bind) is computed from the iovec lengths up front.

Refs: recvmsg(2), sendmsg(2), unix(7) SCM_RIGHTS, POSIX.1-2017 §2.14. Verified live: with #4+#5+#6 the cross-process tree runs CLEAN through the screenshot handshake (unreceived-descriptors = 0, 5-process tree intact, parent alive).


---

## 🏆 RESULT: Firefox headless screenshot PNG ACHIEVED (NDE-8, be0730f)
On the full chain (e10s routing + heap/SMP deadlock fixes + the three SCM_RIGHTS fixes #4/#5/#6), upstream `firefox --headless --screenshot` runs the cross-process screenshot pipeline to completion on AstryxOS:

```
gate ladder: lib-load ✓ x11-ready ✓ compositor-init ✓ ff-launch ✓
             content-proc ✓ screenshot-actors ✓ png-write ✓
```

- `needs-unreceived-descriptors` = **0** through the whole run (the SCM fd-delivery is faithful end-to-end)
- The cross-process IPDL screenshot handshake completes: `ScreenshotParent` / `getDimensions` / `sendQuery` route across the AF_UNIX channel, drawSnapshot renders the page
- FF writes a **valid PNG** to `/tmp/out.png` — magic `89 50 4e 47 0d 0a 1a 0a`, IHDR **1366×768, 8-bit RGBA**, IDAT (30186-byte write)
- **`PID 1 exit_group(0)`** — clean success exit (prior boots crashed with `exit_group(11)` on the dropped 2-handle screenshot message)

The three SCM_RIGHTS fixes (#4 first-byte-touch, #5 recv-cap, #6 enqueue-reorder) were the last gate between the chain and the screenshot. All land CI-green.
