### PR TITLE
tooling: per-gate host timing in the serial monitor + perf-dashboard feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,36 @@ jobs:
       - name: check fault-immunity tokens (ke::bugcheck + no_alloc_fmt)
         run: bash scripts/check_fault_immune.sh
 
+  tooling-smoke:
+    # Host-only smoke tests for the dev-dashboard tooling (no kernel build, no
+    # QEMU boot — pure Python against synthetic + real serial-log fixtures, <10s
+    # total). Gates the PR on the dashboard parsers/derivations staying correct:
+    #   * serial-web-smoke.py     — the serial monitor's endpoints + per-gate
+    #                               TIMING (elapsed/delta from the marks sidecar
+    #                               and the kernel-tick derivation).
+    #   * perf-bench-smoke.py     — the perf taxonomy, import-logs, AND the
+    #                               ingest-marks bridge (gate marks -> a
+    #                               time-series record the perf dashboard reads).
+    #   * perf-baseline-linux-smoke.py — the Linux-baseline record shape.
+    # Failure mode this prevents: a regression in the gate<->phase mapping, the
+    # tick->ms derivation, or the marks-sidecar schema silently corrupting the
+    # numbers BOTH dashboards display, with no kernel-boot job to catch it.
+    name: tooling smoke (host-only dashboards)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: serial-web smoke (serial monitor + per-gate timing)
+        run: python3 scripts/serial-web-smoke.py
+      - name: perf-bench smoke (taxonomy + ingest-marks bridge)
+        run: python3 scripts/perf-bench-smoke.py
+      - name: perf baseline-linux smoke (record shape)
+        run: python3 scripts/perf-baseline-linux-smoke.py
+
   kernel-build:
     name: bootloader + kernel builds
     runs-on: ubuntu-latest

--- a/scripts/gate_marks.py
+++ b/scripts/gate_marks.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""gate_marks.py — shared gate-timing helpers for the AstryxOS dev dashboards.
+
+SINGLE SOURCE OF TRUTH for "when did this boot reach each gate, in host time?"
+The serial monitor (serial-web.py, :8088) and the perf dashboard
+(perf-bench.py -> perf-web.py, :8099) must never disagree on a gate's time, so
+the gate definitions and the gate->time methodology live here, in ONE module
+that both import.
+
+  * The GATE LADDER itself is still owned by serial-web.py's MILESTONES (the
+    canonical bring-up + render ladder). This module re-exports it via
+    perf_markers (which imports serial-web's MILESTONES), so there is exactly one
+    place a gate is defined.
+  * The GATE<->PERF-PHASE MAPPING (GATE_TO_PHASE) is the bridge between the two
+    dashboards: each gate that ENDS a perf phase names that phase, so a per-gate
+    delta in the serial monitor IS the phase_ms value perf-bench records. The
+    mapping is documented in ONE place (here) so the dashboards never diverge.
+
+MARKS SIDECAR — the exact-host-time source for LIVE sessions
+------------------------------------------------------------
+The harness watcher (qemu-harness.py _watcher_thread) streams the serial log with
+the host clock and, the instant it first sees a milestone marker, appends a
+record to ``~/.astryx-harness/<sid>.marks.jsonl``::
+
+    {"kind": "gate", "label": "<milestone>", "host_ts": <epoch>, "tick": <int|null>,
+     "line": <int>, "ts": <epoch>}
+
+One line per gate, first-arrival only, append-only, additive fields only. This is
+the robust exact-host-time source: the watcher always runs for a live session, so
+serial-web can read the marks and show the true wall-clock arrival of each gate
+without re-deriving it from kernel ticks.
+
+For HISTORICAL logs (no watcher ran, no marks sidecar, no per-line host stamp)
+the arrival time is derived from the kernel-tick axis (launch started_at + the
+[HB]/PROC-METRICS tick at the gate line, at the published 100 Hz timer = 10
+ms/tick). Tick-derived times are flagged ``approx=True`` so a consumer never
+confuses them with an exact live stamp.
+
+Public-spec note: the 100 Hz timer figure (1 tick = 10 ms) is the kernel's
+published PIT/APIC rate.
+"""
+
+import os
+import json
+
+# Reuse the canonical ladder + tick rate from perf_markers (which itself imports
+# serial-web.py's MILESTONES — so the gate ladder is single-sourced).
+import perf_markers as pm
+
+# Re-export so callers can `from gate_marks import MILESTONES` without caring
+# whether it came from serial-web or the vendored fallback.
+MILESTONES = pm.MILESTONES
+MS_PER_TICK = pm.MS_PER_TICK
+# The AND-anchored marker-match rule (substring | tuple-of-substrings-all-on-line)
+# from serial-web/perf_markers — re-exported so the harness watcher uses the SAME
+# matcher as the dashboards (no divergent fork of the gate-detection logic).
+match = pm._match
+
+
+# ── gate <-> perf-phase mapping (the bridge between the two dashboards) ────────
+# Each gate that ENDS a perf phase names that phase. The per-gate delta in the
+# serial monitor (time since the PREVIOUS gate) is therefore exactly the duration
+# of the named phase, and perf-bench ingest-marks writes it straight into
+# phase_ms[<phase>]. Gates that do not close a distinct perf phase map to None
+# (they still get an elapsed/delta shown in the serial monitor; they just don't
+# feed a phase_ms slot). This is the ONE place the two taxonomies are reconciled.
+#
+# serial-web MILESTONE        ->  perf-bench PHASE it closes (or None)
+GATE_TO_PHASE = {
+    "kernel entry":      None,            # phase opener; no prior gate to delta from
+    "heap guard":        None,            # within KERNEL-EARLY; no distinct phase
+    "APIC init":         "KERNEL-EARLY",  # bootloader -> apic
+    "SMP / scheduler":   None,            # within DRIVERS bring-up
+    "drivers":           "DRIVERS",       # apic -> drivers/blk
+    "VFS / mount":       "VFS-MOUNT",     # drivers -> vfs mount
+    "init / userspace":  None,            # within INIT
+    "X11 ready":         "INIT",          # vfs/init -> X11 ready (INIT end anchor)
+    "firefox exec":      "FF-STARTUP",    # X11 -> firefox-bin exec
+    "TLS / network":     "LIBXUL-INIT",   # ff exec/libxul -> first TCP
+    "content procs":     None,            # within NETWORK/TLS handshake
+    "screenshot-actors": "NETWORK/TLS",   # tcp -> screenshot IPDL
+    "drawSnapshot":      "RENDER-SETUP",  # screenshot -> composite/draw
+    "PNG write":         "ENCODE",        # draw -> PNG magic written
+    "exit_group":        "TEARDOWN",      # PNG -> pid1 exit_group
+}
+
+
+def marks_path(sid, harness_dir):
+    """Path to the per-session gate-marks sidecar."""
+    return os.path.join(harness_dir, sid + ".marks.jsonl")
+
+
+def append_gate_mark(sid, harness_dir, label, host_ts, tick, line):
+    """Append a single first-arrival gate mark (called by the harness watcher).
+
+    Best-effort and append-only: a write failure is swallowed so the watcher's
+    panic/idle duties are never disrupted by marks I/O."""
+    rec = {"kind": "gate", "label": label, "host_ts": host_ts,
+           "tick": tick, "line": line, "ts": host_ts}
+    try:
+        with open(marks_path(sid, harness_dir), "a") as f:
+            f.write(json.dumps(rec) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def read_gate_marks(sid, harness_dir):
+    """Read the marks sidecar -> {label: {host_ts, tick, line}} (first-arrival).
+
+    Returns {} when no sidecar exists (historical logs). Only the FIRST record
+    for a label is kept (the watcher only writes first-arrival, but be defensive
+    against a re-attached watcher writing a duplicate)."""
+    out = {}
+    p = marks_path(sid, harness_dir)
+    if not os.path.exists(p):
+        return out
+    try:
+        with open(p, "r", errors="replace") as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    d = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if d.get("kind") != "gate":
+                    continue
+                lab = d.get("label")
+                if lab and lab not in out:
+                    out[lab] = {"host_ts": d.get("host_ts"),
+                                "tick": d.get("tick"),
+                                "line": d.get("line")}
+    except OSError:
+        pass
+    return out
+
+
+def tick_to_elapsed_s(tick, started_at, first_tick=0):
+    """Approximate host-elapsed-since-launch (seconds) for a gate at kernel
+    `tick`, derived from the published 100 Hz timer. `started_at` is unused for
+    the elapsed value (elapsed is a pure tick delta from first_tick) but is kept
+    in the signature so a caller that wants absolute host time can add it. Returns
+    None when `tick` is unknown."""
+    if tick is None:
+        return None
+    base = first_tick if first_tick is not None else 0
+    if tick < base:
+        return None
+    return (tick - base) * MS_PER_TICK / 1000.0
+
+
+def gate_timeline(timeline, marks, started_at, first_tick=0):
+    """Attach per-gate host timing to a serial-web `scan_progress` timeline.
+
+    `timeline` is the list of {label, hit, line, tick, dtick} dicts.
+    `marks`     is read_gate_marks() output (exact host stamps), or {} historical.
+    `started_at` is the session launch epoch (from <sid>.json), or None.
+    `first_tick` is the earliest kernel tick on this log (for the tick-derived
+                 approximate axis baseline).
+
+    For each HIT gate, adds (additive — never renames existing keys):
+      host_elapsed  float|None  seconds since launch at this gate's arrival
+      host_delta    float|None  seconds since the PREVIOUS hit gate (the "compare
+                                performance" signal)
+      approx        bool        True when the time is tick-derived (no exact mark)
+      host_ts       float|None  absolute host epoch of arrival (exact marks only)
+
+    Priority per gate: exact host mark (marks sidecar) > tick-derived approx.
+    The delta is computed on whichever axis the gate's elapsed is on, falling back
+    consistently so the ladder stays monotone."""
+    out = []
+    prev_elapsed = None
+    for step in timeline:
+        s = dict(step)  # copy; additive
+        lab = s.get("label")
+        host_elapsed = None
+        host_ts = None
+        approx = False
+        if s.get("hit"):
+            mk = marks.get(lab)
+            if mk and mk.get("host_ts") is not None and started_at:
+                # exact: watcher stamped the host arrival time
+                host_ts = mk["host_ts"]
+                host_elapsed = max(0.0, host_ts - started_at)
+                approx = False
+            else:
+                # approximate: derive from the kernel tick at this gate line
+                te = tick_to_elapsed_s(s.get("tick"), started_at, first_tick)
+                if te is not None:
+                    host_elapsed = te
+                    approx = True
+        host_delta = None
+        if host_elapsed is not None and prev_elapsed is not None:
+            host_delta = max(0.0, host_elapsed - prev_elapsed)
+        if host_elapsed is not None:
+            prev_elapsed = host_elapsed
+        # round to 1 ms to keep the JSON clean (float-subtraction noise otherwise)
+        s["host_elapsed"] = round(host_elapsed, 3) if host_elapsed is not None else None
+        s["host_delta"] = round(host_delta, 3) if host_delta is not None else None
+        s["host_ts"] = host_ts
+        s["approx"] = approx
+        out.append(s)
+    return out

--- a/scripts/perf-bench-smoke.py
+++ b/scripts/perf-bench-smoke.py
@@ -250,6 +250,108 @@ def main():
         check("export-json schema_v==1", out.get("schema_v") == 1)
         check("export-json timeseries_count==1", out.get("timeseries_count") == 1)
 
+        # ── ingest-marks: serial-monitor gate marks -> a time-series record ───
+        # A second session WITH a marks sidecar (the live path). The watcher would
+        # write these; here we write them via the shared helper. Phase_ms for the
+        # gate-closed phases must equal the per-gate host deltas (independently
+        # hand-computed), on the HOST axis (exact), and the point must land in the
+        # store so perf-web /api/series surfaces it. NOTE: placed AFTER the
+        # list/export-json count checks so it does not perturb their n==1 baseline.
+        import gate_marks as gmk  # noqa: PLC0415
+        msid = "marksess00000001"
+        mlog = harness_dir / (msid + ".serial.log")
+        # full forward-ordered ladder so scan_progress reaches firefox exec
+        mlog.write_text(
+            "[BOOT] AstryxOS kernel kernel_main Booting\n"
+            "[HEAP GUARD] Guard pages installed\n"
+            "[ACPI] Phase 5b APIC init\n"
+            "[SMP] scheduler online AP online Phase 6\n"
+            "[DRIVERS] virtio Phase 7\n"
+            "[VFS] ext2 mounted rootfs\n"
+            "[INIT] PID 1 spawn\n"
+            "[FFTEST] X11 server ready\n"
+            "[EXEC] firefox-bin\n")
+        mstart = 7000.0
+        (harness_dir / (msid + ".json")).write_text(json.dumps({
+            "sid": msid, "started_at": mstart, "features": "firefox-test,kdb",
+            "kvm_effective": True, "smp": 2, "running": False}))
+        (harness_dir / (msid + ".events.jsonl")).write_text(json.dumps({
+            "kind": "cpu_model", "kvm_effective": True, "ts": mstart}) + "\n")
+        # exact host stamps: APIC@+2, drivers@+5, VFS@+9, X11@+23, firefox@+24
+        mstamps = [("kernel entry", 7000.2), ("heap guard", 7000.4),
+                   ("APIC init", 7002.0), ("SMP / scheduler", 7003.0),
+                   ("drivers", 7005.0), ("VFS / mount", 7009.0),
+                   ("init / userspace", 7010.0), ("X11 ready", 7023.0),
+                   ("firefox exec", 7024.0)]
+        for lab, ts in mstamps:
+            gmk.append_gate_mark(msid, str(harness_dir), lab, ts, None, 1)
+        rc, out, raw = run(["ingest-marks", msid, "--full"], env=env)
+        check("ingest-marks rc==0", rc == 0, raw[-300:] if rc else "")
+        check("ingest-marks ok", out.get("ok") is True, str(out.get("ok")))
+        check("ingest-marks not approx (exact stamps)",
+              out.get("marks_approx") is False, str(out.get("marks_approx")))
+        gpm = out.get("gate_phase_ms") or {}
+        # KERNEL-EARLY = APIC(+2.0) - heap-guard(+0.4) = 1.6s = 1600 ms
+        check("ingest KERNEL-EARLY == 1600ms (7002.0-7000.4)",
+              gpm.get("KERNEL-EARLY") == 1600, str(gpm.get("KERNEL-EARLY")))
+        # DRIVERS = drivers(+5) - SMP(+3) = 2.0s = 2000ms
+        check("ingest DRIVERS == 2000ms", gpm.get("DRIVERS") == 2000,
+              str(gpm.get("DRIVERS")))
+        # VFS-MOUNT = VFS(+9) - drivers(+5) = 4.0s = 4000ms
+        check("ingest VFS-MOUNT == 4000ms", gpm.get("VFS-MOUNT") == 4000,
+              str(gpm.get("VFS-MOUNT")))
+        # INIT = X11(+23) - init/userspace(+10) = 13.0s = 13000ms
+        check("ingest INIT == 13000ms (X11 - init/userspace)",
+              gpm.get("INIT") == 13000, str(gpm.get("INIT")))
+        # FF-STARTUP = firefox(+24) - X11(+23) = 1.0s = 1000ms
+        check("ingest FF-STARTUP == 1000ms", gpm.get("FF-STARTUP") == 1000,
+              str(gpm.get("FF-STARTUP")))
+        rec = out.get("record") or {}
+        check("ingest record source == ingest-marks",
+              rec.get("source") == "ingest-marks", str(rec.get("source")))
+        check("ingest record phase_ms on host axis for INIT",
+              (rec.get("phase_axis") or {}).get("INIT") == "host",
+              str((rec.get("phase_axis") or {}).get("INIT")))
+        check("ingest record kvm recovered True", rec.get("kvm") is True)
+        check("ingest record total_ms == 24000 (last gate elapsed)",
+              rec.get("total_ms") == 24000, str(rec.get("total_ms")))
+
+        # ── ingest-marks APPROX path: no sidecar, tick-derived ────────────────
+        # An independent hand-computed tick case: ticks 100/300/400 -> the same
+        # derivation serial-web uses (10ms/tick). Marks sidecar ABSENT.
+        tsid = "marktick00000001"
+        tlog = harness_dir / (tsid + ".serial.log")
+        tlog.write_text(
+            "[HB] tick=0 cpu=0 pf=0 sc=0\n"
+            "[BOOT] AstryxOS kernel kernel_main Booting\n"
+            "[HEAP GUARD] Guard pages installed\n"
+            "[HB] tick=100 cpu=0 pf=1 sc=1\n"
+            "[ACPI] Phase 5b APIC init\n"
+            "[SMP] scheduler online AP online Phase 6\n"
+            "[HB] tick=300 cpu=0 pf=1 sc=1\n"
+            "[DRIVERS] virtio Phase 7\n"
+            "[HB] tick=400 cpu=0 pf=1 sc=1\n"
+            "[VFS] ext2 mounted rootfs\n")
+        (harness_dir / (tsid + ".json")).write_text(json.dumps({
+            "sid": tsid, "started_at": 6000.0, "features": "kdb"}))
+        rc, out, raw = run(["ingest-marks", tsid], env=env)
+        check("ingest-marks (tick) rc==0", rc == 0, raw[-200:] if rc else "")
+        check("ingest-marks (tick) is approx", out.get("marks_approx") is True,
+              str(out.get("marks_approx")))
+        tgpm = out.get("gate_phase_ms") or {}
+        # DRIVERS = tick300(+3.0s) - tick100(APIC,+1.0s) = 2.0s = 2000ms;
+        # VFS-MOUNT = tick400(+4.0s) - tick300(+3.0s) = 1.0s = 1000ms.
+        check("ingest (tick) DRIVERS == 2000ms", tgpm.get("DRIVERS") == 2000,
+              str(tgpm.get("DRIVERS")))
+        check("ingest (tick) VFS-MOUNT == 1000ms", tgpm.get("VFS-MOUNT") == 1000,
+              str(tgpm.get("VFS-MOUNT")))
+
+        # ── the ingested points land in the store (perf-web reads this file) ──
+        rc, out, raw = run(["list", "--source", "ingest-marks", "--limit", "5"],
+                           env=env)
+        check("list source=ingest-marks finds the points",
+              out.get("n") == 2, str(out.get("n")))
+
         # ── run build-only gate (no build, no boot) ──────────────────────────
         rc, out, raw = run(["run", "--no-build", "--build-only", "--dry-run"],
                            env=env)

--- a/scripts/perf-bench.py
+++ b/scripts/perf-bench.py
@@ -92,6 +92,7 @@ import subprocess
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import perf_markers as pm   # noqa: E402
+import gate_marks as gmk    # noqa: E402  (gate<->phase mapping + marks sidecar)
 
 SCHEMA_V = 1
 HARNESS_DIR = os.path.expanduser(os.environ.get("ASTRYX_HARNESS_DIR",
@@ -272,6 +273,188 @@ def _deepest_phase(durations):
         if d["from_line"] is not None or d["to_line"] is not None:
             deepest = name
     return deepest
+
+
+# ── gate-marks -> phase_ms (the serial-monitor <-> perf-dashboard bridge) ─────
+def _scan_progress_timeline(log_path):
+    """Forward-ordered milestone timeline (label/hit/line/tick) for a log, using
+    serial-web.py's scan_progress when available (single source of truth), else a
+    minimal re-scan with the shared MILESTONES ladder. Returns (timeline, first_tick)."""
+    sw = pm._sw  # the serial-web module perf_markers already imported (or None)
+    if sw is not None and hasattr(sw, "scan_progress"):
+        prog = sw.scan_progress(log_path)
+        return prog.get("timeline", []), (prog.get("first_tick") or 0)
+    # Fallback: vendored re-scan (mirrors scan_progress' first-hit + dtick logic).
+    found, idx, cur_tick, first_tick, n = {}, 0, None, None, 0
+    try:
+        with open(log_path, "r", errors="replace") as f:
+            for line in f:
+                n += 1
+                tk = pm._TICK_KERNEL.search(line)
+                if tk:
+                    cur_tick = int(tk.group(1))
+                    if first_tick is None:
+                        first_tick = cur_tick
+                while idx < len(gmk.MILESTONES) and gmk.match(line, gmk.MILESTONES[idx][1]):
+                    found[gmk.MILESTONES[idx][0]] = (n, cur_tick)
+                    idx += 1
+    except OSError:
+        pass
+    timeline = []
+    prev = None
+    for lab, _m in gmk.MILESTONES:
+        h = found.get(lab)
+        dtick = (h[1] - prev) if (h and h[1] is not None and prev is not None) else None
+        if h and h[1] is not None:
+            prev = h[1]
+        timeline.append({"label": lab, "hit": h is not None,
+                         "line": h[0] if h else None,
+                         "tick": h[1] if h else None, "dtick": dtick})
+    return timeline, (first_tick or 0)
+
+
+def _marks_to_phase_ms(sid, log_path, started_at):
+    """Turn a session's gate marks (or tick-derived timeline) into a perf-style
+    {phase_name: ms} dict via the shared GATE_TO_PHASE mapping.
+
+    Each gate that ENDS a perf phase (GATE_TO_PHASE[label] is not None) contributes
+    its per-gate host_delta (seconds-since-previous-gate) as that phase's ms. The
+    delta is the SAME 'compare performance' signal the serial monitor shows, so the
+    two dashboards agree by construction.
+
+    Returns (phase_ms, phase_axis, phase_lines, reached_marker, approx_any,
+             total_marks_ms, n_marks). `approx_any` is True when ANY contributing
+    gate was tick-derived (no exact watcher mark)."""
+    timeline, first_tick = _scan_progress_timeline(log_path)
+    marks = gmk.read_gate_marks(sid, HARNESS_DIR)
+    timed = gmk.gate_timeline(timeline, marks, started_at, first_tick=first_tick)
+
+    phase_ms = {}
+    phase_axis = {}
+    phase_lines = {}
+    approx_any = False
+    deepest_label = None
+    n_marks = 0
+    last_elapsed = None
+    for step in timed:
+        lab = step.get("label")
+        if not step.get("hit"):
+            continue
+        deepest_label = lab
+        if step.get("host_elapsed") is not None:
+            last_elapsed = step["host_elapsed"]
+            n_marks += 1
+        phase = gmk.GATE_TO_PHASE.get(lab)
+        if phase is None:
+            continue
+        d = step.get("host_delta")
+        if d is not None:
+            phase_ms[phase] = round(d * 1000.0)         # seconds -> ms
+            phase_axis[phase] = "host" if not step.get("approx") else "tick"
+            phase_lines[phase] = {"to": step.get("line")}
+            if step.get("approx"):
+                approx_any = True
+    total_marks_ms = round(last_elapsed * 1000.0) if last_elapsed is not None else None
+    return (phase_ms, phase_axis, phase_lines, deepest_label, approx_any,
+            total_marks_ms, n_marks)
+
+
+# ── subcommand: ingest-marks ─────────────────────────────────────────────────
+def cmd_ingest_marks(args):
+    """Turn a single session's gate marks into a time-series record so a boot
+    watched in the SERIAL MONITOR (:8088) shows up on the PERF dashboard (:8099).
+
+    Builds the base record exactly like `import-logs` (same revision attribution,
+    host/kvm/features/png detection, schema), then OVERLAYS the gate-marks-derived
+    phase_ms onto it. Additive: every existing field is preserved; new keys are
+    `phase_ms_source`, `marks_approx`, `total_marks_ms`, `n_gate_marks`.
+    """
+    sid = args.sid
+    log_path = os.path.join(HARNESS_DIR, sid + ".serial.log")
+    if not os.path.exists(log_path):
+        print(json.dumps({"ok": False, "error": "no_serial_log",
+                          "sid": sid, "path": log_path}))
+        return 1
+
+    host = socket.gethostname()
+    # revision attribution + launch anchor + session meta — same as import-logs
+    commit_timeline = _build_commit_timeline()
+    try:
+        mtime = os.path.getmtime(log_path)
+    except OSError:
+        mtime = time.time()
+    rev, subj = _attribute_revision(mtime, commit_timeline)
+    started_at, launch_src = pm.launch_anchor(sid, log_path, HARNESS_DIR)
+    features_auth, kvm, smp = _session_meta(sid)
+
+    # base record (tick-axis phase_ms, png, max_sc, etc. — the import path)
+    rec = _record_from_log(
+        log_path, sid, rev, subj, host, source="ingest-marks",
+        started_at=started_at, features_auth=features_auth, kvm=kvm, smp=smp)
+    rec["rev_attribution"] = "mtime-bisect" if rev != "unknown" else "none"
+    rec["launch_src"] = launch_src
+
+    # overlay the gate-marks-derived phase durations (host axis when exact)
+    (gphase_ms, gphase_axis, gphase_lines, deepest_label, approx_any,
+     total_marks_ms, n_marks) = _marks_to_phase_ms(sid, log_path, started_at)
+
+    if n_marks == 0:
+        print(json.dumps({
+            "ok": False, "error": "no_gate_marks_or_ticks", "sid": sid,
+            "note": ("No <sid>.marks.jsonl sidecar AND no recoverable kernel "
+                     "ticks at gate lines — nothing to ingest. A LIVE session "
+                     "watched through the harness gets a marks sidecar "
+                     "automatically; a historical log needs [HB]/PROC-METRICS "
+                     "tick lines for the approximate derivation."),
+        }, indent=2))
+        return 1
+
+    # merge: gate-marks phase_ms takes precedence for the phases it covers; the
+    # tick-axis values from _record_from_log fill the rest. Additive-only.
+    merged_phase_ms = dict(rec.get("phase_ms") or {})
+    merged_phase_axis = dict(rec.get("phase_axis") or {})
+    merged_phase_lines = dict(rec.get("phase_lines") or {})
+    merged_phase_ms.update(gphase_ms)
+    merged_phase_axis.update(gphase_axis)
+    for k, v in gphase_lines.items():
+        cur = dict(merged_phase_lines.get(k) or {})
+        cur.update(v)
+        merged_phase_lines[k] = cur
+    rec["phase_ms"] = merged_phase_ms
+    rec["phase_axis"] = merged_phase_axis
+    rec["phase_lines"] = merged_phase_lines
+
+    # additive provenance keys (downstream tolerates extra keys)
+    rec["phase_ms_source"] = "gate-marks"
+    rec["marks_approx"] = approx_any
+    rec["total_marks_ms"] = total_marks_ms
+    rec["n_gate_marks"] = n_marks
+    rec["deepest_gate"] = deepest_label
+    rec["gate_phase_ms"] = gphase_ms   # the gate-only slice, for transparency
+    # total_ms: prefer the marks-derived end-to-last-gate when it's exact and the
+    # import path left total_ms null (historical anchor lost). Keep additive.
+    if rec.get("total_ms") is None and not approx_any and total_marks_ms is not None:
+        rec["total_ms"] = total_marks_ms
+
+    if not args.dry_run:
+        _append_timeseries(rec)
+
+    print(json.dumps({
+        "ok": True,
+        "sid": sid,
+        "revision": rev,
+        "host": host,
+        "kvm": kvm,
+        "deepest_gate": deepest_label,
+        "n_gate_marks": n_marks,
+        "marks_approx": approx_any,
+        "gate_phase_ms": gphase_ms,
+        "total_marks_ms": total_marks_ms,
+        "reached_png": rec.get("reached_png"),
+        "wrote_to": None if args.dry_run else TIMESERIES,
+        "record": rec if args.full else None,
+    }, indent=2))
+    return 0
 
 
 # ── subcommand: import-logs ──────────────────────────────────────────────────
@@ -697,6 +880,17 @@ def main():
     r.add_argument("--dry-run", action="store_true",
                    help="do not write to the store")
     r.set_defaults(func=cmd_run)
+
+    im = sub.add_parser("ingest-marks",
+                        help="turn ONE session's gate marks into a time-series "
+                             "record (serial-monitor -> perf-dashboard bridge)")
+    im.add_argument("sid", help="harness session id (reads "
+                                "~/.astryx-harness/<sid>.serial.log + .marks.jsonl)")
+    im.add_argument("--dry-run", action="store_true",
+                    help="compute + print but do not write the store")
+    im.add_argument("--full", action="store_true",
+                    help="include the full record object in the output")
+    im.set_defaults(func=cmd_ingest_marks)
 
     il = sub.add_parser("import-logs",
                         help="parse existing serial logs into time-series records")

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -894,15 +894,45 @@ _PANIC_RE = re.compile(
 )
 _IDLE_SECONDS = 30
 
+# Kernel-tick regex for stamping each gate mark with the latest tick (so a
+# historical re-derivation cross-checks against the exact host stamp). Same
+# kernel-only form serial-web/perf_markers use ([HB]/PROC-METRICS tick=).
+_WATCH_TICK_RE = re.compile(r"(?:\[HB\]|PROC-METRICS\]) tick=(\d+)")
+
+
+def _load_gate_marks():
+    """Lazy-import the shared gate-marks helper. Returns the module, or None when
+    it is not on this branch (an older master that predates the dashboards) — in
+    which case the watcher simply skips gate stamping and keeps its panic/idle
+    duties. Additive: never fails the watcher."""
+    try:
+        import gate_marks  # noqa: PLC0415
+        return gate_marks
+    except Exception:
+        return None
+
+
 def _watcher_thread(sid: str, serial_log: str, qmp_sock: str, pid: int):
     """
-    Monitors the serial log for panic patterns and idle periods.
+    Monitors the serial log for panic patterns and idle periods, and stamps the
+    host arrival time of each bring-up/render gate to <sid>.marks.jsonl (the
+    exact-host-time source the serial monitor reads). Gate detection is
+    forward-ordered (milestone N+1 only fires at/after N) — identical discipline
+    to serial-web's scan_progress — so render markers don't false-positive on
+    Firefox's serialized-JS startup cache.
+
     Runs as a daemon thread started by `start`.
     """
     last_size = 0
     last_activity = time.monotonic()
     idle_event_sent = False
     log_path = Path(serial_log)
+
+    # Gate stamping state (forward-ordered, append first-arrival only).
+    _gm = _load_gate_marks()
+    _gate_idx = 0
+    _cur_tick = None
+    _line_no = 0
 
     while _pid_alive(pid):
         try:
@@ -918,6 +948,39 @@ def _watcher_thread(sid: str, serial_log: str, qmp_sock: str, pid: int):
                     new_data = f.read(size - last_size)
                 new_text = new_data.decode("utf-8", errors="replace")
                 for line in new_text.splitlines():
+                    _line_no += 1
+                    # Track latest kernel tick so each gate mark carries the tick
+                    # at its arrival (lets a historical re-derivation cross-check).
+                    # The whole gate block is best-effort: any failure here must
+                    # NOT disrupt the watcher's panic/idle duties (the harness is
+                    # critical infra), so it is wrapped defensively.
+                    if _gm is not None:
+                        try:
+                            _tk = _WATCH_TICK_RE.search(line)
+                            if _tk:
+                                _cur_tick = int(_tk.group(1))
+                            # Forward-ordered milestone stamping: the instant we
+                            # first see milestone N's marker (and only at/after
+                            # N-1), record its host arrival time. One line can
+                            # satisfy several milestones in sequence (while-advance).
+                            while (_gate_idx < len(_gm.MILESTONES)
+                                   and _gm.match(line, _gm.MILESTONES[_gate_idx][1])):
+                                _label = _gm.MILESTONES[_gate_idx][0]
+                                _gm.append_gate_mark(
+                                    sid, str(HARNESS_DIR), _label,
+                                    host_ts=time.time(), tick=_cur_tick,
+                                    line=_line_no)
+                                _emit_event(sid, {
+                                    "event": "gate",
+                                    "label": _label,
+                                    "tick": _cur_tick,
+                                    "line": _line_no,
+                                })
+                                _gate_idx += 1
+                        except Exception:
+                            # disable gate stamping for the rest of this run; keep
+                            # the watcher alive for panics/idles.
+                            _gm = None
                     m = _PANIC_RE.search(line)
                     if m:
                         snap_name = f"{sid}-panic"

--- a/scripts/serial-web-smoke.py
+++ b/scripts/serial-web-smoke.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+serial-web-smoke.py — Host-side smoke test for scripts/serial-web.py.
+
+Validates every dashboard backend parser/endpoint against synthetic serial-log
+fixtures, with NO kernel boot and NO QEMU. Imports serial-web.py's pure
+functions directly and also exercises the HTTP layer end-to-end on an ephemeral
+port. Fast (<2s), deterministic, and CI-safe.
+
+    python3 scripts/serial-web-smoke.py
+
+Exit codes:
+    0  — all checks passed
+    1  — one or more checks failed
+
+Covers (matches the operator-requested feature set):
+  * /api/sessions  — launch-time fields (started_at/elapsed/started_src) from
+                     <sid>.json, plus the log-mtime fallback when json is absent.
+  * /api/milestones — forward-ordered first-hit timeline (line numbers).
+  * /api/context    — N±ctx window slice around a gate line.
+  * /api/metrics    — latest [PROC-METRICS] per pid + [HB], aggregates,
+                      breakdown, both STUCK_IN_NR= and cur_nr= variants.
+  * /api/blkmap     — [BLK] histogram bucketing across the 4194304-sector device,
+                      has_trace=False when no [BLK] lines are present.
+  * /api/milestones per-gate TIMING — host elapsed (+Ns) + per-gate delta (Δ+Ns)
+                      from the marks sidecar (EXACT live stamps) and from
+                      kernel-tick derivation (APPROX historical), incl. the
+                      monotone/forward-ordered delta invariant.
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  [{PASS if cond else FAIL}] {name}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def load_module(harness_dir):
+    """Import serial-web.py with HARNESS_DIR pointed at our fixture dir."""
+    spec = importlib.util.spec_from_file_location("sw", os.path.join(HERE, "serial-web.py"))
+    sw = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sw)
+    sw.HARNESS_DIR = harness_dir
+    return sw
+
+
+# ── synthetic fixtures ────────────────────────────────────────────────────────
+SERIAL = """\
+[BOOT] AstryxOS kernel starting
+[HEAP GUARD] Guard pages installed
+[ACPI] Phase 5b: APIC init
+[SMP] scheduler online, AP online (Phase 6)
+[DRIVERS] Phase 7: probing virtio devices
+[VIRTIO-BLK] Initialized: io=0xc000, capacity=4194304 sectors, queue_size=256
+[VFS] ext2 mounted rootfs
+[INIT] PID 1 spawn /sbin/init
+[BLK] op=R lba=0 len=1 pid=0
+[BLK] op=R lba=2 len=8 pid=0
+[BLK] op=R lba=131072 len=2048 pid=1
+[BLK] op=W lba=4000000 len=8 pid=2
+[FFTEST] X11 server ready
+[EXEC] /disk/usr/lib/firefox-esr/firefox-bin
+[HB] tick=10000 cpu=0 pf=500 sc=1200
+[PROC-METRICS] tick=10000 pid=1 name=/disk/usr/lib/firefox-esr/firefox-bin sc=800 (vm=400 file=300 net=10 sync=20 proc=30 sig=20 other=20) pf=300 disk=R262144/W0 rreq=300 net=R0/W100 STUCK_IN_NR=7@9000t
+[PROC-METRICS] tick=10000 pid=2 name=/disk/usr/lib/firefox-esr/firefox-bin sc=200 (vm=100 file=80 net=0 sync=5 proc=8 sig=4 other=3) pf=120 disk=R4096/W4096 rreq=20 net=R0/W0 cur_nr=2@100t
+[HB] tick=10500 cpu=1 pf=520 sc=1500
+[PROC-METRICS] tick=10500 pid=1 name=/disk/usr/lib/firefox-esr/firefox-bin sc=900 (vm=450 file=320 net=12 sync=22 proc=32 sig=22 other=20) pf=320 disk=R524288/W0 rreq=400 net=R0/W200 cur_nr=5@25t
+"""
+
+
+# Full forward-ordered ladder with interleaved kernel ticks. Each gate line is
+# preceded by an [HB] tick= so the tick-derivation can stamp it. Ticks: kernel
+# entry @0, APIC @100 (=1.0s), drivers @300 (=3.0s), VFS @400 (=4.0s),
+# X11 @900 (=9.0s), firefox @950 (=9.5s) — at the published 100 Hz (10ms/tick).
+TIMED_SERIAL = """\
+[HB] tick=0 cpu=0 pf=0 sc=0
+[BOOT] AstryxOS kernel kernel_main Booting
+[HEAP GUARD] Guard pages installed
+[HB] tick=100 cpu=0 pf=1 sc=1
+[ACPI] Phase 5b APIC init
+[SMP] scheduler online AP online Phase 6
+[HB] tick=300 cpu=0 pf=1 sc=1
+[DRIVERS] virtio Phase 7
+[HB] tick=400 cpu=0 pf=1 sc=1
+[VFS] ext2 mounted rootfs
+[INIT] PID 1 spawn
+[HB] tick=900 cpu=0 pf=1 sc=1
+[FFTEST] X11 server ready
+[HB] tick=950 cpu=0 pf=1 sc=1
+[EXEC] firefox-bin
+"""
+
+
+def _gate_timing_checks(sw, tmp):
+    """Per-gate timing: EXACT (marks sidecar) + APPROX (tick-derived), and the
+    forward-ordered/monotone delta invariant. Independently hand-computed values."""
+    import gate_marks as gm
+
+    # ---- APPROX path: no marks sidecar, derive from kernel ticks ----
+    sidA = "timedapprox01"
+    logA = os.path.join(tmp, sidA + ".serial.log")
+    with open(logA, "w") as f:
+        f.write(TIMED_SERIAL)
+    with open(os.path.join(tmp, sidA + ".json"), "w") as f:
+        json.dump({"sid": sidA, "started_at": time.time() - 60,
+                   "features": "firefox-test,kdb", "running": False}, f)
+    tA = {x["label"]: x for x in sw.scan_milestones_timed(sidA, logA)}
+    # tick 100 -> 1.0s, 300 -> 3.0s, 400 -> 4.0s, 900 -> 9.0s, 950 -> 9.5s
+    check("approx APIC elapsed +1.0s",
+          tA["APIC init"]["host_elapsed"] == 1.0, tA["APIC init"]["host_elapsed"])
+    check("approx APIC is approx (tick-derived)", tA["APIC init"]["approx"] is True)
+    check("approx drivers elapsed +3.0s",
+          tA["drivers"]["host_elapsed"] == 3.0, tA["drivers"]["host_elapsed"])
+    # per-gate DELTA: drivers since APIC = 3.0-1.0 = 2.0s (the key compare signal)
+    check("approx drivers delta = +2.0s (vs APIC)",
+          tA["drivers"]["host_delta"] == 2.0, tA["drivers"]["host_delta"])
+    check("approx VFS delta = +1.0s (4.0-3.0)",
+          tA["VFS / mount"]["host_delta"] == 1.0, tA["VFS / mount"]["host_delta"])
+    check("approx X11 delta = +5.0s (9.0-4.0)",
+          tA["X11 ready"]["host_delta"] == 5.0, tA["X11 ready"]["host_delta"])
+    # monotone: every hit gate's elapsed is non-decreasing in ladder order
+    seq = [x["host_elapsed"] for x in sw.scan_milestones_timed(sidA, logA)
+           if x["hit"] and x["host_elapsed"] is not None]
+    check("approx elapsed monotone non-decreasing",
+          all(seq[i] <= seq[i + 1] for i in range(len(seq) - 1)), seq)
+
+    # ---- EXACT path: marks sidecar with known host stamps ----
+    sidE = "timedexact01"
+    logE = os.path.join(tmp, sidE + ".serial.log")
+    with open(logE, "w") as f:
+        f.write(TIMED_SERIAL)
+    started = 5000.0
+    with open(os.path.join(tmp, sidE + ".json"), "w") as f:
+        json.dump({"sid": sidE, "started_at": started,
+                   "features": "firefox-test,kdb", "running": True}, f)
+    # watcher would stamp these; here we write them directly via the shared helper
+    stamps = [("kernel entry", 5000.2), ("heap guard", 5000.4),
+              ("APIC init", 5002.0), ("SMP / scheduler", 5003.0),
+              ("drivers", 5005.0), ("VFS / mount", 5009.0),
+              ("init / userspace", 5010.0), ("X11 ready", 5023.0),
+              ("firefox exec", 5024.0)]
+    for lab, ts in stamps:
+        gm.append_gate_mark(sidE, tmp, lab, host_ts=ts, tick=None, line=1)
+    tE = {x["label"]: x for x in sw.scan_milestones_timed(sidE, logE)}
+    # X11 arrived at 5023.0, launch 5000.0 -> elapsed 23.0s exact (NOT approx)
+    check("exact X11 elapsed +23.0s",
+          tE["X11 ready"]["host_elapsed"] == 23.0, tE["X11 ready"]["host_elapsed"])
+    check("exact X11 NOT approx", tE["X11 ready"]["approx"] is False)
+    check("exact X11 has absolute host_ts",
+          tE["X11 ready"]["host_ts"] == 5023.0, tE["X11 ready"]["host_ts"])
+    # X11 delta from previous HIT gate (init/userspace @5010) = 23.0-10.0 = 13.0s
+    check("exact X11 delta = +13.0s (vs init/userspace)",
+          tE["X11 ready"]["host_delta"] == 13.0, tE["X11 ready"]["host_delta"])
+    check("exact drivers delta = +2.0s (5005-5003)",
+          tE["drivers"]["host_delta"] == 2.0, tE["drivers"]["host_delta"])
+
+    # ---- the shared gate<->phase mapping is internally consistent ----
+    mlabels = {l for l, _ in gm.MILESTONES}
+    check("GATE_TO_PHASE covers every milestone",
+          set(gm.GATE_TO_PHASE) == mlabels,
+          set(gm.GATE_TO_PHASE) ^ mlabels)
+
+    # ---- HTTP: /api/milestones surfaces the timing fields ----
+    from http.server import ThreadingHTTPServer
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), sw.H)
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/milestones?sid={sidE}",
+                timeout=5) as r:
+            body = r.read()
+        check("/api/milestones has host_elapsed", b"host_elapsed" in body)
+        check("/api/milestones has host_delta", b"host_delta" in body)
+    finally:
+        srv.shutdown()
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="serialweb-smoke-")
+    sid = "smoketest1234"
+    log = os.path.join(tmp, sid + ".serial.log")
+    with open(log, "w") as f:
+        f.write(SERIAL)
+    started = time.time() - 119          # 1m59s ago
+    with open(os.path.join(tmp, sid + ".json"), "w") as f:
+        json.dump({"sid": sid, "pid": 4242, "started_at": started,
+                   "features": "firefox-test,kdb,blk-trace", "running": True}, f)
+    # a second session with NO json — exercises the log-mtime fallback
+    sid2 = "nojson5678"
+    log2 = os.path.join(tmp, sid2 + ".serial.log")
+    with open(log2, "w") as f:
+        f.write("[BOOT] AstryxOS kernel\n")
+
+    sw = load_module(tmp)
+
+    print("── pure parsers ──")
+    # sessions / launch info
+    sessions = {s["sid"]: s for s in sw.list_sessions()}
+    s1 = sessions.get(sid, {})
+    check("sessions includes fixture", sid in sessions)
+    check("started_at from json", abs((s1.get("started_at") or 0) - started) < 1, s1.get("started_at"))
+    check("started_src == json", s1.get("started_src") == "json", s1.get("started_src"))
+    check("elapsed ~119s", s1.get("elapsed") is not None and 115 <= s1["elapsed"] <= 125, s1.get("elapsed"))
+    check("pid surfaced", s1.get("pid") == 4242, s1.get("pid"))
+    s2 = sessions.get(sid2, {})
+    check("no-json fallback started_src", s2.get("started_src") == "log-ctime", s2.get("started_src"))
+    check("no-json fallback has started_at", s2.get("started_at") is not None)
+
+    # milestones — forward-ordered first hits
+    ms = {m["label"]: m for m in sw.scan_milestones(log)}
+    check("milestone kernel-entry hit", ms["kernel entry"]["hit"])
+    check("milestone X11 hit with line", ms["X11 ready"]["hit"] and ms["X11 ready"]["line"] > 0)
+    check("milestone firefox-exec hit", ms["firefox exec"]["hit"])
+    check("milestone PNG not hit", not ms["PNG write"]["hit"])
+    # forward ordering: X11 line < firefox-exec line
+    check("milestones forward-ordered", ms["X11 ready"]["line"] < ms["firefox exec"]["line"])
+
+    # context window around a gate line
+    x11_line = ms["X11 ready"]["line"]
+    ctx = sw.read_context(log, x11_line, 3)
+    check("context start<=line<=end", ctx["start"] <= x11_line <= ctx["end"])
+    check("context returns lines", len(ctx["lines"]) > 0)
+    check("context target line present",
+          any(l["n"] == x11_line and "X11 server ready" in l["t"] for l in ctx["lines"]))
+
+    # metrics — both STUCK_IN_NR and cur_nr variants parse
+    size = os.path.getsize(log)
+    mt = sw.scan_metrics(log, size)
+    check("metrics hb parsed", mt.get("hb") and mt["hb"]["sc"] == 1500, mt.get("hb"))
+    pids = {p["pid"]: p for p in mt.get("pids", [])}
+    check("metrics pid1 latest sc", pids.get(1, {}).get("sc") == 900, pids.get(1, {}).get("sc"))
+    check("metrics pid1 cur_nr stuck", pids.get(1, {}).get("stuck_nr") == 5, pids.get(1, {}).get("stuck_nr"))
+    check("metrics pid2 STUCK fallback parse", 2 in pids)
+    check("metrics breakdown parsed", pids.get(1, {}).get("bd", {}).get("file") == 320)
+    check("metrics aggregate sc", mt["agg"]["sc"] == 900 + 200, mt["agg"]["sc"])
+    check("metrics ram_total 2GiB", mt["ram_total"] == 2 * 1024 * 1024 * 1024)
+
+    # blkmap — histogram across the device
+    bk = sw.scan_blkmap(log, size, 256)
+    check("blkmap has_trace True", bk["has_trace"])
+    check("blkmap n_req == 4", bk["n_req"] == 4, bk["n_req"])
+    check("blkmap device sectors", bk["sectors"] == 4194304)
+    tr = sum(b["r"] for b in bk["buckets"])
+    tw = sum(b["w"] for b in bk["buckets"])
+    check("blkmap read sectors == 1+8+2048", tr == 1 + 8 + 2048, tr)
+    check("blkmap write sectors == 8", tw == 8, tw)
+    # write request at lba 4000000 -> high bucket
+    spb = bk["sectors_per_bucket"]
+    wbucket = 4000000 // spb
+    check("blkmap write in high bucket", bk["buckets"][wbucket]["w"] == 8, bk["buckets"][wbucket])
+    # no-trace log reports has_trace False
+    bk2 = sw.scan_blkmap(log2, os.path.getsize(log2), 256)
+    check("blkmap no-trace -> has_trace False", not bk2["has_trace"])
+
+    # ── per-gate TIMING: elapsed-since-launch + per-gate delta ──
+    print("── per-gate timing ──")
+    _gate_timing_checks(sw, tmp)
+
+    # ── HTTP layer end-to-end on an ephemeral port ──
+    print("── HTTP endpoints ──")
+    from http.server import ThreadingHTTPServer
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), sw.H)
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    base = f"http://127.0.0.1:{port}"
+
+    def get(path):
+        with urllib.request.urlopen(base + path, timeout=5) as r:
+            return r.status, r.read()
+
+    try:
+        st, body = get("/api/sessions")
+        check("GET /api/sessions 200", st == 200)
+        check("GET /api/sessions has started_at", b"started_at" in body)
+        st, body = get(f"/api/milestones?sid={sid}")
+        check("GET /api/milestones 200", st == 200 and b'"hit"' in body)
+        st, body = get(f"/api/context?sid={sid}&line={x11_line}&ctx=3")
+        check("GET /api/context 200", st == 200 and b'"lines"' in body)
+        st, body = get(f"/api/metrics?sid={sid}")
+        check("GET /api/metrics 200", st == 200 and b'"agg"' in body)
+        st, body = get(f"/api/blkmap?sid={sid}&grid=128")
+        check("GET /api/blkmap 200", st == 200 and b'"buckets"' in body)
+        st, body = get("/")
+        check("GET / dashboard 200", st == 200 and b"AstryxOS" in body)
+        # path-traversal / bad sid rejected
+        try:
+            get("/api/metrics?sid=../../etc/passwd")
+            rejected = False
+        except urllib.error.HTTPError as e:
+            rejected = e.code in (400, 404)
+        check("path traversal rejected", rejected)
+    finally:
+        srv.shutdown()
+
+    # cleanup
+    for f in os.listdir(tmp):
+        os.unlink(os.path.join(tmp, f))
+    os.rmdir(tmp)
+
+    print()
+    if failures:
+        print(f"\033[31m{len(failures)} check(s) FAILED:\033[0m " + ", ".join(failures))
+        return 1
+    print("\033[32mAll serial-web smoke checks passed.\033[0m")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/serial-web.py
+++ b/scripts/serial-web.py
@@ -1,0 +1,896 @@
+#!/usr/bin/env python3
+"""serial-web.py — a tiny, dependency-free live dashboard for AstryxOS QEMU
+serial logs (read-only; safe alongside live boots).
+
+  GET /                       dashboard (session list + live log viewer)
+  GET /api/sessions           JSON: every session + gate/sc/tick + launch time
+  GET /api/stream?sid=<sid>   SSE: tail then every newly-appended line
+  GET /api/milestones?sid=    JSON: forward-ordered milestone timeline
+  GET /api/context?sid=&line=N&ctx=400
+                              JSON: the ~N±ctx serial lines around `line`
+                              (for the clickable gate rail — jump to a gate)
+  GET /api/metrics?sid=       JSON: latest [PROC-METRICS]/[HB] sample — CPU/mem
+                              proxy/IO bytes+IOPS/net, plus per-pid breakdown
+  GET /api/blkmap?sid=&grid=N JSON: data.img block-map histogram built from
+                              feature-gated [BLK] op/lba/len trace lines
+
+  python3 scripts/serial-web.py [--port 8088] [--host 0.0.0.0]
+
+All endpoints are read-only and one-shot (the harness convention): each request
+reads the on-disk serial log / session json, computes, and returns. No state is
+kept server-side; the client keeps the rolling sparkline buffers.
+"""
+import os, sys, json, time, glob, argparse, re
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+# Shared gate-timing helper (marks sidecar + gate<->phase mapping). Imported so
+# the milestone rail can show per-gate host elapsed/delta from the SAME source
+# the harness watcher stamps and perf-bench ingests. Optional: if it is not on
+# this checkout, the dashboard degrades to the original hit/line/tick view.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import gate_marks as _gate_marks  # noqa: E402
+except Exception:
+    _gate_marks = None
+
+HARNESS_DIR = os.path.expanduser("~/.astryx-harness")
+SID_RE = re.compile(r"^[A-Za-z0-9_-]{4,64}$")
+TAIL_BYTES = 96 * 1024
+GATE_SCAN_BYTES = 256 * 1024
+GATE_SCAN_MAX_AGE = 3600         # compute gate/sc for sessions <1h old; result is
+                                 # cached by (mtime,size) so frozen logs scan once,
+                                 # live logs re-scan each poll (only the 2-3 active ones)
+METRICS_SCAN_BYTES = 512 * 1024  # tail window for the latest PROC-METRICS/HB sample
+BLK_SCAN_BYTES = 8 * 1024 * 1024 # tail window for the [BLK] block-map histogram
+GUEST_RAM_BYTES = 2 * 1024 * 1024 * 1024   # 2 GiB guest RAM (from the qemu cmdline)
+DISK_SECTORS = 4194304           # virtio-blk capacity=4194304 sectors (data.img)
+SECTOR_BYTES = 512
+
+# render ladder, deepest first (idx, label, substring markers)
+GATES = [
+    (8, "PNG",               ("89504e47", "out.png written", "kdb-read-png")),
+    (7, "drawSnapshot",      ("drawSnapshot", "CrossProcessPaint", "libpng16")),
+    (6, "screenshot-actors", ("ScreenshotParent", "getDimensions")),
+    (5, "content-proc",      ("isForBrowser",)),
+    (4, "network",           ("] Established", "Established →", "[TCP]")),
+    (3, "ff-launch",         ("firefox-bin",)),
+    (2, "x11",               ("X11 server ready", "Xastryx")),
+    (1, "lib-load",          ("libxul",)),
+]
+GATE_MAX = 8
+_SC_RE = re.compile(r"pid=1[^\n]*?sc=(\d+)")
+_TICK_RE = re.compile(r"tick=(\d+)")
+_PANIC_RE = re.compile(r"PANIC|HEAP GUARD\] overflow|SCHEDULER_DEADLOCK|ke_bugcheck")
+
+
+def scan_gate(path, size):
+    try:
+        with open(path, "rb") as f:
+            f.seek(max(0, size - GATE_SCAN_BYTES))
+            text = f.read().decode("latin-1", "replace")
+    except OSError:
+        return {}
+    gi, gl = 0, "boot"
+    for idx, label, marks in GATES:
+        if any(m in text for m in marks):
+            gi, gl = idx, label
+            break
+    sc = tick = None
+    m = list(_SC_RE.finditer(text))
+    if m:
+        sc = int(m[-1].group(1))
+    t = list(_TICK_RE.finditer(text))
+    if t:
+        tick = int(t[-1].group(1))
+    return {"gate": gl, "gate_idx": gi, "gate_max": GATE_MAX,
+            "sc": sc, "tick": tick, "panic": bool(_PANIC_RE.search(text))}
+
+
+# Ordered bring-up + render milestones. Each: (label, markers). A marker is a
+# substring (str) OR a tuple-of-substrings (ALL must be on the SAME line) — the
+# AND form anchors render-stage markers to the real kernel [FF/write] IPDL line
+# so they don't false-positive on the same strings inside FF's serialized JS
+# source / startup cache. Easily extended — add an entry, it shows everywhere.
+MILESTONES = [
+    ("kernel entry",      ("AstryxOS kernel", "kernel_main", "Booting")),
+    ("heap guard",        ("[HEAP GUARD] Guard pages installed",)),
+    ("APIC init",         ("Phase 5b", "APIC init")),
+    ("SMP / scheduler",   ("scheduler online", "SMP", "AP online", "Phase 6")),
+    ("drivers",           ("virtio", "e1000", "ahci", "vmware_svga", "Phase 7")),
+    ("VFS / mount",       ("mounted", "ext2", "fat32", "rootfs")),
+    ("init / userspace",  ("init started", "PID 1", "spawn")),
+    ("X11 ready",         ("X11 server ready", "Xastryx")),
+    ("firefox exec",      ("firefox-bin",)),
+    ("TLS / network",     ("[TCP] Established", "] Established →")),
+    ("content procs",     ("isForBrowser",)),
+    # render stages: AND-anchored to the actual kernel [FF/write]/[FF/write-fd]
+    # log line, NOT the bare string (which also lives in the cached JS source).
+    ("screenshot-actors", (("[FF/write]", "getDimensions"), ("[FF/write]", "ScreenshotParent"), ("[FF/write]", "sendQuery"))),
+    ("drawSnapshot",      ("libpng16.so",)),
+    ("PNG write",         ("89504e47", "out.png written")),
+    ("exit_group",        ("exit_group(",)),
+]
+# Only the kernel's own tick lines, not arbitrary "tick=" in FF/JS output.
+_TICK_KERNEL = re.compile(r"(?:\[HB\]|PROC-METRICS\]) tick=(\d+)")
+
+
+def _match(line, marks):
+    """True if `line` satisfies any marker in `marks`. A marker is a substring,
+    or a tuple of substrings ALL of which must appear on the line (AND)."""
+    for mk in marks:
+        if isinstance(mk, tuple):
+            if all(s in line for s in mk):
+                return True
+        elif mk in line:
+            return True
+    return False
+
+
+# Cache: path -> (mtime, size, result). ONE forward-ordered scan per session,
+# reused until the log changes — so the left badge and the right timeline ALWAYS
+# agree (both read this), and stopped logs are free.
+_prog_cache = {}
+
+
+def scan_progress(path):
+    """FORWARD-ORDERED scan -> {timeline, gate (deepest hit label), gate_idx,
+    gate_max, sc (latest pid=1), tick (latest kernel), panic}. The single source
+    of truth for BOTH the session-list gate badge and the milestone rail, so they
+    can never disagree. Milestone N+1 only matches at/after milestone N's line,
+    which (with the AND-anchored render markers) filters the cached-JS-source
+    false positives."""
+    try:
+        st = os.stat(path)
+    except OSError:
+        return {}
+    c = _prog_cache.get(path)
+    if c and c[0] == st.st_mtime and c[1] == st.st_size:
+        return c[2]
+    found = {}
+    idx = 0
+    cur_tick = sc = None
+    first_tick = None
+    panic = False
+    n = 0
+    try:
+        with open(path, "r", errors="replace") as f:
+            for line in f:
+                n += 1
+                tk = _TICK_KERNEL.search(line)
+                if tk:
+                    cur_tick = int(tk.group(1))
+                    if first_tick is None:
+                        first_tick = cur_tick
+                scm = _SC_RE.search(line)
+                if scm:
+                    sc = int(scm.group(1))
+                if not panic and _PANIC_RE.search(line):
+                    panic = True
+                while idx < len(MILESTONES) and _match(line, MILESTONES[idx][1]):
+                    found[MILESTONES[idx][0]] = (n, cur_tick)
+                    idx += 1
+                # don't early-break: keep scanning so the latest sc/tick (current
+                # state) stays fresh even after the deepest milestone is hit.
+    except OSError:
+        pass
+    timeline, prev, deep_idx, deep_lab = [], None, -1, None
+    for i, (lab, _m) in enumerate(MILESTONES):
+        h = found.get(lab)
+        delta = (h[1] - prev) if (h and h[1] is not None and prev is not None) else None
+        if h and h[1] is not None:
+            prev = h[1]
+        if h:
+            deep_idx, deep_lab = i, lab
+        timeline.append({"label": lab, "hit": h is not None,
+                         "line": h[0] if h else None,
+                         "tick": h[1] if h else None, "dtick": delta})
+    res = {"timeline": timeline, "gate": deep_lab or "boot",
+           "gate_idx": max(deep_idx, 0), "gate_max": len(MILESTONES),
+           "sc": sc, "tick": cur_tick, "first_tick": first_tick, "panic": panic}
+    _prog_cache[path] = (st.st_mtime, st.st_size, res)
+    return res
+
+
+def scan_milestones(path):
+    """Back-compat wrapper for /api/milestones — the timeline from scan_progress.
+
+    Returns the bare timeline (hit/line/tick/dtick). For the per-gate host
+    elapsed/delta view use scan_milestones_timed(sid, path)."""
+    return scan_progress(path).get("timeline", [])
+
+
+def scan_milestones_timed(sid, path):
+    """Timeline ENRICHED with per-gate host elapsed/delta (the 'compare
+    performance' signal). Each hit gate gains, ADDITIVELY (existing keys
+    untouched):
+        host_elapsed  float|None  seconds since launch at the gate's arrival
+        host_delta    float|None  seconds since the PREVIOUS hit gate
+        host_ts       float|None  absolute host epoch (exact live marks only)
+        approx        bool        True when tick-derived (no exact watcher mark)
+
+    Source priority per gate: the exact host stamp the harness watcher wrote to
+    <sid>.marks.jsonl > a kernel-tick derivation (approx). Falls back to the bare
+    timeline when the shared gate_marks helper is unavailable."""
+    prog = scan_progress(path)
+    timeline = prog.get("timeline", [])
+    if _gate_marks is None:
+        return timeline
+    started_at, _src = _launch_info(sid, path,
+                                    os.stat(path) if os.path.exists(path) else None)
+    marks = _gate_marks.read_gate_marks(sid, HARNESS_DIR)
+    return _gate_marks.gate_timeline(
+        timeline, marks, started_at, first_tick=prog.get("first_tick") or 0)
+
+
+def read_context(path, line, ctx):
+    """Return the window of serial lines [line-ctx, line+ctx] (1-based line nums)
+    so the UI can jump the log view to a gate's exact line. Reads the file once
+    and slices — read-only, bounded by `ctx` so an absurd ctx can't OOM us."""
+    ctx = max(1, min(int(ctx), 5000))
+    line = max(1, int(line))
+    lo = max(1, line - ctx)
+    hi = line + ctx
+    out = []
+    n = 0
+    try:
+        with open(path, "r", errors="replace") as f:
+            for raw in f:
+                n += 1
+                if n < lo:
+                    continue
+                if n > hi:
+                    break
+                out.append({"n": n, "t": raw.rstrip("\n")})
+    except OSError:
+        pass
+    return {"line": line, "start": lo, "end": min(hi, n), "total": n, "lines": out}
+
+
+# ── Guest metrics: latest [PROC-METRICS] per pid + global [HB] ────────────────
+# [PROC-METRICS] tick=306000 pid=5 name=… sc=2184 (vm=1254 file=690 net=7 sync=38
+#   proc=70 sig=40 other=85) pf=10076 disk=R1801216/W0 rreq=2174 net=R0/W100
+#   STUCK_IN_NR=7@190912t      (older logs) / cur_nr=5@25t (newer)
+_PM_RE = re.compile(
+    r"\[PROC-METRICS\] tick=(?P<tick>\d+) pid=(?P<pid>\d+) name=(?P<name>\S+) "
+    r"sc=(?P<sc>\d+) \((?P<bd>[^)]*)\) pf=(?P<pf>\d+) "
+    r"disk=R(?P<dr>\d+)/W(?P<dw>\d+) rreq=(?P<rreq>\d+) "
+    r"net=R(?P<nr>\d+)/W(?P<nw>\d+)"
+    r"(?:.*?(?:STUCK_IN_NR|cur_nr)=(?P<stuck>\d+)@(?P<stuckt>\d+)t)?"
+)
+_HB_RE = re.compile(r"\[HB\] tick=(\d+) cpu=(\d+) pf=(\d+) sc=(\d+)")
+
+
+def scan_metrics(path, size):
+    """Latest guest-metrics sample: the most-recent [PROC-METRICS] line for each
+    pid (within the tail window) + the most-recent [HB] global heartbeat. Returns
+    raw counters; the client derives rates from successive polls (it keeps the
+    rolling buffer). 'mem' is a pf-pressure PROXY against 2 GiB — there is no
+    exact used-bytes counter in the serial log."""
+    try:
+        with open(path, "rb") as f:
+            f.seek(max(0, size - METRICS_SCAN_BYTES))
+            text = f.read().decode("latin-1", "replace")
+    except OSError:
+        return {}
+    # latest HB
+    hb = None
+    for m in _HB_RE.finditer(text):
+        hb = {"tick": int(m.group(1)), "cpu": int(m.group(2)),
+              "pf": int(m.group(3)), "sc": int(m.group(4))}
+    # latest PROC-METRICS per pid (keep order of last-seen tick)
+    pids = {}
+    for m in _PM_RE.finditer(text):
+        pid = int(m.group("pid"))
+        bd = {}
+        for part in m.group("bd").split():
+            if "=" in part:
+                k, v = part.split("=", 1)
+                try:
+                    bd[k] = int(v)
+                except ValueError:
+                    pass
+        pids[pid] = {
+            "pid": pid,
+            "tick": int(m.group("tick")),
+            "name": m.group("name").rsplit("/", 1)[-1][:28],
+            "sc": int(m.group("sc")),
+            "bd": bd,
+            "pf": int(m.group("pf")),
+            "disk_r": int(m.group("dr")),
+            "disk_w": int(m.group("dw")),
+            "rreq": int(m.group("rreq")),
+            "net_r": int(m.group("nr")),
+            "net_w": int(m.group("nw")),
+            "stuck_nr": int(m.group("stuck")) if m.group("stuck") else None,
+        }
+    plist = sorted(pids.values(), key=lambda p: p["pid"])
+    # aggregate totals across pids (for the top-line IO/IOPS gauges)
+    agg = {"sc": 0, "pf": 0, "disk_r": 0, "disk_w": 0,
+           "rreq": 0, "net_r": 0, "net_w": 0}
+    for p in plist:
+        for k in agg:
+            agg[k] += p[k]
+    return {
+        "hb": hb,
+        "tick": (hb["tick"] if hb else (plist[-1]["tick"] if plist else None)),
+        "pids": plist,
+        "agg": agg,
+        "ram_total": GUEST_RAM_BYTES,
+        "mem_proxy_note": "pf-pressure proxy; no exact used-bytes in serial",
+    }
+
+
+# ── data.img block-map: histogram of [BLK] op/lba/len over the device ─────────
+_BLK_RE = re.compile(r"\[BLK\] op=(?P<op>[RW]) lba=(?P<lba>\d+) len=(?P<len>\d+)")
+
+
+def scan_blkmap(path, size, grid):
+    """Bucket every [BLK] request into a `grid`-cell histogram across the
+    4194304-sector device. Returns per-bucket read-sector and write-sector
+    totals so the UI can colour read vs write intensity. Returns has_trace=False
+    when no [BLK] lines are present (kernel not built with --features blk-trace),
+    so the UI can show a 'enable blk-trace' hint instead of an empty grid."""
+    grid = max(16, min(int(grid), 2048))
+    try:
+        with open(path, "rb") as f:
+            f.seek(max(0, size - BLK_SCAN_BYTES))
+            text = f.read().decode("latin-1", "replace")
+    except OSError:
+        return {"has_trace": False, "grid": grid, "buckets": []}
+    reads = [0] * grid
+    writes = [0] * grid
+    n_req = 0
+    max_lba = 0
+    sectors_per_bucket = DISK_SECTORS / grid
+    for m in _BLK_RE.finditer(text):
+        lba = int(m.group("lba"))
+        ln = int(m.group("len"))
+        n_req += 1
+        if lba + ln > max_lba:
+            max_lba = lba + ln
+        # spread the request's sectors across the bucket(s) it spans
+        b0 = int(lba / sectors_per_bucket)
+        b1 = int((lba + ln - 1) / sectors_per_bucket)
+        if b0 == b1:
+            arr = reads if m.group("op") == "R" else writes
+            if 0 <= b0 < grid:
+                arr[b0] += ln
+        else:
+            arr = reads if m.group("op") == "R" else writes
+            for b in range(max(0, b0), min(grid, b1 + 1)):
+                lo = b * sectors_per_bucket
+                hi = (b + 1) * sectors_per_bucket
+                ov = min(hi, lba + ln) - max(lo, lba)
+                if ov > 0:
+                    arr[b] += int(ov)
+    buckets = [{"r": reads[i], "w": writes[i]} for i in range(grid)]
+    return {
+        "has_trace": n_req > 0,
+        "grid": grid,
+        "n_req": n_req,
+        "sectors": DISK_SECTORS,
+        "sectors_per_bucket": int(sectors_per_bucket),
+        "max_lba": max_lba,
+        "buckets": buckets,
+    }
+
+
+# ── launch-time / session listing ─────────────────────────────────────────────
+def _launch_info(sid, log_path, log_stat):
+    """Absolute + relative launch time, anchored to the host clock. Reads
+    started_at from <sid>.json; falls back to the serial log's first-mtime
+    (best available proxy) when the json is missing."""
+    started = None
+    src = "json"
+    meta = os.path.join(HARNESS_DIR, sid + ".json")
+    if os.path.exists(meta):
+        try:
+            m = json.load(open(meta))
+            if isinstance(m.get("started_at"), (int, float)):
+                started = float(m["started_at"])
+        except Exception:
+            pass
+    if started is None:
+        # fallback: earliest known timestamp for the log (ctime ~ creation)
+        try:
+            started = log_stat.st_ctime
+            src = "log-ctime"
+        except Exception:
+            started = None
+    return started, src
+
+
+def list_sessions():
+    out = []
+    logs = glob.glob(os.path.join(HARNESS_DIR, "*.serial.log"))
+    logs.sort(key=lambda p: os.path.getmtime(p) if os.path.exists(p) else 0, reverse=True)
+    now = time.time()
+    for log in logs:
+        sid = os.path.basename(log)[:-len(".serial.log")]
+        try:
+            st = os.stat(log)
+        except OSError:
+            continue
+        age = int(now - st.st_mtime)
+        feats, running, pid = "", None, None
+        started_at, started_src = _launch_info(sid, log, st)
+        meta = os.path.join(HARNESS_DIR, sid + ".json")
+        if os.path.exists(meta):
+            try:
+                m = json.load(open(meta))
+                feats = m.get("features", "") or ""
+                running = m.get("running")
+                pid = m.get("pid")
+            except Exception:
+                pass
+        elapsed = (now - started_at) if started_at else None
+        s = {"sid": sid, "features": feats, "size": st.st_size,
+             "age": age, "active": age < 20, "running": running, "pid": pid,
+             "started_at": started_at, "started_src": started_src,
+             "elapsed": int(elapsed) if elapsed is not None else None,
+             "mtime": st.st_mtime}
+        if age < GATE_SCAN_MAX_AGE:
+            p = scan_progress(log)   # SAME source as the milestone rail
+            s.update({"gate": p.get("gate"), "gate_idx": p.get("gate_idx"),
+                      "gate_max": p.get("gate_max"), "sc": p.get("sc"),
+                      "tick": p.get("tick"), "panic": p.get("panic")})
+        out.append(s)
+    return out
+
+
+PAGE = """<!doctype html><html><head><meta charset="utf-8">
+<title>AstryxOS · serial monitor</title>
+<style>
+ :root{--bg:#0b0e14;--panel:#11151f;--edge:#1e2533;--fg:#c9d1d9;--dim:#5c6675;--accent:#39d353}
+ *{box-sizing:border-box} html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);
+   font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+ #app{display:flex;height:100vh}
+ #side{width:340px;min-width:340px;border-right:1px solid var(--edge);overflow:auto;background:var(--panel)}
+ #shead{padding:10px 12px;border-bottom:1px solid var(--edge);position:sticky;top:0;background:var(--panel);z-index:2}
+ #shead h1{font-size:13px;margin:0 0 8px;letter-spacing:.5px} #shead h1 small{color:var(--dim);font-weight:400}
+ input,button{background:#0b0e14;border:1px solid var(--edge);color:var(--fg);border-radius:5px;padding:5px 8px;font:inherit}
+ button{cursor:pointer} button:hover{border-color:var(--accent)}
+ #q{width:100%} #shead label{color:var(--dim);font-size:11px;cursor:pointer;display:inline-block;margin-top:6px}
+ .s{padding:9px 12px;border-bottom:1px solid var(--edge);cursor:pointer}
+ .s:hover{background:#161b27} .s.sel{background:#1b2230;border-left:3px solid var(--accent);padding-left:9px}
+ .s .sid{font-weight:600} .s .meta{color:var(--dim);font-size:11px;margin-top:2px}
+ .s .launch{color:#56b6c2;font-size:10px;margin-top:2px}
+ .dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:#37404f;vertical-align:middle}
+ .dot.on{background:var(--accent);box-shadow:0 0 6px var(--accent)} .dot.panic{background:#ff7b72;box-shadow:0 0 6px #ff7b72}
+ .gate{margin-top:5px;height:5px;background:#1b2230;border-radius:3px;overflow:hidden}
+ .gate>i{display:block;height:100%;background:var(--accent)} .gate.gp>i{background:#d2a8ff} .gate.ge>i{background:#ff7b72}
+ .glab{font-size:10px;color:var(--dim);margin-top:3px} .glab b{color:#7ee787}
+ #main{flex:1;display:flex;flex-direction:column;min-width:0}
+ #bar{padding:7px 12px;border-bottom:1px solid var(--edge);background:var(--panel);display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+ #bar .t{font-weight:600} #bar .badge{font-size:11px;color:#7ee787;border:1px solid var(--edge);padding:2px 7px;border-radius:10px}
+ #bar .x{color:var(--dim);font-size:11px} #bar label{color:var(--dim);cursor:pointer;font-size:11px}
+ #bar button{font-size:11px;padding:3px 8px}
+ #flt{width:150px}
+ #logwrap{flex:1;display:flex;min-height:0}
+ #log{flex:1;overflow:auto;padding:8px 12px;white-space:pre-wrap;word-break:break-all}
+ #log .l{display:block} #log .l:hover{background:#11151f} #log .l.hide{display:none}
+ #log .l.gatehit{background:#1b2230;border-left:3px solid var(--accent);padding-left:6px;font-weight:600}
+ mark{background:#7c5cff;color:#fff;border-radius:2px}
+ .ff{color:#7ee787} .err{color:#ff7b72;font-weight:600} .warn{color:#f0c674}
+ .met{color:#56b6c2} .futex{color:#6b7686} .png{color:#d2a8ff;font-weight:600}
+ #empty{color:var(--dim);padding:24px}
+ #miles{display:flex;flex-wrap:wrap;gap:6px;padding:8px 12px;border-bottom:1px solid var(--edge);background:#0d111a}
+ #miles:empty{display:none}
+ .mile{font-size:11px;padding:3px 9px;border-radius:12px;border:1px solid var(--edge);color:var(--dim);background:#11151f;white-space:nowrap}
+ .mile.hit{color:#7ee787;border-color:#214a2c;background:#0e1c14;cursor:pointer}
+ .mile.hit:hover{box-shadow:0 0 6px rgba(126,231,135,.5)}
+ .mile.hit.last{border-color:var(--accent);box-shadow:0 0 6px rgba(57,211,83,.4)}
+ .mile.png{color:#d2a8ff;border-color:#3a2a52;background:#160e22} .mile b{color:#56b6c2;font-weight:600}
+ .mile .dlt,.rstep .dlt{color:#f0c674;font-weight:600} .rstep .rel{color:#56b6c2}
+ /* right-hand progression rail overlay */
+ #rail{width:0;transition:width .15s;overflow:hidden;border-left:1px solid var(--edge);background:#0d111a}
+ #rail.open{width:210px;min-width:210px;overflow:auto}
+ #rail h3{font-size:11px;color:var(--dim);margin:10px 12px 4px;letter-spacing:.5px;text-transform:uppercase}
+ .rstep{display:flex;align-items:flex-start;gap:8px;padding:5px 12px;font-size:11px;position:relative}
+ .rstep .ic{width:14px;flex:none;text-align:center;color:#37404f}
+ .rstep.hit .ic{color:var(--accent)} .rep .lab{color:var(--dim)}
+ .rstep.hit{cursor:pointer} .rstep.hit:hover{background:#161b27}
+ .rstep.hit .lab{color:#7ee787} .rstep.last{background:#1b2230;border-left:3px solid var(--accent)}
+ .rstep .lab small{display:block;color:var(--dim);font-size:10px}
+ .rstep::before{content:'';position:absolute;left:18px;top:18px;bottom:-5px;width:1px;background:var(--edge)}
+ .rstep:last-child::before{display:none}
+ /* banner */
+ #banner{display:none;padding:6px 12px;font-size:12px;font-weight:600;color:#0b0e14;background:#ff7b72}
+ #banner.warn{background:#f0c674} #banner.stall{background:#d2a8ff}
+ /* metrics panel */
+ #metrics{display:none;border-bottom:1px solid var(--edge);background:#0d111a;padding:7px 12px;gap:14px;flex-wrap:wrap;align-items:stretch}
+ #metrics.show{display:flex}
+ .gm{min-width:118px} .gm .k{font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px}
+ .gm .v{font-size:15px;font-weight:600;color:#7ee787} .gm .v small{font-size:10px;color:var(--dim);font-weight:400}
+ .gm canvas{display:block;margin-top:2px}
+ .gm.mem .bar{height:6px;background:#1b2230;border-radius:3px;margin-top:4px;overflow:hidden}
+ .gm.mem .bar>i{display:block;height:100%;background:#d2a8ff}
+ #pids{display:none;border-bottom:1px solid var(--edge);background:#0b0e14;padding:5px 12px;font-size:11px;overflow-x:auto;white-space:nowrap}
+ #pids.show{display:block} #pids .p{display:inline-block;margin-right:14px;color:var(--dim)}
+ #pids .p b{color:#56b6c2} #pids .p .sc{color:#7ee787}
+ /* block map */
+ #blk{display:none;border-bottom:1px solid var(--edge);background:#0d111a;padding:7px 12px}
+ #blk.show{display:block} #blk .hd{font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px}
+ #blk .hd b{color:#56b6c2} #blkcanvas{display:block;width:100%;height:34px;image-rendering:pixelated;border:1px solid var(--edge);border-radius:3px}
+ #blk .hint{color:var(--dim);font-size:11px} #blk .lg{font-size:10px;color:var(--dim);margin-top:3px}
+ #blk .lg i{display:inline-block;width:9px;height:9px;border-radius:2px;vertical-align:middle;margin:0 3px 0 9px}
+ .toggles{display:flex;gap:6px} .toggles button.on{border-color:var(--accent);color:#7ee787}
+</style></head><body><div id=app>
+ <div id=side>
+   <div id=shead><h1>AstryxOS serial <small id=cnt></small></h1>
+     <input id=q placeholder="filter sessions (sid / features)…">
+     <label><input type=checkbox id=onlyactive checked> active &amp; recent only</label>
+     &nbsp;<label><input type=checkbox id=autolive> auto-follow live</label></div>
+   <div id=list></div></div>
+ <div id=main>
+   <div id=bar><span class=t id=title>— select a session —</span>
+     <span class=badge id=gate style=display:none></span>
+     <span class=x id=sc></span><span class=x id=rate></span>
+     <span class=x id=launch></span>
+     <span style=flex:1></span>
+     <span class=toggles>
+       <button id=tMetrics class=on title="guest metrics + sparklines">metrics</button>
+       <button id=tBlk title="data.img block map (needs blk-trace)">blkmap</button>
+       <button id=tRail class=on title="gate progression rail">rail</button>
+     </span>
+     <input id=flt placeholder="filter lines…"><label><input type=checkbox id=follow checked> follow</label>
+     <button id=jumpLive style=display:none>↧ live</button>
+     <button id=jumpGate title="jump to last gate / PNG / panic">⤓ last</button>
+   </div>
+   <div id=banner></div>
+   <div id=metrics class=show></div>
+   <div id=pids></div>
+   <div id=blk></div>
+   <div id=miles></div>
+   <div id=logwrap>
+     <div id=log><div id=empty>Pick a session on the left to stream its serial output.</div></div>
+     <div id=rail class=open></div>
+   </div>
+ </div></div>
+<script>
+let cur=null,es=null,sessions=[],rate={n:0,t:Date.now()};
+let miles=[],frozen=false,metaCur=null;
+let mPrev=null,mTime=0;                       // last metrics sample (for rate deltas)
+const buf={sc:[],pf:[],dio:[],iops:[],net:[]}; // rolling sparkline buffers
+const BUFMAX=60;
+const list=document.getElementById('list'),log=document.getElementById('log');
+const $=id=>document.getElementById(id);
+const fmt=s=>s==null?'':s<60?s+'s':s<3600?(s/60|0)+'m':Math.floor(s/3600)+'h '+Math.floor(s%3600/60)+'m';
+const human=n=>n==null?'':n>=1e9?(n/1e9).toFixed(1)+'G':n>=1e6?(n/1e6).toFixed(1)+'M':n>=1e3?(n/1e3).toFixed(1)+'k':(''+Math.round(n));
+const bytes=n=>n==null?'':n>=1e9?(n/1073741824).toFixed(1)+'GB':n>=1e6?(n/1048576).toFixed(1)+'MB':n>=1e3?(n/1024).toFixed(1)+'KB':n+'B';
+function utc(ts){if(!ts)return '';const d=new Date(ts*1000);return d.toISOString().slice(11,19)+' UTC';}
+function classify(t){
+  if(/PANIC|HEAP GUARD|SCHEDULER_DEADLOCK|bugcheck|\\bFAIL\\b|#PF|#GP|#UD|channel error/.test(t))return'err';
+  if(/89504e47|drawSnapshot|out\\.png|libpng|CrossProcessPaint|kdb-read-png/.test(t))return'png';
+  if(/^\\[FF\\/|ScreenshotParent|getDimensions|isForBrowser|Established/.test(t))return'ff';
+  if(/WARN|WARNING/.test(t))return'warn';
+  if(/PROC-METRICS|\\[HB\\] tick|\\[BLK\\] /.test(t))return'met';
+  if(/FUTEX|CLEARTID|UNIXPOLL/.test(t))return'futex';
+  return'';}
+function gateClass(s){return s.panic?'gate ge':s.gate_idx>=((s.gate_max||15)-3)?'gate gp':'gate';}
+function render(){
+  const q=$('q').value.toLowerCase(),onlyA=$('onlyactive').checked;
+  let r=sessions.filter(s=>(!onlyA||s.active||s.age<600)&&(!q||s.sid.includes(q)||(s.features||'').toLowerCase().includes(q)));
+  $('cnt').textContent='('+r.length+'/'+sessions.length+')';
+  list.innerHTML=r.map(s=>{
+    const pct=s.gate_idx!=null?Math.round(s.gate_idx/(s.gate_max||15)*100):0;
+    const gl=s.gate?`<div class=glab>gate <b>${s.gate}</b> ${s.gate_idx}/${s.gate_max||15}${s.sc!=null?' · sc '+human(s.sc):''}${s.panic?' · ⚠ panic':''}</div>`:'';
+    const gb=s.gate_idx!=null?`<div class="${gateClass(s)}"><i style=width:${pct}%></i></div>${gl}`:'';
+    const lt=s.started_at?`<div class=launch>▸ ${utc(s.started_at)} · ${fmt(s.elapsed)} ago${s.started_src!=='json'?' (≈)':''}</div>`:'';
+    return `<div class="s${s.sid===cur?' sel':''}" data-sid="${s.sid}">
+     <div class=sid><span class="dot ${s.panic?'panic':s.active?'on':''}"></span>${s.sid}</div>
+     <div class=meta>${(s.features||'—').slice(0,40)} · ${(s.size/1024|0)}KB · ${fmt(s.age)} ago${s.active?' · live':''}</div>${lt}${gb}</div>`;
+  }).join('')||'<div id=empty>No matching sessions.</div>';
+  list.querySelectorAll('.s').forEach(e=>e.onclick=()=>openS(e.dataset.sid));
+}
+async function refresh(){
+  try{sessions=await(await fetch('/api/sessions')).json()}catch(e){return}
+  if($('autolive').checked){const live=sessions.find(s=>s.active);if(live&&live.sid!==cur)openS(live.sid);}
+  const c=sessions.find(s=>s.sid===cur); metaCur=c||metaCur;
+  if(c){const g=$('gate');if(c.gate){g.style.display='';g.textContent='gate '+c.gate+' '+c.gate_idx+'/'+(c.gate_max||15);g.style.color=c.panic?'#ff7b72':c.gate_idx>=((c.gate_max||15)-3)?'#d2a8ff':'#7ee787';}
+        $('sc').textContent=c.sc!=null?'sc '+human(c.sc):'';
+        $('launch').textContent=c.started_at?('⏱ '+utc(c.started_at)+' · up '+fmt(c.elapsed)):'';
+        banner(c);}
+  render();
+}
+function banner(c){
+  const b=$('banner');
+  if(c.panic){b.className='';b.style.display='block';b.textContent='⚠ KERNEL FAULT — panic / heap-guard / deadlock / bugcheck detected in tail';return;}
+  // stall alert: active session whose lines/sec has gone to ~0
+  if(c.active&&rate.last!=null&&rate.last<1&&c.gate_idx<((c.gate_max||15)-1)){b.className='stall';b.style.display='block';b.textContent='◷ STALL — serial output ~0 lines/s on a live session (gate '+(c.gate||'?')+')';return;}
+  b.style.display='none';
+}
+function openS(sid){
+  cur=sid; document.getElementById('title').textContent=sid; log.innerHTML=''; frozen=false;
+  if(es)es.close(); rate={n:0,t:Date.now(),last:null}; mPrev=null;
+  for(const k in buf)buf[k]=[];
+  $('jumpLive').style.display='none';
+  startStream(sid);
+  render(); loadMiles(sid); pollMetrics(); pollBlk();
+}
+function startStream(sid){
+  if(es)es.close();
+  es=new EventSource('/api/stream?sid='+encodeURIComponent(sid));
+  es.onmessage=ev=>{
+    if(frozen)return;            // viewing a gate context region — don't append live
+    rate.n++;
+    appendLine(ev.data);
+    if(log.childElementCount>6000)for(let i=0;i<1500;i++)log.removeChild(log.firstChild);
+    if($('follow').checked&&!log.lastChild.classList.contains('hide'))log.scrollTop=log.scrollHeight;
+  };
+}
+function appendLine(text,nNum,isGate){
+  const d=document.createElement('span'); d.className='l '+classify(text)+(isGate?' gatehit':'');
+  d.dataset.t=text.toLowerCase(); if(nNum)d.dataset.n=nNum; d.textContent=text;
+  applyFlt(d); log.appendChild(d); return d;
+}
+// elapsed/delta seconds -> "+2m14s" / "Δ +18s". `approx` (tick-derived, no exact
+// watcher mark) gets a leading '~' so it's never confused with a live stamp.
+function dur(s){if(s==null)return '';s=Math.round(s);if(s<60)return s+'s';
+  const m=Math.floor(s/60),r=s%60;return m<60?m+'m'+(r?r+'s':''):Math.floor(m/60)+'h'+(m%60)+'m';}
+function elapStr(x){if(x.host_elapsed==null)return '';return (x.approx?'~+':'+')+dur(x.host_elapsed);}
+function deltaStr(x){if(x.host_delta==null)return '';return 'Δ '+(x.approx?'~+':'+')+dur(x.host_delta);}
+async function loadMiles(sid){
+  let m; try{m=await(await fetch('/api/milestones?sid='+encodeURIComponent(sid))).json()}catch(e){return}
+  if(sid!==cur)return; miles=m;
+  let lastHit=-1; m.forEach((x,i)=>{if(x.hit)lastHit=i;});
+  // top milestone chips: label + elapsed-since-launch + per-gate Δ (the compare
+  // signal). Absolute wall time + line/tick provenance live in the tooltip.
+  $('miles').innerHTML=m.map((x,i)=>{
+    const cls='mile'+(x.hit?' hit':'')+(i===lastHit?' last':'')+(/PNG|drawSnapshot/.test(x.label)?' png':'');
+    const el=x.hit?elapStr(x):'', dl=x.hit?deltaStr(x):'';
+    const timing=(el||dl)?(' <b>'+el+'</b>'+(dl?' <span class=dlt>'+dl+'</span>':'')):'';
+    const wall=x.host_ts!=null?(' · '+utc(x.host_ts)):'';
+    const ti=x.hit?('line '+x.line+(x.tick!=null?' · tick '+x.tick:'')+(x.dtick!=null?' · +'+x.dtick+' ticks':'')+(x.host_elapsed!=null?' · '+(x.approx?'≈':'')+'+'+dur(x.host_elapsed)+' since launch'+(x.host_delta!=null?', Δ+'+dur(x.host_delta)+' vs prev gate':''):'')+wall+(x.approx?' (tick-derived approx)':'')+' — click to jump'):'not reached';
+    return '<span class="'+cls+'" data-line="'+(x.line||'')+'" data-label="'+x.label+'" title="'+ti+'">'+(x.hit?'✓':'○')+' '+x.label+timing+'</span>';
+  }).join('');
+  $('miles').querySelectorAll('.mile.hit').forEach(e=>{if(e.dataset.line)e.onclick=()=>jumpToLine(+e.dataset.line,e.dataset.label);});
+  // right-hand progression rail: same per-gate elapsed + Δ, stacked.
+  $('rail').innerHTML='<h3>progression</h3>'+m.map((x,i)=>{
+    const cls='rstep'+(x.hit?' hit':'')+(i===lastHit?' last':'');
+    const el=x.hit?elapStr(x):'', dl=x.hit?deltaStr(x):'';
+    const tline='line '+x.line+(x.tick!=null?' · @'+human(x.tick):'');
+    const sub=x.hit?((el?'<span class=rel>'+el+(dl?' · <span class=dlt>'+dl+'</span>':'')+'</span>':'')+tline):'not yet';
+    return '<div class="'+cls+'" data-line="'+(x.line||'')+'" data-label="'+x.label+'"><span class=ic>'+(x.hit?'✓':'○')+'</span>'
+      +'<span class=lab>'+x.label+'<small>'+sub+'</small></span></div>';
+  }).join('');
+  $('rail').querySelectorAll('.rstep.hit').forEach(e=>{if(e.dataset.line)e.onclick=()=>jumpToLine(+e.dataset.line,e.dataset.label);});
+}
+// jump the log view to a gate's serial line: disable follow, freeze the live
+// stream, fetch the ±ctx context window, render it with the gate line marked.
+async function jumpToLine(line,label){
+  if(!line||!cur)return;
+  $('follow').checked=false; frozen=true; $('jumpLive').style.display='';
+  let d; try{d=await(await fetch('/api/context?sid='+encodeURIComponent(cur)+'&line='+line+'&ctx=400')).json()}catch(e){return}
+  log.innerHTML=''; let target=null;
+  d.lines.forEach(ln=>{const el=appendLine(ln.t,ln.n,ln.n===line);if(ln.n===line)target=el;});
+  const hdr=document.createElement('div');hdr.style.cssText='color:#39d353;padding:2px 0 6px;font-weight:600';
+  hdr.textContent='▸ context around '+(label||('line '+line))+' (lines '+d.start+'–'+d.end+'). Click ↧ live to resume.';
+  log.insertBefore(hdr,log.firstChild);
+  if(target)target.scrollIntoView({block:'center'});
+}
+function jumpLive(){frozen=false;$('follow').checked=true;$('jumpLive').style.display='none';log.innerHTML='';startStream(cur);}
+// jump-to-interesting: scan loaded log for PNG / panic / last gate, scroll to it
+function jumpGate(){
+  const els=[...log.querySelectorAll('.l')];
+  let t=els.reverse().find(e=>/89504e47|out\\.png|PANIC|HEAP GUARD|SCHEDULER_DEADLOCK|bugcheck|ScreenshotParent/.test(e.textContent));
+  if(t){t.scrollIntoView({block:'center'});t.style.outline='2px solid #d2a8ff';setTimeout(()=>t.style.outline='',1500);}
+  else if(miles.length){const lh=[...miles].reverse().find(x=>x.hit);if(lh&&lh.line)jumpToLine(lh.line,lh.label);}
+}
+function applyFlt(el){const f=$('flt').value.toLowerCase();if(!f){el.classList.remove('hide');return;}el.classList.toggle('hide',!el.dataset.t.includes(f));}
+$('flt').oninput=()=>{const f=$('flt').value.toLowerCase();log.querySelectorAll('.l').forEach(applyFlt);};
+$('q').oninput=render; $('onlyactive').onchange=render; $('autolive').onchange=refresh;
+$('jumpLive').onclick=jumpLive; $('jumpGate').onclick=jumpGate;
+
+// ── sparklines ────────────────────────────────────────────────────────────
+function spark(id,data,color,unit){
+  const c=$(id);if(!c)return;const w=c.width=110,h=c.height=26,x=c.getContext('2d');
+  x.clearRect(0,0,w,h);if(!data.length)return;
+  const mx=Math.max(...data,1e-9);x.strokeStyle=color;x.lineWidth=1;x.beginPath();
+  data.forEach((v,i)=>{const px=i/(BUFMAX-1)*w,py=h-2-(v/mx)*(h-4);i?x.lineTo(px,py):x.moveTo(px,py);});
+  x.stroke();x.globalAlpha=.13;x.lineTo((data.length-1)/(BUFMAX-1)*w,h);x.lineTo(0,h);x.closePath();x.fillStyle=color;x.fill();x.globalAlpha=1;
+}
+function push(k,v){buf[k].push(v);if(buf[k].length>BUFMAX)buf[k].shift();}
+async function pollMetrics(){
+  if(!cur||!$('tMetrics').classList.contains('on'))return;
+  let m;try{m=await(await fetch('/api/metrics?sid='+encodeURIComponent(cur))).json()}catch(e){return}
+  if(!m||!m.agg){$('metrics').classList.remove('show');return;}
+  $('metrics').classList.add('show');
+  const now=Date.now()/1000,dt=mPrev?Math.max(now-mTime,.5):0;
+  let scR=0,pfR=0,dioR=0,iopsR=0,netR=0;
+  if(mPrev&&dt>0){
+    scR=Math.max(0,(m.agg.sc-mPrev.sc)/dt);
+    pfR=Math.max(0,(m.agg.pf-mPrev.pf)/dt);
+    dioR=Math.max(0,((m.agg.disk_r+m.agg.disk_w)-(mPrev.disk_r+mPrev.disk_w))/dt);
+    iopsR=Math.max(0,(m.agg.rreq-mPrev.rreq)/dt);
+    netR=Math.max(0,((m.agg.net_r+m.agg.net_w)-(mPrev.net_r+mPrev.net_w))/dt);
+    push('sc',scR);push('pf',pfR);push('dio',dioR);push('iops',iopsR);push('net',netR);
+  }
+  mPrev={...m.agg}; mTime=now;
+  const memPct=Math.min(100,(m.agg.pf*4096/m.ram_total)*100); // pf*4K vs 2GiB — PROXY
+  const cpu=m.hb?('cpu'+m.hb.cpu):'';
+  $('metrics').innerHTML=
+    gm('sc/s (CPU≈)',human(scR)+' <small>'+cpu+'</small>','sp_sc')+
+    gm('pf/s',human(pfR),'sp_pf')+
+    memGm(memPct,m.agg.pf)+
+    gm('disk B/s',bytes(dioR),'sp_dio')+
+    gm('IOPS',human(iopsR)+' <small>rreq</small>','sp_iops')+
+    gm('net B/s',bytes(netR),'sp_net');
+  spark('sp_sc',buf.sc,'#7ee787');spark('sp_pf',buf.pf,'#f0c674');
+  spark('sp_dio',buf.dio,'#56b6c2');spark('sp_iops',buf.iops,'#d2a8ff');spark('sp_net',buf.net,'#ff7b72');
+  // per-pid breakdown (top syscall-counts)
+  const top=[...m.pids].sort((a,b)=>b.sc-a.sc).slice(0,6);
+  $('pids').className='show';
+  $('pids').innerHTML='<span style="color:#5c6675">pids:</span> '+top.map(p=>
+    `<span class=p><b>${p.pid}</b> ${p.name} <span class=sc>sc ${human(p.sc)}</span> pf ${human(p.pf)} dR ${bytes(p.disk_r)}${p.stuck_nr?' <span style="color:#ff7b72">⊘nr'+p.stuck_nr+'</span>':''}</span>`).join('')||'—';
+}
+function gm(k,v,cid){return `<div class=gm><div class=k>${k}</div><div class=v>${v}</div><canvas id=${cid}></canvas></div>`;}
+function memGm(pct,pf){return `<div class="gm mem"><div class=k>mem proxy</div><div class=v>${pct.toFixed(1)}<small>% · pf×4K/2GiB</small></div><div class=bar><i style=width:${pct}%></i></div></div>`;}
+
+// ── data.img block map ────────────────────────────────────────────────────
+let blkGrid=256;
+async function pollBlk(){
+  if(!cur||!$('tBlk').classList.contains('on'))return;
+  let m;try{m=await(await fetch('/api/blkmap?sid='+encodeURIComponent(cur)+'&grid='+blkGrid)).json()}catch(e){return}
+  $('blk').className='show';
+  if(!m||!m.has_trace){
+    $('blk').innerHTML='<div class=hd>data.img block map</div><div class=hint>No <b>[BLK]</b> trace lines in this log. Boot with <b>--features firefox-test,kdb,blk-trace</b> to populate the per-sector heatmap (default builds emit no [BLK] line and pay zero overhead).</div>';
+    return;}
+  $('blk').innerHTML='<div class=hd>data.img block map · <b>'+human(m.n_req)+'</b> reqs · '+m.grid+' buckets × '+human(m.sectors_per_bucket)+' sectors · max lba '+human(m.max_lba)+'/'+human(m.sectors)+'</div>'
+    +'<canvas id=blkcanvas></canvas><div class=lg><i style=background:#39d353></i>read <i style=background:#ff7b72></i>write <i style="background:linear-gradient(90deg,#39d353,#f0c674,#ff7b72)"></i>mixed · brighter = busier</div>';
+  drawBlk(m.buckets);
+}
+function drawBlk(bk){
+  const c=$('blkcanvas');if(!c)return;const w=c.width=bk.length,h=c.height=1,x=c.getContext('2d');
+  let mr=1,mw=1;bk.forEach(b=>{if(b.r>mr)mr=b.r;if(b.w>mw)mw=b.w;});
+  const img=x.createImageData(w,1);
+  bk.forEach((b,i)=>{
+    const r=b.r/mr,wv=b.w/mw,a=i*4;
+    if(b.r===0&&b.w===0){img.data[a]=17;img.data[a+1]=21;img.data[a+2]=31;}
+    else{img.data[a]=Math.round(40+wv*215);img.data[a+1]=Math.round(40+r*171);img.data[a+2]=Math.round(40+(r+wv)*30);}
+    img.data[a+3]=255;
+  });
+  x.putImageData(img,0,0);
+}
+
+// toggles
+function tog(btn,after){btn.onclick=()=>{btn.classList.toggle('on');
+  if(btn===$('tRail'))$('rail').classList.toggle('open',btn.classList.contains('on'));
+  if(btn===$('tMetrics')&&!btn.classList.contains('on')){$('metrics').classList.remove('show');$('pids').classList.remove('show');}
+  if(btn===$('tBlk')&&!btn.classList.contains('on'))$('blk').classList.remove('show');
+  if(after&&btn.classList.contains('on'))after();};}
+tog($('tMetrics'),pollMetrics);tog($('tBlk'),pollBlk);tog($('tRail'),null);
+$('tRail').onclick=()=>{$('tRail').classList.toggle('on');$('rail').classList.toggle('open',$('tRail').classList.contains('on'));};
+
+setInterval(()=>{const now=Date.now(),dt=(now-rate.t)/1000;if(dt>=2){const r=rate.n/dt;rate.last=r;$('rate').textContent=cur?r.toFixed(0)+' ln/s':'';rate={n:0,t:now,last:r};}},1000);
+refresh(); setInterval(refresh,3000);
+setInterval(()=>{if(cur)loadMiles(cur);},5000);
+setInterval(pollMetrics,2000);
+setInterval(pollBlk,3000);
+</script></body></html>"""
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _hdr(self, code=200, ctype="text/html; charset=utf-8", extra=None):
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        if extra:
+            for k, v in extra.items():
+                self.send_header(k, v)
+        self.end_headers()
+
+    def _log_path(self, sid):
+        """Validate sid and resolve its serial log inside HARNESS_DIR, or None."""
+        if not SID_RE.match(sid):
+            return None
+        path = os.path.join(HARNESS_DIR, sid + ".serial.log")
+        if not os.path.realpath(path).startswith(os.path.realpath(HARNESS_DIR)):
+            return None
+        return path if os.path.exists(path) else None
+
+    def _json(self, obj):
+        self._hdr(ctype="application/json")
+        self.wfile.write(json.dumps(obj).encode())
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        q = parse_qs(u.query)
+        if u.path == "/":
+            self._hdr(); self.wfile.write(PAGE.encode())
+        elif u.path == "/api/sessions":
+            self._json(list_sessions())
+        elif u.path == "/api/milestones":
+            sid = q.get("sid", [""])[0]
+            p = self._log_path(sid)
+            if not p:
+                self._hdr(404, "text/plain"); self.wfile.write(b"no log"); return
+            self._json(scan_milestones_timed(sid, p))
+        elif u.path == "/api/context":
+            p = self._log_path(q.get("sid", [""])[0])
+            if not p:
+                self._hdr(404, "text/plain"); self.wfile.write(b"no log"); return
+            try:
+                line = int(q.get("line", ["1"])[0])
+                ctx = int(q.get("ctx", ["400"])[0])
+            except ValueError:
+                self._hdr(400, "text/plain"); self.wfile.write(b"bad args"); return
+            self._json(read_context(p, line, ctx))
+        elif u.path == "/api/metrics":
+            p = self._log_path(q.get("sid", [""])[0])
+            if not p:
+                self._hdr(404, "text/plain"); self.wfile.write(b"no log"); return
+            try:
+                size = os.path.getsize(p)
+            except OSError:
+                size = 0
+            self._json(scan_metrics(p, size))
+        elif u.path == "/api/blkmap":
+            p = self._log_path(q.get("sid", [""])[0])
+            if not p:
+                self._hdr(404, "text/plain"); self.wfile.write(b"no log"); return
+            try:
+                size = os.path.getsize(p)
+                grid = int(q.get("grid", ["256"])[0])
+            except (OSError, ValueError):
+                size, grid = 0, 256
+            self._json(scan_blkmap(p, size, grid))
+        elif u.path == "/api/stream":
+            self._stream(q.get("sid", [""])[0])
+        else:
+            self._hdr(404, "text/plain"); self.wfile.write(b"404")
+
+    def _stream(self, sid):
+        path = self._log_path(sid)
+        if not path:
+            self._hdr(400 if not SID_RE.match(sid) else 404, "text/plain")
+            self.wfile.write(b"bad sid" if not SID_RE.match(sid) else b"no log")
+            return
+        self._hdr(ctype="text/event-stream", extra={
+            "Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"})
+        try:
+            with open(path, "rb") as f:
+                f.seek(0, os.SEEK_END)
+                size = f.tell()
+                f.seek(max(0, size - TAIL_BYTES))
+                if size > TAIL_BYTES:
+                    f.readline()
+                buf = b""
+                idle = 0
+                while True:
+                    chunk = f.read(65536)
+                    if chunk:
+                        idle = 0
+                        buf += chunk
+                        *lines, buf = buf.split(b"\n")
+                        for ln in lines:
+                            self.wfile.write(b"data: " + ln.replace(b"\r", b"") + b"\n\n")
+                        self.wfile.flush()
+                    else:
+                        idle += 1
+                        if idle % 30 == 0:
+                            self.wfile.write(b": ka\n\n"); self.wfile.flush()
+                        time.sleep(0.5)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=int(os.environ.get("SERIAL_WEB_PORT", 8088)))
+    ap.add_argument("--host", default=os.environ.get("SERIAL_WEB_HOST", "0.0.0.0"))
+    a = ap.parse_args()
+    srv = ThreadingHTTPServer((a.host, a.port), H)
+    srv.daemon_threads = True
+    print(f"[serial-web] serving {HARNESS_DIR} on http://{a.host}:{a.port}", flush=True)
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds **per-gate host timing** to the serial monitor (`serial-web.py`, :8088) — for each gate the boot reached, show next to it the **elapsed-since-launch** (`+2m14s`) and the **per-gate delta** (`Δ +18s`, time since the previous gate — the key "compare performance" signal) — and **feeds those same gate marks into the perf dashboard** (`perf-web`/`perf-bench`, :8099) so a session watched in the serial monitor shows up as a time-series point.

Also brings `serial-web.py` + `serial-web-smoke.py` onto master (they previously lived only on `origin/ff/real-website`); they are tooling-only files that belong alongside `perf-web`/`perf-bench`.

## Single source of truth

The gate→time definitions are single-sourced so the two dashboards never disagree:
- `serial-web.py` owns the `MILESTONES` gate ladder.
- `perf_markers.py` already imports it for the perf phase taxonomy.
- New `gate_marks.py` adds the **gate↔perf-phase mapping** (`GATE_TO_PHASE`) plus the marks-sidecar + timeline helpers. A per-gate delta in the serial monitor *is* the `phase_ms` perf-bench records, by construction.

## Per-gate timing sources (priority order)

- **LIVE** — the harness watcher (`qemu-harness.py` `_watcher_thread`) stamps each milestone's host arrival time to `~/.astryx-harness/<sid>.marks.jsonl` the instant it is first detected (forward-ordered; defensively wrapped so a stamping failure never disrupts the watcher's panic/idle duties). serial-web reads the marks → exact host times.
- **HISTORICAL** — derived from the kernel-tick axis (launch `started_at` + the `[HB]`/`PROC-METRICS` tick at the gate line, 100 Hz = 10 ms/tick), flagged approximate (`~` prefix) so it is never confused with an exact stamp.

`/api/milestones` now returns **additive** per-gate fields: `host_elapsed`, `host_delta`, `host_ts`, `approx`. The milestone chips and progression rail render `+2m14s  Δ +18s`; absolute wall time stays in the tooltip.

## Perf feed

`perf-bench.py ingest-marks <sid>` turns a session's gate marks into a time-series record — mapping gate deltas onto the perf phase taxonomy via `GATE_TO_PHASE` so the deltas become `phase_ms`. Reuses the `import-logs` record schema (revision via mtime-bisect, host, kvm, features, `phase_ms`, `total_ms`, `reached_png`); **additive-only** new keys (`phase_ms_source`, `marks_approx`, `total_marks_ms`, `n_gate_marks`, `gate_phase_ms`, `deepest_gate`). The point then lands on perf-web `/api/series`.

## Harness change (additive)

A new `<sid>.marks.jsonl` sidecar + `"gate"` events in `events.jsonl`. **No existing JSON field is renamed.**

## Validation (host-only, no boot — uses the 600+ existing logs)

- `serial-web-smoke.py` + `perf-bench-smoke.py` gain per-gate-delta checks (exact marks **and** tick-derived, both independently hand-computed), the marks→timeseries ingestion, and the gate↔phase mapping consistency.
- New **`tooling-smoke` CI job** (host-only, no kernel build) runs all three Python smokes — prevents a regression in the gate↔phase mapping, the tick→ms derivation, or the marks-sidecar schema from silently corrupting the numbers **both** dashboards display, with no kernel-boot job to catch it.
- Verified end-to-end against a real 6.2 MB FF-boot log (`ingest-marks` → host-axis/approx point on `/api/series`) and a **live watcher-stamped session** (exact host marks read back by serial-web).

All tools stay non-interactive, one-shot argv, structured JSON; charts stay offline/self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)