### PR TITLE
kernel/epoll: enforce EPOLLET edge-triggered notification

### DIFF
--- a/kernel/src/ipc/epoll.rs
+++ b/kernel/src/ipc/epoll.rs
@@ -18,7 +18,7 @@ pub const EPOLLOUT:     u32 = 0x0004;
 pub const EPOLLERR:     u32 = 0x0008;
 pub const EPOLLHUP:     u32 = 0x0010;
 pub const EPOLLRDHUP:   u32 = 0x2000;
-pub const EPOLLET:      u32 = 1 << 31; // edge-triggered (accepted but not enforced)
+pub const EPOLLET:      u32 = 1 << 31; // edge-triggered (enforced in sys_epoll_wait via per-watch et_seen)
 pub const EPOLLONESHOT: u32 = 1 << 30;
 
 /// Equivalent to Linux `struct epoll_event` (packed, 12 bytes).
@@ -35,6 +35,18 @@ pub struct EpollWatch {
     pub fd:     usize,
     pub events: u32,
     pub data:   u64,
+    /// Edge-trigger baseline (`EPOLLET` only).  For a watch registered with
+    /// `EPOLLET`, `epoll_wait(2)` must report a given readiness bit only on
+    /// the rising edge — when the monitored fd transitions from not-having
+    /// to having that condition — and NOT again until the condition is first
+    /// cleared and then re-occurs (`epoll(7)`, "Level-triggered and
+    /// edge-triggered").  `et_seen` records the subset of readiness bits that
+    /// were already delivered on a prior `epoll_wait` and have stayed
+    /// continuously asserted since: those bits are suppressed on subsequent
+    /// calls.  A bit that drops to not-ready is cleared from `et_seen`, so a
+    /// later re-rise fires a fresh edge.  Unused (always 0) for
+    /// level-triggered watches.
+    pub et_seen: u32,
 }
 
 /// Per-process monotonically increasing identifier for epoll instances.
@@ -125,7 +137,7 @@ impl EpollInstance {
     /// and no spurious HUP/ERR readiness leaks into the parking decision.
     pub fn add(&mut self, fd: usize, events: u32, data: u64) -> bool {
         if self.watches.iter().any(|w| w.fd == fd) { return false; }
-        self.watches.push(EpollWatch { fd, events, data });
+        self.watches.push(EpollWatch { fd, events, data, et_seen: 0 });
         true
     }
 
@@ -148,6 +160,11 @@ impl EpollInstance {
         if let Some(w) = self.watches.iter_mut().find(|w| w.fd == fd) {
             w.events = events;
             w.data   = data;
+            // `EPOLL_CTL_MOD` re-arms the watch: per `epoll(7)`, changing the
+            // interest mask of an `EPOLLET` watch makes any currently-asserted
+            // condition count as a fresh edge on the next `epoll_wait`.  Reset
+            // the edge baseline so a level-ready fd is reported once more.
+            w.et_seen = 0;
             true
         } else {
             false

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -10863,7 +10863,7 @@ fn sys_epoll_ctl(epfd: usize, op: u64, fd: usize, event_ptr: u64) -> i64 {
 
 /// epoll_wait — collect ready events into caller's buffer.
 fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i32) -> i64 {
-    use crate::ipc::epoll::{EpollEvent, EPOLLERR, EPOLLHUP};
+    use crate::ipc::epoll::{EpollEvent, EPOLLERR, EPOLLHUP, EPOLLET};
     if maxevents == 0 { return -22; } // EINVAL
     let pid = crate::proc::current_pid_lockless();
 
@@ -10873,13 +10873,20 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // dup'd epoll fds share the inode and thus the same instance.
     // Symmetric with sys_epoll_ctl above; see that block for the full
     // by-id rationale (PIVOT-I2 Phase D, 2026-05-23).
-    let watches_snap: alloc::vec::Vec<(usize, u32, u64)> = {
+    // Each snapshot entry is `(fd, subscribed, data, et_seen)`.  `et_seen`
+    // is the per-watch edge-trigger baseline for `EPOLLET` watches (the
+    // subset of readiness bits already delivered on a prior call and still
+    // continuously asserted); 0 for level-triggered watches.  `epoll_id`
+    // is retained so the (possibly updated) edge baselines can be written
+    // back into the live `EpollInstance` after the poll completes.
+    let epoll_id: u64;
+    let watches_snap: alloc::vec::Vec<(usize, u32, u64, u32)> = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = match procs.iter().find(|p| p.pid == pid) {
             Some(p) => p,
             None    => return -9, // EBADF
         };
-        let epoll_id = match proc.file_descriptors.get(epfd).and_then(|f| f.as_ref()) {
+        epoll_id = match proc.file_descriptors.get(epfd).and_then(|f| f.as_ref()) {
             Some(f) if f.open_path == "[epoll]" => f.inode,
             _                                   => return -9, // EBADF
         };
@@ -10887,51 +10894,105 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
             Some(i) => i,
             None    => return -9,
         };
-        inst.watches.iter().map(|w| (w.fd, w.events, w.data)).collect()
+        inst.watches.iter().map(|w| (w.fd, w.events, w.data, w.et_seen)).collect()
     }; // lock released here
+
+    // Live edge-trigger baselines, one per snapshot entry (index-aligned).
+    // Seeded from the stored `et_seen` and mutated by `do_poll` / `probe_ready`
+    // as edges are consumed and re-armed; flushed back to the live instance
+    // at Step 3.  A `RefCell` lets the `Fn` closures below mutate it without
+    // capturing `&mut` (they are also called from the park predicate path).
+    let et_state: core::cell::RefCell<alloc::vec::Vec<u32>> =
+        core::cell::RefCell::new(watches_snap.iter().map(|w| w.3).collect());
+
+    // Compute the mask `epoll_wait(2)` would deliver for one watch, honouring
+    // the level-vs-edge contract of `epoll(7)`.
+    //
+    //   * The base "interest" is built as two disjoint parts, unchanged from
+    //     the level-triggered ABI fix:
+    //       - the caller-subscribed bits currently ready (`subscribed & ready`)
+    //       - any EPOLLERR / EPOLLHUP ready even when unsubscribed
+    //         (`ready & (EPOLLERR | EPOLLHUP)`).
+    //     EPOLLRDHUP is NOT always-on, so it flows through the first term only.
+    //     The stored `subscribed` mask is the caller's raw interest and is
+    //     never mutated.
+    //
+    //   * Level-triggered watch (no EPOLLET): the full `interest` is delivered
+    //     on every call as long as the condition holds — identical to before.
+    //
+    //   * Edge-triggered watch (EPOLLET): per `epoll(7)` ("Level-triggered and
+    //     edge-triggered"), a readiness bit is delivered only on its rising
+    //     edge — when the fd transitions from not-having to having it — and not
+    //     again until that condition is first cleared and then re-occurs.  The
+    //     per-watch `seen` baseline (in `et_state[idx]`) records which bits
+    //     were already delivered and have stayed continuously asserted.  We
+    //     deliver only the newly-risen bits (`interest & !seen`), re-arm any
+    //     bit that has since dropped (`seen &= interest`), and fold the just-
+    //     reported bits into the baseline (`seen |= report`).  A watched fd
+    //     that stays level-ready without the consumer draining it (e.g. a
+    //     wakeup eventfd whose counter the reactor leaves nonzero) is reported
+    //     exactly once, so `epoll_wait` blocks on the next call instead of
+    //     spinning — matching Linux edge-trigger semantics.
+    //
+    // Read-only edge/level computation: the mask `epoll_wait(2)` WOULD deliver
+    // for watch `idx` right now, without mutating the baseline.  The effective
+    // post-re-arm baseline is `seen & interest`, so the deliverable set is
+    // `interest & !(seen & interest)` = `interest & !seen`; the re-arm step is
+    // pure bookkeeping for persistence and does not change the current report.
+    // Used by `probe_ready` so the park predicate never *consumes* an edge.
+    let peek_for = |idx: usize, subscribed: u32, ready_ev: u32| -> u32 {
+        let interest =
+            (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
+        if subscribed & EPOLLET == 0 {
+            return interest; // level-triggered: report whenever ready
+        }
+        let seen = et_state.borrow()[idx];
+        interest & !seen // rising-edge bits only (read-only)
+    };
+
+    // Consuming edge/level computation: same deliverable mask as `peek_for`,
+    // but it also commits the baseline update for EPOLLET watches (re-arm
+    // dropped bits, then mark the just-delivered bits seen).  Only the call
+    // sites that ACTUALLY return events to userspace use this — never the park
+    // predicate — so a rising edge is consumed exactly once.
+    let deliver_for = |idx: usize, subscribed: u32, ready_ev: u32| -> u32 {
+        let interest =
+            (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
+        if subscribed & EPOLLET == 0 {
+            return interest; // level-triggered: report whenever ready
+        }
+        let mut et = et_state.borrow_mut();
+        let seen = &mut et[idx];
+        *seen &= interest;            // re-arm any bit that dropped to not-ready
+        let report = interest & !*seen; // rising-edge bits only
+        *seen |= report;              // remember what we just delivered
+        report
+    };
 
     // ── Step 2: poll without holding the lock ────────────────────────────────
     let do_poll = |fired: &mut alloc::vec::Vec<EpollEvent>| {
-        for &(fd, subscribed, data) in &watches_snap {
+        for (idx, &(fd, subscribed, data, _)) in watches_snap.iter().enumerate() {
             if fired.len() >= maxevents { break; }
             let ready_ev = epoll_poll_events(pid, fd);
-            // Per `epoll(7)`: "EPOLLERR and EPOLLHUP ... it is not necessary
-            // to set [them] in events"; the kernel reports them whenever they
-            // occur, independent of the caller's interest set.  Build the
-            // delivered mask as two disjoint parts:
-            //   * the caller-subscribed bits that are currently ready
-            //     (`subscribed & ready_ev`), and
-            //   * any EPOLLERR / EPOLLHUP that is ready, delivered even when
-            //     unsubscribed (`ready_ev & (EPOLLERR | EPOLLHUP)`).
-            // EPOLLRDHUP is NOT in the always-on set — Linux only reports it
-            // when subscribed — so it flows through the first term only.
-            //
-            // The stored `subscribed` mask is the caller's raw interest and is
-            // never mutated; ERR/HUP are force-added to the *ready* side here
-            // at the single delivery site.  This keeps the readiness/wake
-            // matching wake-safe: a healthy fd reporting only EPOLLOUT against
-            // an EPOLLIN-only watch yields `(EPOLLIN & EPOLLOUT) | (EPOLLOUT &
-            // (ERR|HUP)) = 0`, so no spurious-ready perturbs the parking
-            // decision — exactly as before this ABI fix.
-            let interest =
-                (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
-            if interest != 0 {
-                fired.push(EpollEvent { events: interest, data });
+            let report = deliver_for(idx, subscribed, ready_ev);
+            if report != 0 {
+                fired.push(EpollEvent { events: report, data });
             }
         }
     };
 
-    // Read-only readiness probe over the watch snapshot — true if any
-    // watched fd currently has a deliverable event.  Mirrors `do_poll`'s
-    // interest/ERR/HUP masking but allocates nothing and pushes nothing;
-    // used as the recheck-under-lock predicate for `wait_poll_event` so
-    // the check-and-park lost-wakeup window is closed (prepare-to-wait).
+    // Read-only readiness probe over the watch snapshot — true if any watched
+    // fd currently has a deliverable event.  Mirrors `do_poll`'s edge/level
+    // masking but NON-consumingly (via `peek_for`): an EPOLLET fd whose edge
+    // has already been delivered and merely stays level-ready must NOT keep
+    // the predicate "ready" — otherwise the park never commits and the spin
+    // persists.  Allocates nothing and pushes nothing; used as the
+    // recheck-under-lock predicate for `wait_poll_event` so the
+    // check-and-park lost-wakeup window is closed (prepare-to-wait).
     let probe_ready = || -> bool {
-        for &(fd, subscribed, _data) in &watches_snap {
+        for (idx, &(fd, subscribed, _data, _)) in watches_snap.iter().enumerate() {
             let ready_ev = epoll_poll_events(pid, fd);
-            let interest =
-                (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
-            if interest != 0 { return true; }
+            if peek_for(idx, subscribed, ready_ev) != 0 { return true; }
         }
         false
     };
@@ -11016,7 +11077,38 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
         }
     }
 
-    // ── Step 3: copy events to the caller's buffer ───────────────────────────
+    // ── Step 3: flush updated EPOLLET edge baselines back to the instance ────
+    // `et_state` accumulated the per-watch rising-edge consumption during the
+    // poll/wait loop above.  Persist it so a subsequent `epoll_wait` on the
+    // same instance honours the edge (does not re-report a still-asserted
+    // EPOLLET condition).  Matched by fd — not snapshot index — so a watch
+    // that an `epoll_ctl(DEL/ADD)` reordered between snapshot and now is left
+    // untouched (a concurrently re-added fd starts with a fresh `et_seen=0`).
+    // Only entries whose subscribed mask carried EPOLLET need writing; LT
+    // watches keep `et_seen == 0` throughout, so they are skipped.
+    {
+        let et = et_state.borrow();
+        let needs_flush = watches_snap.iter().enumerate().any(|(i, w)| {
+            (w.1 & EPOLLET != 0) && (et[i] != w.3)
+        });
+        if needs_flush {
+            let mut procs = crate::proc::PROCESS_TABLE.lock();
+            if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {
+                if let Some(inst) = proc.epoll_sets.iter_mut().find(|e| e.id == epoll_id) {
+                    for (i, snap) in watches_snap.iter().enumerate() {
+                        if snap.1 & EPOLLET == 0 { continue; }
+                        if let Some(w) = inst.watches.iter_mut()
+                            .find(|w| w.fd == snap.0 && w.events == snap.1)
+                        {
+                            w.et_seen = et[i];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Step 4: copy events to the caller's buffer ───────────────────────────
     let count = fired.len();
     if count > 0 && events_ptr != 0 {
         unsafe {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2757,6 +2757,18 @@ pub fn run() -> ! {
     total += 1;
     if test_293_epoll_listening_unix_has_pending() { passed += 1; }
 
+    // ── Test 294: epoll EPOLLET edge-trigger on a level-ready eventfd ──────
+    // A watch registered with EPOLLET must report a readiness condition only
+    // on its rising edge: an eventfd whose counter stays nonzero (never
+    // drained) is delivered EPOLLIN exactly ONCE, then the next epoll_wait
+    // returns 0 — NOT the same level-ready event on every call.  Draining the
+    // eventfd (counter→0) and re-writing it re-arms the edge.  This is the
+    // regression guard for the gecko main-MessagePump spin (a wakeup eventfd
+    // left level-ready monopolised the CPU under pure level-triggered epoll).
+    // Refs: epoll(7) "Level-triggered and edge-triggered", eventfd(2).
+    total += 1;
+    if test_294_epoll_edge_triggered_eventfd() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -48775,6 +48787,154 @@ fn test_293_epoll_listening_unix_has_pending() -> bool {
 
     if ok {
         test_pass!("epoll EPOLLIN parity on listening AF_UNIX with pending connection (Test 293)");
+    }
+    ok
+}
+
+// ── Test 294: epoll EPOLLET edge-trigger on a level-ready eventfd ─────────────
+//
+// Regression guard for the gecko main-MessagePump epoll spin: a wakeup eventfd
+// registered with EPOLLET that stays level-ready (counter never drained to 0)
+// must be reported EPOLLIN on its rising edge ONCE, then suppressed on
+// subsequent epoll_wait calls — NOT re-delivered on every call (which under a
+// purely level-triggered implementation pins the polling thread at 100% CPU).
+// Draining the eventfd and re-writing it re-arms a fresh edge.
+//
+// Refs: epoll(7) "Level-triggered and edge-triggered notification",
+// epoll_ctl(2), epoll_wait(2), eventfd(2).
+fn test_294_epoll_edge_triggered_eventfd() -> bool {
+    test_header!("epoll EPOLLET edge-trigger on a level-ready eventfd (Test 294)");
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+
+    // Linux ABI for this process (epoll/eventfd are Linux-personality syscalls).
+    let pid = crate::proc::current_pid();
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = true;
+            p.subsystem = crate::win32::SubsystemType::Linux;
+        }
+    }
+
+    fn make_ev(events: u32, data: u64) -> [u8; 12] {
+        let mut b = [0u8; 12];
+        b[0..4].copy_from_slice(&events.to_le_bytes());
+        b[4..12].copy_from_slice(&data.to_le_bytes());
+        b
+    }
+    fn ev_events(b: &[u8; 12]) -> u32 {
+        u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+    }
+
+    const EPOLLIN: u32 = 0x0001;
+    const EPOLLET: u32 = 1 << 31;
+    const CTL_ADD: u64 = 1;
+    // eventfd2 / epoll syscall numbers (Linux x86-64 ABI).
+    const SYS_EPOLL_CTL:    u64 = 233;
+    const SYS_EPOLL_WAIT:   u64 = 232;
+    const SYS_EPOLL_CREATE: u64 = 291; // epoll_create1
+    const SYS_EVENTFD2:     u64 = 290;
+    const SYS_CLOSE:        u64 = 3;
+    const SYS_READ:         u64 = 0;
+    const SYS_WRITE:        u64 = 1;
+
+    let mut ok = true;
+
+    // eventfd2(initval=0, flags=0) → a fresh counter-zero eventfd.
+    let efd = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+    if efd < 0 {
+        test_fail!("epollet", "eventfd2 = {}", efd);
+        return false;
+    }
+    let epfd = dispatch(SYS_EPOLL_CREATE, 0, 0, 0, 0, 0, 0);
+    if epfd < 0 {
+        test_fail!("epollet", "epoll_create1 = {}", epfd);
+        let _ = dispatch(SYS_CLOSE, efd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+
+    // Register the eventfd EPOLLIN|EPOLLET.
+    {
+        let ev = make_ev(EPOLLIN | EPOLLET, 0xE7);
+        let r = dispatch(SYS_EPOLL_CTL, epfd as u64, CTL_ADD, efd as u64, ev.as_ptr() as u64, 0, 0);
+        if r != 0 {
+            test_fail!("epollet", "epoll_ctl(ADD, ET) = {}", r);
+            ok = false;
+        }
+    }
+
+    // Write 1 to the eventfd → counter 0→1: the rising edge.  (We deliberately
+    // never read the eventfd, so it stays level-ready throughout.)
+    {
+        let v: u64 = 1;
+        let r = dispatch(SYS_WRITE, efd as u64, (&v as *const u64) as u64, 8, 0, 0, 0);
+        if r != 8 {
+            test_fail!("epollet", "write(eventfd, 1) = {} (want 8)", r);
+            ok = false;
+        }
+    }
+
+    // First epoll_wait(timeout=0): MUST deliver the rising-edge EPOLLIN once.
+    {
+        let mut buf = [[0u8; 12]; 4];
+        let r = dispatch(SYS_EPOLL_WAIT, epfd as u64, buf[0].as_mut_ptr() as u64, 4, 0, 0, 0);
+        if r == 1 && ev_events(&buf[0]) & EPOLLIN != 0 {
+            test_println!("  wait#1 → 1 event EPOLLIN (rising edge delivered) ✓");
+        } else {
+            test_fail!("epollet", "wait#1 r={} events={:#x} (want 1 / EPOLLIN)",
+                r, ev_events(&buf[0]));
+            ok = false;
+        }
+    }
+
+    // Second epoll_wait(timeout=0): the eventfd is STILL level-ready (counter
+    // never drained), but under EPOLLET the edge was already consumed → MUST
+    // return 0.  A purely level-triggered kernel returns 1 here forever — the
+    // spin this fix closes.
+    {
+        let mut buf = [[0u8; 12]; 4];
+        let r = dispatch(SYS_EPOLL_WAIT, epfd as u64, buf[0].as_mut_ptr() as u64, 4, 0, 0, 0);
+        if r == 0 {
+            test_println!("  wait#2 → 0 events (edge already consumed, no re-report) ✓");
+        } else {
+            test_fail!("epollet",
+                "wait#2 r={} events={:#x} — EPOLLET fd re-reported while level-ready (spin bug)",
+                r, ev_events(&buf[0]));
+            ok = false;
+        }
+    }
+
+    // Drain the eventfd (read → counter back to 0) then re-write → fresh edge.
+    {
+        let mut rbuf = [0u8; 8];
+        let r = dispatch(SYS_READ, efd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+        if r != 8 {
+            test_fail!("epollet", "read(eventfd) = {} (want 8 to drain)", r);
+            ok = false;
+        }
+        let v: u64 = 1;
+        let _ = dispatch(SYS_WRITE, efd as u64, (&v as *const u64) as u64, 8, 0, 0, 0);
+    }
+
+    // Third epoll_wait: the drain-then-write produced a NEW rising edge → MUST
+    // deliver EPOLLIN once again (proves re-arm works, not a one-shot latch).
+    {
+        let mut buf = [[0u8; 12]; 4];
+        let r = dispatch(SYS_EPOLL_WAIT, epfd as u64, buf[0].as_mut_ptr() as u64, 4, 0, 0, 0);
+        if r == 1 && ev_events(&buf[0]) & EPOLLIN != 0 {
+            test_println!("  wait#3 → 1 event EPOLLIN (re-armed after drain+write) ✓");
+        } else {
+            test_fail!("epollet", "wait#3 r={} events={:#x} (want 1 / EPOLLIN re-arm)",
+                r, ev_events(&buf[0]));
+            ok = false;
+        }
+    }
+
+    let _ = dispatch(SYS_CLOSE, epfd as u64, 0, 0, 0, 0, 0);
+    let _ = dispatch(SYS_CLOSE, efd as u64, 0, 0, 0, 0, 0);
+
+    if ok {
+        test_pass!("epoll EPOLLET edge-trigger on a level-ready eventfd (Test 294)");
     }
     ok
 }


### PR DESCRIPTION
## Summary

`sys_epoll_wait` was purely level-triggered — it ignored the `EPOLLET` bit ("accepted but not enforced"). A watch registered `EPOLLET` on an fd that stays level-ready (e.g. a wakeup eventfd whose counter is never drained to 0) was re-reported on **every** `epoll_wait` call, so a reactor thread registered that way never blocked: it span `epoll_wait` at the tick rate, monopolised its CPU, and starved the sibling threads servicing other descriptors.

Per `epoll(7)` ("Level-triggered and edge-triggered notification"), an `EPOLLET` watch must report a readiness condition only on its **rising edge** and not again until the condition is first cleared and then re-occurs.

## Fix

- New per-watch baseline `EpollWatch::et_seen` records the readiness bits already delivered and still continuously asserted.
- `sys_epoll_wait` delivers only the newly-risen bits (`interest & !seen`) for `EPOLLET` watches, re-arms any bit that dropped to not-ready (`seen &= interest`), and folds the just-delivered bits into the baseline.
- `EPOLL_CTL_MOD` resets the baseline (a re-arm, per `epoll(7)`).
- The park predicate (`probe_ready`) consults the baseline **non-consumingly** so an already-delivered EPOLLET edge does not block the park.
- The baseline is flushed back to the live instance after the poll, matched by fd (tolerates a concurrent `epoll_ctl` reorder).
- **Level-triggered watches are byte-for-byte unchanged.**

The eventfd/pipe/socket write paths already ring the global poll bell on a readiness change, so a parked `EPOLLET` waiter is woken on the next genuine edge.

## Test

Adds `test_runner` **Test 294**: an `EPOLLET`-registered eventfd left level-ready is delivered `EPOLLIN` exactly once, the next `epoll_wait` returns 0, and a drain+rewrite re-arms a fresh edge. Test 59 (level-triggered epoll, incl. AF_UNIX socketpair EPOLLIN gating) passes unchanged.

## Measured effect (Firefox headless-screenshot, `firefox-test-core`)

At the screenshot-IPC gate, the parent (pid 1) main thread is gecko's reactor spinning `epoll_pwait` on a set whose wakeup eventfd is registered `EPOLLIN|EPOLLRDHUP|EPOLLET` and is level-ready:

| Metric | Before | After |
|---|---|---|
| `syscall-trend` 4s (pid 1) | **16,384 samples, 100% `epoll_pwait`** | **91 samples, 0% `epoll_pwait`** |
| pid 1 `sc_total` | 46,480,976 | ~35,000 |
| pid 1 `sc_sync` share | 99.95% | ~48% |

The CPU-monopolising spin is eliminated; the main thread now parks and is woken on real edges, and the ET wakeup eventfds are observed draining.

## Scope note

This removes the confirmed epoll-spin gate. It does **not** by itself produce the PNG: with the spin gone, Firefox stalls at a **deeper, distinct gate** — the cross-process screenshot-IPC handshake (pid 1 in `futex`, content procs pid 5/pid 6 blocked, content-channel fds holding unread `EPOLLIN` data that the wedged handshake never drains). That is a separate divergence to be addressed on its own.

Refs: `epoll(7)`, `epoll_ctl(2)`, `epoll_wait(2)`, `eventfd(2)`, POSIX.1-2017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)