### PR TITLE
kernel/mm/heap: mask interrupts across the heap lock (fix re-entrant ISR-alloc deadlock) + dual-regs tool

### DIFF
--- a/kernel/src/mm/heap.rs
+++ b/kernel/src/mm/heap.rs
@@ -670,11 +670,85 @@ impl LinkedListAllocator {
     }
 }
 
+/// RAII bracket that clears IF for the duration of a heap critical section,
+/// restoring the caller's prior interrupt state on drop.
+///
+/// ## Why the heap lock must run with interrupts masked
+///
+/// The kernel heap is guarded by a single non-reentrant `spin::Mutex`
+/// (`LockedHeapAllocator.0`).  A plain `spin::Mutex` does **not** mask
+/// interrupts while held: the free-list walk in `alloc`/`dealloc` runs with
+/// `IF` left at whatever the caller had.  Almost every allocation happens in
+/// ordinary kernel code with interrupts enabled, so the LAPIC timer ISR can
+/// fire *while this core holds the heap lock*.
+///
+/// The timer ISR's periodic metrics dump
+/// (`crate::proc::proc_metrics::maybe_emit_periodic`) itself allocates
+/// (`Vec`/`String`/`format!`).  When the ISR lands on a core that is mid-walk
+/// inside the heap lock, the ISR re-enters `alloc`, takes the same
+/// `spin::Mutex`, and busy-spins forever waiting for a lock the *interrupted*
+/// frame on the very same core can never release — a re-entrant self-deadlock
+/// that strands the core in a non-preemptible Ring-0 spin (the timer ISR
+/// skips kernel-mode preemption), freezing the whole machine.
+///
+/// Masking interrupts for the (tiny, bounded) free-list critical section
+/// makes a heap allocation atomic with respect to ISRs on the local core, so
+/// no interrupt handler can ever observe the lock held and re-enter the
+/// allocator.  This mirrors the same discipline `_serial_print` already uses
+/// around the `SERIAL` mutex, and follows the standard "spinlock that may be
+/// taken from interrupt context must be IRQ-safe" rule (an irqsave spinlock).
+/// Cross-core safety is unchanged: the `spin::Mutex` still serialises CPUs;
+/// masking only prevents *same-core* ISR re-entry.
+struct HeapIrqGuard {
+    /// True if IF was set on entry and must be restored to set on drop.
+    reenable: bool,
+}
+
+impl HeapIrqGuard {
+    #[inline(always)]
+    fn new() -> Self {
+        // Read RFLAGS, then mask interrupts.  `pushfq` reflects IF before the
+        // following `cli`, so we capture the caller's true prior state even
+        // when nested inside another IRQ-masked region (then `reenable` is
+        // false and drop is a no-op — correct).
+        let rflags: u64;
+        unsafe {
+            core::arch::asm!(
+                "pushfq",
+                "pop {rflags}",
+                "cli",
+                rflags = out(reg) rflags,
+                options(nomem, preserves_flags),
+            );
+        }
+        HeapIrqGuard { reenable: rflags & (1 << 9) != 0 }
+    }
+}
+
+impl Drop for HeapIrqGuard {
+    #[inline(always)]
+    fn drop(&mut self) {
+        if self.reenable {
+            // SAFETY: restoring IF to exactly the value the caller had on
+            // entry.  If the caller already had interrupts masked we leave
+            // them masked.
+            unsafe {
+                core::arch::asm!("sti", options(nomem, nostack, preserves_flags));
+            }
+        }
+    }
+}
+
 /// Thread-safe wrapper around the heap allocator.
 struct LockedHeapAllocator(Mutex<LinkedListAllocator>);
 
 unsafe impl GlobalAlloc for LockedHeapAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Mask interrupts across the lock-held critical section so the timer
+        // ISR (which itself allocates via the periodic metrics dump) cannot
+        // fire on this core while the heap lock is held and re-enter the
+        // allocator into a same-core spin deadlock.  See `HeapIrqGuard`.
+        let _irq = HeapIrqGuard::new();
         let ptr = self.0.lock().alloc(layout);
         if !ptr.is_null() {
             crate::perf::record_heap_alloc(layout.size());
@@ -684,6 +758,7 @@ unsafe impl GlobalAlloc for LockedHeapAllocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         crate::perf::record_heap_free(layout.size());
+        let _irq = HeapIrqGuard::new();
         self.0.lock().dealloc(ptr, layout)
     }
 }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -4576,6 +4576,56 @@ def cmd_regs(args):
     _out({"ok": True, "regs": regs})
 
 
+def cmd_dual_regs(args):
+    """Enumerate every QEMU vCPU thread, read RIP/CS/RSP/RBP for each, and
+    symbolize the kernel-space RIP.
+
+    Purpose: SMP spin-lock deadlock autopsy.  When the whole machine freezes
+    on a held-across-dispatch spin::Mutex, one core strands the lock while the
+    other busy-spins in a non-preemptible Ring-0 loop.  This command names the
+    RIP each vCPU is parked at so the busy-spinner core (the one looping in a
+    lock-acquire path) and the holder core can be identified in one shot.
+
+    Output per-cpu: thread id, RIP (hex), symbolized RIP, CS (ring via low 2
+    bits), RSP, RBP.  No guest mutation — pure read via the GDB stub.
+    """
+    sess = _load_session(args.sid)
+    port = _get_gdb_port(sess)
+
+    gdb = GdbClient("127.0.0.1", port)
+    if not gdb.connect():
+        _err(f"Cannot connect to GDB stub on port {port} (tried {port}..{port+4})")
+    cpus = []
+    try:
+        tids = gdb.list_threads()
+        if not tids:
+            tids = [1]  # single-vCPU stub that doesn't advertise threads
+        for tid in tids:
+            gdb.select_thread(tid)
+            regs = gdb.read_regs()
+            rip = int(regs.get("rip", "0x0"), 16)
+            cs = int(regs.get("cs", "0x0"), 16)
+            sym = _autopsy_resolve_kernel_rip(rip)
+            cpus.append({
+                "tid":  tid,
+                "rip":  hex(rip),
+                "sym":  sym,
+                "cs":   hex(cs),
+                "ring": cs & 0x3,
+                "rsp":  regs.get("rsp"),
+                "rbp":  regs.get("rbp"),
+                "rax":  regs.get("rax"),
+                "rdi":  regs.get("rdi"),
+                "rsi":  regs.get("rsi"),
+            })
+    except Exception as e:
+        _err(f"GDB dual-regs error: {e}")
+    finally:
+        gdb.close()
+
+    _out({"ok": True, "n_cpus": len(cpus), "cpus": cpus})
+
+
 def cmd_mem(args):
     """Read memory via GDB 'm addr,len' packet; cap at 4096 bytes."""
     sess = _load_session(args.sid)
@@ -10514,6 +10564,12 @@ def main():
     p_regs = sub.add_parser("regs", help="[Tier2] Read x86_64 registers via GDB stub")
     p_regs.add_argument("sid")
 
+    # dual-regs — read RIP/CS/RSP for EVERY vCPU + symbolize (SMP deadlock autopsy)
+    p_dual_regs = sub.add_parser(
+        "dual-regs",
+        help="[Tier2] Read RIP/CS/RSP/RBP for every vCPU and symbolize the kernel RIP")
+    p_dual_regs.add_argument("sid")
+
     # mem
     p_mem = sub.add_parser("mem", help="[Tier2] Read guest memory via GDB stub")
     p_mem.add_argument("sid")
@@ -11282,6 +11338,7 @@ def main():
         "snap-gate": cmd_snap_gate,
         # Tier 2
         "regs":   cmd_regs,
+        "dual-regs": cmd_dual_regs,
         "mem":    cmd_mem,
         "sym":    cmd_sym,
         "bp":     cmd_bp,


### PR DESCRIPTION
Split from the cross-process screenshot chain (#502) — the two unambiguous wins, landed independently of the e10s routing change (which is held pending the content-process-init gate).

## 1. Heap re-entrant-allocation deadlock fix (the correctness win)
The kernel heap `LockedHeapAllocator` is a non-reentrant `spin::Mutex<LinkedListAllocator>` that did **not** mask interrupts while held. When the LAPIC timer ISR allocates — `arch/x86_64/irq.rs timer_tick` → `proc_metrics::emit_periodic` does `Vec`/`String`/`format!` — while interrupted kernel code already holds the heap lock, the ISR spins forever on a lock the interrupted-on-the-same-core code can never release. A same-core re-entrant self-deadlock (both vCPUs wedged, kdb starved).

Fix: a `HeapIrqGuard` brackets the heap lock acquisition in `alloc`/`dealloc` to mask interrupts for the (short, bounded) duration the lock is held, so the timer ISR cannot re-enter the allocator mid-critical-section. GDB-confirmed at a real freeze (Firefox, sc~492M); the fix advances the workload past it (492M → 765M+). Cites Intel SDM interrupt-masking semantics; public specs only.

## 2. `dual-regs` harness tool
`qemu-harness.py dual-regs` reads RIP/CS/RSP for **every** vCPU via the GDB stub and symbolizes — a one-shot SMP-deadlock autopsy (catches the both-cores-Ring-0-spin signature that single-CPU `regs` misses). Used to GDB-confirm the deadlock above.

## CI
Builds + the kernel test suite. The heap-lock change is the correctness-critical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)