### PR TITLE
harness: livelock auto-reap guard for spinning FF render boots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,14 @@ jobs:
         run: python3 scripts/perf-bench-smoke.py
       - name: perf baseline-linux smoke (record shape)
         run: python3 scripts/perf-baseline-linux-smoke.py
+      # Host-only subset of the harness smoke: the data.img staleness detector,
+      # the ci/allow-fail allowlist, the snap-gate/blk-trace CLI surfaces, the
+      # PNG decoders, AND the livelock auto-reap detector (LivelockDetector +
+      # the pid=1 PROC-METRICS sc regex + the new `start` flags). No QEMU boot.
+      # Failure mode this prevents: a refactor silently breaking the livelock
+      # guard so a spinning FF render boot pins a host core indefinitely.
+      - name: qemu-harness host-only smoke (staleness + livelock reap)
+        run: python3 scripts/qemu-harness-smoke.py --staleness-only
 
   kernel-build:
     name: bootloader + kernel builds

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -918,6 +918,126 @@ def run_kdb_read_png_check():
     print()
 
 
+def run_livelock_reap_check():
+    """
+    Tier 1.5 host-only check: the LivelockDetector + the auto-reap CLI surface.
+
+    No QEMU launched (< 1s). Drives the pure detector with synthetic metrics
+    sequences so a future refactor cannot silently break the guard that stops a
+    spinning FF boot from pinning a core:
+
+      * a livelock sequence (pid=1 sc explodes while the deepest gate is frozen
+        past the wall-clock window) MUST flag `suspected` then `should_reap`
+      * a healthy sequence (sc climbs AND the gate advances) MUST NOT flag/reap
+      * a success sequence (reaches the png-write gate, then churns) MUST NOT
+        reap — a rendered screenshot is success, not a livelock
+      * --no-livelock-reap / a 0 threshold disables the guard
+      * the pid=1 PROC-METRICS sc regex extracts the count from an interleaved
+        line and ignores pid!=1 metrics
+      * the new `start` flags are advertised in --help
+    """
+    print("=== Tier 1.5: livelock auto-reap detector + CLI (host-only) ===")
+    print()
+
+    import importlib.util
+    h_path = Path(__file__).resolve().parent / "qemu-harness.py"
+    spec = importlib.util.spec_from_file_location("qemu_harness_smoke_ll", h_path)
+    mod = importlib.util.module_from_spec(spec)
+    _orig_argv = sys.argv
+    sys.argv = ["qemu-harness.py", "list"]
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    finally:
+        sys.argv = _orig_argv
+
+    LD = getattr(mod, "LivelockDetector", None)
+    check("LivelockDetector importable", LD is not None, "")
+    if LD is None:
+        return
+    SC = 50_000_000
+    SECS = 180.0
+    # The success gate is the last FF ladder index — derive it the same way the
+    # watcher does so the test tracks the real ladder length.
+    try:
+        SUCCESS = len(mod._load_ff_gates()) - 1
+    except Exception:
+        SUCCESS = 7
+
+    # ── Livelock: sc 0->200M while gate frozen at idx 5, past the window ───────
+    d = LD(reap_sc=SC, reap_secs=SECS, success_gate_idx=SUCCESS)
+    d.observe(sc=100, gate_idx=5, now=1000.0)
+    d.observe(sc=200_000_000, gate_idx=5, now=1060.0)   # 60s: churn but no time
+    check("livelock: suspected before window",   d.suspected is True, "")
+    check("livelock: NOT reaped before window",  d.should_reap(now=1060.0) is False, "")
+    d.observe(sc=200_000_000, gate_idx=5, now=1200.0)   # 200s: window elapsed
+    reap = d.should_reap(now=1200.0)
+    check("livelock: reaped after window",       reap is True, "")
+    check("livelock: sc_at_reap latched",        d.reap_sc_at == 200_000_000, str(d.reap_sc_at))
+    check("livelock: frozen_secs latched",       round(d.reap_frozen_secs) == 200, str(d.reap_frozen_secs))
+    check("livelock: reap latches (2nd False)",  d.should_reap(now=1200.0) is False, "")
+
+    # ── Healthy: sc climbs AND gate advances every step → never flag/reap ──────
+    d2 = LD(reap_sc=SC, reap_secs=SECS, success_gate_idx=SUCCESS)
+    t, sc, flagged, reaped = 0.0, 0, False, False
+    for g in range(0, min(7, SUCCESS)):
+        t += 60; sc += 60_000_000
+        d2.observe(sc=sc, gate_idx=g, now=t)
+        flagged = flagged or d2.suspected
+        reaped = reaped or d2.should_reap(now=t)
+    check("healthy: never suspected",            flagged is False, "")
+    check("healthy: never reaped",               reaped is False, "")
+
+    # ── Success: reach png-write then churn hard → never reap ─────────────────
+    d3 = LD(reap_sc=SC, reap_secs=SECS, success_gate_idx=SUCCESS)
+    t = 0.0
+    for g in range(0, SUCCESS + 1):
+        t += 10; d3.observe(sc=g * 1000, gate_idx=g, now=t)
+    d3.observe(sc=900_000_000, gate_idx=SUCCESS, now=t + 10_000)
+    check("success: not suspected after png",    d3.suspected is False, "")
+    check("success: not reaped after png",       d3.should_reap(now=t + 10_000) is False, "")
+
+    # ── Disabled paths ────────────────────────────────────────────────────────
+    d4 = LD(reap_sc=SC, reap_secs=SECS, enabled=False, success_gate_idx=SUCCESS)
+    d4.observe(sc=100, gate_idx=5, now=0); d4.observe(sc=500_000_000, gate_idx=5, now=10_000)
+    check("disabled(enabled=False): inert",      not d4.suspected and not d4.should_reap(now=10_000), "")
+    check("disabled(reap_sc=0): enabled False",  LD(reap_sc=0, reap_secs=SECS).enabled is False, "")
+    check("disabled(reap_secs=0): enabled False", LD(reap_sc=SC, reap_secs=0).enabled is False, "")
+
+    # ── Under-threshold churn never reaps ─────────────────────────────────────
+    d5 = LD(reap_sc=SC, reap_secs=SECS, success_gate_idx=SUCCESS)
+    d5.observe(sc=0, gate_idx=3, now=0); d5.observe(sc=40_000_000, gate_idx=3, now=10_000)
+    check("under-threshold: never reaped",       d5.should_reap(now=10_000) is False, "")
+
+    # ── No-gate boot that churns → SHOULD reap (wedge before any gate) ─────────
+    d6 = LD(reap_sc=SC, reap_secs=SECS, success_gate_idx=SUCCESS)
+    d6.observe(sc=0, gate_idx=-1, now=0); d6.observe(sc=200_000_000, gate_idx=-1, now=300)
+    check("no-gate churn: reaped",               d6.should_reap(now=300) is True, "")
+
+    # ── pid=1 PROC-METRICS sc regex ───────────────────────────────────────────
+    RE = getattr(mod, "_PROC_METRICS_PID1_SC_RE", None)
+    check("pid=1 sc regex present", RE is not None, "")
+    if RE is not None:
+        ln = (b"[FUTEX_WAIT_STACK] tid=60 pid=1 uaddr=0x7e[PROC-METRICS] "
+              b"tick=420514 pid=1 name=/disk/usr/lib/firefox-esr/firefox-bin "
+              b"sc=758998 (vm=6446 file=300940)")
+        m = RE.search(ln)
+        check("pid=1 sc from interleaved line",  bool(m) and int(m.group(1)) == 758998,
+              str(m.group(1) if m else None))
+        check("pid=2 metrics ignored",
+              RE.search(b"[PROC-METRICS] tick=500 pid=2 name=x sc=12345 (...)") is None, "")
+        check("pid=12 metrics ignored",
+              RE.search(b"[PROC-METRICS] tick=1 pid=12 name=x sc=5 (...)") is None, "")
+
+    # ── start --help advertises the new flags ─────────────────────────────────
+    _, raw, _ = _h("start", "--help")
+    check("start --livelock-reap-sc advertised",   "--livelock-reap-sc" in raw, "")
+    check("start --livelock-reap-secs advertised", "--livelock-reap-secs" in raw, "")
+    check("start --no-livelock-reap advertised",   "--no-livelock-reap" in raw, "")
+    print()
+
+
 def run_blk_trace_argv_check():
     """
     Tier 1.5 host-only check: blk-trace drain/flush CLI + `start --build-only`.
@@ -1004,6 +1124,7 @@ def main():
     run_read_ff_png_check()
     run_kdb_read_png_check()
     run_blk_trace_argv_check()
+    run_livelock_reap_check()
 
     if args.staleness_only:
         # Early exit for CI cycles that just want the cheap host-only checks.

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -53,6 +53,23 @@ Tier 1 — session management:
                                           [--gdb-port PORT] [--gdb-wait]
                                           [--firefox-variant musl|glibc]
                                           [--snapshottable]
+                                          [--livelock-reap-sc N]
+                                          [--livelock-reap-secs SECS]
+                                          [--no-livelock-reap]
+        Livelock auto-reap (default ON): a spinning FF render boot — pid 1
+        busy-looping (waitpid/futex) while the deepest gate is frozen — drives
+        the pid=1 syscall count into the hundreds-of-millions/billions at ~100%
+        host CPU with NO forward progress.  The watcher auto-stops such a boot
+        so it stops pinning a core and skewing concurrent timing runs.  The
+        rule: once the pid=1 syscall count churns by > --livelock-reap-sc
+        (default 50,000,000) WHILE the deepest FF gate stays frozen for longer
+        than --livelock-reap-secs (default 180s), the session is cleanly stopped
+        (same path as `stop`), marked terminal_cause="livelock-autoreap" in the
+        session JSON + events.jsonl, and a "[HARNESS] livelock auto-reap: …"
+        line is logged.  BEFORE a reap, `status`/`list`/the serial monitor show
+        a live `livelock_suspected: true` flag.  Pass --no-livelock-reap (or set
+        either threshold to 0) to keep a spinning session alive for inspection
+        (debugging/autopsy holds).
     python3 scripts/qemu-harness.py stop <sid>
     python3 scripts/qemu-harness.py list
     python3 scripts/qemu-harness.py wait <sid> <regex> [--ms MS]
@@ -899,6 +916,234 @@ _IDLE_SECONDS = 30
 # kernel-only form serial-web/perf_markers use ([HB]/PROC-METRICS tick=).
 _WATCH_TICK_RE = re.compile(r"(?:\[HB\]|PROC-METRICS\]) tick=(\d+)")
 
+# ── Livelock auto-reap ────────────────────────────────────────────────────────
+#
+# A spinning FF render boot (the livelock variant of the screenshot-IPC stall —
+# e.g. pid 1 busy-looping on waitpid/futex while the deepest gate is frozen)
+# drives the pid=1 syscall counter into the hundreds-of-millions / billions at
+# ~100% host CPU while making NO forward progress.  Left alone it pins a core
+# until the wall-clock timeout, skewing concurrent timing boots.  The watcher
+# already tails the serial log; the detector below turns "huge syscall churn,
+# zero gate progress" into a clean auto-stop.
+#
+# The authoritative live pid=1 syscall count comes from the per-process metrics
+# line the kernel emits every ~500 ticks:
+#
+#   [PROC-METRICS] tick=420514 pid=1 name=/disk/.../firefox-bin sc=758998 (...)
+#
+# That line can be prefixed by another marker on the same physical line (the
+# serial mux interleaves emitters), so the regex anchors on the `PROC-METRICS]`
+# token rather than start-of-line.  Only pid=1 is tracked (the dispatching
+# process whose runaway churn is the symptom).
+_PROC_METRICS_PID1_SC_RE = re.compile(rb"PROC-METRICS\] .*?\bpid=1\b.*?\bsc=(\d+)")
+
+# Defaults: ON.  A boot must churn > 50M pid=1 syscalls with the deepest gate
+# frozen for > 180 s of wall-clock before it is reaped.  Both are tunable per
+# session via `start --livelock-reap-sc N --livelock-reap-secs N`, and the whole
+# guard is disabled with `start --no-livelock-reap`.
+LIVELOCK_REAP_SC_DEFAULT   = 50_000_000
+LIVELOCK_REAP_SECS_DEFAULT = 180.0
+
+
+class LivelockDetector:
+    """Pure (no-I/O) "syscall-churn-without-gate-progress" detector.
+
+    The watcher feeds it observations as the serial log advances:
+
+        det = LivelockDetector(reap_sc=50_000_000, reap_secs=180.0)
+        det.observe(sc=12_345, gate_idx=3, now=t)   # repeatedly
+        if det.suspected: ...                       # live "coming" flag
+        if det.should_reap(now=t): reap()           # terminal verdict
+
+    State is a single moving anchor: the (sc, time) captured the last time the
+    *deepest gate index* advanced.  Livelock is declared when, relative to that
+    anchor, the syscall counter has advanced by more than `reap_sc` AND the gate
+    has stayed put for more than `reap_secs` of wall-clock.  Any gate advance
+    re-anchors and clears suspicion, so a boot that is churning syscalls *and*
+    making progress is never flagged.
+
+    `suspected` is the early-warning flag (both conditions partially met — churn
+    over threshold, gate frozen, but the time window not yet elapsed) so a
+    dashboard can badge a spinning session *before* it is reaped.  `should_reap`
+    is the strict terminal predicate.
+
+    `success_gate_idx` (the last/png-write gate index) makes the detector REFUSE
+    to suspect or reap once the success gate is reached — a boot that rendered
+    the screenshot is done, not livelocked, even if it keeps churning syscalls
+    afterwards.  Pass -1 (the default) to disable this guard.
+
+    Disabled (`enabled=False`, set when reap_sc<=0 or reap_secs<=0, or
+    --no-livelock-reap) the detector observes but never suspects or reaps.
+    """
+
+    def __init__(self, reap_sc: int, reap_secs: float, enabled: bool = True,
+                 success_gate_idx: int = -1):
+        self.reap_sc = int(reap_sc)
+        self.reap_secs = float(reap_secs)
+        # A non-positive threshold (either axis) disables the guard outright —
+        # callers can pass 0 to mean "off" without a separate flag.
+        self.enabled = bool(enabled) and self.reap_sc > 0 and self.reap_secs > 0
+        # The success/terminal gate index (png-write).  Once the boot reaches
+        # it the detector goes inert — a rendered screenshot is success, never
+        # a livelock.  -1 = no success gate (detector always armed).
+        self.success_gate_idx = int(success_gate_idx)
+        self.anchor_sc = 0          # pid=1 sc at the last gate advance
+        self.anchor_time = None     # wall-clock at the last gate advance
+        self.deepest_gate_idx = -1  # deepest FF gate index seen so far
+        self.last_sc = 0            # most recent pid=1 sc observed
+        self.last_gate_idx = -1
+        # Frozen at reap time so the event/JSON report the exact numbers that
+        # tripped the guard.
+        self.reaped = False
+        self.reap_sc_at = None
+        self.reap_frozen_secs = None
+
+    def observe(self, sc, gate_idx, now):
+        """Record one observation.  `sc` is the latest pid=1 syscall count (or
+        None if this line carried no pid=1 metrics), `gate_idx` the deepest FF
+        gate index reached so far (-1 = none), `now` a monotonic timestamp."""
+        if self.anchor_time is None:
+            # First observation establishes the baseline anchor.
+            self.anchor_time = now
+            self.anchor_sc = sc if sc is not None else 0
+        if sc is not None:
+            self.last_sc = sc
+        if gate_idx is not None and gate_idx > self.deepest_gate_idx:
+            # Forward progress — re-anchor (clears any accumulated suspicion).
+            self.deepest_gate_idx = gate_idx
+            self.anchor_sc = self.last_sc
+            self.anchor_time = now
+        self.last_gate_idx = self.deepest_gate_idx
+
+    @property
+    def sc_delta(self) -> int:
+        return self.last_sc - self.anchor_sc
+
+    def frozen_secs(self, now) -> float:
+        if self.anchor_time is None:
+            return 0.0
+        return now - self.anchor_time
+
+    @property
+    def _reached_success(self) -> bool:
+        """True once the deepest gate is at/past the success (png-write) gate —
+        the boot rendered the screenshot, so it is success, never a livelock."""
+        return (self.success_gate_idx >= 0
+                and self.deepest_gate_idx >= self.success_gate_idx)
+
+    @property
+    def suspected(self) -> bool:
+        """Live early-warning: churn over threshold while the gate is frozen.
+
+        Intentionally does NOT require the time window — it is the "this is
+        heading for a reap" badge a human/agent sees on the dashboard before
+        the terminal verdict fires.  False when disabled or once the success
+        gate (png-write) has been reached."""
+        if not self.enabled or self._reached_success:
+            return False
+        return self.sc_delta > self.reap_sc
+
+    def should_reap(self, now) -> bool:
+        """Strict terminal predicate: churn over threshold AND gate frozen for
+        longer than the configured wall-clock window.  False when disabled,
+        already reaped, or once the success gate (png-write) has been reached."""
+        if not self.enabled or self.reaped or self._reached_success:
+            return False
+        if self.sc_delta <= self.reap_sc:
+            return False
+        if self.frozen_secs(now) <= self.reap_secs:
+            return False
+        # Latch the tripping numbers for the report.
+        self.reaped = True
+        self.reap_sc_at = self.last_sc
+        self.reap_frozen_secs = self.frozen_secs(now)
+        return True
+
+
+def _ll_persist_suspected(sid: str, suspected: bool, det: "LivelockDetector",
+                          gate_id):
+    """Stamp the live `livelock_suspected` early-warning flag (and the current
+    churn/frozen numbers) into the session JSON so `status`, `list`, and the
+    serial-monitor can badge a spinning session BEFORE it is reaped.  Additive
+    fields — never present on sessions started before this landed.  Best-effort:
+    a transient read/write race must not disturb the watcher."""
+    try:
+        sess = _load_session(sid)
+    except SystemExit:
+        return
+    sess["livelock_suspected"] = bool(suspected)
+    sess["livelock_info"] = {
+        "suspected":   bool(suspected),
+        "sc_delta":    det.sc_delta,
+        "frozen_gate": gate_id,
+        "reap_sc":     det.reap_sc,
+        "reap_secs":   det.reap_secs,
+        "enabled":     det.enabled,
+    }
+    try:
+        _save_session(sess)
+    except OSError:
+        pass
+
+
+def _ll_reap_session(sid: str, qmp_sock: str, pid: int,
+                     det: "LivelockDetector", gate_id):
+    """Clean-stop a livelocked session: record `terminal_cause` in the session
+    JSON + events, log a clear [HARNESS] line, then take QEMU down via the same
+    SIGTERM→SIGKILL path `stop` uses.  The session JSON is updated (NOT deleted)
+    so a post-mortem `status <sid>` still shows terminal_cause=livelock-autoreap;
+    a later explicit `stop <sid>` cleans the file up."""
+    frozen = det.reap_frozen_secs if det.reap_frozen_secs is not None else 0.0
+    sc_at = det.reap_sc_at if det.reap_sc_at is not None else det.last_sc
+    # Record on the session JSON first (so the verdict survives even if the
+    # kill below races a manual stop).
+    try:
+        sess = _load_session(sid)
+        sess["terminal_cause"] = "livelock-autoreap"
+        sess["livelock_suspected"] = True
+        sess["livelock_reap_result"] = {
+            "frozen_gate":  gate_id,
+            "sc_at_reap":   sc_at,
+            "sc_delta":     det.sc_delta,
+            "frozen_secs":  round(frozen, 1),
+            "reap_sc":      det.reap_sc,
+            "reap_secs":    det.reap_secs,
+            "reaped_at":    time.time(),
+        }
+        _save_session(sess)
+    except SystemExit:
+        pass
+    except OSError:
+        pass
+    _emit_event(sid, {
+        "event":        "livelock_autoreap",
+        "terminal_cause": "livelock-autoreap",
+        "frozen_gate":  gate_id,
+        "sc_at_reap":   sc_at,
+        "sc_delta":     det.sc_delta,
+        "frozen_secs":  round(frozen, 1),
+        "reap_sc":      det.reap_sc,
+        "reap_secs":    det.reap_secs,
+    })
+    # Clear, greppable host-side log line (goes to the detached watcher's stderr,
+    # which is /dev/null in production — the durable record is the event above).
+    sys.stderr.write(
+        f"[HARNESS] livelock auto-reap: sid={sid} gate={gate_id} "
+        f"sc={sc_at} sc_delta={det.sc_delta} "
+        f"(no gate progress for {round(frozen, 1)}s)\n")
+    # Take QEMU down — same SIGTERM→(3s)→SIGKILL escalation as cmd_stop.
+    if pid and _pid_alive(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            for _ in range(30):
+                if not _pid_alive(pid):
+                    break
+                time.sleep(0.1)
+            if _pid_alive(pid):
+                os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
 
 def _load_gate_marks():
     """Lazy-import the shared gate-marks helper. Returns the module, or None when
@@ -933,6 +1178,37 @@ def _watcher_thread(sid: str, serial_log: str, qmp_sock: str, pid: int):
     _gate_idx = 0
     _cur_tick = None
     _line_no = 0
+
+    # ── Livelock auto-reap setup ──────────────────────────────────────────────
+    # Read the per-session config (thresholds + opt-out) the `start` command
+    # stamped into the session JSON.  Tolerant of legacy sessions that predate
+    # this field — fall back to the built-in defaults (guard ON).
+    try:
+        _sess0 = _load_session(sid)
+    except SystemExit:
+        _sess0 = {}
+    _ll_cfg = (_sess0.get("livelock_reap") or {}) if isinstance(_sess0, dict) else {}
+    # FF gate ladder (same source as `ff-progress`) — forward-ordered deepest
+    # gate the boot has reached.  Best-effort: a missing ladder just leaves the
+    # detector observing sc-only (gate index never advances → it can still reap
+    # a boot that churns without ANY gate, which is the right behaviour).
+    try:
+        _ff_gates = _load_ff_gates()
+    except Exception:
+        _ff_gates = []
+    # The success gate is the last ladder entry (png-write).  Once reached the
+    # detector goes inert — a rendered screenshot is success, not a livelock.
+    _ll_success_idx = (len(_ff_gates) - 1) if _ff_gates else -1
+    _ll_det = LivelockDetector(
+        reap_sc   = _ll_cfg.get("reap_sc", LIVELOCK_REAP_SC_DEFAULT),
+        reap_secs = _ll_cfg.get("reap_secs", LIVELOCK_REAP_SECS_DEFAULT),
+        enabled   = _ll_cfg.get("enabled", True),
+        success_gate_idx = _ll_success_idx,
+    )
+    _ff_gate_idx = -1                # deepest FF gate index reached (-1 = none)
+    _ff_gate_id = None               # its stable id (for the reap report)
+    _ll_last_suspected = None        # last value pushed to the session JSON
+    _ll_last_persist = 0.0           # throttle session-JSON writes
 
     while _pid_alive(pid):
         try:
@@ -1006,6 +1282,48 @@ def _watcher_thread(sid: str, serial_log: str, qmp_sock: str, pid: int):
                             "snapshot": snap_name if snap_ok else None,
                             "snapshot_error": snap_err,
                         })
+
+                    # ── Livelock auto-reap: advance the FF gate index + feed
+                    # the detector the live pid=1 syscall count. Entirely
+                    # best-effort — wrapped so a malformed line can never take
+                    # the watcher's panic/idle duties down.
+                    try:
+                        _rawline = line.encode("utf-8", errors="replace")
+                        # Forward-ordered FF gate advance (same discipline as
+                        # ff-progress): one line may satisfy several gates.
+                        _is_ipc = bool(_FF_IPC_WRITE_RE.search(_rawline))
+                        while (_ff_gate_idx + 1) < len(_ff_gates):
+                            _g = _ff_gates[_ff_gate_idx + 1]
+                            if _g["kind"] == "ipc-body" and not _is_ipc:
+                                if not _g["regex"].search(_rawline):
+                                    break
+                            if not _g["regex"].search(_rawline):
+                                break
+                            _ff_gate_idx += 1
+                            _ff_gate_id = _g["id"]
+                        # Live pid=1 syscall count (None when this line carried
+                        # no pid=1 PROC-METRICS).
+                        _scm = _PROC_METRICS_PID1_SC_RE.search(_rawline)
+                        _sc_val = int(_scm.group(1)) if _scm else None
+                        _now = time.monotonic()
+                        _ll_det.observe(sc=_sc_val, gate_idx=_ff_gate_idx, now=_now)
+                        # Push the early-warning flag to the session JSON for
+                        # status/list/serial-web — but only when it CHANGES, and
+                        # at most every ~5 s, so we never thrash the JSON file.
+                        _susp = _ll_det.suspected
+                        if (_susp != _ll_last_suspected
+                                and (_now - _ll_last_persist) >= 5.0):
+                            _ll_persist_suspected(sid, _susp, _ll_det, _ff_gate_id)
+                            _ll_last_suspected = _susp
+                            _ll_last_persist = _now
+                        # Terminal verdict: churn over threshold AND gate frozen
+                        # for the configured wall-clock window → clean reap.
+                        if _ll_det.should_reap(now=_now):
+                            _ll_reap_session(sid, qmp_sock, pid, _ll_det,
+                                             _ff_gate_id)
+                            return
+                    except Exception:
+                        pass
                 last_size = size
                 last_activity = time.monotonic()
                 idle_event_sent = False
@@ -3499,6 +3817,21 @@ def cmd_start(args):
         "no_kvm_flag":        no_kvm_flag,
         "force_kvm_flag":     force_kvm_flag,
         "breakpoints": [],
+        # Livelock auto-reap config (read by the detached watcher). `enabled`
+        # is False when --no-livelock-reap was passed or either threshold was
+        # set to 0.  Additive — never present on sessions started before this
+        # landed; the watcher falls back to the built-in defaults (guard ON).
+        "livelock_reap": {
+            "enabled": (not getattr(args, "no_livelock_reap", False)
+                        and getattr(args, "livelock_reap_sc",
+                                    LIVELOCK_REAP_SC_DEFAULT) > 0
+                        and getattr(args, "livelock_reap_secs",
+                                    LIVELOCK_REAP_SECS_DEFAULT) > 0),
+            "reap_sc":   getattr(args, "livelock_reap_sc",
+                                 LIVELOCK_REAP_SC_DEFAULT),
+            "reap_secs": getattr(args, "livelock_reap_secs",
+                                 LIVELOCK_REAP_SECS_DEFAULT),
+        },
         # True when data.img was absent at session start (after any auto-symlink
         # attempt). Agents inspecting this field can immediately distinguish a
         # firefox-test wedge caused by missing /disk from a real regression.
@@ -3727,8 +4060,13 @@ def cmd_list(args):
                 sess = json.load(f)
             pid = sess.get("pid", 0)
             alive = _pid_alive(pid) if pid else False
-            if not alive:
-                # Prune dead session
+            stored_terminal = sess.get("terminal_cause")
+            if not alive and not stored_terminal:
+                # Prune dead session.  EXCEPTION: a session the watcher reaped
+                # for livelock carries a stored `terminal_cause` — keep it
+                # listed (with running=False) so the dashboard/agent sees the
+                # `livelock-autoreap` verdict.  An explicit `stop <sid>` removes
+                # the file when the operator is done with it.
                 p.unlink(missing_ok=True)
                 continue
             sessions.append({
@@ -3737,6 +4075,11 @@ def cmd_list(args):
                 "started_at": sess.get("started_at"),
                 "features":   sess.get("features"),
                 "running":    alive,
+                # Additive: authoritative terminal cause (livelock-autoreap when
+                # the watcher reaped a spinning boot) + the live early-warning
+                # flag for boots heading toward a reap.
+                "terminal_cause":     stored_terminal,
+                "livelock_suspected": bool(sess.get("livelock_suspected", False)),
             })
         except (json.JSONDecodeError, KeyError):
             pass
@@ -4166,6 +4509,11 @@ def cmd_status(args):
 
     exit_cause = _classify_exit_cause(sess["serial_log"], alive)
 
+    # Livelock auto-reap: a stored `terminal_cause` (set by the watcher when it
+    # reaped this session) is authoritative over the live-classified exit_cause.
+    stored_terminal = sess.get("terminal_cause")
+    terminal_cause = stored_terminal or (None if alive else exit_cause)
+
     _out({
         "running":         alive,
         "sid":             sid,
@@ -4174,6 +4522,16 @@ def cmd_status(args):
         "uptime_s":        round(uptime, 1),
         "features":        sess.get("features"),
         "exit_cause":      exit_cause,
+        # Authoritative terminal cause: `livelock-autoreap` when the watcher
+        # reaped a spinning boot, else the classified exit cause once dead,
+        # else None while still running.  Additive — never renames exit_cause.
+        "terminal_cause":  terminal_cause,
+        # Live early-warning flag: True when the boot is churning pid=1
+        # syscalls past the reap threshold with the deepest gate frozen, but
+        # the wall-clock window has not yet elapsed (a reap is "coming").
+        "livelock_suspected": bool(sess.get("livelock_suspected", False)),
+        "livelock_info":      sess.get("livelock_info"),
+        "livelock_reap_result": sess.get("livelock_reap_result"),
         # D10: Firefox variant pin.  Additive — never present on sessions
         # started before this field landed.  `kernel_chosen`/`match` are
         # filled in by the post-boot verifier once the [FFTEST] probe line
@@ -11240,6 +11598,31 @@ def main():
                                "Suppress the auto-restage with "
                                "--no-regen-data-img — the mismatch is still "
                                "warned about on stderr.")
+    # Livelock auto-reap (default ON).  A spinning FF render boot (pid 1
+    # busy-looping while the deepest gate is frozen) drives the pid=1 syscall
+    # counter into the hundreds-of-millions/billions at ~100% host CPU with no
+    # forward progress; the watcher auto-stops it so it stops pinning a core
+    # and skewing concurrent timing boots.
+    p_start.add_argument("--livelock-reap-sc", dest="livelock_reap_sc",
+                          type=int, default=LIVELOCK_REAP_SC_DEFAULT,
+                          metavar="N",
+                          help="Auto-reap a boot once its pid=1 syscall count "
+                               f"churns by > N (default {LIVELOCK_REAP_SC_DEFAULT:_}) "
+                               "WHILE the deepest FF gate stays frozen for longer "
+                               "than --livelock-reap-secs. Set to 0 to disable.")
+    p_start.add_argument("--livelock-reap-secs", dest="livelock_reap_secs",
+                          type=float, default=LIVELOCK_REAP_SECS_DEFAULT,
+                          metavar="SECS",
+                          help="Wall-clock window (default "
+                               f"{int(LIVELOCK_REAP_SECS_DEFAULT)}s) of zero "
+                               "deepest-gate progress that — combined with "
+                               "--livelock-reap-sc syscall churn — declares a "
+                               "livelock. Set to 0 to disable.")
+    p_start.add_argument("--no-livelock-reap", dest="no_livelock_reap",
+                          action="store_true",
+                          help="Disable the livelock auto-reap guard for this "
+                               "session entirely. Use for a debugging/autopsy "
+                               "hold you WANT to keep spinning for inspection.")
 
     # stop
     p_stop = sub.add_parser("stop", help="Kill a QEMU session")

--- a/scripts/serial-web.py
+++ b/scripts/serial-web.py
@@ -691,12 +691,19 @@ def list_sessions():
         feats, running, pid = "", None, None
         started_at, started_src = _launch_info(sid, log, st)
         meta = os.path.join(HARNESS_DIR, sid + ".json")
+        # Additive livelock-autoreap surfacing: the watcher stamps these onto
+        # the session JSON so the dashboard can badge a spinning boot before it
+        # is reaped (livelock_suspected) and show the verdict after (terminal).
+        livelock_suspected = False
+        terminal_cause = None
         if os.path.exists(meta):
             try:
                 m = json.load(open(meta))
                 feats = m.get("features", "") or ""
                 running = m.get("running")
                 pid = m.get("pid")
+                livelock_suspected = bool(m.get("livelock_suspected", False))
+                terminal_cause = m.get("terminal_cause")
             except Exception:
                 pass
         elapsed = (now - started_at) if started_at else None
@@ -704,6 +711,8 @@ def list_sessions():
              "age": age, "active": age < 20, "running": running, "pid": pid,
              "started_at": started_at, "started_src": started_src,
              "elapsed": int(elapsed) if elapsed is not None else None,
+             "livelock_suspected": livelock_suspected,
+             "terminal_cause": terminal_cause,
              "mtime": st.st_mtime}
         if age < GATE_SCAN_MAX_AGE:
             p = scan_progress(log)   # SAME source as the milestone rail


### PR DESCRIPTION
## Problem

A spinning Firefox render boot (the livelock variant of the screenshot-IPC stall — pid 1 busy-looping on `waitpid`/futex while the deepest gate is frozen) drives the pid=1 syscall counter into the **hundreds-of-millions / billions** at ~100% host CPU with **no forward progress**. Left alone it pins a full core until the wall-clock timeout, wasting cores and skewing concurrent timing boots. Two such sessions were recently found alive at 48 min (1.02B sc) and 6 min (140M sc), each burning a core. The harness tracked per-session `max_sc` but had no guard to reap a boot whose syscall count explodes without gate progress.

## What this adds

**`LivelockDetector`** (pure, no-I/O, unit-testable) — a single moving anchor at the `(sc, time)` of the last deepest-gate advance. Declares livelock when, relative to that anchor, the pid=1 syscall count has churned by more than `--livelock-reap-sc` (default **50,000,000**) **AND** the deepest FF gate has stayed frozen for longer than `--livelock-reap-secs` (default **180s**). Any gate advance re-anchors and clears suspicion, so a boot that churns *and* progresses is never flagged. Once the **success gate (`png-write`)** is reached the detector goes inert — a rendered screenshot is success, not a livelock.

**Watcher integration** — the detached session watcher parses the authoritative pid=1 syscall count from the `[PROC-METRICS] ... pid=1 ... sc=N` line (regex anchored on the `PROC-METRICS]` token, since the serial mux interleaves emitters) and advances the FF gate ladder (same source as `ff-progress`). On a reap it records `terminal_cause="livelock-autoreap"` + the frozen gate + sc-at-reap in the session JSON and `events.jsonl`, logs a clear `[HARNESS] livelock auto-reap: sid=… gate=… sc=… (no gate progress for Ns)` line, and cleanly stops QEMU (same SIGTERM→SIGKILL path as `stop`).

**Configurable + opt-out** — `start --livelock-reap-sc N --livelock-reap-secs N` (sane defaults ON), and `--no-livelock-reap` to keep a session spinning for a debugging/autopsy hold. Either threshold at `0` also disables.

**Structured visibility (all additive — no renames)** — `status` and `list` now show `terminal_cause` (incl. `livelock-autoreap`) and a live `livelock_suspected` flag (churn past threshold with the gate frozen, *before* the window elapses) so a human/agent sees a reap coming. `list` keeps a reaped session listed (`running=false` + `terminal_cause`) instead of pruning it, so the verdict survives until an explicit `stop`. `serial-web` `/api/sessions` surfaces `livelock_suspected` + `terminal_cause` per session so the dashboard can badge a spinning boot.

## Thresholds / detector logic

| Axis | Default | Flag | Meaning |
|---|---|---|---|
| syscall churn | 50,000,000 | `--livelock-reap-sc N` | pid=1 sc delta since the last gate advance |
| frozen window | 180 s | `--livelock-reap-secs S` | wall-clock the deepest gate has not advanced |
| opt-out | — | `--no-livelock-reap` | disable the guard for this session |

Reap fires only when **both** axes trip and the success gate has not been reached.

## Validation (host-only, no boot)

`run_livelock_reap_check` in `qemu-harness-smoke.py` drives the detector with synthetic **livelock / healthy / success / disabled / under-threshold / no-gate** sequences and the pid=1 sc regex (23 assertions), wired into the CI `tooling-smoke` job via `qemu-harness-smoke.py --staleness-only`. Replayed offline against the real billion-syscall serial logs in `~/.astryx-harness`, the detector reaps each at ~180s of frozen-gate time once churn passes 50M (e.g. one log at **15.3B** pid=1 sc, frozen at `lib-load`), and does **not** false-reap the slow-but-progressing boots.

**CI failure mode this prevents:** a refactor silently breaking the livelock guard so a spinning FF render boot pins a host core indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)