### PR TITLE
vfs+mm/cache: page-cache coherence across truncate/ftruncate (POSIX zero-fill)

### DIFF
--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -586,6 +586,138 @@ pub fn update_range(mount_idx: usize, inode: u64, offset: u64, data: &[u8]) {
     }
 }
 
+/// Bring the page cache into coherence with a file that has just been
+/// resized from `old_size` to `new_size` bytes.
+///
+/// This is the truncate-path cohort for the page cache, analogous to
+/// [`update_range`] for the write path.  A `truncate(2)` / `ftruncate(2)`
+/// changes the file's length on the backing store, but any page that was
+/// already faulted into the page cache (keyed by `(mount_idx, inode,
+/// page_offset)`) keeps its pre-truncate contents.  Per POSIX:
+///
+///   * `ftruncate(2)` / `truncate(2)` (IEEE Std 1003.1-2017): "If the file
+///     previously was smaller than [length], the extended area shall appear
+///     as if it were zero-filled."  A grown region MUST read as zero,
+///     including through an existing `mmap(MAP_SHARED)` mapping.
+///   * `mmap(2)` MAP_SHARED visibility: a change to the file's bytes must be
+///     observed by other mappers of the same region.
+///
+/// Without this, a grown region keeps whatever bytes its cache frame held
+/// before the resize (previous tenant / stale garbage), and a shrunk-then-
+/// regrown region resurrects the discarded tail — both violating the
+/// zero-fill guarantee.
+///
+/// ## Coherence model
+///
+/// Let `boundary = min(old_size, new_size)` — the lowest file offset whose
+/// page contents are no longer authoritative after the resize.  For
+/// SHRINK, that is the new end-of-file; for GROW, it is the old end-of-file
+/// (everything from there on must now read as zero).  This function:
+///
+///   1. Zeroes the partial tail of the page that contains `boundary`, from
+///      `boundary % PAGE` to the page end, in place — if that page is
+///      cached.  Mappers with a live PTE to the boundary page then observe
+///      zeros past the (new or old) EOF without a TLB shootdown, and a
+///      future re-grow that lands within that same page reads zero.
+///   2. Evicts every fully-invalidated cache page at offset
+///      `>= round_up(boundary, PAGE)`, releasing the cache's reference on
+///      each.  The next demand fault re-reads the page from the backing
+///      filesystem, which (having been resized) zero-extends past its own
+///      end — installing a correctly zero-filled frame.
+///
+/// Evicted frames whose reference count drops to zero are routed through
+/// [`crate::mm::tlb::quarantine_free`] rather than freed immediately: a
+/// stale TLB entry for the frame may still be live on a sibling CPU, so
+/// the quarantine grace period (one timer ISR on every online CPU) is
+/// required before the frame is recycled.  Per Intel SDM Vol. 3A §4.10.5,
+/// paging-structure changes must be propagated to all processors before
+/// the physical frame is repurposed.  The quarantine calls are made AFTER
+/// the cache lock is released to preserve the cache → TLB → PMM lock order.
+pub fn truncate_range(mount_idx: usize, inode: u64, old_size: u64, new_size: u64) {
+    const PAGE: u64 = 4096;
+    const PHYS_OFFSET: u64 = 0xFFFF_8000_0000_0000;
+
+    // The lowest offset whose page contents are stale after the resize.
+    let boundary = core::cmp::min(old_size, new_size);
+    let boundary_page = boundary & !(PAGE - 1);
+    let boundary_in_page = (boundary & (PAGE - 1)) as usize;
+    // First fully-invalidated page: round the boundary up to a page bound.
+    // Pages strictly after the boundary page (or the boundary page itself
+    // when `boundary` is page-aligned) are dropped wholesale.
+    let first_full_evict = (boundary + PAGE - 1) & !(PAGE - 1);
+
+    // Collect the physical frames whose cache reference reached zero so we
+    // can quarantine-free them after dropping the cache lock (lock order:
+    // cache → TLB quarantine → PMM).
+    let mut to_quarantine: alloc::vec::Vec<u64> = alloc::vec::Vec::new();
+
+    {
+        let mut cache = PAGE_CACHE.lock();
+
+        // (1) Partial boundary page: zero its tail [boundary_in_page, PAGE)
+        // in place.  Only meaningful when the boundary is not page-aligned
+        // (otherwise there is no surviving partial page — that page is in
+        // the full-evict set below).
+        if boundary_in_page != 0 {
+            if let Some(entry) = cache.get_mut(&(mount_idx, inode, boundary_page)) {
+                // SAFETY: the cache holds a reference to `entry.phys` while
+                // the cache lock is held, so the frame is alive; the kernel
+                // higher-half identity map covers every PMM frame.  We zero
+                // [boundary_in_page, PAGE) which is in-bounds of the 4 KiB
+                // frame.
+                let dst = (PHYS_OFFSET + entry.phys + boundary_in_page as u64) as *mut u8;
+                let n = PAGE as usize - boundary_in_page;
+                unsafe {
+                    core::ptr::write_bytes(dst, 0, n);
+                }
+                entry.dirty = true;
+            }
+        }
+
+        // (2) Evict every fully-invalidated page at offset >= first_full_evict.
+        // The page cache is a BTreeMap, so the keys for this (mount, inode)
+        // form a contiguous band; range-scan [first_full_evict, ∞) and
+        // collect the offsets first (cannot mutate the map while iterating).
+        let mut keys_to_evict: alloc::vec::Vec<u64> = alloc::vec::Vec::new();
+        let lo = (mount_idx, inode, first_full_evict);
+        let hi = (mount_idx, inode, u64::MAX);
+        for (&(_m, _i, off), _entry) in cache.range(lo..=hi) {
+            keys_to_evict.push(off);
+        }
+
+        for off in keys_to_evict {
+            if let Some(entry) = cache.remove(&(mount_idx, inode, off)) {
+                // Release the cache's own reference.  If it was the last
+                // reference, the frame must be reclaimed (via quarantine).
+                let new_rc = crate::mm::refcount::page_ref_dec(entry.phys);
+                if new_rc == 0 {
+                    to_quarantine.push(entry.phys);
+                }
+                // W215 diagnostic provenance, mirroring `evict`.
+                #[cfg(feature = "firefox-test")]
+                {
+                    crate::mm::w215_diag::prov_record(
+                        entry.phys,
+                        crate::mm::w215_diag::KIND_EVICT,
+                        crate::mm::w215_diag::pack_cache_key(inode, off),
+                    );
+                    crate::mm::w215_diag::preins_check_op(
+                        entry.phys,
+                        crate::mm::w215_diag::OP_EVICT,
+                        ((off >> 12) & 0xFFFF_FFFF) as u32,
+                    );
+                    #[cfg(feature = "w215-diag")]
+                    crate::mm::w215_crc::record_evict(entry.phys);
+                }
+            }
+        }
+    } // release cache lock
+
+    for phys in to_quarantine {
+        crate::mm::tlb::quarantine_free(phys);
+    }
+}
+
 /// Evict a page from the cache, releasing the cache's reference.
 /// Returns the physical address of the evicted page, if any.
 pub fn evict(mount_idx: usize, inode: u64, page_offset: u64) -> Option<u64> {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2126,6 +2126,8 @@ pub fn run() -> ! {
         if test_233_vfs_append_page_cache_coherency() { passed += 1; }
         total += 1;
         if test_234_cache_update_range_boundaries() { passed += 1; }
+        total += 1;
+        if test_240_vfs_truncate_page_cache_coherency() { passed += 1; }
     }
 
     // ── Test 235: ELF loader hardening (H4) ──────────────────────────────
@@ -40713,6 +40715,235 @@ fn test_234_cache_update_range_boundaries() -> bool {
     }
     let _ = crate::vfs::remove(path);
     test_pass!("mm::cache::update_range — page-boundary arithmetic");
+    true
+}
+
+// ── Test 240: VFS truncate / page-cache coherency ────────────────────────
+//
+// Regression guard for the truncate-path page-cache coherence bug: prior
+// to `mm::cache::truncate_range`, `truncate(2)` / `ftruncate(2)` resized
+// the backing-file data but never reconciled the page cache, so:
+//
+//   * GROW left a stale (previous-tenant) frame in the extended region —
+//     a MAP_SHARED reader / cached read saw garbage instead of zeros,
+//     violating POSIX ftruncate(2): "the extended area shall appear as if
+//     it were zero-filled."  (This is exactly the blank/garbage shared
+//     surface that a memfd + ftruncate consumer would observe.)
+//   * SHRINK left the discarded tail's frames in the cache, so a re-grow
+//     or re-fault resurrected stale bytes.
+//
+// The test injects cache pages directly (as the demand-fault handler
+// does: alloc PMM frame → fill → `cache::insert`), then exercises
+// `vfs::truncate_path` and asserts the cache cohort is reconciled:
+//   (a) GROW: the old-EOF boundary page's tail is zeroed in place, and
+//       pages beyond old EOF are evicted (lookup → None) so a re-fault
+//       installs a zero-filled frame.
+//   (b) SHRINK: pages beyond the new EOF are evicted and the new-EOF
+//       boundary page's tail is zeroed in place.
+//   (c) regression: a subsequent write still propagates through
+//       `update_range` (coherence is reconciled, not blanket-disabled).
+//
+// Uses `/tmp` (tmpfs/ramfs — the memfd backend) so the injected cache
+// entries map to a real (mount, inode).
+//
+// References:
+//   - IEEE Std 1003.1-2017 ftruncate(2) / truncate(2): extension reads as
+//     zero; the file's bytes are otherwise unchanged.
+//   - IEEE Std 1003.1-2017 mmap(2): MAP_SHARED visibility of file changes.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_240_vfs_truncate_page_cache_coherency() -> bool {
+    test_header!("VFS truncate / page-cache coherency (POSIX ftruncate zero-fill)");
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    const PAGE: usize = 4096;
+
+    let path = "/tmp/test240_trunc_coh.bin";
+    let _ = crate::vfs::remove(path);
+    if let Err(e) = crate::vfs::create_file(path) {
+        test_fail!("test240", "create_file({}) failed: {:?}", path, e);
+        return false;
+    }
+
+    // Initial content: two full pages of a recognizable pattern.  Page 0 =
+    // 'A', page 1 = 'B'.  File size = 8192.
+    let mut initial = alloc::vec![b'A'; 2 * PAGE];
+    for b in initial[PAGE..].iter_mut() { *b = b'B'; }
+    if let Err(e) = crate::vfs::write_file(path, &initial) {
+        test_fail!("test240", "initial write_file failed: {:?}", e);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    test_println!("  initial write 8192B (page0='A', page1='B') ✓");
+
+    let (mount_idx, inode) = match crate::vfs::resolve_path(path) {
+        Ok(r) => r,
+        Err(e) => {
+            test_fail!("test240", "resolve_path failed: {:?}", e);
+            let _ = crate::vfs::remove(path);
+            return false;
+        }
+    };
+
+    // Helper: inject a cache page filled with `fill` at `page_off`,
+    // simulating a demand-paged mmap frame.  Returns the phys, or None on
+    // OOM (caller fails the test).
+    let inject = |page_off: u64, fill: u8| -> Option<u64> {
+        let phys = crate::mm::pmm::alloc_page()?;
+        let va = (PHYS_OFF + phys) as *mut u8;
+        unsafe { core::ptr::write_bytes(va, fill, PAGE); }
+        crate::mm::cache::insert(mount_idx, inode, page_off, phys);
+        Some(phys)
+    };
+
+    // Inject the two file pages, plus a third "stale tenant" page at
+    // offset 8192 holding 'Z' — this simulates a frame that some prior
+    // mapping faulted in past the current EOF (or a recycled tenant).  It
+    // must NOT survive once a grow makes [8192,12288) part of the file as
+    // zero-filled, nor a shrink that drops it.
+    let p0 = match inject(0, b'A') {
+        Some(p) => p, None => { test_fail!("test240","alloc p0"); let _=crate::vfs::remove(path); return false; }
+    };
+    let p1 = match inject(PAGE as u64, b'B') {
+        Some(p) => p, None => { test_fail!("test240","alloc p1"); let _=crate::vfs::remove(path); return false; }
+    };
+    let p2 = match inject(2 * PAGE as u64, b'Z') {
+        Some(p) => p, None => { test_fail!("test240","alloc p2"); let _=crate::vfs::remove(path); return false; }
+    };
+    let _ = (p0, p1, p2);
+    test_println!("  injected cache pages at off 0,4096,8192 (A,B,Z) ✓");
+
+    // ── (a) GROW to a non-page-aligned size that lands inside page 1 ──────
+    // New size 4096+100 = 4196 means: file = page0 (full 'A') + first 100
+    // bytes of page1.  Bytes [4196, EOF) of the file are now zero per
+    // ftruncate(2).  But our injected page1 frame still holds 'B'; the
+    // boundary page (4096) tail [100, 4096) must be zeroed in place, and
+    // the stale page2 (8192, 'Z') must be evicted (it is past the new EOF).
+    //
+    // NOTE: this is a SHRINK relative to the 8192 initial size for the
+    // upper pages but the partial-page semantics are identical — boundary
+    // = min(old,new) = 4196.
+    let grow_target: u64 = PAGE as u64 + 100;
+    if let Err(e) = crate::vfs::truncate_path(path, grow_target) {
+        test_fail!("test240", "truncate to {} failed: {:?}", grow_target, e);
+        let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    // Boundary page (4096) must still be cached, with [0,100) = 'B' and
+    // [100,4096) = 0.
+    match crate::mm::cache::lookup(mount_idx, inode, PAGE as u64) {
+        Some(ph) => {
+            let va = (PHYS_OFF + ph) as *const u8;
+            let head = unsafe { core::ptr::read_volatile(va) };
+            let tail99 = unsafe { core::ptr::read_volatile(va.add(99)) };
+            let tail100 = unsafe { core::ptr::read_volatile(va.add(100)) };
+            let tail_end = unsafe { core::ptr::read_volatile(va.add(PAGE - 1)) };
+            if head != b'B' || tail99 != b'B' || tail100 != 0 || tail_end != 0 {
+                test_fail!("test240",
+                    "boundary page after trunc: [0]={:#x} [99]={:#x} [100]={:#x} [4095]={:#x} \
+                     (expected 0x42 0x42 0x00 0x00)", head, tail99, tail100, tail_end);
+                let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+                let _ = crate::mm::cache::evict(mount_idx, inode, PAGE as u64);
+                let _ = crate::vfs::remove(path);
+                return false;
+            }
+        }
+        None => {
+            test_fail!("test240", "boundary page (4096) evicted — partial page must survive zeroed");
+            let _ = crate::vfs::remove(path);
+            return false;
+        }
+    }
+    // The stale page past the new EOF (8192) MUST be gone.
+    if crate::mm::cache::lookup(mount_idx, inode, 2 * PAGE as u64).is_some() {
+        test_fail!("test240", "stale page at 8192 ('Z') not evicted after truncate to {}", grow_target);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    test_println!("  truncate→4196: boundary[100..]=0, page@8192 evicted ✓");
+
+    // Now GROW past the data: ftruncate to 3 pages (12288).  The FS data
+    // (ramfs Vec) zero-extends; the extension MUST read as zero.  Re-fault
+    // a page at offset 8192 by reading through the FS (as the demand-fault
+    // handler does) and assert it is all-zero — proving the grow region is
+    // not resurrecting the old 'Z'/'B' bytes.
+    if let Err(e) = crate::vfs::truncate_path(path, 3 * PAGE as u64) {
+        test_fail!("test240", "grow truncate to 12288 failed: {:?}", e);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    {
+        let fs = match crate::vfs::fs_at(mount_idx) { Some(f) => f.0, None => {
+            test_fail!("test240","fs_at"); let _=crate::vfs::remove(path); return false; } };
+        let mut buf = alloc::vec![0xCCu8; PAGE];
+        match fs.read(inode, 2 * PAGE as u64, &mut buf) {
+            Ok(n) => {
+                // ramfs zero-extends: the grown page reads as n bytes of zero.
+                if !buf[..n].iter().all(|&b| b == 0) {
+                    test_fail!("test240", "grown region [8192,12288) not zero-filled (n={})", n);
+                    let _ = crate::vfs::remove(path);
+                    return false;
+                }
+            }
+            Err(e) => { test_fail!("test240","read grown region: {:?}", e); let _=crate::vfs::remove(path); return false; }
+        }
+    }
+    test_println!("  grow→12288: extension reads ZERO via FS ✓");
+
+    // ── (b) SHRINK to 0 then verify a re-grow reads zero ──────────────────
+    // Re-inject a tenant page at offset 0 holding 'Q', then truncate to 0.
+    // The page must be evicted (boundary 0 is page-aligned → no partial
+    // page survives).
+    let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+    let _ = crate::mm::cache::evict(mount_idx, inode, PAGE as u64);
+    let pq = match inject(0, b'Q') {
+        Some(p) => p, None => { test_fail!("test240","alloc pq"); let _=crate::vfs::remove(path); return false; }
+    };
+    let _ = pq;
+    if let Err(e) = crate::vfs::truncate_path(path, 0) {
+        test_fail!("test240", "shrink truncate to 0 failed: {:?}", e);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    if crate::mm::cache::lookup(mount_idx, inode, 0).is_some() {
+        test_fail!("test240", "page@0 ('Q') not evicted after truncate to 0");
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    test_println!("  shrink→0: page@0 evicted (no stale tail) ✓");
+
+    // ── (c) regression: a normal write still propagates via update_range ──
+    let again: [u8; 64] = [b'W'; 64];
+    if let Err(e) = crate::vfs::write_file(path, &again) {
+        test_fail!("test240", "post-truncate write_file failed: {:?}", e);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    // Inject a cache page and confirm a subsequent overwrite reaches it
+    // (the update_range path is intact).
+    let pw = match inject(0, 0u8) {
+        Some(p) => p, None => { test_fail!("test240","alloc pw"); let _=crate::vfs::remove(path); return false; }
+    };
+    let again2: [u8; 64] = [b'X'; 64];
+    if let Err(e) = crate::vfs::write_file(path, &again2) {
+        test_fail!("test240", "second write_file failed: {:?}", e);
+        let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    let pw_va = (PHYS_OFF + pw) as *const u8;
+    let w0 = unsafe { core::ptr::read_volatile(pw_va) };
+    if w0 != b'X' {
+        test_fail!("test240", "regression: cache[0]={:#x} after write (expected 'X'=0x58)", w0);
+        let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+    test_println!("  regression: write propagated to cache ('X') ✓");
+
+    // Cleanup.
+    let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+    let _ = crate::vfs::remove(path);
+    test_pass!("VFS truncate / page-cache coherency (POSIX ftruncate zero-fill)");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1686,15 +1686,20 @@ pub fn readdir(path: &str) -> VfsResult<Vec<(String, FileType)>> {
 /// Write data to a file (overwrite from beginning).
 pub fn write_file(path: &str, data: &[u8]) -> VfsResult<usize> {
     let (mount_idx, inode) = resolve_path(path)?;
-    let n = {
+    let (old_size, n) = {
         let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
+        let old_size = fs.stat(inode).map(|s| s.size).unwrap_or(0);
         fs.truncate(inode, 0)?;
-        fs.write(inode, 0, data)?
+        (old_size, fs.write(inode, 0, data)?)
     };
     // Page-cache coherency (POSIX mmap(2) MAP_SHARED + write(2) contract):
-    // update any cache pages that overlap the written range so existing
-    // mmap'd readers observe the new bytes immediately.  See
-    // `mm::cache::update_range` for the contract details.
+    // this overwrite-from-beginning first truncates to 0, then writes the
+    // new bytes.  `update_range` reconciles the [0, n) overlap, but any
+    // cache page that belonged to the OLD file beyond the new length is now
+    // stale (the truncate-to-0 discarded it).  Drop those pages first so a
+    // mmap / cached read does not resurrect the pre-write tail; then bring
+    // the freshly-written range up to date in place.
+    crate::mm::cache::truncate_range(mount_idx, inode, old_size, n as u64);
     if n > 0 {
         crate::mm::cache::update_range(mount_idx, inode, 0, &data[..n]);
     }
@@ -1853,13 +1858,33 @@ pub fn fchmod(pid: crate::proc::Pid, fd_num: usize, mode: u32) -> VfsResult<()> 
 }
 
 /// Truncate a file to `size` bytes by path.
+///
+/// Maintains page-cache coherence per POSIX truncate(2): the bytes that
+/// change visibility as a result of the resize (the discarded tail on a
+/// shrink, or the zero-filled extension on a grow) must be reflected in
+/// any page already faulted into the cache.  See
+/// `mm::cache::truncate_range` for the coherence contract.
 pub fn truncate_path(path: &str, size: u64) -> VfsResult<()> {
     let (mount_idx, inode) = resolve_path(path)?;
     let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
-    fs.truncate(inode, size)
+    // Capture the pre-truncate size so the cache cohort knows which range
+    // became zero-filled (grow) or invalid (shrink).  A stat failure leaves
+    // the cache as-is rather than aborting the truncate; we conservatively
+    // pass old_size == size so only the new EOF boundary page is reconciled.
+    let old_size = fs.stat(inode).map(|s| s.size).unwrap_or(size);
+    fs.truncate(inode, size)?;
+    crate::mm::cache::truncate_range(mount_idx, inode, old_size, size);
+    // Path-keyed read cache must be invalidated so a subsequent
+    // `read_file(path)` does not return the pre-truncate snapshot.
+    invalidate_path_read_cache(path);
+    Ok(())
 }
 
 /// Truncate the file open as `fd_num` for process `pid` to `size` bytes.
+///
+/// As with [`truncate_path`], the page cache is reconciled with the new
+/// file length per POSIX ftruncate(2) so MAP_SHARED mappings and cached
+/// reads observe the zero-filled extension / discarded tail.
 pub fn fd_truncate(pid: crate::proc::Pid, fd_num: usize, size: u64) -> VfsResult<()> {
     let (mount_idx, inode) = {
         let procs = crate::proc::PROCESS_TABLE.lock();
@@ -1871,7 +1896,10 @@ pub fn fd_truncate(pid: crate::proc::Pid, fd_num: usize, size: u64) -> VfsResult
         (fd.mount_idx, fd.inode)
     };
     let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
-    fs.truncate(inode, size)
+    let old_size = fs.stat(inode).map(|s| s.size).unwrap_or(size);
+    fs.truncate(inode, size)?;
+    crate::mm::cache::truncate_range(mount_idx, inode, old_size, size);
+    Ok(())
 }
 
 // ===== Process File Descriptor Operations =====
@@ -1987,6 +2015,10 @@ pub fn open(pid: crate::proc::Pid, path: &str, open_flags: u32) -> VfsResult<usi
 
     if open_flags & flags::O_TRUNC != 0 && file_stat.file_type == FileType::RegularFile {
         fs.truncate(inode, 0)?;
+        // Page-cache coherence (POSIX open(2) O_TRUNC + ftruncate(2)):
+        // discard every cached page of the now-empty file so a subsequent
+        // mmap / cached read does not resurrect the pre-truncate contents.
+        crate::mm::cache::truncate_range(mount_idx, inode, file_stat.size, 0);
     }
 
     let fd = FileDescriptor {


### PR DESCRIPTION
## Problem

`truncate(2)` / `ftruncate(2)` resized the backing file but never reconciled
the page cache (keyed `(mount_idx, inode, page_offset)`). Every **write** path
already kept the cache coherent via `mm::cache::update_range`; truncate was the
one data-changing mutation that did not. So any page already faulted into the
cache kept **stale bytes** after a resize:

- **GROW** — POSIX ftruncate(2): the extended area "shall appear as if it were
  zero-filled" and must be visible through existing `MAP_SHARED` mappings. A
  cached frame in the grown region kept its previous (garbage / previous-tenant)
  contents → a `MAP_SHARED` reader saw garbage instead of zeros.
- **SHRINK** — the discarded tail's cached frames were not evicted → a re-grow
  or re-fault resurrected stale tail bytes.

This is the silent *"structurally-valid surface of the wrong bytes"* failure for
any `memfd` + `ftruncate` consumer that mmaps the shared surface (e.g. a shared
paint surface): a blank/garbage result with no error.

## Fix

Add `mm::cache::truncate_range(mount_idx, inode, old_size, new_size)` — the
truncate-path analogue of `update_range`. With `boundary = min(old, new)` (the
lowest offset whose page contents are no longer authoritative):

1. zero the partial tail of the page containing `boundary` **in place**, so a
   mapper with a live PTE observes zeros past the new/old EOF and a re-grow
   within that same page reads zero;
2. **evict** every fully-invalidated page at offset `>= round_up(boundary)` so
   the next demand fault re-reads the (zero-extended) backing data and installs
   a correctly zero-filled frame.

Evicted last-reference frames route through `tlb::quarantine_free` (preserving
the cache → TLB → PMM lock order; quarantine happens *after* the cache lock is
dropped) so a stale sibling-CPU TLB entry is retired before the frame is
recycled.

Wired into **every** direct `fs.truncate` site in the VFS:
- `truncate_path` — `truncate(2)`
- `fd_truncate` — `ftruncate(2)`
- `open(O_TRUNC)` — the open-time truncate
- `write_file` — truncate-to-0-then-write (drops cached pages beyond the new,
  shorter content instead of leaving them stale)

The pre-resize size is captured via `fs.stat` before the truncate, mirroring how
the write paths obtain file geometry.

## Test

New in-kernel test (`test_runner` test 240), run on tmpfs/ramfs — the memfd
backend. Injects cache pages with a recognizable pattern (as the demand-fault
handler does), then asserts:

- non-page-aligned truncate zeroes the boundary-page tail in place **and**
  evicts the stale page past EOF;
- a GROW makes the extension read **ZERO** through the FS;
- a SHRINK-to-0 evicts the page with no stale tail;
- a subsequent write still propagates via `update_range` (coherence is
  reconciled, not blanket-disabled).

Verified PASS via the harness (`scripts/qemu-harness.py`, `--features test-mode`,
KVM):

```
TEST: VFS truncate / page-cache coherency (POSIX ftruncate zero-fill)
truncate→4196: boundary[100..]=0, page@8192 evicted ✓
grow→12288: extension reads ZERO via FS ✓
shrink→0: page@0 evicted (no stale tail) ✓
regression: write propagated to cache ('X') ✓
[PASS] VFS truncate / page-cache coherency (POSIX ftruncate zero-fill)
```

Sibling coherence tests 232/233/234 still pass. The other suite failures on this
boot (`/disk/bin/*` NotFound, `glibc_hello` InterpNotFound, `monotonic-rate`)
are pre-existing/baseline (data-disk staleness + a KVM timer flake), unrelated to
this change.

## References

- IEEE Std 1003.1-2017 `ftruncate(2)` / `truncate(2)` — zero-filled extension.
- IEEE Std 1003.1-2017 `mmap(2)` — `MAP_SHARED` visibility of file changes.
- Intel SDM Vol. 3A §4.10.5 — TLB / paging-structure coherence before reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)