### PR TITLE
kernel+tooling: default-on render MILESTONE markers for the fast firefox-test-core profile

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -6418,12 +6418,143 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
     }
 }
 
+// ── Render-lifecycle MILESTONE markers (low-frequency, DEFAULT-ON) ──────────
+//
+// Distinct from the `[FF/stderr]`/`[FF/write]` per-write firehose above (which
+// is gated on the `*-trace` features and transcribes EVERY tracked write — one
+// PIO VM-exit per byte, ~78% of a full boot log). These milestone markers are
+// the OPPOSITE: a tiny curated substring set covering the headless-screenshot
+// render lifecycle, each emitted EXACTLY ONCE per boot (first-arrival), so the
+// total cost is a handful of serial lines for the whole run — not a firehose.
+//
+// They exist so the deep render gates are visible on the fast default profile
+// (`firefox-test-core`, diagnostic serial OFF) without re-enabling the firehose:
+// the serial monitor and perf phase taxonomy detect `screenshot-actors`,
+// `drawSnapshot`, etc. from these `[GATE] <label>` lines instead of from the
+// now-gated-off `[FF/write]` mirror.
+//
+// Each curated substring maps to one bit of `MILESTONE_SEEN`; once a bit is set
+// the marker never re-emits, so a matching string appearing thousands of times
+// in FF's IPDL traffic still produces a single line. The earlier bring-up gates
+// are emitted elsewhere: content-process spawn from the exec path
+// (`[GATE] content-procs`, next to the `[EXEC] …-isForBrowser` argv line) and
+// libxul load from the open path (`[GATE] libxul`, because the per-open
+// `[FF/open]` mirror is trace-gated). So this write-payload set only needs the
+// render-stage substrings that have no other default-on signal.
+//
+// (label, substring) — order is the bit index; keep ≤32 entries (u32 mask).
+#[cfg(feature = "firefox-test-core")]
+const MILESTONE_MARKERS: &[(&str, &[u8])] = &[
+    // screenshot-actors stage — the IPDL screenshot query/parent actors. These
+    // protocol-actor names are specific to the headless-screenshot path and do
+    // not appear in ordinary page content.
+    ("screenshot-actors", b"getDimensions"),
+    ("screenshot-actors", b"ScreenshotParent"),
+    ("screenshot-actors", b"sendQuery"),
+    // drawSnapshot / cross-process paint stage — the actual composite + draw.
+    // `drawSnapshot` and `CrossProcessPaint` are render-API-specific symbols.
+    ("drawSnapshot",      b"drawSnapshot"),
+    ("drawSnapshot",      b"CrossProcessPaint"),
+    // NOTE: the FINAL screenshot-PNG write is intentionally NOT detected here by
+    // the raw `\x89PNG` magic — Firefox writes many internal PNGs (favicons,
+    // theme/UI assets) whose payloads also start with that signature, so a
+    // magic-based `[GATE] PNG` would false-positive long before the real
+    // screenshot. The authoritative, single-per-run PNG-write signal is the FF
+    // supervisor's functional `[FFTEST] /tmp/out.png present` /
+    // `[FF-OUT-PNG:… sig_ok=true …]` lines (default-on on firefox-test-core),
+    // which the gate consumers key on for the PNG gate.
+];
+
+/// First-arrival bitmask for [`MILESTONE_MARKERS`]: bit `i` set ⇒ marker `i`
+/// has already emitted its `[GATE]` line. Lockless, default-relaxed — a benign
+/// double-emit under a 2-CPU race is harmless (the monitor takes first-arrival),
+/// and the common case (bit already set) is a single atomic load with no store.
+#[cfg(feature = "firefox-test-core")]
+static MILESTONE_SEEN: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+
+/// Scan a write payload for the curated render-lifecycle milestone substrings
+/// and emit one `[GATE] <label>` line the FIRST time each is seen this boot.
+///
+/// Called from the tracked-write path on the DEFAULT (core) profile. Cheap: a
+/// bounded substring search over an already-snapshotted buffer, skipped entirely
+/// once every milestone bit is set. Never allocates, never takes a lock.
+#[cfg(feature = "firefox-test-core")]
+#[inline]
+fn emit_render_milestones(snapshot: &[u8]) {
+    use core::sync::atomic::Ordering;
+    let seen = MILESTONE_SEEN.load(Ordering::Relaxed);
+    // Fast exit once every curated marker has fired (the steady state for the
+    // vast majority of a boot's writes).
+    let all_mask: u32 = (1u32 << MILESTONE_MARKERS.len()) - 1;
+    if seen == all_mask {
+        return;
+    }
+    for (i, (label, needle)) in MILESTONE_MARKERS.iter().enumerate() {
+        let bit = 1u32 << i;
+        if seen & bit != 0 {
+            continue; // already emitted this marker
+        }
+        if !slice_contains(snapshot, needle) {
+            continue;
+        }
+        // First arrival — claim the bit and emit exactly one milestone line.
+        // fetch_or returns the PRE-update value; only the CPU that observed the
+        // bit clear emits, so a concurrent partner cannot double-print.
+        let prev = MILESTONE_SEEN.fetch_or(bit, Ordering::Relaxed);
+        if prev & bit == 0 {
+            crate::serial_println!("[GATE] {}", label);
+        }
+    }
+}
+
+/// Bounded substring search (`haystack.windows(needle.len()).any(== needle)`),
+/// kept allocation-free for the milestone hot path.
+#[cfg(feature = "firefox-test-core")]
+#[inline]
+fn slice_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
 /// Linux write(fd, buf, count) — same semantics as AstryxOS write.
 pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     let buf_ptr = buf as *const u8;
     let count = count as usize;
 
     if count == 0 { return 0; }
+
+    // Render-lifecycle MILESTONE markers (low-frequency, DEFAULT-ON on the
+    // Firefox bring-up profile). Scans the write payload for a curated set of
+    // render-stage substrings and emits ONE `[GATE] <label>` line the first
+    // time each is seen — a handful of lines for the whole boot, NOT the
+    // per-write `[FF/write]` firehose below (which stays *-trace-gated). This
+    // makes the deep render gates visible on the fast `firefox-test-core` boot
+    // (where the firehose is OFF) without paying the firehose cost.
+    //
+    // Gated on `firefox-test-core` (present in every FF profile incl. the full
+    // `firefox-test`/`*-trace` superset) so plain `test-mode` / production
+    // builds are byte-identical. The snapshot is bounded (512 B) and skipped
+    // once every milestone bit is set, so the steady-state cost is one atomic
+    // load per tracked write.
+    #[cfg(feature = "firefox-test-core")]
+    {
+        let mpid = crate::proc::current_pid_lockless();
+        if (mpid == 1 || crate::syscall::ring::is_tracked(mpid))
+            && MILESTONE_SEEN.load(core::sync::atomic::Ordering::Relaxed)
+                != (1u32 << MILESTONE_MARKERS.len()) - 1
+        {
+            let take = count.min(512);
+            // SMAP-bracketed snapshot of the user buffer — the milestone scan
+            // reads kernel memory only (Intel SDM Vol. 3A §4.6.1).
+            let snap: alloc::vec::Vec<u8> = unsafe {
+                let _g = crate::arch::x86_64::smap::UserGuard::new();
+                core::slice::from_raw_parts(buf_ptr, take).to_vec()
+            };
+            emit_render_milestones(&snap);
+        }
+    }
 
     // Diagnostic stdout/stderr mirror ([FF/stderr] / [FF/write] / [FF/write-fd]).
     // This is the single largest serial source on a Firefox boot (~78% of a
@@ -6699,6 +6830,22 @@ fn sys_open_linux_inner(pathname: u64, flags: u64, _mode: u64) -> i64 {
     #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace"))]
     if pid == 1 || crate::syscall::ring::is_tracked(pid) {
         crate::serial_println!("[FF/open] pid={} path={}", pid, path);
+    }
+    // libxul load MILESTONE (low-frequency, DEFAULT-ON). The per-open `[FF/open]`
+    // mirror above is trace-gated, so on the fast `firefox-test-core` boot the
+    // gate monitor has no default-on signal that the main shared library mapped.
+    // Emit a single `[GATE] libxul` the first time libxul is opened by a tracked
+    // process — one line per boot, not the per-open firehose.
+    #[cfg(feature = "firefox-test-core")]
+    {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        static LIBXUL_GATE_SEEN: AtomicBool = AtomicBool::new(false);
+        if (pid == 1 || crate::syscall::ring::is_tracked(pid))
+            && path.ends_with("libxul.so")
+            && !LIBXUL_GATE_SEEN.swap(true, Ordering::Relaxed)
+        {
+            crate::serial_println!("[GATE] libxul");
+        }
     }
     // Attach the resolved path string to the pending ring entry so the ring
     // dump can show what each open() / openat() actually tried to open.

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1470,6 +1470,24 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
                 pid, tid, shown, total_args
             );
         }
+
+        // Content-process spawn MILESTONE (low-frequency, DEFAULT-ON). The
+        // `[EXEC] …-isForBrowser …` argv line above is already functional and
+        // default-on, but it is a per-exec line; emit a single stable
+        // `[GATE] content-procs` the first time a `-isForBrowser` content
+        // process is launched so the fast-profile gate monitor has an
+        // unambiguous marker (the bare `isForBrowser` substring also appears in
+        // FF's cached JS, hence the dedicated kernel-emitted gate). Fires once.
+        #[cfg(feature = "firefox-test-core")]
+        {
+            use core::sync::atomic::{AtomicBool, Ordering};
+            static CONTENTPROC_GATE_SEEN: AtomicBool = AtomicBool::new(false);
+            let is_content = argv_owned.iter().any(|a| a == "-isForBrowser")
+                || argv_owned.iter().any(|a| a == "-contentproc");
+            if is_content && !CONTENTPROC_GATE_SEEN.swap(true, Ordering::Relaxed) {
+                crate::serial_println!("[GATE] content-procs");
+            }
+        }
     }
 
     // Validate it's an ELF binary (resolve_shebang guarantees this on Ok).

--- a/scripts/perf-bench-smoke.py
+++ b/scripts/perf-bench-smoke.py
@@ -198,6 +198,53 @@ def main():
               "tcp" not in scan2["anchors"])
         notcp_log.unlink()
 
+        # ── firefox-test-core (firehose OFF): [GATE] markers drive the taxonomy ─
+        # On the fast default profile the `[FF/write]`/`[FF/open]` per-write
+        # mirror is OFF; the render anchors must instead fire on the low-frequency
+        # kernel `[GATE] <label>` milestone markers. This proves the perf phase
+        # taxonomy still derives RENDER/ENCODE/TEARDOWN on a core-profile boot.
+        core_log_text = (
+            "BdsDxe: starting Boot0002 \"UEFI QEMU HARDDISK\"\n"
+            "[AstryxBoot] Initializing UEFI bootloader...\n"
+            "[Aether] Phase 5b: APIC init...\n"
+            "[VFS] Probing virtio-blk device (4194304 sectors) for partitions...\n"
+            "[X11] Xastryx ready on /tmp/.X11-unix/X0 (fd=0)\n"
+            "[FFTEST] X11 server ready\n"
+            "[FFTEST] Launching /disk/usr/lib/firefox/firefox-bin ...\n"
+            "[EXEC] pid=1 tid=1 argv=\"firefox-bin\" \"--headless\" (2 of 14 args)\n"
+            "[HB] tick=100 cpu=0 pf=10 sc=50\n"
+            "[GATE] libxul\n"
+            "[HB] tick=500 cpu=1 pf=50 sc=400\n"
+            "[GATE] screenshot-actors\n"
+            "[HB] tick=600 cpu=1 pf=60 sc=500\n"
+            "[FFTEST] /tmp/out.png present (12345 bytes) — streaming\n"
+            "[HB] tick=900 cpu=0 pf=90 sc=800\n"
+            "[FF-OUT-PNG:path=/tmp/out.png size=12345 sig_ok=true complete=true]\n"
+            "[HB] tick=1000 cpu=0 pf=100 sc=900\n"
+            "[PROC] PID 1 exit_group(0) caller_tid=2\n"
+        )
+        core_log = harness_dir / "smoke0000gates.serial.log"
+        core_log.write_text(core_log_text)
+        scan3 = pm.scan_phase_boundaries(str(core_log))
+        a3 = scan3["anchors"]
+        check("core: [GATE] libxul anchors LIBXUL-INIT", "libxul" in a3,
+              str(sorted(a3)))
+        check("core: [GATE] screenshot-actors anchors render", "screenshot" in a3,
+              str(sorted(a3)))
+        check("core: FF-OUT-PNG(sig_ok) anchors png_written", "png_written" in a3,
+              str(sorted(a3)))
+        check("core: render reaches exit_group anchor",
+              scan3["deepest_anchor"] == "exit_group", scan3["deepest_anchor"])
+        d3 = pm.phase_durations(scan3)
+        # screenshot tick=500 -> out_png_open ([FF-OUT-PNG present] tick=600) => 1000 ms
+        check("core: RENDER-SETUP derived from [GATE] markers (1000ms)",
+              d3["RENDER-SETUP"]["tick_ms"] == 1000.0,
+              str(d3["RENDER-SETUP"]["tick_ms"]))
+        # firehose really off in this fixture
+        check("core: firehose off in fixture (0 [FF/write])",
+              "[FF/write]" not in core_log_text)
+        core_log.unlink()
+
         # ── events.jsonl host-anchoring: true launch ts + kvm_effective ───────
         # The session json is absent (historical case). The first events.jsonl
         # line (cpu_model) carries the true started_at + kvm_effective; the import

--- a/scripts/perf_markers.py
+++ b/scripts/perf_markers.py
@@ -111,12 +111,18 @@ else:
         ("X11 ready",         ("X11 server ready", "Xastryx")),
         ("firefox exec",      ("firefox-bin",)),
         ("TLS / network",     ("[TCP] Established", "] Established →")),
-        ("content procs",     ("isForBrowser",)),
-        ("screenshot-actors", (("[FF/write]", "getDimensions"),
+        # Mirror of serial-web.py — render gates accept the low-frequency
+        # kernel `[GATE] <label>` markers (default-ON on firefox-test-core) so
+        # they fire when the per-write `[FF/write]` firehose is OFF, plus the
+        # `[FF/write]`-anchored tuples for full-trace boots.
+        ("content procs",     ("[GATE] content-procs", ("[EXEC]", "isForBrowser"))),
+        ("screenshot-actors", ("[GATE] screenshot-actors",
+                               ("[FF/write]", "getDimensions"),
                                ("[FF/write]", "ScreenshotParent"),
                                ("[FF/write]", "sendQuery"))),
-        ("drawSnapshot",      ("libpng16.so",)),
-        ("PNG write",         ("89504e47", "out.png written")),
+        ("drawSnapshot",      ("[GATE] drawSnapshot", "libpng16.so")),
+        ("PNG write",         (("[FF-OUT-PNG:", "sig_ok=true"),
+                               "/tmp/out.png present", "89504e47", "out.png written")),
         ("exit_group",        ("exit_group(",)),
     ]
     _TICK_KERNEL = re.compile(r"(?:\[HB\]|PROC-METRICS\]) tick=(\d+)")
@@ -208,16 +214,26 @@ PHASES = [
     ("VFS-MOUNT",         ("[VFS] Probing virtio-blk",),                  ("X11 server ready", "Xastryx ready"),                     "host"),
     ("INIT",              ("X11 server ready", "Xastryx ready"),          ("[FFTEST] Launching", "[EXEC] pid=1"),                    "host"),
     ("FF-STARTUP",        ("[FFTEST] Launching", "[EXEC] pid=1"),         (("[FF/open]", "libxul.so"),),                             "host"),
-    ("LIBXUL-INIT",       (("[FF/open]", "libxul.so"),),                  ("[TCP] Established", "[TCP] Accepted", "] Established →"), "tick"),
+    # The render-stage from/to markers below additively accept the low-frequency
+    # `[GATE] <label>` markers (default-ON on firefox-test-core) alongside the
+    # historical `[FF/write]`/`[FF/open]` trace markers. NOTE: this PHASES table
+    # documents the taxonomy + supplies PHASE_NAMES/PHASE_AXIS; the actual scan
+    # is driven by ANCHORS / PHASE_SPAN above (kept in sync).
+    ("LIBXUL-INIT",       ("[GATE] libxul", ("[FF/open]", "libxul.so")),  ("[TCP] Established", "[TCP] Accepted", "] Established →"), "tick"),
     ("NETWORK/TLS",       ("[TCP] Established", "[TCP] Accepted",
-                           "] Established →"),                            (("[FF/write]", "getDimensions"),
+                           "] Established →"),                            ("[GATE] screenshot-actors",
+                                                                           ("[FF/write]", "getDimensions"),
                                                                            ("[FF/write]", "ScreenshotParent")),                      "tick"),
-    ("RENDER-SETUP",      (("[FF/write]", "getDimensions"),
-                           ("[FF/write]", "ScreenshotParent")),          (("[FF/open]", "/tmp/out.png"),),                          "tick"),
-    ("RENDER",            (("[FF/write]", "getDimensions"),
-                           ("[FF/write]", "ScreenshotParent")),          (("[FF/open]", "/tmp/out.png"),),                          "tick"),
-    ("ENCODE",            (("[FF/open]", "/tmp/out.png"),),               ("89504e47",),                                             "tick"),
-    ("TEARDOWN",          ("89504e47",),                                  (("[PROC]", "PID 1 exit_group"),),                         "host"),
+    ("RENDER-SETUP",      ("[GATE] screenshot-actors",
+                           ("[FF/write]", "getDimensions"),
+                           ("[FF/write]", "ScreenshotParent")),          (("[FF/open]", "/tmp/out.png"), "/tmp/out.png present"),    "tick"),
+    ("RENDER",            ("[GATE] screenshot-actors",
+                           ("[FF/write]", "getDimensions"),
+                           ("[FF/write]", "ScreenshotParent")),          (("[FF/open]", "/tmp/out.png"), "/tmp/out.png present"),    "tick"),
+    ("ENCODE",            (("[FF/open]", "/tmp/out.png"), "/tmp/out.png present"),
+                                                                         (("[FF-OUT-PNG:", "sig_ok=true"), "89504e47"), "tick"),
+    ("TEARDOWN",          (("[FF-OUT-PNG:", "sig_ok=true"), "89504e47"),
+                                                                         (("[PROC]", "PID 1 exit_group"),),                         "host"),
 ]
 
 # The ordered list of phase boundary *marker sets* that the monotone scan walks.
@@ -251,19 +267,31 @@ ANCHORS = [
     # `[VFS/resolve] component=libxul.so` line that can precede ff_launch and so
     # mis-anchor FF-STARTUP to ~zero. The AND-tuple ties the anchor to the FF
     # open path, a deterministic post-launch boundary.
-    ("libxul",         (("[FF/open]", "libxul.so"),)),
+    # Render-stage anchors accept the low-frequency kernel `[GATE] <label>`
+    # markers (default-ON on the fast firefox-test-core profile, where the
+    # `[FF/write]`/`[FF/open]` diagnostic mirror is OFF) in ADDITION to the
+    # historical trace markers (still present on a full firefox-test/*-trace
+    # boot). Either source advances the phase taxonomy — additive, never a
+    # rename of the existing markers.
+    ("libxul",         ("[GATE] libxul", ("[FF/open]", "libxul.so"))),
     ("tcp",            ("[TCP] Established", "[TCP] Accepted", "] Established →")),
-    ("screenshot",     (("[FF/write]", "getDimensions"),
+    ("screenshot",     ("[GATE] screenshot-actors",
+                        ("[FF/write]", "getDimensions"),
                         ("[FF/write]", "ScreenshotParent"))),
     # render_start: a DISTINCT composite/draw line, when the build emits one.
     # Optional — absent on these builds, in which case RENDER collapses to null
     # and RENDER-SETUP carries the whole screenshot->encode-open interval (MECE).
-    ("render_start",   ("CrossProcessPaint", "drawSnapshot")),
+    ("render_start",   ("[GATE] drawSnapshot", "CrossProcessPaint", "drawSnapshot")),
     # out_png_open: the test harness opens the output PNG file — the real draw->
     # encode boundary (replaces the structurally-wrong libpng16.so load marker).
-    ("out_png_open",   (("[FF/open]", "/tmp/out.png"),)),
-    # png_written: PNG magic in the write payload. Exactly one per success run.
-    ("png_written",    ("89504e47",)),
+    # On firefox-test-core the `[FF/open]` mirror is OFF, so also accept the
+    # functional FF-supervisor screenshot-present line as the encode-open edge.
+    ("out_png_open",   (("[FF/open]", "/tmp/out.png"), "/tmp/out.png present")),
+    # png_written: PNG magic, or the functional FF-supervisor valid-PNG line
+    # (`[FF-OUT-PNG:… sig_ok=true …]`). Exactly one per success run. NOTE: the
+    # raw `[GATE] PNG` magic marker is deliberately NOT emitted by the kernel —
+    # FF writes many internal PNGs that would false-positive (see syscall.rs).
+    ("png_written",    (("[FF-OUT-PNG:", "sig_ok=true"), "89504e47")),
     # exit_group: the pid=1 (Firefox launcher) teardown specifically. The bare
     # `exit_group(` token matches EVERY child process exit (PID 2/4/5/6 emit it
     # long before the launcher), so anchor on the `[PROC] PID 1 exit_group` form

--- a/scripts/serial-web-smoke.py
+++ b/scripts/serial-web-smoke.py
@@ -190,6 +190,79 @@ def _gate_timing_checks(sw, tmp):
         srv.shutdown()
 
 
+# A `firefox-test-core` (fast default) boot: the per-write `[FF/write]`/
+# `[FF/stderr]`/`[FF/open]` diagnostic firehose is OFF, so the ONLY render-gate
+# signal is the low-frequency kernel-emitted `[GATE] <label>` milestone markers
+# (plus the functional `[EXEC] …-isForBrowser` argv line). The headless demo
+# renders a local file:// page, so there is NO TCP line (TLS / network is
+# legitimately absent). This is exactly the case PR #518's serial split created
+# a blind spot for — before the milestone markers the monitor showed "firefox
+# exec" as the deepest gate even though FF reached content-proc spawn + the
+# render handshake. This fixture proves the ladder now advances past it.
+CORE_PROFILE_SERIAL = """\
+[BOOT] AstryxOS kernel kernel_main Booting
+[HEAP GUARD] Guard pages installed
+[ACPI] Phase 5b APIC init
+[SMP] scheduler online AP online Phase 6
+[DRIVERS] virtio Phase 7
+[VFS] ext2 mounted rootfs
+[X11] Xastryx ready on /tmp/.X11-unix/X0 (fd=0)
+[FFTEST] X11 server ready
+[PROC] Created kernel process firefox-bin PID 1 TID 1
+[EXEC] pid=1 tid=1 argv="firefox-bin" "--headless" (2 of 14 args shown)
+[HB] tick=200 cpu=0 pid=1 sc=120000
+[GATE] libxul
+[HB] tick=400 cpu=0 pid=1 sc=300000
+[EXEC] pid=1 tid=9 argv="firefox-bin" "-contentproc" "-isForBrowser" (3 of 16 args shown)
+[GATE] content-procs
+[HB] tick=800 cpu=0 pid=1 sc=1600000
+[GATE] screenshot-actors
+[HB] tick=1200 cpu=0 pid=1 sc=2000000
+[GATE] drawSnapshot
+[FFTEST] /tmp/out.png present (12345 bytes) — streaming
+[FF-OUT-PNG:path=/tmp/out.png size=12345 sig_ok=true complete=true]
+[PROC] PID 1 exit_group(0)
+"""
+
+
+def _core_profile_gate_checks(sw, tmp):
+    """firefox-test-core (firehose OFF): the `[GATE]` milestone markers + the
+    functional FF-supervisor PNG line must advance the ladder PAST 'firefox
+    exec' to the deep render gates. Also exercises the OPTIONAL-skip rule: the
+    no-network file:// render emits no TCP line ('TLS / network' absent) AND the
+    fixture emits 'X11 server ready' BEFORE the 'PID 1' line ('init / userspace'
+    out of order) — neither may stall the strictly-monotone ladder."""
+    sid = "coreprofile01"
+    log = os.path.join(tmp, sid + ".serial.log")
+    with open(log, "w") as f:
+        f.write(CORE_PROFILE_SERIAL)
+    prog = sw.scan_progress(log)
+    hit = {s["label"] for s in prog["timeline"] if s["hit"]}
+    # The blind-spot fix: deepest gate is NOT stuck at 'firefox exec' (or before).
+    check("core: deepest gate past 'firefox exec'",
+          prog["gate"] not in ("firefox exec", "init / userspace", "boot"),
+          prog["gate"])
+    # PNG write is detected via the functional FF-supervisor line, the rest via
+    # the kernel `[GATE]` markers — all default-on on firefox-test-core.
+    for g in ("content procs", "screenshot-actors", "drawSnapshot", "PNG write"):
+        check(f"core: '{g}' reached on fast profile (firehose off)", g in hit,
+              sorted(hit))
+    # firefox exec must still be hit (the gate we advance PAST).
+    check("core: 'firefox exec' hit (then surpassed)", "firefox exec" in hit)
+    # Optional gates: absent/out-of-order, but the ladder still reaches PNG.
+    check("core: 'TLS / network' optional (absent on file://, not stalling)",
+          "TLS / network" not in hit and "PNG write" in hit)
+    check("core: 'init / userspace' optional-skip (X11-before-PID1, not stalling)",
+          "X11 ready" in hit and "firefox exec" in hit)
+    # Prove the firehose really is off in this fixture (no per-write mirror).
+    fire = (CORE_PROFILE_SERIAL.count("[FF/write]")
+            + CORE_PROFILE_SERIAL.count("[FF/stderr]")
+            + CORE_PROFILE_SERIAL.count("[FF/write-fd]")
+            + CORE_PROFILE_SERIAL.count("[FF/open]"))
+    check("core: firehose stayed off (0 [FF/write]/[FF/stderr]/[FF/open])",
+          fire == 0, fire)
+
+
 def main():
     tmp = tempfile.mkdtemp(prefix="serialweb-smoke-")
     sid = "smoketest1234"
@@ -270,6 +343,10 @@ def main():
     # ── per-gate TIMING: elapsed-since-launch + per-gate delta ──
     print("── per-gate timing ──")
     _gate_timing_checks(sw, tmp)
+
+    # ── firefox-test-core (fast profile, firehose OFF) gate visibility ──
+    print("── core-profile gate visibility ──")
+    _core_profile_gate_checks(sw, tmp)
 
     # ── HTTP layer end-to-end on an ephemeral port ──
     print("── HTTP endpoints ──")

--- a/scripts/serial-web.py
+++ b/scripts/serial-web.py
@@ -47,16 +47,25 @@ GUEST_RAM_BYTES = 2 * 1024 * 1024 * 1024   # 2 GiB guest RAM (from the qemu cmdl
 DISK_SECTORS = 4194304           # virtio-blk capacity=4194304 sectors (data.img)
 SECTOR_BYTES = 512
 
-# render ladder, deepest first (idx, label, substring markers)
+# render ladder, deepest first (idx, label, substring markers). Each render gate
+# accepts BOTH the low-frequency kernel-emitted `[GATE] <label>` milestone marker
+# (default-ON on the fast firefox-test-core profile) AND the historical
+# diagnostic/JS strings (present on a full-trace boot) — so a gate is detected
+# whichever serial source is enabled. This is a tail-window substring scan (no
+# AND-anchoring), so the `[GATE]` markers carry the load on the fast profile.
 GATES = [
-    (8, "PNG",               ("89504e47", "out.png written", "kdb-read-png")),
-    (7, "drawSnapshot",      ("drawSnapshot", "CrossProcessPaint", "libpng16")),
-    (6, "screenshot-actors", ("ScreenshotParent", "getDimensions")),
-    (5, "content-proc",      ("isForBrowser",)),
+    (8, "PNG",               ("[FF-OUT-PNG:path=/tmp/out.png size=",
+                              "/tmp/out.png present", "89504e47", "out.png written",
+                              "kdb-read-png")),
+    (7, "drawSnapshot",      ("[GATE] drawSnapshot", "drawSnapshot",
+                              "CrossProcessPaint", "libpng16")),
+    (6, "screenshot-actors", ("[GATE] screenshot-actors", "ScreenshotParent",
+                              "getDimensions")),
+    (5, "content-proc",      ("[GATE] content-procs", "isForBrowser")),
     (4, "network",           ("] Established", "Established →", "[TCP]")),
     (3, "ff-launch",         ("firefox-bin",)),
     (2, "x11",               ("X11 server ready", "Xastryx")),
-    (1, "lib-load",          ("libxul",)),
+    (1, "lib-load",          ("[GATE] libxul", "libxul")),
 ]
 GATE_MAX = 8
 _SC_RE = re.compile(r"pid=1[^\n]*?sc=(\d+)")
@@ -103,14 +112,51 @@ MILESTONES = [
     ("X11 ready",         ("X11 server ready", "Xastryx")),
     ("firefox exec",      ("firefox-bin",)),
     ("TLS / network",     ("[TCP] Established", "] Established →")),
-    ("content procs",     ("isForBrowser",)),
-    # render stages: AND-anchored to the actual kernel [FF/write]/[FF/write-fd]
-    # log line, NOT the bare string (which also lives in the cached JS source).
-    ("screenshot-actors", (("[FF/write]", "getDimensions"), ("[FF/write]", "ScreenshotParent"), ("[FF/write]", "sendQuery"))),
-    ("drawSnapshot",      ("libpng16.so",)),
-    ("PNG write",         ("89504e47", "out.png written")),
+    # content-process spawn. `[GATE] content-procs` is the kernel-emitted
+    # milestone marker (default-ON on firefox-test-core, fires once); the
+    # `[EXEC] …-isForBrowser …` argv line is the functional default-on fallback
+    # (the bare `isForBrowser` substring also lives in FF's cached JS, so we
+    # anchor it to the kernel `[EXEC]` line). On a full-trace boot all fire.
+    ("content procs",     ("[GATE] content-procs", ("[EXEC]", "isForBrowser"))),
+    # render stages. On the FAST `firefox-test-core` profile the per-write
+    # `[FF/write]` IPDL mirror is OFF, so these match the low-frequency
+    # kernel-emitted `[GATE] <label>` markers instead. The `[FF/write]`-anchored
+    # tuples are kept for full-trace boots (firefox-test / *-trace), where they
+    # also fire — both detect the same gate, whichever serial source is on.
+    ("screenshot-actors", ("[GATE] screenshot-actors",
+                           ("[FF/write]", "getDimensions"),
+                           ("[FF/write]", "ScreenshotParent"),
+                           ("[FF/write]", "sendQuery"))),
+    ("drawSnapshot",      ("[GATE] drawSnapshot", "libpng16.so")),
+    # PNG write. The FINAL screenshot PNG is NOT detected by a raw [GATE]/magic
+    # marker (Firefox writes many internal PNGs — favicons, theme assets — that
+    # would false-positive). The authoritative, single-per-run signal is the FF
+    # supervisor's functional `[FFTEST] /tmp/out.png present` /
+    # `[FF-OUT-PNG:… sig_ok=true …]` lines (default-on on firefox-test-core); the
+    # `89504e47` magic / `out.png written` are kept for full-trace boots.
+    ("PNG write",         (("[FF-OUT-PNG:", "sig_ok=true"),
+                           "/tmp/out.png present", "89504e47", "out.png written")),
     ("exit_group",        ("exit_group(",)),
 ]
+
+# OPTIONAL milestones: gates that can be absent OR arrive out-of-order on a
+# successful run, and so must never STALL the strictly-monotone ladder below.
+# When a DEEPER milestone matches the current line but an in-between optional
+# gate was not yet seen, the scan advances past the optional gate (same
+# discipline as perf_markers.ANCHOR_OPTIONAL). Two members:
+#   * "TLS / network" — the headless demo renders a local file:// page with no
+#     network I/O, so the TCP gate legitimately never fires, yet content-process
+#     spawn + the render gates DO.
+#   * "init / userspace" — the FF supervisor emits "X11 server ready" BEFORE the
+#     "[PROC] … PID 1" line this gate keys on, so on a strict in-order scan the
+#     ladder would dead-end here (X11-ready can't fire while the cursor waits on
+#     PID 1) and EVERY deeper gate — firefox exec, [GATE] libxul/content-procs,
+#     the render gates — would show as un-hit. Marking it optional lets the
+#     ladder advance to the gates the boot actually reached. (Pre-existing
+#     ordering quirk, surfaced once the deep [GATE] markers made the deeper
+#     gates reachable on the fast profile.)
+OPTIONAL_MILESTONES = {"TLS / network", "init / userspace"}
+
 # Only the kernel's own tick lines, not arbitrary "tick=" in FF/JS output.
 _TICK_KERNEL = re.compile(r"(?:\[HB\]|PROC-METRICS\]) tick=(\d+)")
 
@@ -167,9 +213,22 @@ def scan_progress(path):
                     sc = int(scm.group(1))
                 if not panic and _PANIC_RE.search(line):
                     panic = True
-                while idx < len(MILESTONES) and _match(line, MILESTONES[idx][1]):
-                    found[MILESTONES[idx][0]] = (n, cur_tick)
-                    idx += 1
+                while idx < len(MILESTONES):
+                    if _match(line, MILESTONES[idx][1]):
+                        found[MILESTONES[idx][0]] = (n, cur_tick)
+                        idx += 1
+                        continue
+                    # Current milestone didn't match. If it is OPTIONAL and a
+                    # DEEPER milestone matches this line, skip the optional gate
+                    # so it can't stall the ladder (e.g. a file:// render emits
+                    # no TCP line, but `[GATE] content-procs` / render markers do).
+                    if MILESTONES[idx][0] in OPTIONAL_MILESTONES and any(
+                        _match(line, MILESTONES[j][1])
+                        for j in range(idx + 1, len(MILESTONES))
+                    ):
+                        idx += 1
+                        continue
+                    break
                 # don't early-break: keep scanning so the latest sc/tick (current
                 # state) stays fresh even after the deepest milestone is hit.
     except OSError:


### PR DESCRIPTION
## Problem

PR #518 split `firefox-test` → `firefox-test-core` (fast default, diagnostic serial OFF) + `firefox-test-trace` (full firehose). The serial monitor (`serial-web.py`) and the perf phase taxonomy (`perf-bench.py` / `perf_markers.py`) detected the DEEP render gates (`screenshot-actors`, `drawSnapshot`, PNG) **only** via the per-write `[FF/write]` mirror — which #518 gated behind `firefox-test-trace`.

On the now-default `firefox-test-core` profile that mirror is OFF, so the monitor showed **"firefox exec" as the deepest gate** even when Firefox reached content-process spawn and the screenshot handshake. This is a **monitoring blind spot the perf split created, not a boot regression** — and it forces anyone watching render progress back onto the slow full-trace firehose, defeating the perf campaign.

## Fix — a cheap, default-on MILESTONE mirror (a handful of lines, not a firehose)

The full per-write `[FF/stderr]`/`[FF/write]` mirror stays behind `firefox-test-trace` (correct — it's the ~37 MB firehose). This adds a SEPARATE, default-on (`firefox-test-core`), pattern-filtered milestone emitter.

**Kernel** (`#[cfg(feature = "firefox-test-core")]`, byte-identical when off):
- `sys_write_linux`: scan tracked-write payloads for a curated render-lifecycle substring set and emit one `[GATE] <label>` line the FIRST time each is seen (an `AtomicU32` first-arrival bitmask — each fires ~once; the scan is skipped once all bits are set). Curated set: `getDimensions`, `ScreenshotParent`, `sendQuery` (→ `screenshot-actors`); `drawSnapshot`, `CrossProcessPaint` (→ `drawSnapshot`).
- exec path: `[GATE] content-procs` once on the first `-isForBrowser`/`-contentproc` launch.
- open path: `[GATE] libxul` once on first `libxul.so` open (the per-open `[FF/open]` mirror is trace-gated).
- The final screenshot PNG is intentionally **not** detected by raw PNG magic — FF writes many internal PNGs (favicons, theme assets) that would false-positive. The authoritative single-per-run signal is the FF supervisor's functional `[FFTEST] /tmp/out.png present` / `[FF-OUT-PNG:… sig_ok=true …]` lines (already default-on on core).

**Consumers** (single source of truth; **additive — no existing keys renamed**):
- `serial-web.py` `MILESTONES`/`GATES`: detect the deep gates via the new `[GATE]` markers (+ functional `[EXEC]…isForBrowser` / `FF-OUT-PNG` lines). Mark `TLS / network` (no TCP on a `file://` render) and `init / userspace` (X11-ready precedes the `PID 1` line) **OPTIONAL** so the strictly-monotone ladder can't stall before the gates the boot actually reached.
- `perf_markers.py` `ANCHORS`/`PHASES` (+ vendored `MILESTONES` mirror): accept the `[GATE]` markers so the perf phase taxonomy still derives `phase_ms` on the fast profile. `gate_marks.py` `GATE_TO_PHASE` is unchanged (labels are stable).

## Verification (harness-only)

**Live `firefox-test-core` boot** — `[GATE] libxul`, `[GATE] content-procs`, `[GATE] screenshot-actors` all fired with the firehose **fully OFF**: `[FF/write]=[FF/stderr]=[FF/write-fd]=[FF/open]=0`. The serial monitor advanced from "firefox exec" to **screenshot-actors**.

**Before/after serial-monitor depth on the same live core log:**
- BEFORE (master markers): deepest = `firefox exec` (stalls — render gates keyed only on the gated-off `[FF/write]` mirror).
- AFTER (this PR): deepest = `screenshot-actors`, via the `[GATE]` markers, firehose still 0.

`firefox-test` (full trace) still gets the complete `[FF/write]` mirror, unchanged. All three build profiles (`firefox-test-core`, `firefox-test`, default desktop) compile clean.

**Host-side smoke tests (extended):**
- `serial-web-smoke.py`: new core-profile checks prove a firehose-OFF log advances past "firefox exec" → content-procs → screenshot-actors → drawSnapshot → PNG write, and that the optional-skip handles the no-TCP / X11-before-PID1 cases.
- `perf-bench-smoke.py`: new check proves the phase taxonomy derives the render pipeline from `[GATE]` markers on a firehose-OFF log.

Both smoke suites green; `serial-web-smoke`'s existing `GATE_TO_PHASE covers every milestone` invariant still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)