### PR TITLE
net/linux: recvmsg MSG_CTRUNC + partial-fit SCM install; epoll AF_UNIX has_pending parity (NDE-12)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2461,6 +2461,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // memory.  Held for the call duration; we drop it before
                 // the subsequent allocations / table walks below.
                 const MSG_TRUNC: u32 = 0x20;
+                // recvmsg(2): MSG_CTRUNC indicates that some ancillary control
+                // data was discarded because the receiver's `msg_control`
+                // buffer was too small.  Independent of MSG_TRUNC (data
+                // truncation); both may be set on the same call.
+                const MSG_CTRUNC: u32 = 0x8;
                 bytes_read = {
                     let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
                     let buf = unsafe { core::slice::from_raw_parts_mut(dst, eff_cap) };
@@ -2500,21 +2505,63 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // not pick up a later frame's fds.
                 if bytes_read >= 0 {
                     let consumed = crate::net::unix::recv_consumed(unix_id);
-                    if let Some(scm_fds) = crate::syscall::scm_dequeue(unix_id, consumed) {
+                    // Pop the batch together with its bound stream offset so an
+                    // un-installed remainder can be re-queued at the SAME offset
+                    // (recvmsg(2) / cmsg(3): control data that does not fit is
+                    // not dropped — MSG_CTRUNC is raised and the unfitting fds
+                    // remain available to a subsequent larger-buffer recvmsg).
+                    if let Some((batch_off, mut scm_fds)) =
+                        crate::syscall::scm_dequeue_with_offset(unix_id, consumed)
+                    {
+                        let nfds = scm_fds.len();
+                        // Read the receiver's msg_control geometry up front so we
+                        // know how many descriptors actually fit BEFORE moving any
+                        // into the fd table.  cmsg(3): a single SCM_RIGHTS cmsg of
+                        // n fds occupies `CMSG_SPACE(n*4)` = 16 (cmsghdr) + n*4
+                        // bytes (we lay the fd array immediately after the 16-byte
+                        // header with no extra alignment padding, matching the
+                        // CMSG_FIRSTHDR/CMSG_DATA offsets glibc & musl compute).
+                        let (ctrl_ptr, ctrl_len) = unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            (core::ptr::read_unaligned(msghdr_ptr.add(4)),
+                             core::ptr::read_unaligned(msghdr_ptr.add(5)) as usize)
+                        };
+                        // How many fds fit: floor((ctrl_len - 16) / 4), clamped to
+                        // the batch size and to 0 when ctrl_len < 16.  A ctrl_ptr
+                        // of 0, or a range that fails user-pointer validation, is
+                        // treated as "nothing fits" so the whole batch is re-queued
+                        // and MSG_CTRUNC is raised.
+                        let mut fits = ((ctrl_len.saturating_sub(16)) / 4).min(nfds);
+                        // `validate_user_ptr` is bypassed inside a
+                        // KernelDispatchGuard (in-kernel test driver passing
+                        // kernel-VA buffers); in production it is the only
+                        // defence against a kernel-VA in msg_control directing
+                        // a supervisor write — see CWE-823 note below.
+                        let ctrl_ok = ctrl_ptr != 0
+                            && fits > 0
+                            && (crate::syscall::user_ptr_check_bypassed()
+                                || crate::syscall::validate_user_ptr(ctrl_ptr, 16 + fits * 4));
+                        if ctrl_ptr == 0 || !ctrl_ok {
+                            fits = 0;
+                        }
+                        // Split off the descriptors that will NOT be installed on
+                        // this call; they are re-queued at the batch's original
+                        // stream offset so a follow-up recvmsg adopts them.
+                        let remainder: Vec<crate::vfs::FileDescriptor> =
+                            scm_fds.split_off(fits);
                         // Regular-file / memfd descriptors were pinned at enqueue
                         // (PENDING_SCM holds an inode reference invisible to the
                         // VFS fd-table scan).  Once installed in the receiver's
                         // fd table below, the slot itself keeps the inode alive,
                         // so the in-flight pin can be released.  Snapshot the
-                        // (mount_idx, inode) pairs BEFORE the descriptors are
-                        // moved into the table; unpin AFTER PROCESS_TABLE is
-                        // dropped (unpin_inode also takes PROCESS_TABLE).
+                        // (mount_idx, inode) pairs for the INSTALLED prefix only —
+                        // the re-queued remainder keeps its enqueue-time pin.
                         let to_unpin: Vec<(usize, u64)> = scm_fds.iter()
                             .filter(|f| f.file_type == crate::vfs::FileType::RegularFile
                                         && f.mount_idx != usize::MAX)
                             .map(|f| (f.mount_idx, f.inode))
                             .collect();
-                        // Allocate fds in the receiver's process.
+                        // Allocate fds in the receiver's process for the prefix.
                         let new_fd_nums: Vec<i32> = {
                             let mut procs = crate::proc::PROCESS_TABLE.lock();
                             if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
@@ -2537,44 +2584,61 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         for (m, ino) in to_unpin {
                             crate::vfs::unpin_inode(m, ino);
                         }
-                        // Write SCM_RIGHTS cmsghdr into msg_control.  All
-                        // reads/writes here target user memory — single
-                        // SMAP guard spanning the whole block.
+                        // Re-queue the un-installed remainder at the SAME stream
+                        // offset the batch was dequeued from (recvmsg(2) /
+                        // cmsg(3): descriptors that did not fit are NOT orphaned —
+                        // CWE-772).  Keeping the original byte_offset preserves the
+                        // first-byte-touch delivery contract so the next recvmsg
+                        // with a larger control buffer adopts them.
+                        if !remainder.is_empty() {
+                            crate::syscall::scm_queue(unix_id, batch_off, remainder);
+                        }
+                        // The control buffer truncated the batch (either some fds
+                        // did not fit, or ctrl_ptr was 0 / rejected with nfds > 0):
+                        // set MSG_CTRUNC.  OR it into the existing msg_flags so the
+                        // MSG_TRUNC data-truncation bit written by the data path
+                        // above is preserved — both can co-occur (recvmsg(2)).
+                        if new_fd_nums.len() < nfds {
+                            unsafe {
+                                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                                let flags_ptr = (arg2 + 48) as *mut u32;
+                                let cur = core::ptr::read_unaligned(flags_ptr);
+                                core::ptr::write_unaligned(flags_ptr, cur | MSG_CTRUNC);
+                            }
+                        }
+                        // Write the SCM_RIGHTS cmsghdr for the INSTALLED prefix.
+                        // All reads/writes here target user memory — single SMAP
+                        // guard spanning the whole block.
                         //
                         // CWE-823: ctrl_ptr is read from user-controlled
-                        // msghdr.msg_control and is the destination of
-                        // kernel writes below.  Range-validate against the
-                        // exact byte span the writes will touch (`needed`)
-                        // before any write so a kernel-VA in msg_control
-                        // cannot direct the kernel to overwrite arbitrary
-                        // kernel memory with attacker-shaped cmsghdr bytes
-                        // (SOL_SOCKET=1, SCM_RIGHTS=1, then the receiver's
-                        // freshly-installed fd numbers).  SMAP catches the
-                        // missing-AC=1 case for user pages but does not
-                        // catch supervisor writes to kernel-VA; the range
-                        // check is the only line of defence for that.
-                        let needed = 16 + new_fd_nums.len() * 4;
+                        // msghdr.msg_control and is the destination of kernel
+                        // writes below.  The span actually written
+                        // (`16 + fits*4`) was range-validated above
+                        // (`ctrl_ok`); we never write past it.  SMAP catches the
+                        // missing-AC=1 case for user pages; the range check is the
+                        // only line of defence against a kernel-VA in msg_control.
                         unsafe {
                             let _g = crate::arch::x86_64::smap::UserGuard::new();
-                            let ctrl_ptr = core::ptr::read_unaligned(msghdr_ptr.add(4));
-                            let ctrl_len = core::ptr::read_unaligned(msghdr_ptr.add(5)) as usize;
-                            if ctrl_ptr != 0
-                                && ctrl_len >= needed
-                                && crate::syscall::validate_user_ptr(ctrl_ptr, needed)
-                            {
-                                core::ptr::write_unaligned(ctrl_ptr as *mut u64, needed as u64);
+                            if !new_fd_nums.is_empty() {
+                                // ctrl_ok held when fits>0, so the span below was
+                                // validated; cmsg_len = CMSG_LEN(fits*4) = 16 + n*4.
+                                let written = 16 + new_fd_nums.len() * 4;
+                                core::ptr::write_unaligned(ctrl_ptr as *mut u64, written as u64);
                                 core::ptr::write_unaligned((ctrl_ptr + 8)  as *mut i32, 1i32); // SOL_SOCKET
                                 core::ptr::write_unaligned((ctrl_ptr + 12) as *mut i32, 1i32); // SCM_RIGHTS
                                 for (i, &new_fd) in new_fd_nums.iter().enumerate() {
                                     core::ptr::write_unaligned((ctrl_ptr + 16 + i as u64 * 4) as *mut i32, new_fd);
                                 }
-                                core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, needed as u64);
+                                // msg_controllen = bytes actually written.
+                                core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, written as u64);
                             } else if ctrl_ptr != 0 {
-                                // No room or ctrl_ptr not in user space.  The
-                                // msghdr_ptr was already user-range-validated
-                                // at the top of the recvmsg arm, so this
-                                // single field write is safe even when
-                                // ctrl_ptr is rejected.
+                                // Nothing installed (buffer too small for even one
+                                // fd, or ctrl_ptr rejected): no cmsg written,
+                                // CMSG_FIRSTHDR()==NULL.  msg_controllen = 0;
+                                // MSG_CTRUNC was set above.  The msghdr_ptr was
+                                // user-range-validated at the top of the arm, so
+                                // this single field write is safe even when
+                                // ctrl_ptr itself was rejected.
                                 core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, 0u64);
                             }
                         }
@@ -10032,7 +10096,7 @@ fn write_hex64(out: &mut Vec<u8>, mut v: u64) {
 ///  - closed/invalid:      EPOLLERR
 /// Poll the readiness events for `fd` in process `pid`.
 /// Returns a bitmask of EPOLL* flags that are currently set.
-fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
+pub(crate) fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
     use crate::ipc::epoll::{EPOLLIN, EPOLLOUT, EPOLLERR, EPOLLHUP, EPOLLRDHUP};
 
     // Snapshot fd metadata with a brief lock hold.  `mount_idx == usize::MAX`
@@ -10120,7 +10184,18 @@ fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
                     // of parking forever on a pure fd handoff.
                     let has_scm = crate::syscall::has_scm_deliverable(
                         inode, crate::net::unix::recv_consumed(inode));
-                    if has_d || has_scm {
+                    // A LISTENING AF_UNIX socket with a queued connection is
+                    // read-ready: accept(2) will not block.  `has_pending`
+                    // reports the listen(2) accept backlog (backlog_len > 0).
+                    // `poll`/`select` already gate POLLIN on it
+                    // (`syscall::poll_revents` / `do_select`); without it here,
+                    // an epoll-driven accept loop never wakes for an incoming
+                    // connection — POLLIN under poll/select but no EPOLLIN under
+                    // epoll_wait (epoll(7) / accept(2)).  A connected socketpair
+                    // has backlog_len == 0, so this is a no-op for it and only
+                    // restores listening-socket accept-readiness parity.
+                    let has_pend = crate::net::unix::has_pending(inode);
+                    if has_d || has_scm || has_pend {
                         ev |= EPOLLIN;
                     }
                     // `epoll(7)` distinguishes a read-side half-close from a

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -552,6 +552,32 @@ pub fn scm_dequeue(receiver_id: u64, consumed: u64) -> Option<Vec<crate::vfs::Fi
     Some(q.remove(pos).fds)
 }
 
+/// Like [`scm_dequeue`] but also returns the popped batch's bound
+/// `byte_offset`.  The caller needs the offset to re-queue an *un-installed
+/// remainder* at the SAME stream position via [`scm_queue`] when the receiver's
+/// `msg_control` buffer was too small for the whole batch.
+///
+/// Per `recvmsg(2)` / `cmsg(3)`: when the ancillary buffer cannot hold every
+/// passed descriptor, the kernel delivers as many as fit and raises
+/// `MSG_CTRUNC`; the descriptors that did not fit are NOT silently dropped — a
+/// subsequent `recvmsg` with a larger control buffer must be able to receive
+/// them.  This helper lets the recvmsg path pop the batch, install the prefix
+/// that fits, then re-queue the tail at its original `byte_offset` (via
+/// [`scm_queue`]) so it stays attached to the same stream frame and is
+/// delivered on the next call rather than orphaned (CWE-772).
+pub fn scm_dequeue_with_offset(
+    receiver_id: u64,
+    consumed: u64,
+) -> Option<(u64, Vec<crate::vfs::FileDescriptor>)> {
+    let mut q = PENDING_SCM.lock();
+    let pos = q.iter().enumerate()
+        .filter(|(_, b)| b.receiver_id == receiver_id && consumed >= b.byte_offset)
+        .min_by_key(|(_, b)| b.byte_offset)
+        .map(|(i, _)| i)?;
+    let batch = q.remove(pos);
+    Some((batch.byte_offset, batch.fds))
+}
+
 /// Drain *all* pending `SCM_RIGHTS` batches destined for `receiver_id` and
 /// return their queued `FileDescriptor`s, removing the batches from the queue.
 ///

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2634,6 +2634,24 @@ pub fn run() -> ! {
     total += 1;
     if test_291_scm_coalesced_stream_read_cap() { passed += 1; }
 
+    // ── Test 292: recvmsg short cbuf — MSG_CTRUNC + partial-fit SCM install ─
+    // When a recvmsg(2) SCM_RIGHTS batch of K fds does not fit the caller's
+    // msg_control buffer, exactly the fds that FIT are installed + reported in
+    // the cmsg, msg_controllen reflects the bytes written, MSG_CTRUNC is set,
+    // and the un-installed remainder is re-queued (not orphaned) so a later
+    // larger-buffer recvmsg delivers it.  Refs: recvmsg(2) (MSG_CTRUNC),
+    // cmsg(3), unix(7) SCM_RIGHTS.
+    total += 1;
+    if test_292_recvmsg_ctrunc_partial_scm_install() { passed += 1; }
+
+    // ── Test 293: epoll EPOLLIN parity on a listening AF_UNIX socket ───────
+    // A listening AF_UNIX socket with a queued connection is read-ready;
+    // epoll_wait(2) must report EPOLLIN for it just as poll(2)/select(2) do
+    // (both gate on the listen accept backlog).  Refs: epoll(7), accept(2),
+    // poll(2), unix(7).
+    total += 1;
+    if test_293_epoll_listening_unix_has_pending() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -46716,4 +46734,350 @@ fn test_291_scm_coalesced_stream_read_cap() -> bool {
     unix::close(b);
     test_pass!("coalesced stream read delivers one fd batch per recv (Test 291)");
     true
+}
+
+// ── Test 292: recvmsg short control buffer — MSG_CTRUNC + partial-fit install ─
+//
+// When a recvmsg(2) carries an SCM_RIGHTS batch of K fds but the caller's
+// `msg_control` buffer can hold only K-1, recvmsg(2) / cmsg(3) require:
+//   * exactly the K-1 fds that FIT are installed in the receiver fd table and
+//     reported back in the cmsg (cmsg_len = CMSG_LEN((K-1)*4) = 16 + (K-1)*4),
+//   * msg_controllen is set to the bytes actually written (16 + (K-1)*4),
+//   * MSG_CTRUNC (0x8) is raised in msg_flags to signal the truncation, and
+//   * the un-installed remainder is NOT orphaned (CWE-772): a follow-up
+//     recvmsg with an adequate control buffer must deliver the leftover fd.
+//
+// Before this fix the kernel installed EVERY fd of the batch unconditionally,
+// then — finding the buffer too small — wrote NO cmsg, set msg_controllen=0,
+// and set NO MSG_CTRUNC.  Userspace saw CMSG_FIRSTHDR()==NULL (zero fds) with
+// no truncation signal while all K fds silently occupied receiver fd-table
+// slots (leaked).  This drives the real recvmsg (nr=47) syscall through
+// dispatch_linux_kernel and asserts the corrected behaviour end-to-end.
+//
+// Refs: recvmsg(2) (MSG_CTRUNC), cmsg(3) (CMSG_LEN/CMSG_SPACE), unix(7)
+// SCM_RIGHTS, POSIX.1-2017 §2.14.
+fn test_292_recvmsg_ctrunc_partial_scm_install() -> bool {
+    use crate::net::unix;
+    test_header!("recvmsg short control buffer: MSG_CTRUNC + partial-fit SCM install (Test 292)");
+
+    const MSG_CTRUNC: u32 = 0x8;
+    const K: usize = 3; // fds in the batch; buffer will hold K-1 = 2.
+
+    // STREAM pair; receiver is `b`.  Allocate process-level fds so the recvmsg
+    // syscall can find the socket and install delivered descriptors.
+    let (id_a, id_b) = unix::socketpair(unix::SockKind::Stream,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if id_a == u64::MAX || id_b == u64::MAX {
+        test_fail!("recvmsg_ctrunc", "socketpair returned MAX");
+        return false;
+    }
+    let pid = crate::proc::current_pid_lockless();
+    let fd_b = crate::syscall::alloc_unix_socket_fd(pid, id_b, false, false);
+    if fd_b < 0 {
+        test_fail!("recvmsg_ctrunc", "alloc_unix_socket_fd(b) = {}", fd_b);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+
+    // Distinguishable throw-away descriptors.  mount_idx == usize::MAX keeps
+    // them out of the inode-pin / unix-close machinery so the test exercises
+    // ONLY the fd-table install + cmsg-write + requeue logic.
+    let mk_fd = |ino: u64| crate::vfs::FileDescriptor {
+        inode: ino, mount_idx: usize::MAX, offset: 0, flags: 0,
+        file_type: crate::vfs::FileType::RegularFile,
+        is_console: false, cloexec: false,
+        open_path: alloc::string::String::new(),
+    };
+
+    // Queue a control-ONLY batch of K fds bound to the current stream tail, so
+    // it is immediately deliverable as a 0-byte readable message (the recvmsg
+    // data path returns EAGAIN on the empty ring and is promoted to a 0-byte
+    // success because a deliverable SCM batch is queued).  Tag fds 0xC0..0xC2.
+    let tail = unix::enqueue_offset_for(id_b);
+    crate::syscall::scm_queue(id_b, tail,
+        alloc::vec![mk_fd(0xC0), mk_fd(0xC1), mk_fd(0xC2)]);
+    if !crate::syscall::has_scm_deliverable(id_b, unix::recv_consumed(id_b)) {
+        test_fail!("recvmsg_ctrunc", "K-fd batch not deliverable after enqueue");
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+
+    // ── recvmsg #1: control buffer sized for K-1 fds = 16 + 2*4 = 24 bytes ──
+    // msghdr (x86_64): off16=msg_iov, off24=msg_iovlen, off32=msg_control,
+    // off40=msg_controllen, off48=msg_flags.  Flat [u64;7] covers off 0..55.
+    let mut rxbuf = [0u8; 8];
+    let mut iov: [u64; 2] = [rxbuf.as_mut_ptr() as u64, 8];
+    let mut ctrl1 = [0u8; 24]; // room for exactly K-1 = 2 fds
+    let mut hdr = [0u64; 7];
+    hdr[2] = iov.as_mut_ptr() as u64;      // msg_iov     (off 16)
+    hdr[3] = 1u64;                         // msg_iovlen  (off 24)
+    hdr[4] = ctrl1.as_mut_ptr() as u64;    // msg_control (off 32)
+    hdr[5] = ctrl1.len() as u64;           // msg_controllen (off 40)
+    hdr[6] = 0;                            // msg_flags   (off 48)
+
+    let ret1 = crate::syscall::dispatch_linux_kernel(
+        47, fd_b as u64, hdr.as_mut_ptr() as u64, 0, 0, 0, 0);
+    if ret1 != 0 {
+        test_fail!("recvmsg_ctrunc", "recvmsg #1 returned {} (want 0 data bytes)", ret1);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+
+    let controllen1 = hdr[5] as usize;
+    let flags1 = (hdr[6] & 0xFFFF_FFFF) as u32;
+    // cmsghdr: cmsg_len (u64) @0, cmsg_level (i32) @8, cmsg_type (i32) @12,
+    //          fd array starting @16.
+    let cmsg_len1 = u64::from_le_bytes(ctrl1[0..8].try_into().unwrap()) as usize;
+    let cmsg_level1 = i32::from_le_bytes(ctrl1[8..12].try_into().unwrap());
+    let cmsg_type1 = i32::from_le_bytes(ctrl1[12..16].try_into().unwrap());
+    let fd0 = i32::from_le_bytes(ctrl1[16..20].try_into().unwrap());
+    let fd1 = i32::from_le_bytes(ctrl1[20..24].try_into().unwrap());
+
+    // K-1 fds must fit: msg_controllen == 16 + 2*4 == 24, cmsg_len matches.
+    if controllen1 != 16 + (K - 1) * 4 {
+        test_fail!("recvmsg_ctrunc",
+            "msg_controllen #1 = {} (want {})", controllen1, 16 + (K - 1) * 4);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    if cmsg_len1 != 16 + (K - 1) * 4 || cmsg_level1 != 1 || cmsg_type1 != 1 {
+        test_fail!("recvmsg_ctrunc",
+            "cmsg #1 hdr wrong: len={} level={} type={} (want len={} SOL_SOCKET=1 SCM_RIGHTS=1)",
+            cmsg_len1, cmsg_level1, cmsg_type1, 16 + (K - 1) * 4);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    // MSG_CTRUNC must be set (the third fd did not fit).
+    if flags1 & MSG_CTRUNC == 0 {
+        test_fail!("recvmsg_ctrunc",
+            "MSG_CTRUNC not set in msg_flags={:#010x} after short-buffer recvmsg", flags1);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    // The reported fds must be REAL installed slots in the receiver fd table,
+    // pointing at the first two batch inodes (0xC0, 0xC1).  Verify directly.
+    let installed_ok = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == pid).map(|p| {
+            let a_ok = p.file_descriptors.get(fd0 as usize)
+                .and_then(|o| o.as_ref()).map(|f| f.inode) == Some(0xC0);
+            let b_ok = p.file_descriptors.get(fd1 as usize)
+                .and_then(|o| o.as_ref()).map(|f| f.inode) == Some(0xC1);
+            a_ok && b_ok
+        }).unwrap_or(false)
+    };
+    if !installed_ok {
+        test_fail!("recvmsg_ctrunc",
+            "cmsg fds [{},{}] do not resolve to installed inodes [0xC0,0xC1]", fd0, fd1);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    test_println!("  recvmsg #1: installed 2 fds [{},{}]=inodes[0xC0,0xC1], controllen={}, MSG_CTRUNC set ✓",
+        fd0, fd1, controllen1);
+
+    // ── recvmsg #2: adequate buffer must deliver the leftover fd (no leak) ──
+    // The remainder was re-queued at the SAME byte offset, so it is still
+    // deliverable; a larger control buffer adopts it.
+    let mut ctrl2 = [0u8; 64];
+    let mut hdr2 = [0u64; 7];
+    hdr2[2] = iov.as_mut_ptr() as u64;
+    hdr2[3] = 1u64;
+    hdr2[4] = ctrl2.as_mut_ptr() as u64;
+    hdr2[5] = ctrl2.len() as u64;
+    hdr2[6] = 0;
+
+    let ret2 = crate::syscall::dispatch_linux_kernel(
+        47, fd_b as u64, hdr2.as_mut_ptr() as u64, 0, 0, 0, 0);
+    if ret2 != 0 {
+        test_fail!("recvmsg_ctrunc", "recvmsg #2 returned {} (want 0)", ret2);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    let controllen2 = hdr2[5] as usize;
+    let flags2 = (hdr2[6] & 0xFFFF_FFFF) as u32;
+    let cmsg_len2 = u64::from_le_bytes(ctrl2[0..8].try_into().unwrap()) as usize;
+    let fd2 = i32::from_le_bytes(ctrl2[16..20].try_into().unwrap());
+
+    if controllen2 != 16 + 4 || cmsg_len2 != 16 + 4 {
+        test_fail!("recvmsg_ctrunc",
+            "recvmsg #2 controllen={} cmsg_len={} (want {} for the 1 leftover fd)",
+            controllen2, cmsg_len2, 16 + 4);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd2 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    if flags2 & MSG_CTRUNC != 0 {
+        test_fail!("recvmsg_ctrunc",
+            "recvmsg #2 spuriously set MSG_CTRUNC (flags={:#010x}) for a fitting buffer", flags2);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd2 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    // The leftover fd must resolve to the third batch inode (0xC2) — proving
+    // the remainder was re-queued, not orphaned.
+    let leftover_ok = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == pid)
+            .and_then(|p| p.file_descriptors.get(fd2 as usize)?.as_ref())
+            .map(|f| f.inode) == Some(0xC2)
+    };
+    if !leftover_ok {
+        test_fail!("recvmsg_ctrunc",
+            "recvmsg #2 leftover fd {} does not resolve to inode 0xC2 (remainder lost)", fd2);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd2 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    // And nothing should remain queued for the receiver.
+    if crate::syscall::has_scm_deliverable(id_b, unix::recv_consumed(id_b)) {
+        test_fail!("recvmsg_ctrunc", "batch still deliverable after both recvmsgs (leak)");
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd2 as u64, 0, 0, 0, 0, 0);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+        unix::close(id_a); unix::close(id_b);
+        return false;
+    }
+    test_println!("  recvmsg #2: delivered leftover fd {}=inode 0xC2, controllen={}, no MSG_CTRUNC (requeue, no leak) ✓",
+        fd2, controllen2);
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+    let _ = crate::syscall::dispatch_linux_kernel(3, fd0 as u64, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux_kernel(3, fd1 as u64, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux_kernel(3, fd2 as u64, 0, 0, 0, 0, 0);
+    let _ = crate::syscall::dispatch_linux_kernel(3, fd_b as u64, 0, 0, 0, 0, 0);
+    unix::close(id_a);
+    unix::close(id_b);
+    test_pass!("recvmsg short control buffer: MSG_CTRUNC + partial-fit SCM install (Test 292)");
+    true
+}
+
+// ── Test 293: epoll EPOLLIN on a LISTENING AF_UNIX socket with a pending conn ─
+//
+// A listening AF_UNIX socket that has a queued (not-yet-accepted) connection is
+// read-ready: accept(2) will not block, and epoll(7)/poll(2)/select(2) must all
+// report the socket as readable.  `poll`/`select` already gate POLLIN on the
+// listen accept backlog (net::unix::has_pending → backlog_len > 0), but the
+// epoll readiness computation (epoll_poll_events) gated EPOLLIN only on
+// has_data || has_scm — so an epoll-driven accept loop never woke for an
+// incoming connection (POLLIN under poll/select, but no EPOLLIN under
+// epoll_wait).  This verifies the parity fix: epoll_poll_events must report
+// EPOLLIN for a listening socket once a connection is queued, exactly as
+// poll_revents does.  A connected socketpair (backlog_len == 0) is unaffected.
+//
+// Refs: epoll(7), accept(2), poll(2), unix(7).
+fn test_293_epoll_listening_unix_has_pending() -> bool {
+    use crate::net::unix;
+    use crate::ipc::epoll::EPOLLIN;
+    test_header!("epoll EPOLLIN parity on listening AF_UNIX with pending connection (Test 293)");
+
+    let creds = unix::PeerCreds { pid: 0, uid: 0, gid: 0 };
+    let pid = crate::proc::current_pid_lockless();
+
+    // Listening server socket bound to a test-private abstract-ish path.
+    let srv = unix::create(unix::SockKind::Stream, creds);
+    if srv == u64::MAX {
+        test_fail!("epoll_listen", "create(server) returned MAX");
+        return false;
+    }
+    const SRV_PATH: &[u8] = b"/test-293-epoll-listen.sock";
+    if unix::bind(srv, SRV_PATH) != 0 {
+        test_fail!("epoll_listen", "bind(server) failed");
+        unix::close(srv);
+        return false;
+    }
+    if unix::listen(srv) != 0 {
+        test_fail!("epoll_listen", "listen(server) failed");
+        unix::close(srv);
+        return false;
+    }
+
+    // Process-level fd for the listening socket so epoll_poll_events can find it.
+    let fd_srv = crate::syscall::alloc_unix_socket_fd(pid, srv, false, false);
+    if fd_srv < 0 {
+        test_fail!("epoll_listen", "alloc_unix_socket_fd(server) = {}", fd_srv);
+        unix::close(srv);
+        return false;
+    }
+
+    // Before any connect: no pending connection → epoll must NOT report EPOLLIN.
+    let ev_idle = crate::subsys::linux::syscall::epoll_poll_events(pid, fd_srv as usize);
+    if ev_idle & EPOLLIN != 0 {
+        test_fail!("epoll_listen",
+            "epoll_poll_events reported EPOLLIN ({:#06x}) on an idle listener (no pending conn)",
+            ev_idle);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_srv as u64, 0, 0, 0, 0, 0);
+        unix::close(srv);
+        return false;
+    }
+    test_println!("  idle listener: epoll_poll_events={:#06x} (no EPOLLIN) ✓", ev_idle);
+
+    // Client connects → server backlog_len becomes 1 → has_pending(srv) == true.
+    let cli = unix::create(unix::SockKind::Stream, creds);
+    if cli == u64::MAX {
+        test_fail!("epoll_listen", "create(client) returned MAX");
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_srv as u64, 0, 0, 0, 0, 0);
+        unix::close(srv);
+        return false;
+    }
+    if unix::connect(cli, SRV_PATH, creds) != 0 {
+        test_fail!("epoll_listen", "connect(client) failed");
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_srv as u64, 0, 0, 0, 0, 0);
+        unix::close(cli);
+        unix::close(srv);
+        return false;
+    }
+    if !unix::has_pending(srv) {
+        test_fail!("epoll_listen", "has_pending(server) false after connect (test setup error)");
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd_srv as u64, 0, 0, 0, 0, 0);
+        unix::close(cli);
+        unix::close(srv);
+        return false;
+    }
+
+    // The parity assertion: epoll_poll_events MUST now report EPOLLIN.
+    let ev_pending = crate::subsys::linux::syscall::epoll_poll_events(pid, fd_srv as usize);
+    let ok = ev_pending & EPOLLIN != 0;
+    if !ok {
+        test_fail!("epoll_listen",
+            "epoll_poll_events={:#06x} has NO EPOLLIN for a listener with a pending connection \
+             (poll/select would report POLLIN — epoll parity broken)",
+            ev_pending);
+    } else {
+        test_println!("  pending listener: epoll_poll_events={:#06x} (EPOLLIN set — parity with poll) ✓",
+            ev_pending);
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+    // Drain the backlog so close() does not leave a dangling accept-side peer.
+    let acc = unix::accept(srv);
+    if acc >= 0 { unix::close(acc as u64); }
+    let _ = crate::syscall::dispatch_linux_kernel(3, fd_srv as u64, 0, 0, 0, 0, 0);
+    unix::close(cli);
+    unix::close(srv);
+
+    if ok {
+        test_pass!("epoll EPOLLIN parity on listening AF_UNIX with pending connection (Test 293)");
+    }
+    ok
 }


### PR DESCRIPTION
Two AF_UNIX ABI-fidelity fixes surfaced by a Firefox render investigation. Both are genuine POSIX divergences but were proven **inactive** on the current Firefox path, so they land on their own merit as correctness improvements off master.

## Fix 1 — recvmsg(2) MSG_CTRUNC + partial-fit SCM_RIGHTS install
`kernel/src/subsys/linux/syscall.rs` (nr=47 AF_UNIX arm)

**Before:** when the receiver's `msg_control` buffer was too small for the whole fd batch (`ctrl_len < 16 + nfds*4`), the kernel installed **every** fd of the batch into the receiver fd-table, then wrote **no** cmsg, set `msg_controllen=0`, and set **no** `MSG_CTRUNC`. Userspace saw `CMSG_FIRSTHDR()==NULL` (zero fds) with no truncation signal, while every fd silently occupied a receiver fd-table slot — leaked/orphaned (CWE-772). `MSG_CTRUNC` was undefined kernel-wide.

**After**, per recvmsg(2)/cmsg(3)/unix(7):
- `fits = floor((ctrl_len - 16) / 4)` clamped to `nfds` (0 when `ctrl_len < 16`, or `ctrl_ptr` is NULL / fails user-pointer validation);
- install **only** the first `fits` fds; write one `SCM_RIGHTS` cmsghdr (`cmsg_len = CMSG_LEN(fits*4) = 16 + fits*4`) with exactly those fd numbers; set `msg_controllen` to the bytes actually written;
- when `fits < nfds`, **OR** `MSG_CTRUNC` (0x8) into `msg_flags`, preserving the `MSG_TRUNC` (0x20) data-truncation bit the data path may have set (both can co-occur);
- re-queue the un-installed remainder at the **same** stream `byte_offset` the batch was dequeued from, so a follow-up recvmsg with a larger control buffer adopts them — never orphaned.

New helper `scm_dequeue_with_offset()` pops the batch with its bound offset so the remainder can be re-queued via `scm_queue()` at its original position (first-byte-touch delivery contract preserved).

## Fix 2 — epoll AF_UNIX EPOLLIN `has_pending` parity
`kernel/src/subsys/linux/syscall.rs` (`epoll_poll_events`)

`epoll_poll_events` gated AF_UNIX `EPOLLIN` on `has_data || has_scm`, but `poll_revents` and `select` gate on `has_data || has_pending || has_scm`, where `has_pending` is the listen(2) accept backlog (`backlog_len > 0`). So an epoll-driven accept loop on a **listening** AF_UNIX socket never woke for a queued connection (POLLIN under poll/select, but no EPOLLIN under epoll_wait). Per epoll(7)/accept(2) a listening socket with a pending connection is read-ready. Fix ORs `has_pending` into the epoll EPOLLIN gate for parity. Connected socketpairs have `backlog_len==0`, so this is a **no-op** for them — it only restores listening-socket accept-readiness.

## Tests (`kernel/src/test_runner.rs`)
- **Test 292** — queue a 3-fd SCM batch; recvmsg with a control buffer sized for 2 → exactly 2 fds installed + reported (`controllen=24`), `msg_flags & MSG_CTRUNC` set; a second recvmsg with an adequate buffer delivers the 3rd fd (`controllen=20`, no MSG_CTRUNC) — proves requeue, no leak. Drives the real recvmsg syscall end-to-end.
- **Test 293** — listening AF_UNIX socket with a pending connect → `epoll_poll_events` reports `EPOLLIN` (`0x5` = EPOLLIN|EPOLLOUT), matching poll; idle listener reports no EPOLLIN.

Both tests pass (verified via `qemu-harness.py` test-mode run):
```
recvmsg #1: installed 2 fds [1,2]=inodes[0xC0,0xC1], controllen=24, MSG_CTRUNC set ✓
recvmsg #2: delivered leftover fd 3=inode 0xC2, controllen=20, no MSG_CTRUNC (requeue, no leak) ✓
[PASS] recvmsg short control buffer: MSG_CTRUNC + partial-fit SCM install (Test 292)
pending listener: epoll_poll_events=0x0005 (EPOLLIN set — parity with poll) ✓
[PASS] epoll EPOLLIN parity on listening AF_UNIX with pending connection (Test 293)
```

Refs: recvmsg(2) (MSG_CTRUNC), cmsg(3) (CMSG_LEN/CMSG_SPACE), unix(7) SCM_RIGHTS, POSIX.1-2017 §2.14; epoll(7), accept(2), poll(2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)