### PR TITLE
firefox-test: keep master's headless demo on the known-good file:// page

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -906,14 +906,7 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // See: https://firefox-source-docs.mozilla.org/widget/headless.html
         "MOZ_HEADLESS=1",
         "MOZ_DISABLE_CONTENT_SANDBOX=1",
-        // NB: we intentionally do NOT set MOZ_DISABLE_NONLOCAL_CONNECTIONS.
-        // When set to any value other than "0", Firefox refuses every
-        // connect(2) to a non-loopback address in-process (the socket
-        // transport returns NS_ERROR_CONNECTION_REFUSED before any SYN is
-        // emitted), so a remote --screenshot URL never drives the network
-        // path.  Leaving it unset is the default automation behaviour and is
-        // required for fetching a real internet page.
-        // See: https://firefox-source-docs.mozilla.org/testing/marionette/Prefs.html
+        "MOZ_DISABLE_NONLOCAL_CONNECTIONS=1",
         "MOZ_DISABLE_AUTO_SAFE_MODE=1",
         // Short-circuit SetExceptionHandler() before it touches the
         // Crash Reports directory tree.  Release builds of Firefox check

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1261,9 +1261,9 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // addr2line / gdb resolve C++ names natively (no Mozilla tecken
             // dependency).  All three fall through to the same --headless
             // --screenshot pipeline.
-            const CMDLINE_MUSL_132: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png http://1.1.1.1/";
-            const CMDLINE_MUSL_ESR: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png http://1.1.1.1/";
-            const CMDLINE_GLIBC:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png http://1.1.1.1/";
+            const CMDLINE_MUSL_132: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            const CMDLINE_MUSL_ESR: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            const CMDLINE_GLIBC:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
             // Use stat() (resolve_path + FileSystemOps::stat) for the existence
             // probe instead of read_file().  read_file() allocates a Vec sized
             // to the full file (~795 KB for firefox-bin), reads every byte, and


### PR DESCRIPTION
Restores master's default headless `--screenshot` target to the local
`file:///tmp/hello.html` page (which renders cleanly) and restores the
`MOZ_DISABLE_NONLOCAL_CONNECTIONS=1` spawn env.

## Why

The crash-recovery-supervisor branch was stacked on top of the in-flight
real-website work rather than cleanly based on master, so merging it
inadvertently carried the demo *config* commit (`71c04a2`) onto master:
it repointed all three `CMDLINE_*` constants at `http://1.1.1.1/` and
dropped the nonlocal-connection block. The remote-URL render path is not
yet complete (the cross-process navigation hand-off is still under
investigation), so master's headline demo would otherwise stall instead
of producing the known-good PNG.

This is a pure revert of that one config commit. The underlying network
datapath correctness fixes (`a4d211d`: recvmsg `msg_name` marshal per
RFC 1035 §7.3, TCP out-of-order/FIN guard) are **retained** on master —
they are correct and invisible to the file:// demo. The remote-URL
config will return with the real-website PR once that path renders.

Reverts only `71c04a2`; no other behavior changes.