### PR TITLE
serial-web: in-dashboard base64 PNG screenshot decoder/viewer (VGA framebuffer + Firefox render)

### DIFF
--- a/scripts/serial-web-smoke.py
+++ b/scripts/serial-web-smoke.py
@@ -27,14 +27,18 @@ Covers (matches the operator-requested feature set):
                       kernel-tick derivation (APPROX historical), incl. the
                       monotone/forward-ordered delta invariant.
 """
+import base64
 import importlib.util
 import json
 import os
+import struct
 import sys
 import tempfile
 import threading
 import time
+import urllib.error
 import urllib.request
+import zlib
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PASS = "\033[32mPASS\033[0m"
@@ -263,6 +267,212 @@ def _core_profile_gate_checks(sw, tmp):
           fire == 0, fire)
 
 
+# ── screenshot streams: base64 PNG decode (VGA framebuffer + Firefox render) ──
+PNG_SIG = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+
+def _make_png(w, h):
+    """A real, valid PNG built with stdlib zlib only (NO Pillow). 8-bit RGBA,
+    one IDAT, one IEND. Its IHDR carries w/h so the dimension parse is exercised."""
+    def chunk(typ, data):
+        c = typ + data
+        return struct.pack(">I", len(data)) + c + struct.pack(
+            ">I", zlib.crc32(c) & 0xFFFFFFFF)
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0)   # 8-bit, colour-type 6
+    # filter byte 0 + RGBA scanlines (a flat colour compresses small/fast)
+    raw = b"".join(b"\x00" + b"\x39\xd3\x53\xff" * w for _ in range(h))
+    return (PNG_SIG + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(raw, 6)) + chunk(b"IEND", b""))
+
+
+def _emit_stream(png, kind, drop_tail=0, end=True):
+    """Render `png` as the chunked base64 serial stream for `kind` (vga|ff). When
+    drop_tail>0, omit the last `drop_tail` chunks (and the END marker) to model
+    an in-progress/partial stream. Mirrors the kernel's 76-char chunk width."""
+    b64 = base64.b64encode(png).decode()
+    parts = [b64[i:i + 76] for i in range(0, len(b64), 76)]
+    M = len(parts)
+    keep = M - drop_tail
+    lines = []
+    if kind == "ff":
+        lines.append(f"[FF-OUT-PNG:path=/tmp/out.png size={len(png)} sig_ok=true]")
+        tag = "FF-OUT-PNG-B64"
+        endtag = "[FF-OUT-PNG-END]"
+    else:
+        tag = "SCREENSHOT-B64"
+        endtag = "[SCREENSHOT-B64-END]"
+    for i in range(keep):
+        lines.append(f"[{tag}:{i}/{M}] {parts[i]}")
+    if end and drop_tail == 0:
+        lines.append(endtag)
+    return "\n".join(lines) + "\n", M, keep
+
+
+def _screenshot_checks(sw, tmp):
+    """The screenshot decode endpoint: complete + partial streams for BOTH the
+    VGA framebuffer (kind=vga) and the Firefox render (kind=ff). Validates the
+    decoded PNG signature/dimensions, completeness flags, partial-pct, the
+    metadata endpoint, and graceful degradation (no 500 on a torn stream; a
+    clean JSON 404 when absent). All synthetic — CI-safe, no real logs needed."""
+    # ---- complete VGA + complete FF in one log ----
+    png_vga = _make_png(800, 450)        # matches the real fixture dimensions
+    png_ff = _make_png(64, 48)
+    sid = "shots01"
+    log = os.path.join(tmp, sid + ".serial.log")
+    vga_txt, vgaM, _ = _emit_stream(png_vga, "vga")
+    ff_txt, ffM, _ = _emit_stream(png_ff, "ff")
+    with open(log, "w") as f:
+        f.write("[BOOT] AstryxOS kernel\n" + vga_txt + ff_txt)
+
+    dv = sw._decode_shot(log, "vga")
+    check("shots vga decodes to valid PNG", dv["sig_ok"] and dv["png"][:8] == PNG_SIG)
+    check("shots vga complete", dv["complete"] is True, dv["complete"])
+    check("shots vga dims 800x450", dv["w"] == 800 and dv["h"] == 450, (dv["w"], dv["h"]))
+    check("shots vga byte-exact", dv["bytes"] == len(png_vga), (dv["bytes"], len(png_vga)))
+    check("shots vga chunks==total", dv["chunks"] == vgaM and dv["total"] == vgaM)
+
+    df = sw._decode_shot(log, "ff")
+    check("shots ff decodes to valid PNG", df["sig_ok"] and df["png"][:8] == PNG_SIG)
+    check("shots ff complete", df["complete"] is True, df["complete"])
+    check("shots ff dims 64x48", df["w"] == 64 and df["h"] == 48, (df["w"], df["h"]))
+    check("shots ff byte-exact + guest_size cross-check",
+          df["bytes"] == len(png_ff) == df["guest_size"],
+          (df["bytes"], len(png_ff), df["guest_size"]))
+
+    # ---- metadata endpoint: both present, no png bytes shipped ----
+    md = sw.scan_screenshots(log)
+    check("scan_screenshots vga present+complete",
+          md["vga"]["present"] and md["vga"]["complete"])
+    check("scan_screenshots ff present+complete",
+          md["ff"]["present"] and md["ff"]["complete"])
+    check("scan_screenshots strips png bytes (metadata only)",
+          "png" not in md["vga"] and "png" not in md["ff"])
+    check("scan_screenshots consistent schema (both branches have end_seen/received)",
+          all(k in md["vga"] for k in ("end_seen", "received", "first_gap", "partial_pct")))
+
+    # ---- PARTIAL VGA: drop ~33% of the tail + the END marker ----
+    sidp = "shotspart01"
+    logp = os.path.join(tmp, sidp + ".serial.log")
+    drop = vgaM // 3
+    vpart, _, vkeep = _emit_stream(png_vga, "vga", drop_tail=drop)
+    with open(logp, "w") as f:
+        f.write(vpart)
+    dp = sw._decode_shot(logp, "vga")
+    check("shots PARTIAL does not error (graceful)", dp["error"] is None, dp["error"])
+    check("shots PARTIAL present but not complete",
+          dp["present"] and dp["complete"] is False, (dp["present"], dp["complete"]))
+    check("shots PARTIAL still a valid PNG prefix (IHDR present)",
+          dp["sig_ok"] and dp["png"][:8] == PNG_SIG)
+    check("shots PARTIAL keeps IHDR dims (800x450)",
+          dp["w"] == 800 and dp["h"] == 450, (dp["w"], dp["h"]))
+    check("shots PARTIAL pct == int(100*keep/total)",
+          dp["partial_pct"] == int(100 * vkeep / vgaM),
+          (dp["partial_pct"], vkeep, vgaM))
+    check("shots PARTIAL end_seen False (no END marker)", dp["end_seen"] is False)
+
+    # ---- absent stream: clean 'present:false', no crash ----
+    sidn = "shotsnone01"
+    logn = os.path.join(tmp, sidn + ".serial.log")
+    with open(logn, "w") as f:
+        f.write("[BOOT] AstryxOS kernel\n[FFTEST] no screenshot here\n")
+    dn = sw._decode_shot(logn, "vga")
+    check("shots absent -> present False, no error", not dn["present"] and dn["error"] is None)
+
+    # ---- HTTP layer: serve PNG bytes, headers, JSON 404 on absent ----
+    from http.server import ThreadingHTTPServer
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), sw.H)
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        # complete VGA -> 200 image/png, PNG magic, complete header
+        req = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/screenshot?sid={sid}&kind=vga", timeout=5)
+        body = req.read()
+        check("GET /api/screenshot vga 200 image/png",
+              req.status == 200 and req.headers.get("Content-Type") == "image/png")
+        check("GET /api/screenshot vga returns PNG bytes", body[:8] == PNG_SIG)
+        check("GET /api/screenshot vga X-Screenshot-Complete true",
+              req.headers.get("X-Screenshot-Complete") == "true")
+        check("GET /api/screenshot vga X-Screenshot-Dimensions 800x450",
+              req.headers.get("X-Screenshot-Dimensions") == "800x450")
+        # complete FF -> 200 image/png
+        reqf = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/screenshot?sid={sid}&kind=ff", timeout=5)
+        bodyf = reqf.read()
+        check("GET /api/screenshot ff 200 PNG bytes",
+              reqf.status == 200 and bodyf[:8] == PNG_SIG)
+        # partial VGA -> 200 but Complete:false (degrades, not 500)
+        reqp = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/screenshot?sid={sidp}&kind=vga", timeout=5)
+        bodyp = reqp.read()
+        check("GET /api/screenshot PARTIAL 200 (not 500) + PNG bytes",
+              reqp.status == 200 and bodyp[:8] == PNG_SIG)
+        check("GET /api/screenshot PARTIAL Complete header false",
+              reqp.headers.get("X-Screenshot-Complete") == "false")
+        # absent FF on a vga-only log -> JSON 404
+        try:
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/screenshot?sid={sidp}&kind=ff", timeout=5)
+            absent404 = False
+        except urllib.error.HTTPError as e:
+            absent404 = (e.code == 404
+                         and e.headers.get("Content-Type") == "application/json")
+        check("GET /api/screenshot absent -> JSON 404 (no 500)", absent404)
+        # bad kind -> 400 JSON
+        try:
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/screenshot?sid={sid}&kind=bogus", timeout=5)
+            bad400 = False
+        except urllib.error.HTTPError as e:
+            bad400 = e.code == 400
+        check("GET /api/screenshot bad kind -> 400", bad400)
+        # metadata endpoint
+        with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/screenshots?sid={sid}", timeout=5) as r:
+            mbody = json.loads(r.read())
+        check("GET /api/screenshots both kinds + no png bytes",
+              mbody["vga"]["complete"] and mbody["ff"]["complete"]
+              and "png" not in mbody["vga"])
+        # the dashboard HTML wires up the screenshots panel + endpoint
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=5) as r:
+            page = r.read()
+        check("dashboard HTML references screenshots panel",
+              b"id=shots" in page and b"/api/screenshot?" in page
+              and b"VGA framebuffer" in page and b"Firefox render" in page)
+    finally:
+        srv.shutdown()
+
+
+def _real_fixture_checks(sw):
+    """Opportunistic check against the REAL operator fixtures, only when this
+    host has them (skipped silently in CI, which has no ~/.astryx-harness logs).
+    fcc3cb95d128 = a COMPLETE [SCREENSHOT-B64] (25275/25275 -> 800x450 PNG);
+    137d5d460cc0 = a PARTIAL one (16990/25275)."""
+    hd = os.path.expanduser("~/.astryx-harness")
+    comp = os.path.join(hd, "fcc3cb95d128.serial.log")
+    part = os.path.join(hd, "137d5d460cc0.serial.log")
+    if not (os.path.exists(comp) and os.path.exists(part)):
+        print("  (real fixtures absent — host-fixture checks skipped)")
+        return
+    old = sw.HARNESS_DIR
+    sw.HARNESS_DIR = hd
+    try:
+        dc = sw._decode_shot(comp, "vga")
+        check("REAL complete fixture -> valid 800x450 PNG",
+              dc["complete"] and dc["sig_ok"] and dc["w"] == 800 and dc["h"] == 450,
+              (dc["complete"], dc["w"], dc["h"]))
+        check("REAL complete fixture 25275 chunks",
+              dc["total"] == 25275 and dc["chunks"] == 25275, (dc["chunks"], dc["total"]))
+        dp = sw._decode_shot(part, "vga")
+        check("REAL partial fixture decodes gracefully (no error, valid prefix)",
+              dp["error"] is None and dp["sig_ok"] and dp["present"], dp["error"])
+        check("REAL partial fixture not complete + pct ~67",
+              dp["complete"] is False and dp["partial_pct"] == 67, dp["partial_pct"])
+    finally:
+        sw.HARNESS_DIR = old
+
+
 def main():
     tmp = tempfile.mkdtemp(prefix="serialweb-smoke-")
     sid = "smoketest1234"
@@ -347,6 +557,11 @@ def main():
     # ── firefox-test-core (fast profile, firehose OFF) gate visibility ──
     print("── core-profile gate visibility ──")
     _core_profile_gate_checks(sw, tmp)
+
+    # ── screenshot streams: base64 PNG decode (VGA framebuffer + FF render) ──
+    print("── screenshot decode (VGA framebuffer + Firefox render) ──")
+    _screenshot_checks(sw, tmp)
+    _real_fixture_checks(sw)
 
     # ── HTTP layer end-to-end on an ephemeral port ──
     print("── HTTP endpoints ──")

--- a/scripts/serial-web.py
+++ b/scripts/serial-web.py
@@ -13,6 +13,16 @@ serial logs (read-only; safe alongside live boots).
                               proxy/IO bytes+IOPS/net, plus per-pid breakdown
   GET /api/blkmap?sid=&grid=N JSON: data.img block-map histogram built from
                               feature-gated [BLK] op/lba/len trace lines
+  GET /api/screenshots?sid=   JSON: metadata for BOTH base64 PNG streams a
+                              firefox-test/test-mode boot emits —
+                              {vga:{present,complete,chunks,total,w,h,…}, ff:{…}}
+  GET /api/screenshot?sid=&kind=vga|ff
+                              image/png: the decoded screenshot. kind=vga is the
+                              VGA framebuffer ([SCREENSHOT-B64:…], Test 198);
+                              kind=ff is Firefox's render (/tmp/out.png,
+                              [FF-OUT-PNG-B64:…]). Partial/in-progress streams
+                              serve best-effort (200 + X-Screenshot-Complete:
+                              false); absent/invalid streams return a JSON 404.
 
   python3 scripts/serial-web.py [--port 8088] [--host 0.0.0.0]
 
@@ -435,6 +445,212 @@ def scan_blkmap(path, size, grid):
     }
 
 
+# ── screenshot streams: decode the base64 PNG the boot emits over serial ──────
+#
+# A firefox-test / test-mode boot emits TWO DISTINCT chunked base64 PNG streams.
+# Both share the same wire shape (0-based index N, total M, base64 payload) but
+# carry DIFFERENT images — the UI must label them unambiguously:
+#
+#   VGA framebuffer (Test 198) — the guest's console/GUI screen (the QEMU VGA
+#   framebuffer), 800x450 RGBA in practice:
+#       [SCREENSHOT-B64:N/M] <base64 chunk>
+#       ...
+#       [SCREENSHOT-B64-END]
+#
+#   Firefox render (/tmp/out.png) — Firefox's actual off-screen rendered page,
+#   emitted after FF exits (the DEMO GOAL output), DISTINCT from the framebuffer.
+#   Preceded by a header line carrying the guest-side byte size:
+#       [FF-OUT-PNG:path=/tmp/out.png size=<N> sig_ok=<bool>]
+#       [FF-OUT-PNG-B64:N/M] <base64 chunk>
+#       ...
+#       [FF-OUT-PNG-END]
+#
+# Decode (identical to qemu-harness.py read-png / read-ff-png): collect the
+# chunks in index order, concatenate the base64, decode (RFC 4648 §4), and the
+# result is a PNG (8-byte magic 89 50 4E 47 0D 0A 1A 0A, W3C PNG §5.2 / ISO
+# 15948). PARTIAL / in-progress streams are decoded best-effort: we keep the
+# leading contiguous run of chunks (0,1,2,… until the first gap), pad the
+# concatenated base64 to a multiple of 4, and decode what is present — so a
+# truncated stream still yields a (partial) PNG the browser can render the top
+# of, rather than a 500.
+#
+# Two image "kinds" the endpoints accept: kind=vga (the framebuffer) and
+# kind=ff (the Firefox render). Read-only, like every other endpoint.
+
+PNG_SIGNATURE = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+_SHOT_KINDS = {
+    "vga": {
+        "label":  "VGA framebuffer (Test 198)",
+        "source": "QEMU VGA framebuffer — the guest console/GUI screen",
+        # header is optional for the VGA stream (no size line); chunk + end only
+        "header_re": None,
+        "chunk_re": re.compile(r"\[SCREENSHOT-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"),
+        "end_re":   re.compile(r"\[SCREENSHOT-B64-END\]"),
+    },
+    "ff": {
+        "label":  "Firefox render (/tmp/out.png)",
+        "source": "Firefox's off-screen rendered page, emitted after FF exits",
+        "header_re": re.compile(
+            r"\[FF-OUT-PNG:path=(\S+)\s+size=(\d+)\s+sig_ok=(true|false)"),
+        "chunk_re": re.compile(r"\[FF-OUT-PNG-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"),
+        "end_re":   re.compile(r"\[FF-OUT-PNG-END\]"),
+    },
+}
+
+# Cap a single screenshot decode: 25275 chunks x ~64 base64 chars ~= 1.6 MB of
+# base64 -> ~1.2 MB PNG. Bound the scan so a pathological log can't OOM us.
+SHOT_SCAN_MAX_LINES = 4_000_000
+
+
+def _png_dimensions(png_bytes):
+    """(width, height) from the IHDR chunk, or (None, None). The IHDR is the
+    first chunk after the 8-byte signature: bytes [16:20]=width, [20:24]=height,
+    big-endian uint32 (W3C PNG §11.2.2). Tolerates a partial PNG as long as the
+    first 24 bytes (signature + length + 'IHDR' + W + H) are present."""
+    if len(png_bytes) < 24 or png_bytes[:8] != PNG_SIGNATURE:
+        return None, None
+    if png_bytes[12:16] != b"IHDR":
+        return None, None
+    w = int.from_bytes(png_bytes[16:20], "big")
+    h = int.from_bytes(png_bytes[20:24], "big")
+    return w, h
+
+
+def _collect_shot_chunks(path, spec):
+    """Single forward scan of the serial log for one screenshot stream's chunks.
+    Returns (chunks, total, end_seen, header). `chunks` is {idx: b64}; `total`
+    is the announced M (None if no chunk line seen); `end_seen` is True once the
+    stream's END marker appears; `header` is {path,size,sig_ok} for the ff
+    stream (None otherwise). Best-effort and read-only — never raises."""
+    import base64  # noqa: F401  (kept local, mirrors harness convention)
+    chunks = {}
+    total = None
+    end_seen = False
+    header = None
+    header_re = spec["header_re"]
+    chunk_re = spec["chunk_re"]
+    end_re = spec["end_re"]
+    n = 0
+    try:
+        with open(path, "r", errors="replace") as f:
+            for line in f:
+                n += 1
+                if n > SHOT_SCAN_MAX_LINES:
+                    break
+                if header_re is not None and header is None:
+                    hm = header_re.search(line)
+                    if hm:
+                        header = {"path": hm.group(1),
+                                  "size": int(hm.group(2)),
+                                  "sig_ok": hm.group(3) == "true"}
+                m = chunk_re.search(line)
+                if m:
+                    idx = int(m.group(1))
+                    tot = int(m.group(2))
+                    if total is None:
+                        total = tot
+                    # Tolerate a single stream only (ignore stray lines that
+                    # announce a different M than the first chunk's).
+                    if tot == total and idx >= 0:
+                        chunks[idx] = m.group(3)
+                    continue
+                if end_re.search(line):
+                    end_seen = True
+    except OSError:
+        pass
+    return chunks, total, end_seen, header
+
+
+def _contiguous_b64(chunks, total):
+    """Concatenate the leading CONTIGUOUS run of chunks (0,1,2,… until the first
+    missing index). Returns (b64_concat, contig_count, first_gap). For a
+    complete stream contig_count == total and first_gap is None."""
+    parts = []
+    i = 0
+    limit = total if total is not None else (max(chunks) + 1 if chunks else 0)
+    while i < limit and i in chunks:
+        parts.append(chunks[i])
+        i += 1
+    first_gap = None if (total is not None and i >= total) else i
+    return "".join(parts), i, first_gap
+
+
+def _decode_shot(path, kind):
+    """Decode one screenshot stream from `path` to PNG bytes, best-effort.
+
+    Returns a dict (never raises on a malformed/partial stream):
+        present     bool   any chunk line for this kind was seen
+        complete    bool   END marker seen AND all 0..M-1 chunks present
+        chunks      int    contiguous chunks decoded (leading run)
+        total       int|None  announced M
+        png         bytes|None decoded PNG (signature-verified prefix)
+        bytes       int    decoded byte length
+        w,h         int|None  PNG dimensions from IHDR
+        sig_ok      bool   decoded bytes start with the PNG magic
+        partial_pct int|None  100*chunks/total when total known and <100
+        guest_size  int|None  ff stream's header-reported byte size
+        error       str|None  set only when present but undecodable
+    """
+    import base64
+    spec = _SHOT_KINDS[kind]
+    chunks, total, end_seen, header = _collect_shot_chunks(path, spec)
+    if not chunks:
+        return {"kind": kind, "label": spec["label"], "source": spec["source"],
+                "present": False, "complete": False, "chunks": 0,
+                "received": 0, "total": total, "first_gap": 0,
+                "end_seen": end_seen, "bytes": 0, "w": None, "h": None,
+                "sig_ok": False, "partial_pct": None, "png": None,
+                "guest_size": header["size"] if header else None,
+                "error": None}
+    b64, contig, first_gap = _contiguous_b64(chunks, total)
+    # Normalise the concatenated base64 to a decodable length. A base64 group is
+    # 4 chars -> 3 bytes; a partial/truncated tail can leave 1-3 leftover chars.
+    # A remainder of 1 is invalid (encodes 0 bytes) — drop it; a remainder of 2
+    # or 3 is a valid final group once padded with '='. So: trim to a multiple
+    # of 4, then re-pad the LAST whole-or-partial group. Concretely, drop the
+    # trailing (len % 4) chars (the torn group) so what remains is a clean
+    # multiple of 4 we can decode without raising. This loses at most the final
+    # 2 bytes of a partial PNG — the browser still renders the leading scanlines.
+    rem = len(b64) % 4
+    b64_clean = b64[:-rem] if rem else b64
+    png = b""
+    error = None
+    try:
+        png = base64.b64decode(b64_clean, validate=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        error = f"base64_decode_failed: {exc}"
+        png = b""
+    sig_ok = len(png) >= 8 and png[:8] == PNG_SIGNATURE
+    if png and not sig_ok and error is None:
+        error = "png_signature_mismatch"
+    w, h = _png_dimensions(png)
+    have_all = (total is not None and contig >= total)
+    complete = bool(end_seen and have_all and sig_ok)
+    pct = (int(100 * contig / total) if (total and total > 0 and not complete)
+           else (100 if complete else None))
+    return {"kind": kind, "label": spec["label"], "source": spec["source"],
+            "present": True, "complete": complete, "chunks": contig,
+            "received": len(chunks), "total": total, "first_gap": first_gap,
+            "end_seen": end_seen, "bytes": len(png), "w": w, "h": h,
+            "sig_ok": sig_ok, "partial_pct": pct, "png": png,
+            "guest_size": header["size"] if header else None,
+            "error": error}
+
+
+def scan_screenshots(path):
+    """Metadata for BOTH screenshot streams in one log, WITHOUT shipping the PNG
+    bytes — what the UI needs to decide which thumbnails to show. Returns
+    {vga:{present,complete,chunks,total,w,h,partial_pct,…}, ff:{…}}. The decoded
+    PNG itself is fetched separately from /api/screenshot."""
+    out = {}
+    for kind in ("vga", "ff"):
+        d = _decode_shot(path, kind)
+        d.pop("png", None)   # metadata only — keep the JSON small
+        out[kind] = d
+    return out
+
+
 # ── launch-time / session listing ─────────────────────────────────────────────
 def _launch_info(sid, log_path, log_stat):
     """Absolute + relative launch time, anchored to the host clock. Reads
@@ -574,6 +790,32 @@ PAGE = """<!doctype html><html><head><meta charset="utf-8">
  #blk .hd b{color:#56b6c2} #blkcanvas{display:block;width:100%;height:34px;image-rendering:pixelated;border:1px solid var(--edge);border-radius:3px}
  #blk .hint{color:var(--dim);font-size:11px} #blk .lg{font-size:10px;color:var(--dim);margin-top:3px}
  #blk .lg i{display:inline-block;width:9px;height:9px;border-radius:2px;vertical-align:middle;margin:0 3px 0 9px}
+ /* screenshots panel — decoded base64 PNG streams (VGA framebuffer + FF render) */
+ #shots{display:none;border-bottom:1px solid var(--edge);background:#0d111a;padding:8px 12px}
+ #shots.show{display:block} #shots .hd{font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px;margin-bottom:6px}
+ #shots .grid{display:flex;gap:14px;flex-wrap:wrap}
+ #shots .hint{color:var(--dim);font-size:11px}
+ .shot{border:1px solid var(--edge);border-radius:6px;background:#11151f;padding:8px;width:236px}
+ .shot.ff{border-color:#3a2a52} .shot.vga{border-color:#214a52}
+ .shot .knd{font-size:11px;font-weight:600;display:flex;align-items:center;gap:6px;margin-bottom:5px}
+ .shot.vga .knd{color:#56b6c2} .shot.ff .knd{color:#d2a8ff}
+ .shot .knd .tag{font-size:9px;font-weight:600;padding:1px 5px;border-radius:8px;text-transform:uppercase;letter-spacing:.5px}
+ .shot.vga .knd .tag{background:#0e1c22;color:#56b6c2;border:1px solid #214a52}
+ .shot.ff .knd .tag{background:#160e22;color:#d2a8ff;border:1px solid #3a2a52}
+ .shot .thumb{width:100%;height:124px;background:#0b0e14 repeating-conic-gradient(#161b27 0 25%,#0b0e14 0 50%) 0 0/16px 16px;
+   border:1px solid var(--edge);border-radius:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;cursor:pointer}
+ .shot .thumb img{max-width:100%;max-height:100%;display:block;image-rendering:auto}
+ .shot .thumb.empty{color:var(--dim);font-size:11px;cursor:default;text-align:center;padding:6px}
+ .shot .src{color:var(--dim);font-size:10px;margin:5px 0 3px;line-height:1.3}
+ .shot .stat{font-size:10px;color:var(--dim);display:flex;flex-wrap:wrap;gap:4px 8px}
+ .shot .stat .ok{color:#7ee787} .shot .stat .part{color:#f0c674} .shot .stat .dim{color:#56b6c2}
+ .shot .pbar{height:4px;background:#1b2230;border-radius:2px;margin-top:5px;overflow:hidden}
+ .shot.vga .pbar>i{display:block;height:100%;background:#56b6c2} .shot.ff .pbar>i{display:block;height:100%;background:#d2a8ff}
+ /* full-size lightbox */
+ #lightbox{display:none;position:fixed;inset:0;background:rgba(2,4,8,.92);z-index:50;align-items:center;justify-content:center;flex-direction:column;cursor:zoom-out}
+ #lightbox.show{display:flex} #lightbox img{max-width:94vw;max-height:86vh;border:1px solid var(--edge);box-shadow:0 0 30px rgba(0,0,0,.7);image-rendering:auto}
+ #lightbox .cap{margin-top:10px;font-size:12px;color:var(--fg);background:var(--panel);border:1px solid var(--edge);padding:6px 12px;border-radius:6px}
+ #lightbox .cap b{color:#7ee787} #lightbox .cap .part{color:#f0c674}
  .toggles{display:flex;gap:6px} .toggles button.on{border-color:var(--accent);color:#7ee787}
 </style></head><body><div id=app>
  <div id=side>
@@ -591,6 +833,7 @@ PAGE = """<!doctype html><html><head><meta charset="utf-8">
      <span class=toggles>
        <button id=tMetrics class=on title="guest metrics + sparklines">metrics</button>
        <button id=tBlk title="data.img block map (needs blk-trace)">blkmap</button>
+       <button id=tShots class=on title="decoded screenshot streams (VGA framebuffer + Firefox render)">shots</button>
        <button id=tRail class=on title="gate progression rail">rail</button>
      </span>
      <input id=flt placeholder="filter lines…"><label><input type=checkbox id=follow checked> follow</label>
@@ -601,12 +844,14 @@ PAGE = """<!doctype html><html><head><meta charset="utf-8">
    <div id=metrics class=show></div>
    <div id=pids></div>
    <div id=blk></div>
+   <div id=shots></div>
    <div id=miles></div>
    <div id=logwrap>
      <div id=log><div id=empty>Pick a session on the left to stream its serial output.</div></div>
      <div id=rail class=open></div>
    </div>
  </div></div>
+ <div id=lightbox><img id=lbimg alt=""><div class=cap id=lbcap></div></div>
 <script>
 let cur=null,es=null,sessions=[],rate={n:0,t:Date.now()};
 let miles=[],frozen=false,metaCur=null;
@@ -665,8 +910,9 @@ function openS(sid){
   if(es)es.close(); rate={n:0,t:Date.now(),last:null}; mPrev=null;
   for(const k in buf)buf[k]=[];
   $('jumpLive').style.display='none';
+  shotsSig=''; shotsMetaCache=null; $('shots').innerHTML='';
   startStream(sid);
-  render(); loadMiles(sid); pollMetrics(); pollBlk();
+  render(); loadMiles(sid); pollMetrics(); pollBlk(); pollShots();
 }
 function startStream(sid){
   if(es)es.close();
@@ -813,13 +1059,86 @@ function drawBlk(bk){
   x.putImageData(img,0,0);
 }
 
+// ── screenshots: decoded base64 PNG streams (VGA framebuffer + FF render) ──
+// Two DISTINCT streams a firefox-test/test-mode boot emits, labeled
+// unambiguously so a VGA framebuffer is never mistaken for a Firefox render.
+// Metadata comes from /api/screenshots (no PNG bytes); each present stream's
+// <img src> points at /api/screenshot?kind=… which decodes + serves the PNG.
+let shotsSig='';                     // cache-bust + change-detect signature
+function pctOf(s){return s.complete?100:(s.partial_pct!=null?s.partial_pct:0);}
+function shotCard(sid,kind,s){
+  const cls='shot '+kind;
+  const tag=kind==='vga'?'VGA':'FF';
+  // image src: cache-bust on (chunks,complete) so a growing partial refreshes,
+  // but a frozen complete log isn't re-decoded every poll.
+  const v=encodeURIComponent(sid)+'.'+kind+'.'+s.chunks+'.'+(s.complete?1:0);
+  const src='/api/screenshot?sid='+encodeURIComponent(sid)+'&kind='+kind+'&v='+v;
+  const dims=s.w!=null?(s.w+'×'+s.h):'—';
+  const comp=s.complete
+    ?'<span class=ok>✓ complete</span>'
+    :'<span class=part>◔ partial '+pctOf(s)+'%</span>';
+  const chunks=s.total!=null?(s.chunks+'/'+s.total+' chunks'):(s.chunks+' chunks');
+  const thumb=s.sig_ok
+    ?('<div class=thumb data-kind="'+kind+'" data-src="'+src+'"><img src="'+src+'" alt="'+s.label+'"></div>')
+    :('<div class="thumb empty">stream present but no valid PNG yet<br><small>'+(s.error||'awaiting chunks')+'</small></div>');
+  return '<div class="'+cls+'">'
+    +'<div class=knd><span class=tag>'+tag+'</span>'+s.label+'</div>'
+    +thumb
+    +'<div class=src>'+s.source+'<br>session <b>'+sid+'</b></div>'
+    +'<div class=stat>'+comp+' <span class=dim>'+dims+'</span> '+chunks
+      +(s.bytes?' · '+bytes(s.bytes):'')+'</div>'
+    +'<div class=pbar><i style=width:'+pctOf(s)+'%></i></div>'
+    +'</div>';
+}
+let shotsMetaCache=null;             // last metadata (for the lightbox caption)
+async function pollShots(){
+  if(!cur||!$('tShots').classList.contains('on'))return;
+  let m;try{m=await(await fetch('/api/screenshots?sid='+encodeURIComponent(cur))).json()}catch(e){return}
+  if(cur==null)return;
+  shotsMetaCache=m;
+  const present=['vga','ff'].filter(k=>m[k]&&m[k].present);
+  // signature: only re-render when something actually changed (avoids the <img>
+  // flicker that re-setting innerHTML every poll would cause).
+  const sig=present.map(k=>k+':'+m[k].chunks+':'+(m[k].complete?1:0)+':'+(m[k].sig_ok?1:0)).join('|');
+  $('shots').className='show';
+  if(!present.length){
+    if(shotsSig!=='__none__'){
+      $('shots').innerHTML='<div class=hd>screenshots</div><div class=hint>'
+        +'No <b>[SCREENSHOT-B64]</b> (VGA framebuffer, Test 198) or '
+        +'<b>[FF-OUT-PNG-B64]</b> (Firefox render, /tmp/out.png) stream in this log. '
+        +'A <b>firefox-test</b> / <b>test-mode</b> boot emits these after the screenshot is taken.</div>';
+      shotsSig='__none__';
+    }
+    return;
+  }
+  if(sig===shotsSig)return; shotsSig=sig;
+  $('shots').innerHTML='<div class=hd>screenshots · decoded base64 PNG streams</div>'
+    +'<div class=grid>'+present.map(k=>shotCard(cur,k,m[k])).join('')+'</div>';
+  $('shots').querySelectorAll('.thumb[data-src]').forEach(e=>{
+    e.onclick=()=>openLightbox(e.dataset.src,e.dataset.kind);});
+}
+function openLightbox(src,kind){
+  const m=shotsMetaCache&&shotsMetaCache[kind];
+  $('lbimg').src=src;
+  if(m){
+    const comp=m.complete?'<b>complete</b>':'<span class=part>partial '+pctOf(m)+'%</span>';
+    $('lbcap').innerHTML=m.label+' · session '+cur+' · '
+      +(m.w!=null?m.w+'×'+m.h+' · ':'')+comp
+      +(m.total!=null?' · '+m.chunks+'/'+m.total+' chunks':'');
+  } else $('lbcap').textContent=kind;
+  $('lightbox').classList.add('show');
+}
+$('lightbox').onclick=()=>$('lightbox').classList.remove('show');
+document.addEventListener('keydown',e=>{if(e.key==='Escape')$('lightbox').classList.remove('show');});
+
 // toggles
 function tog(btn,after){btn.onclick=()=>{btn.classList.toggle('on');
   if(btn===$('tRail'))$('rail').classList.toggle('open',btn.classList.contains('on'));
   if(btn===$('tMetrics')&&!btn.classList.contains('on')){$('metrics').classList.remove('show');$('pids').classList.remove('show');}
   if(btn===$('tBlk')&&!btn.classList.contains('on'))$('blk').classList.remove('show');
+  if(btn===$('tShots')&&!btn.classList.contains('on'))$('shots').classList.remove('show');
   if(after&&btn.classList.contains('on'))after();};}
-tog($('tMetrics'),pollMetrics);tog($('tBlk'),pollBlk);tog($('tRail'),null);
+tog($('tMetrics'),pollMetrics);tog($('tBlk'),pollBlk);tog($('tShots'),pollShots);tog($('tRail'),null);
 $('tRail').onclick=()=>{$('tRail').classList.toggle('on');$('rail').classList.toggle('open',$('tRail').classList.contains('on'));};
 
 setInterval(()=>{const now=Date.now(),dt=(now-rate.t)/1000;if(dt>=2){const r=rate.n/dt;rate.last=r;$('rate').textContent=cur?r.toFixed(0)+' ln/s':'';rate={n:0,t:now,last:r};}},1000);
@@ -827,6 +1146,7 @@ refresh(); setInterval(refresh,3000);
 setInterval(()=>{if(cur)loadMiles(cur);},5000);
 setInterval(pollMetrics,2000);
 setInterval(pollBlk,3000);
+setInterval(pollShots,4000);
 </script></body></html>"""
 
 
@@ -897,10 +1217,79 @@ class H(BaseHTTPRequestHandler):
             except (OSError, ValueError):
                 size, grid = 0, 256
             self._json(scan_blkmap(p, size, grid))
+        elif u.path == "/api/screenshots":
+            # metadata for BOTH streams (no PNG bytes) — the UI uses this to
+            # decide which thumbnails to show without decoding twice.
+            p = self._log_path(q.get("sid", [""])[0])
+            if not p:
+                self._hdr(404, "text/plain"); self.wfile.write(b"no log"); return
+            self._json(scan_screenshots(p))
+        elif u.path == "/api/screenshot":
+            self._screenshot(q.get("sid", [""])[0], q.get("kind", ["vga"])[0])
         elif u.path == "/api/stream":
             self._stream(q.get("sid", [""])[0])
         else:
             self._hdr(404, "text/plain"); self.wfile.write(b"404")
+
+    def _screenshot(self, sid, kind):
+        """Decode a session's screenshot stream and serve it as image/png.
+
+        kind=vga -> the VGA framebuffer ([SCREENSHOT-B64:…], Test 198);
+        kind=ff  -> Firefox's render (/tmp/out.png, [FF-OUT-PNG-B64:…]).
+
+        Partial / in-progress streams are served best-effort (HTTP 200, with an
+        X-Screenshot-Complete: false header so the caller can tell). Only a
+        genuinely absent or signature-invalid stream returns a JSON 404 — we
+        never 500 on a truncated log."""
+        if kind not in _SHOT_KINDS:
+            self._hdr(400, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "bad_kind",
+                 "valid": sorted(_SHOT_KINDS)}).encode())
+            return
+        p = self._log_path(sid)
+        if not p:
+            self._hdr(404, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "no_log", "sid": sid}).encode())
+            return
+        d = _decode_shot(p, kind)
+        png = d.get("png") or b""
+        # No valid PNG to serve: report clearly as JSON (never 500). Either the
+        # stream is absent, or its leading bytes aren't a PNG (torn/garbage).
+        if not d["present"] or not d["sig_ok"] or len(png) < 8:
+            self._hdr(404, "application/json")
+            self.wfile.write(json.dumps({
+                "ok": False,
+                "error": ("no_stream" if not d["present"]
+                          else (d.get("error") or "no_valid_png")),
+                "sid": sid, "kind": kind, "label": d["label"],
+                "present": d["present"], "chunks": d["chunks"],
+                "total": d["total"], "bytes": d["bytes"],
+            }).encode())
+            return
+        # Serve the PNG (complete or partial). Custom X- headers carry the
+        # provenance so callers/curl can see kind + completeness without the
+        # metadata endpoint. Content-Disposition names it for a save.
+        extra = {
+            "X-Screenshot-Kind":     kind,
+            "X-Screenshot-Label":    d["label"],
+            "X-Screenshot-Complete": "true" if d["complete"] else "false",
+            "X-Screenshot-Chunks":   f"{d['chunks']}/{d['total']}"
+                                     if d["total"] is not None else str(d["chunks"]),
+            "X-Screenshot-Bytes":    str(len(png)),
+            "Cache-Control":         "no-cache",
+            "Content-Disposition":   f'inline; filename="{sid}.{kind}.png"',
+        }
+        if d["w"] is not None:
+            extra["X-Screenshot-Dimensions"] = f"{d['w']}x{d['h']}"
+        if d["partial_pct"] is not None:
+            extra["X-Screenshot-Partial-Pct"] = str(d["partial_pct"])
+        try:
+            self._hdr(ctype="image/png", extra=extra)
+            self.wfile.write(png)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
 
     def _stream(self, sid):
         path = self._log_path(sid)


### PR DESCRIPTION
## What

The serial monitor dashboard (`scripts/serial-web.py`, served on :8088) now **decodes and displays** the two distinct base64 PNG streams a `firefox-test` / `test-mode` boot emits over serial — so a human can SEE them rendered, each labeled unambiguously.

A human recently confused a `[SCREENSHOT-B64]` (the VGA framebuffer) for a Firefox render. The two streams are genuinely different images:

| kind | markers | what it is |
|---|---|---|
| `vga` | `[SCREENSHOT-B64:N/M]` … `[SCREENSHOT-B64-END]` | **VGA framebuffer (Test 198)** — the guest console/GUI screen (800×450 RGBA in practice) |
| `ff` | `[FF-OUT-PNG:…]` `[FF-OUT-PNG-B64:N/M]` … END | **Firefox render (/tmp/out.png)** — FF's actual rendered page (the demo-goal output), emitted after FF exits |

The decode mirrors `qemu-harness.py read-png` / `read-ff-png`: collect chunks in index order, concatenate the base64, decode (RFC 4648 §4), verify the PNG signature (W3C PNG §5.2 / ISO 15948).

## Endpoints (additive — nothing renamed)

- **`GET /api/screenshot?sid=&kind=vga|ff`** → `Content-Type: image/png`. Serves the decoded PNG. **Partial / in-progress streams degrade gracefully** (HTTP 200 + `X-Screenshot-Complete: false` + `X-Screenshot-Partial-Pct`); absent / signature-invalid streams return a clear **JSON 404 — never a 500**. Provenance on `X-Screenshot-*` headers (kind, label, complete, chunks, bytes, dimensions). Dimensions parsed from the IHDR (PNG §11.2.2) — no image library; the browser renders the PNG.
- **`GET /api/screenshots?sid=`** → `{vga:{present,complete,chunks,total,w,h,partial_pct,…}, ff:{…}}` metadata so the UI knows what to show without decoding twice.

## UI

A **"Screenshots" panel** (toolbar toggle, dark-theme-matched) shows an inline thumbnail per present stream, each clearly **labeled with its kind**, source session, dimensions, and completeness (`✓ complete` / `◔ partial N%`). Clicking opens a full-size lightbox. The `<img src>` points at `/api/screenshot` — offline, self-contained, no CDN. Thumbnail src cache-busts on `(chunks, complete)` so a growing partial refreshes while a frozen complete log isn't re-decoded each poll.

## Validation (host-only, no boot)

- Complete fixture `fcc3cb95d128` (25275/25275 chunks) decodes to a valid 800×450 RGBA PNG.
- Partial fixture `137d5d460cc0` (16990/25275) decodes best-effort to a valid-prefix PNG, `complete=false`, `partial_pct=67`, **no error**.
- `serial-web-smoke.py` extended with complete + partial coverage for **both** kinds (synthetic PNGs via stdlib `zlib`, no Pillow), HTTP-layer checks (image/png, headers, JSON 404 on absent, 400 on bad kind), and an opportunistic real-fixture check (skipped silently in CI).
- Path-traversal rejected on both new endpoints (inherited `_log_path` SID validation + realpath prefix).

## Why CI-safe

Server is Python-stdlib only. The smoke suite uses synthetic fixtures (CI has no `~/.astryx-harness` logs), so the new `tooling-smoke` checks pass without a kernel boot. **Failure mode this prevents:** a regression in the base64-chunk decode, the partial-stream trimming, or the PNG signature/dimension parse silently breaking the screenshot viewer with no kernel-boot job to catch it.

## Files

- `scripts/serial-web.py` — decode module + 2 endpoints + UI panel/lightbox
- `scripts/serial-web-smoke.py` — screenshot decode coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)