### PR TITLE
linux/waitid+wait4: fix siginfo_t offsets so FF parent stops spinning on WNOWAIT (render unblock)

### DIFF
--- a/docs/LINUX_SYSCALL_COVERAGE.md
+++ b/docs/LINUX_SYSCALL_COVERAGE.md
@@ -10,6 +10,22 @@ No GPL-contaminated derivation: all descriptions sourced from `man 2` pages and 
 
 ## Recent conformance fixes
 
+- **2026-06-05** — `waitid(2)` (247) `siginfo_t` field offsets corrected to the
+  x86\_64 (LP64) layout of `<asm-generic/siginfo.h>`: the `_sifields` union is
+  8-byte aligned and begins at offset 16, so `si_pid` is at **offset 16** (was
+  written at 12), `si_uid` at 20, and `si_status` at **24** (was never
+  written).  A reader that branches on `si_pid` — gecko's `IsProcessDead`
+  (`waitid(P_PID, …, WEXITED|WNOWAIT)` to observe, then a reaping `waitid`),
+  which does `if (si.si_pid == 0) return Running;` — saw a zeroed `si_pid`,
+  concluded the child was still alive, and re-issued the **blocking**
+  `waitid(WNOWAIT)` forever, pinning the caller's thread (observed as a
+  >900M-call `waitpid` spin that starved the Firefox render reactor).  The
+  exit status is now decomposed per the SIGCHLD contract (`CLD_EXITED` +
+  status, or `CLD_KILLED` + signal).  Companion fix: `wait4(2)` (61) now
+  writes the encoded `wstatus` (WIFEXITED/WEXITSTATUS, WIFSIGNALED/WTERMSIG)
+  per `wait(2)` — it previously ignored the `wstatus` pointer.  Pinned by
+  test 516 (byte-level `siginfo_t` layout) in `test_runner.rs`.  Per
+  POSIX.1-2017 `waitid(2)` / `wait(2)` and Linux `<asm-generic/siginfo.h>`.
 - **2026-05-30** — **musl / Linux-ABI completeness audit** added at
   `docs/MUSL_ABI_COMPLETENESS_AUDIT_2026-05-30.md`, scoped to the syscall
   surface musl libc (Alpine/libxul) actually issues.  Verdict: the surface is
@@ -175,7 +191,7 @@ Ranked by frequency in real program traces. Syscalls that would most unblock rea
 | 57 | `fork` | Full |
 | 59 | `execve` | Full; reads C-string path, delegates to exec subsystem |
 | 60 | `exit` | Full; exit_thread |
-| 61 | `wait4` | Full; delegates to sys_waitpid |
+| 61 | `wait4` | Full; reaps child and writes encoded `wstatus` (WIFEXITED/WEXITSTATUS, WIFSIGNALED/WTERMSIG) per wait(2) |
 | 62 | `kill` | Full; signal delivery |
 | 63 | `uname` | Full; returns AstryxOS utsname |
 | 65 | `shmctl` (note: UAPI 65 is `semop`) | Dispatches to sysv_shm::shmctl — **number mismatch: UAPI 65=semop, 31=shmdt, 67=shmdt** |
@@ -230,7 +246,7 @@ Ranked by frequency in real program traces. Syscalls that would most unblock rea
 | 232 | `epoll_wait` | Full |
 | 233 | `epoll_ctl` | Full |
 | 234 | `tgkill` | Full; signal by tgid |
-| 247 | `waitid` | Full; fills siginfo_t |
+| 247 | `waitid` | Full; honours WNOWAIT; fills `siginfo_t` at architectural x86-64 offsets (si_pid@16, si_uid@20, si_status@24) per `<asm-generic/siginfo.h>` |
 | 253 | `inotify_add_watch` | Full (stub impl but wired) |
 | 254 | `inotify_rm_watch` | Full (stub impl but wired) |
 | 257 | `openat` | Full; AT_FDCWD + relative path resolution |

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -4077,7 +4077,37 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             0 // dead — exit_thread diverges
         }
         // 61: wait4(pid, wstatus, options, rusage)
-        61 => crate::syscall::sys_waitpid(arg1 as i64, arg3 as u32),
+        //
+        // Returns the reaped child pid AND, when `wstatus` (arg2) is non-NULL,
+        // writes the encoded wait status so the caller's `WIFEXITED` /
+        // `WEXITSTATUS` / `WIFSIGNALED` / `WTERMSIG` macros decode correctly
+        // (Linux man-pages `wait(2)`, "status").  Without this, a `waitpid()`
+        // wrapper (musl/glibc `waitpid` → `wait4`) reads an uninitialised
+        // status and mis-classifies the child's exit.  Encoding:
+        //   normal exit:  (exit_status & 0xff) << 8
+        //   killed:       signo (low 7 bits); AstryxOS stores `-signo`.
+        61 => {
+            let want = arg1 as i64;
+            let mut exit_code: i32 = 0;
+            let ret = crate::syscall::sys_waitpid_ex(
+                want, (arg3 & 1) != 0 /*WNOHANG*/, false /*WNOWAIT*/,
+                Some(&mut exit_code));
+            if ret > 0 && arg2 != 0
+                && (crate::syscall::user_ptr_check_bypassed()
+                    || crate::syscall::validate_user_ptr(arg2, 4))
+            {
+                let wstatus: i32 = if exit_code < 0 {
+                    (-exit_code) & 0x7f                  // WIFSIGNALED: WTERMSIG
+                } else {
+                    (exit_code & 0xff) << 8              // WIFEXITED:  WEXITSTATUS
+                };
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::write_unaligned(arg2 as *mut i32, wstatus);
+                }
+            }
+            ret
+        }
         // 62: kill(pid, sig)
         62 => crate::signal::kill(arg1, arg2 as u8),
         // 72: fcntl(fd, cmd, arg)
@@ -4306,21 +4336,59 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             // waitid(reap)" idiom (used by process launchers to observe a
             // child's exit before collecting it) does not race-reap the child
             // on the first call and hang the second against an already-gone pid.
-            let ret = crate::syscall::sys_waitpid_ex(
-                pid, options & WNOHANG != 0, options & WNOWAIT != 0);
-            if ret > 0 && !infop.is_null() {
-                // Fill minimal siginfo_t: si_signo=SIGCHLD(17), si_errno=0,
-                // si_code=CLD_EXITED(1), si_pid=child_pid, si_status=exit_code
-                // siginfo_t is 128 bytes; we only fill the first 20 bytes.
-                unsafe {
-                    let _g = crate::arch::x86_64::smap::UserGuard::new();
-                    core::ptr::write_bytes(infop, 0, 128);
-                    core::ptr::write_unaligned(infop.add(0)  as *mut i32, 17); // si_signo = SIGCHLD
-                    core::ptr::write_unaligned(infop.add(8)  as *mut i32, 1);  // si_code  = CLD_EXITED
-                    core::ptr::write_unaligned(infop.add(12) as *mut i32, ret as i32); // si_pid
+            match crate::syscall::sys_waitid(
+                pid, options & WNOHANG != 0, options & WNOWAIT != 0)
+            {
+                crate::syscall::WaitidOutcome::Collected { pid: child, si_code, si_status } => {
+                    // Serialise the user `siginfo_t` for SIGCHLD per
+                    // POSIX.1-2017 `waitid(2)` and Linux
+                    // `<asm-generic/siginfo.h>`.  The x86-64 (LP64) field
+                    // offsets live in `crate::syscall` (si_pid @16, si_status
+                    // @24 — the `_sifields` union is 8-byte aligned and starts
+                    // at offset 16, NOT 12).  Writing si_pid at the wrong
+                    // offset makes a reader that branches on `si_pid` (gecko's
+                    // IsProcessDead: `if (si.si_pid == 0) return Running;`) see a
+                    // zero pid and busy-loop the blocking `waitid(WNOWAIT)`
+                    // forever, pinning the caller's thread.
+                    if !infop.is_null()
+                        && (crate::syscall::user_ptr_check_bypassed()
+                            || crate::syscall::validate_user_ptr(
+                                arg3, crate::syscall::SI_SIZE))
+                    {
+                        let uid = {
+                            let cur = crate::proc::current_pid_lockless();
+                            crate::proc::PROCESS_TABLE.lock()
+                                .iter().find(|p| p.pid == cur)
+                                .map(|p| p.uid as i32).unwrap_or(0)
+                        };
+                        let mut si = [0u8; crate::syscall::SI_SIZE];
+                        crate::syscall::fill_sigchld_siginfo(
+                            &mut si, si_code, child as i32, uid, si_status);
+                        unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            core::ptr::copy_nonoverlapping(
+                                si.as_ptr(), infop, crate::syscall::SI_SIZE);
+                        }
+                    }
+                    0 // waitid returns 0 on success (not child pid)
                 }
+                // WNOHANG, nothing ready: per `waitid(2)`, return 0 with a
+                // zeroed `si_pid` so the caller sees "no child changed state".
+                crate::syscall::WaitidOutcome::NoHang => {
+                    if !infop.is_null()
+                        && (crate::syscall::user_ptr_check_bypassed()
+                            || crate::syscall::validate_user_ptr(
+                                arg3, crate::syscall::SI_SIZE))
+                    {
+                        unsafe {
+                            let _g = crate::arch::x86_64::smap::UserGuard::new();
+                            core::ptr::write_bytes(infop, 0, crate::syscall::SI_SIZE);
+                        }
+                    }
+                    0
+                }
+                crate::syscall::WaitidOutcome::Err(e) => e, // negative errno
             }
-            if ret > 0 { 0 } else { ret } // waitid returns 0 on success (not child pid)
         }
         // 257: openat(dirfd, pathname, flags, mode)
         257 => {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2492,7 +2492,110 @@ pub(crate) fn sys_waitpid(pid: i64, options: u32) -> i64 {
     // The only POSIX option the legacy entry honours is WNOHANG (=1); see
     // `sys_waitpid_ex` for the WNOWAIT (peek-without-reap) variant used by
     // `waitid(2)`.
-    sys_waitpid_ex(pid, (options & 1) != 0 /*WNOHANG*/, false /*WNOWAIT*/)
+    sys_waitpid_ex(pid, (options & 1) != 0 /*WNOHANG*/, false /*WNOWAIT*/, None)
+}
+
+/// POSIX `<signal.h>` / Linux `<asm-generic/siginfo.h>` SIGCHLD `si_code`s.
+/// (POSIX.1-2017 `<signal.h>`; Linux man-pages `sigaction(2)`, "SIGCHLD".)
+pub(crate) const CLD_EXITED: i32 = 1; // child called _exit(2)
+pub(crate) const CLD_KILLED: i32 = 2; // child terminated by signal (no core)
+
+/// Result of a `waitid(2)` collect, decomposed for the user `siginfo_t`.
+pub(crate) enum WaitidOutcome {
+    /// A child changed state.  `si_code`/`si_status` follow the SIGCHLD
+    /// contract: `CLD_EXITED`+exit-status, or `CLD_KILLED`+signal number.
+    Collected { pid: u64, si_code: i32, si_status: i32 },
+    /// WNOHANG requested and no matching child has changed state.
+    NoHang,
+    /// Negative errno (e.g. `-ECHILD` when there is no matching child).
+    Err(i64),
+}
+
+/// Map AstryxOS's raw `exit_code` to the POSIX `waitid(2)` `(si_code,
+/// si_status)` pair.  A non-negative code is an `_exit(2)` status (`CLD_EXITED`,
+/// low 8 bits per `wait(2)` "WEXITSTATUS"); a negative code is `-signo` from a
+/// terminating signal (`CLD_KILLED`, `si_status = signo`) — AstryxOS encodes a
+/// signal-terminated child as `-signo` in the signal-default-terminate /
+/// SIGKILL paths of `signal::check_signals`.
+fn exit_code_to_siginfo(exit_code: i32) -> (i32, i32) {
+    if exit_code < 0 {
+        (CLD_KILLED, -exit_code)
+    } else {
+        (CLD_EXITED, exit_code & 0xff)
+    }
+}
+
+/// Test-only accessor for [`exit_code_to_siginfo`] (Test 516).
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+pub(crate) fn test_exit_code_to_siginfo(exit_code: i32) -> (i32, i32) {
+    exit_code_to_siginfo(exit_code)
+}
+
+// ── x86-64 `siginfo_t` field offsets (LP64) ─────────────────────────────────
+//
+// Per POSIX.1-2017 `<signal.h>` and Linux `<asm-generic/siginfo.h>`.  The
+// header is three `int`s (si_signo, si_errno, si_code) = 12 bytes, then the
+// `union __sifields`.  That union contains members with 8-byte alignment
+// (`void *_addr` in `_sigfault`, `__ARCH_SI_CLOCK_T _utime` in `_sigchld`), so
+// it is 8-byte aligned and begins at offset 16 — NOT 12.  The SIGCHLD arm
+// (`_sigchld`) then lays out `_pid` (16), `_uid` (20), `_status` (24).
+//
+// Total `siginfo_t` size is `SI_MAX_SIZE` = 128 bytes.
+pub(crate) const SI_SIZE:       usize = 128;
+pub(crate) const SI_OFF_SIGNO:  usize = 0;  // int si_signo
+pub(crate) const SI_OFF_CODE:   usize = 8;  // int si_code
+pub(crate) const SI_OFF_PID:    usize = 16; // pid_t _sigchld._pid  (union @16)
+pub(crate) const SI_OFF_UID:    usize = 20; // uid_t _sigchld._uid
+pub(crate) const SI_OFF_STATUS: usize = 24; // int   _sigchld._status
+
+// Compile-time guard: the SIGCHLD union fields must sit inside the struct and
+// past the 12-byte header (so they never alias si_signo/si_errno/si_code).
+const _: () = {
+    assert!(SI_OFF_PID >= 16 && SI_OFF_PID + 4 <= SI_SIZE);
+    assert!(SI_OFF_UID == SI_OFF_PID + 4);
+    assert!(SI_OFF_STATUS == SI_OFF_UID + 4);
+};
+
+/// Serialise a SIGCHLD `siginfo_t` for `waitid(2)` into a 128-byte buffer at
+/// the architectural x86-64 offsets.  Zeroes the whole struct first so no
+/// padding/union bytes leak.  Shared by the syscall handler and its test so the
+/// byte layout has a single source of truth.
+pub(crate) fn fill_sigchld_siginfo(
+    buf: &mut [u8; SI_SIZE],
+    si_code: i32,
+    si_pid: i32,
+    si_uid: i32,
+    si_status: i32,
+) {
+    *buf = [0u8; SI_SIZE];
+    const SIGCHLD: i32 = 17;
+    buf[SI_OFF_SIGNO..SI_OFF_SIGNO + 4].copy_from_slice(&SIGCHLD.to_ne_bytes());
+    buf[SI_OFF_CODE..SI_OFF_CODE + 4].copy_from_slice(&si_code.to_ne_bytes());
+    buf[SI_OFF_PID..SI_OFF_PID + 4].copy_from_slice(&si_pid.to_ne_bytes());
+    buf[SI_OFF_UID..SI_OFF_UID + 4].copy_from_slice(&si_uid.to_ne_bytes());
+    buf[SI_OFF_STATUS..SI_OFF_STATUS + 4].copy_from_slice(&si_status.to_ne_bytes());
+}
+
+/// `waitid(2)` collect that reports the full `siginfo_t` decomposition the
+/// syscall must hand back to user space.
+///
+/// This is the kernel side that makes gecko's `IsProcessDead`
+/// (`waitid(P_PID, …, WEXITED|WNOWAIT)` to observe, then a reaping `waitid`)
+/// terminate instead of busy-looping: that caller branches on `si.si_pid`
+/// (offset 16) and `si.si_code` (offset 8) per `<asm-generic/siginfo.h>`, so
+/// the syscall layer must serialise those fields at the architectural offsets,
+/// not return only the pid.  See POSIX.1-2017 `waitid(2)`.
+pub(crate) fn sys_waitid(pid: i64, wnohang: bool, wnowait: bool) -> WaitidOutcome {
+    let mut exit_code: i32 = 0;
+    let ret = sys_waitpid_ex(pid, wnohang, wnowait, Some(&mut exit_code));
+    if ret > 0 {
+        let (si_code, si_status) = exit_code_to_siginfo(exit_code);
+        WaitidOutcome::Collected { pid: ret as u64, si_code, si_status }
+    } else if ret == 0 {
+        WaitidOutcome::NoHang
+    } else {
+        WaitidOutcome::Err(ret)
+    }
 }
 
 /// Core wait implementation shared by `wait4(2)` and `waitid(2)`.
@@ -2509,7 +2612,17 @@ pub(crate) fn sys_waitpid(pid: i64, options: u32) -> i64 {
 ///
 /// Returns the reaped/peeked child pid (`> 0`), 0 (WNOHANG, nothing ready),
 /// or a negative errno (`-ECHILD` when there is no matching child at all).
-pub(crate) fn sys_waitpid_ex(pid: i64, wnohang: bool, wnowait: bool) -> i64 {
+///
+/// When a child is collected and `exit_out` is `Some`, the child's raw
+/// `exit_code` is written through it so the `waitid(2)` path can decompose it
+/// into the user `siginfo_t` (`si_code`/`si_status`).  `wait4(2)` callers pass
+/// `None` (they only need the pid).
+pub(crate) fn sys_waitpid_ex(
+    pid: i64,
+    wnohang: bool,
+    wnowait: bool,
+    mut exit_out: Option<&mut i32>,
+) -> i64 {
     let parent_pid = crate::proc::current_pid_lockless();
 
     crate::serial_println!(
@@ -2523,12 +2636,14 @@ pub(crate) fn sys_waitpid_ex(pid: i64, wnohang: bool, wnowait: bool) -> i64 {
             crate::serial_println!(
                 "[SYSCALL] waitpid: child PID {} exited with code {} (peeked, WNOWAIT)",
                 child_pid, exit_code);
+            if let Some(out) = exit_out.as_deref_mut() { *out = exit_code; }
             return child_pid as i64;
         }
     } else if let Some((child_pid, exit_code)) = crate::proc::waitpid(parent_pid, pid) {
         crate::serial_println!(
             "[SYSCALL] waitpid: child PID {} exited with code {}",
             child_pid, exit_code);
+        if let Some(out) = exit_out.as_deref_mut() { *out = exit_code; }
         return child_pid as i64;
     }
 
@@ -2631,6 +2746,7 @@ pub(crate) fn sys_waitpid_ex(pid: i64, wnohang: bool, wnowait: bool) -> i64 {
                 "[SYSCALL] waitpid: child PID {} exited with code {} (collected without park)",
                 child_pid, exit_code
             );
+            if let Some(out) = exit_out.as_deref_mut() { *out = exit_code; }
             return child_pid as i64;
         }
 
@@ -2668,6 +2784,7 @@ pub(crate) fn sys_waitpid_ex(pid: i64, wnohang: bool, wnowait: bool) -> i64 {
                 "[SYSCALL] waitpid: child PID {} exited with code {}",
                 child_pid, exit_code
             );
+            if let Some(out) = exit_out.as_deref_mut() { *out = exit_code; }
             return child_pid as i64;
         }
     }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2183,6 +2183,18 @@ pub fn run() -> ! {
         if test_515_waitid_wnowait_and_echild() { passed += 1; }
     }
 
+    // ── Test 516: waitid(2) siginfo_t byte layout (gecko IsProcessDead) ──
+    // The user siginfo_t that waitid fills must place si_pid at offset 16 and
+    // si_status at offset 24 (the _sifields union is 8-byte aligned). A reader
+    // that branches on si_pid (gecko's IsProcessDead) busy-loops the blocking
+    // waitid(WNOWAIT) forever if si_pid lands at the wrong offset. Per
+    // POSIX waitid(2) + Linux <asm-generic/siginfo.h>.
+    #[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_516_waitid_siginfo_layout() { passed += 1; }
+    }
+
     // ── Test 229: PMM pte_share_count free-time invariant (W215 fix) ─────
     // Verifies that pmm::free_page refuses to recycle a frame whose
     // refcount table still records a live PTE reference, and that the
@@ -41796,6 +41808,112 @@ fn test_515_waitid_wnowait_and_echild() -> bool {
     crate::proc::proc_metrics::unregister(parent_pid);
 
     test_pass!("waitid WNOWAIT peek + ECHILD-on-already-reaped (POSIX waitid(2))");
+    true
+}
+
+// ── Test 516: waitid(2) siginfo_t byte layout (gecko IsProcessDead) ─────────
+//
+// The Firefox parent's `IsProcessDead` (ipc/chromium/src/base/
+// process_util_posix.cc) calls `waitid(P_PID, pid, &si, WEXITED|WNOWAIT)` to
+// OBSERVE a child's exit, then branches:
+//     if (si.si_pid == 0) return ProcessStatus::Running;   // not exited yet
+//     switch (si.si_code) { case CLD_EXITED: ...; }        // then reaps
+// If the kernel writes `si_pid` at the wrong byte offset, the reader sees a
+// zero `si_pid`, concludes the child is still running, and re-issues the
+// blocking `waitid(WNOWAIT)` forever — pinning the caller's thread (observed
+// as a >900M-call waitpid spin that starved Firefox's render reactor).
+//
+// This test verifies the *serialised bytes*, which the existing kernel-side
+// peek/reap test (515) never checked. Per POSIX.1-2017 `waitid(2)` and the
+// Linux `<asm-generic/siginfo.h>` x86-64 (LP64) layout: the three-int header
+// (si_signo@0, si_errno@4, si_code@8) is followed by the 8-byte-aligned
+// `_sifields` union at offset 16, whose `_sigchld` arm is _pid@16, _uid@20,
+// _status@24.
+#[cfg(any(feature = "firefox-test", feature = "test-mode"))]
+fn test_516_waitid_siginfo_layout() -> bool {
+    use crate::syscall::{
+        fill_sigchld_siginfo, SI_SIZE, SI_OFF_SIGNO, SI_OFF_CODE,
+        SI_OFF_PID, SI_OFF_UID, SI_OFF_STATUS, CLD_EXITED, CLD_KILLED,
+    };
+
+    test_header!("waitid(2) siginfo_t byte layout (POSIX waitid(2))");
+
+    let rd = |buf: &[u8; SI_SIZE], off: usize| -> i32 {
+        i32::from_ne_bytes([buf[off], buf[off+1], buf[off+2], buf[off+3]])
+    };
+
+    // ── 1. Normal exit (CLD_EXITED): child pid 4, status 0 (the FF case) ──
+    let mut si = [0u8; SI_SIZE];
+    fill_sigchld_siginfo(&mut si, CLD_EXITED, 4, 0, 0);
+
+    // si_pid MUST be at offset 16 (the bug wrote it at 12). gecko reads here.
+    if rd(&si, SI_OFF_PID) != 4 {
+        test_fail!("waitid_siginfo", "si_pid@{} = {} (want 4) — gecko sees Running, spins",
+            SI_OFF_PID, rd(&si, SI_OFF_PID));
+        return false;
+    }
+    // The old-bug offset (12) MUST be zero now (it's union padding).
+    if rd(&si, 12) != 0 {
+        test_fail!("waitid_siginfo", "offset 12 = {} (want 0 padding); si_pid leaked here",
+            rd(&si, 12));
+        return false;
+    }
+    if rd(&si, SI_OFF_SIGNO) != 17 {
+        test_fail!("waitid_siginfo", "si_signo@0 = {} (want 17=SIGCHLD)", rd(&si, SI_OFF_SIGNO));
+        return false;
+    }
+    if rd(&si, SI_OFF_CODE) != CLD_EXITED {
+        test_fail!("waitid_siginfo", "si_code@8 = {} (want CLD_EXITED=1)", rd(&si, SI_OFF_CODE));
+        return false;
+    }
+    if rd(&si, SI_OFF_STATUS) != 0 {
+        test_fail!("waitid_siginfo", "si_status@24 = {} (want 0)", rd(&si, SI_OFF_STATUS));
+        return false;
+    }
+    test_println!("  CLD_EXITED: si_pid@16=4, si_code@8=1, si_status@24=0, pad@12=0 ✓");
+
+    // ── 2. Non-zero exit status is placed at offset 24, low 8 bits ────────
+    fill_sigchld_siginfo(&mut si, CLD_EXITED, 7, 0, 42);
+    if rd(&si, SI_OFF_PID) != 7 || rd(&si, SI_OFF_STATUS) != 42 {
+        test_fail!("waitid_siginfo", "exit status: si_pid@16={} si_status@24={} (want 7,42)",
+            rd(&si, SI_OFF_PID), rd(&si, SI_OFF_STATUS));
+        return false;
+    }
+    test_println!("  CLD_EXITED status 42: si_pid@16=7, si_status@24=42 ✓");
+
+    // ── 3. Killed-by-signal: si_code=CLD_KILLED, si_status=signal number ──
+    // (The kernel maps a `-signo` exit_code to CLD_KILLED + signo.)
+    let (code, status) = crate::syscall::test_exit_code_to_siginfo(-9); // SIGKILL
+    fill_sigchld_siginfo(&mut si, code, 5, 1000, status);
+    if rd(&si, SI_OFF_CODE) != CLD_KILLED || rd(&si, SI_OFF_STATUS) != 9 {
+        test_fail!("waitid_siginfo", "killed: si_code@8={} si_status@24={} (want 2,9)",
+            rd(&si, SI_OFF_CODE), rd(&si, SI_OFF_STATUS));
+        return false;
+    }
+    if rd(&si, SI_OFF_UID) != 1000 {
+        test_fail!("waitid_siginfo", "si_uid@20 = {} (want 1000)", rd(&si, SI_OFF_UID));
+        return false;
+    }
+    test_println!("  CLD_KILLED(SIGKILL): si_code@8=2, si_status@24=9, si_uid@20=1000 ✓");
+
+    // ── 4. The struct is fully zeroed outside the written fields (no leak) ─
+    // Every 4-byte word except {0,8,16,20,24} must be zero (offsets 4,12 and
+    // 28..124).
+    let mut leaked = false;
+    let mut off = 0;
+    while off + 4 <= SI_SIZE {
+        let is_written = off == SI_OFF_SIGNO || off == SI_OFF_CODE
+            || off == SI_OFF_PID || off == SI_OFF_UID || off == SI_OFF_STATUS;
+        if !is_written && rd(&si, off) != 0 { leaked = true; break; }
+        off += 4;
+    }
+    if leaked {
+        test_fail!("waitid_siginfo", "stale bytes leaked at offset {} (want fully zeroed pad)", off);
+        return false;
+    }
+    test_println!("  padding/union tail fully zeroed (no stack-byte leak) ✓");
+
+    test_pass!("waitid(2) siginfo_t byte layout (POSIX waitid(2))");
     true
 }
 


### PR DESCRIPTION
## Root cause: producer-side render stall = `waitid(WNOWAIT)` busy-spin from a `siginfo_t` ABI offset bug

Live-captured on the render branch: the Firefox parent (pid1) main thread busy-looped a **blocking** `waitid(P_PID, pid, WEXITED|WNOWAIT)` on an already-exited zombie child **~931 million times** (pid1 sc > 1e9), pinning the main thread so the render reactor never ran. FF reached `[GATE] screenshot-actors` and stalled there forever — the producer-side stall gating the screenshot-IPC handshake (no `drawSnapshot`, no PNG).

Serial census of the buggy run (pid1, 400-line window): **100%** `waitpid(4, wnohang=false wnowait=true)` + `peeked, WNOWAIT`, and pid4 was **never reaped** (the reaping wait was never issued).

### The divergence (OUR kernel, not upstream)

The same musl Firefox renders fine on real Linux. The bug is in our `waitid(2)` handler's `siginfo_t` serialisation.

Firefox's `IsProcessDead` (`ipc/chromium/src/base/process_util_posix.cc`) issues `waitid(P_PID, …, WEXITED|WNOWAIT)` to *observe* a child's exit, then:

```c
if (si.si_pid == 0) return ProcessStatus::Running;   // not exited yet
switch (si.si_code) { case CLD_EXITED: …reissue without WNOWAIT to reap… }
```

On x86-64 (LP64), `<asm-generic/siginfo.h>` lays out the three-int header (`si_signo`@0, `si_errno`@4, `si_code`@8), then the **8-byte-aligned** `union __sifields` at **offset 16** — so the SIGCHLD arm is `_pid`@16, `_uid`@20, `_status`@24. Our handler wrote `si_pid` at **offset 12** (union padding) and never wrote `si_status`. Firefox read `si_pid == 0`, concluded the child was still running, and re-issued the blocking `waitid(WNOWAIT)` forever.

(In-tree corroboration: the SIGSEGV delivery path in `signal.rs` already correctly bases the union at offset 16 — the `waitid` handler was the lone outlier.)

## Fix

- **`waitid` (247):** serialise `siginfo_t` at the architectural offsets via a shared `fill_sigchld_siginfo` helper (`si_pid`@16, `si_uid`@20, `si_status`@24); zero the full 128-byte struct so no padding/union bytes leak; decompose `exit_code` → `(si_code, si_status)` per the SIGCHLD contract (`CLD_EXITED`+status / `CLD_KILLED`+signo); gate the user write with `validate_user_ptr` (CWE-823).
- **`wait4` (61):** write the encoded `wstatus` (`WIFEXITED`/`WEXITSTATUS`, `WIFSIGNALED`/`WTERMSIG`) — it previously ignored the `wstatus` pointer, so musl/glibc `waitpid` wrappers read an uninitialised status.
- `sys_waitpid_ex` gains an `exit_out` out-param so the exit code reaches the serialiser across all collect sites (peek/reap, with/without park). `wait4` callers pass `None`; WNOWAIT semantics (peek-leaves-waitable, ECHILD-on-gone) preserved.
- Compile-time offset asserts pin the union layout; **test 516** pins the *serialised `siginfo_t` bytes* — the gap that let this ship (test 515 only checked the kernel-internal peek/reap helpers, never the user bytes).
- `docs/LINUX_SYSCALL_COVERAGE.md` updated for 61 and 247.

Per POSIX.1-2017 `waitid(2)` / `wait(2)` and Linux `<asm-generic/siginfo.h>`.

## Verification (harness-only, `firefox-test-core,kdb`, KVM)

Booted the fix from this branch:

| | Buggy run (326a78c4aa3b) | Fix run (9c234871cba2) |
|---|---|---|
| `peeked, WNOWAIT` count | ~931,000,000 | **0** |
| blocking `wnowait=true` waits | spinning forever | **0** |
| pid4 reaps | never reaped | reaped **once**, code 0 |
| pid1 syscalls | > 1,000,000,000 (climbing) | 4.48M (frozen, healthy) |
| outcome | pinned at screenshot-actors | clean `exit_group(0)` after screenshot-actors |

The parent now reaps every child exactly once and runs the full process tree to a clean shutdown — **the producer-side livelock is eliminated**. No panic / MOZ_CRASH / channel error.

PNG not yet emitted on this fast-core boot profile (which doesn't drive `loadURI`→`drawSnapshot`); the next gate is the full render-driver path on the `firefox-test` profile. The waitpid stall that pinned the main thread is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)