### PR TITLE
kernel: cross-process SHARED futex keying + reserve UEFI bootstrap stack

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -2590,9 +2590,18 @@ fn op_thread_park_audit(req: &str, out: &mut String) {
         alloc::collections::BTreeMap::new();
     let futex_busy = match try_lock_brief(&crate::syscall::FUTEX_WAITERS) {
         Some(waiters) => {
-            for ((pid_k, uaddr), tids) in waiters.iter() {
+            use crate::syscall::FutexKey;
+            for (k, tids) in waiters.iter() {
+                // Map the key to the diagnostic `(pid, uaddr)` pair the JSON
+                // shape expects.  A process-SHARED futex has no single owning
+                // pid; surface it as `(u64::MAX, byte_off)` so the reverse
+                // lookup still records the waiter without inventing a pid.
+                let (pid_k, uaddr) = match k {
+                    FutexKey::Private(p, u) => (*p, *u),
+                    FutexKey::Shared { byte_off, .. } => (u64::MAX, *byte_off),
+                };
                 for tid in tids {
-                    tid_to_futex.insert(*tid, (*pid_k, *uaddr));
+                    tid_to_futex.insert(*tid, (pid_k, uaddr));
                 }
             }
             false
@@ -3510,7 +3519,16 @@ fn op_cond_autopsy(req: &str, out: &mut String) {
     let mut waiter_rows: Vec<WaiterRow> = Vec::new();
     match try_lock_brief(&crate::syscall::FUTEX_WAITERS) {
         Some(w) => {
-            for (&(wpid, wuaddr), tids) in w.range((pid, lo)..=(pid, hi)) {
+            use crate::syscall::FutexKey;
+            // Scan the same-process PRIVATE-key cluster around `addr`.  A
+            // process-SHARED futex is keyed by backing-object identity, not by
+            // `(pid, uaddr)`, so it does not appear in this virtual-address
+            // window.
+            for (k, tids) in w.range(FutexKey::Private(pid, lo)..=FutexKey::Private(pid, hi)) {
+                let (wpid, wuaddr) = match k {
+                    FutexKey::Private(p, u) => (*p, *u),
+                    FutexKey::Shared { .. } => continue,
+                };
                 if wpid != pid { continue; }
                 if tids.is_empty() { continue; }
                 for &tid in tids.iter() {

--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -376,6 +376,73 @@ pub fn init(boot_info: &BootInfo) {
         boot_info_reserved_pages,
     );
 
+    // Reserve the UEFI bootstrap stack the BSP is *currently executing on*.
+    //
+    // After `ExitBootServices`, UEFI reports the region that backed the
+    // loader's stack as `EfiBootServicesData`, which our converter maps to
+    // `Available` (UEFI §7.2, GetMemoryMap) — so the pages under the live
+    // bootstrap stack are marked free above and become eligible for
+    // `alloc_page`/`alloc_pages`.  But the BSP main/idle thread (TID 0) keeps
+    // running on this very stack for the lifetime of the kernel: `_start` does
+    // NOT switch the BSP onto TID 0's higher-half `kernel_stack_base`
+    // (see `kernel/src/main.rs` and `proc::init`).  If a later
+    // `alloc_pages` (e.g. a clone/pthread kernel-stack allocation under heavy
+    // thread churn) hands out the bootstrap-stack frames, the new thread writes
+    // its own data over TID 0's live stack — clobbering the callee-saved frame
+    // `switch_context_asm` later pops, so the next switch *into* TID 0 faults
+    // with a #GP/non-canonical `ret` (BUGCHECK KERNEL_GPF / UNEXPECTED_KERNEL_
+    // MODE_TRAP on `switch_context_asm`).  Reserve the live stack here, while
+    // we are still on it, exactly as the BootInfo reservation above closes the
+    // same UEFI-reclamation hole for the BootInfo struct.
+    //
+    // We read the current stack pointer and reserve a window that brackets it:
+    // a generous downward guard (the stack grows down, and the BSP poll loop's
+    // deepest call chain plus interrupt frames must fit) and the remainder of
+    // the current page upward (data already pushed above the current RSP).
+    //
+    // Refs: UEFI Specification §7.2 (GetMemoryMap / EfiBootServicesData);
+    //       Intel SDM Vol. 3A §4.10.5 (frames backing live kernel structures
+    //       must remain reserved against PMM recycling); System V AMD64 ABI
+    //       §3.4 (stack grows toward lower addresses).
+    {
+        // Downward guard: the bootstrap stack only ever grows DOWN from the
+        // current RSP during the rest of boot and the BSP poll loop.  128 KiB
+        // dwarfs the BSP's deepest observed call chain (a few KiB) while
+        // costing only 32 frames of otherwise-free low memory.
+        const BOOTSTRAP_STACK_GUARD_DOWN: u64 = 128 * 1024;
+        let rsp: u64;
+        // SAFETY: read-only capture of the current stack pointer; we are
+        // executing on the bootstrap stack here (pmm::init runs before any
+        // stack switch), so RSP names a live address inside it.
+        unsafe { core::arch::asm!("mov {}, rsp", out(reg) rsp, options(nomem, nostack, preserves_flags)); }
+        // The bootstrap stack is in the identity-mapped low region (PML4[0]),
+        // so its physical address equals its virtual address.
+        let stack_lo = rsp.saturating_sub(BOOTSTRAP_STACK_GUARD_DOWN) & !(PAGE_SIZE as u64 - 1);
+        // Cover to the top of the page containing RSP (data pushed above us).
+        let stack_hi = (rsp | (PAGE_SIZE as u64 - 1)).saturating_add(1);
+        let first_page = (stack_lo / PAGE_SIZE as u64) as usize;
+        let last_page  = ((stack_hi - 1) / PAGE_SIZE as u64) as usize;
+        let mut newly_reserved = 0u64;
+        for page in first_page..=last_page {
+            if page < MAX_PAGES {
+                // SAFETY: PMM lock held, page in bounds.  Idempotent against
+                // pages already reserved (kernel image / first-1-MiB below).
+                unsafe {
+                    if !is_page_used_locked(page) {
+                        mark_page_used(page);
+                        if total_available > 0 { total_available -= 1; }
+                        newly_reserved += 1;
+                    }
+                }
+            }
+        }
+        crate::serial_println!(
+            "[PMM] Bootstrap-stack reservation: rsp={:#x} phys=[{:#x}..{:#x}) \
+             pages={}..={} newly_reserved={} (BSP TID 0 live stack)",
+            rsp, stack_lo, stack_hi, first_page, last_page, newly_reserved,
+        );
+    }
+
     // Mark first 1 MiB as reserved (BIOS, VGA, etc.)
     for page in 0..256 {
         // SAFETY: We hold the PMM lock and page is in bounds.

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2474,6 +2474,70 @@ pub fn find_vma_with_parent_fallback(pid: Pid, addr: u64) -> Option<VmaLookupHit
     Some(extract(vma, true))
 }
 
+/// Resolve the backing object of a process-SHARED futex word at `addr`.
+///
+/// Returns `Some((mount_idx, inode, vma_base, file_offset))` **only** when the
+/// VMA covering `addr` in `pid`'s address space (with the same CLONE_VM
+/// parent-fallback as [`find_vma_with_parent_fallback`]) is `MAP_SHARED` AND
+/// file/`memfd`-backed (`VmBacking::File`).  In every other case — a private
+/// mapping, an anonymous mapping (shared or private), an unmapped address, or
+/// no resolvable VmSpace — returns `None`, signalling the caller to use the
+/// PRIVATE `(pid, uaddr)` futex key.
+///
+/// This is the kernel side of the `futex(2)` process-shared rendezvous: a
+/// futex word living on a shared file/`memfd` page must hash to the same key
+/// for any process that maps the same object, regardless of the virtual
+/// address it chose.  The returned `(mount_idx, inode, file_offset)` is the
+/// VMA's backing identity and base file offset; the caller folds in the word's
+/// distance from `vma_base` to obtain the absolute byte offset within the
+/// object.  See [`crate::syscall::resolve_futex_key`].
+///
+/// Acquires `PROCESS_TABLE` briefly; the returned tuple owns no borrows.
+pub fn futex_backing_for(pid: Pid, addr: u64) -> Option<(usize, u64, u64, u64)> {
+    use crate::mm::vma::{VmArea, VmBacking, MAP_SHARED};
+
+    // Pull out (mount_idx, inode, vma_base, file_offset) iff the VMA is a
+    // MAP_SHARED file/memfd-backed region.  Private/anonymous → None.
+    fn shared_file_backing(vma: &VmArea) -> Option<(usize, u64, u64, u64)> {
+        if vma.flags & MAP_SHARED == 0 {
+            return None;
+        }
+        match vma.backing {
+            VmBacking::File { mount_idx, inode, offset, .. } => {
+                Some((mount_idx, inode, vma.base, offset))
+            }
+            // Anonymous (incl. MAP_SHARED|MAP_ANONYMOUS) and Device backings
+            // are pinned by the mm, not a cross-process object — keep them on
+            // the private key path (matches futex(2)).
+            _ => None,
+        }
+    }
+
+    let procs = PROCESS_TABLE.lock();
+    let child = procs.iter().find(|p| p.pid == pid)?;
+
+    // Direct hit on the child's own VmSpace.  If the child has diverged
+    // (its own VmSpace exists but does not cover `addr`), do NOT fall back to
+    // the parent — its VMA list is authoritative.  Same rule as
+    // `find_vma_with_parent_fallback`.
+    if let Some(space) = child.vm_space.as_ref() {
+        return space.find_vma(addr).and_then(shared_file_backing);
+    }
+
+    // Child has no VmSpace (CLONE_VM shared-VM state).  Consult the parent only
+    // when the CR3 matches.
+    let child_cr3 = child.cr3;
+    let parent_pid = child.parent_pid;
+    if child_cr3 == 0 || parent_pid == 0 {
+        return None;
+    }
+    let parent = procs.iter().find(|p| p.pid == parent_pid)?;
+    if parent.cr3 != child_cr3 {
+        return None;
+    }
+    parent.vm_space.as_ref()?.find_vma(addr).and_then(shared_file_backing)
+}
+
 /// Store the clear_child_tid address in a thread for CLONE_CHILD_CLEARTID.
 /// When that thread exits, the kernel will write 0 to that address and wake futex.
 pub fn set_clear_child_tid(pid: Pid, tid: Tid, tidptr: u64) {

--- a/kernel/src/subsys/linux/futex_cluster.rs
+++ b/kernel/src/subsys/linux/futex_cluster.rs
@@ -321,8 +321,19 @@ fn select_candidates(
 
     let mut out: alloc::vec::Vec<Candidate> = alloc::vec::Vec::new();
     {
+        use crate::syscall::FutexKey;
         let waiters = crate::syscall::FUTEX_WAITERS.lock();
-        for (&(wpid, wuaddr), tids) in waiters.range((pid, lo)..(pid, hi)) {
+        // The cluster-wake compensation operates on the same-process
+        // (PRIVATE-key) virtual-address cluster: sibling pthread_cond_t fields
+        // within one process's enclosing object.  A process-SHARED futex is
+        // keyed by backing-object identity (no contiguous virtual range), so it
+        // is excluded — `Private(pid, _)` keys form a contiguous, ascending
+        // slice in the FutexKey ordering.
+        for (k, tids) in waiters.range(FutexKey::Private(pid, lo)..FutexKey::Private(pid, hi)) {
+            let (wpid, wuaddr) = match k {
+                FutexKey::Private(p, u) => (*p, *u),
+                FutexKey::Shared { .. } => continue,
+            };
             if wpid != pid { continue; }
             if wuaddr == wake_uaddr { continue; } // exact match handled by main wake
             if tids.is_empty() { continue; }
@@ -394,13 +405,17 @@ fn select_candidates(
 /// was already woken; our compensation simply didn't wake an additional
 /// one.
 fn wake_one_candidate(pid: u64, cand: &Candidate) -> Option<u64> {
+    use crate::syscall::FutexKey;
+    // Candidates are selected only from the PRIVATE-key cluster, so the
+    // bucket to drain is the private key for `(pid, cand.uaddr)`.
+    let cand_key = FutexKey::Private(pid, cand.uaddr);
     let tid = {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-        let list = waiters.get_mut(&(pid, cand.uaddr))?;
+        let list = waiters.get_mut(&cand_key)?;
         if list.is_empty() { return None; }
         let t = list.remove(0);
         if list.is_empty() {
-            waiters.remove(&(pid, cand.uaddr));
+            waiters.remove(&cand_key);
         }
         t
     };
@@ -444,9 +459,10 @@ pub fn compensate(pid: u64, wake_tid: u64, wake_uaddr: u64, nr_wake: u64) -> u64
             .saturating_add(CLUSTER_HALF_WINDOW)
             .saturating_add(3) & !3u64;
         let any_neighbour = {
+            use crate::syscall::FutexKey;
             let waiters = crate::syscall::FUTEX_WAITERS.lock();
-            waiters.range((pid, lo)..(pid, hi))
-                .any(|(&(p, u), tids)| p == pid && u != wake_uaddr && !tids.is_empty())
+            waiters.range(FutexKey::Private(pid, lo)..FutexKey::Private(pid, hi))
+                .any(|(k, tids)| matches!(k, FutexKey::Private(p, u) if *p == pid && *u != wake_uaddr) && !tids.is_empty())
         };
         if any_neighbour {
             CLUSTER_WAKE_MISSES.fetch_add(1, Ordering::Relaxed);

--- a/kernel/src/subsys/linux/futex_key_diag.rs
+++ b/kernel/src/subsys/linux/futex_key_diag.rs
@@ -101,21 +101,28 @@ pub fn emit_wake_empty(
     // We extract only what we need to print so the lock release happens
     // before any serial I/O.
     let (bucket_present, same_pid_keys, nearest, same_page) = {
+        use crate::syscall::FutexKey;
         let waiters = crate::syscall::FUTEX_WAITERS.lock();
 
-        let bucket_present = if waiters.contains_key(&(pid, uaddr)) { 1u8 } else { 0u8 };
+        // This diagnostic reasons about the same-process (PRIVATE-key) cluster
+        // of futex words; a process-SHARED futex is keyed by backing-object
+        // identity, not by `(pid, uaddr)`, so it has no contiguous virtual
+        // range to scan and is excluded here.
+        let bucket_present =
+            if waiters.contains_key(&FutexKey::Private(pid, uaddr)) { 1u8 } else { 0u8 };
 
         // Page-aligned bounds for the same_page scan.  4 KiB page,
         // 0-extended (uaddr is a u64 user-VA; arithmetic stays in u64).
         let page_lo = uaddr & !0xFFFu64;
         let page_hi = page_lo.saturating_add(0x1000);
 
-        // Walk this `pid`'s slice of FUTEX_WAITERS only — BTreeMap is keyed
-        // lexicographically on `(pid, uaddr)`, so a half-open range from
-        // `(pid, 0)` to `(pid+1, 0)` walks exactly this pid's entries in
-        // ascending uaddr order.
-        let lo = (pid, 0u64);
-        let hi = (pid.saturating_add(1), 0u64);
+        // Walk this `pid`'s PRIVATE slice of FUTEX_WAITERS only — the FutexKey
+        // ordering sorts the `Private` variant lexicographically on
+        // `(pid, uaddr)` (and before any `Shared` key), so a half-open range
+        // from `Private(pid, 0)` to `Private(pid+1, 0)` walks exactly this
+        // pid's private entries in ascending uaddr order.
+        let lo = FutexKey::Private(pid, 0u64);
+        let hi = FutexKey::Private(pid.saturating_add(1), 0u64);
 
         let mut same_pid_keys: u64 = 0;
         let mut same_page: Vec<(u64, usize)> = Vec::with_capacity(SAME_PAGE_CAP);
@@ -123,7 +130,11 @@ pub fn emit_wake_empty(
         // distance.  Cheap: linear pass with bounded inserts.
         let mut nearest: Vec<(u64, usize)> = Vec::with_capacity(NEAREST_CAP * 2);
 
-        for (&(_p, wuaddr), tids) in waiters.range(lo..hi) {
+        for (k, tids) in waiters.range(lo..hi) {
+            let wuaddr = match k {
+                FutexKey::Private(_p, u) => *u,
+                FutexKey::Shared { .. } => continue,
+            };
             same_pid_keys = same_pid_keys.saturating_add(1);
 
             if wuaddr >= page_lo && wuaddr < page_hi && same_page.len() < SAME_PAGE_CAP {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -9293,11 +9293,30 @@ pub fn sys_futex_linux(
 ) -> i64 {
     const FUTEX_PRIVATE_FLAG:   u64 = 0x80;
     const FUTEX_CLOCK_REALTIME: u64 = 0x100;
-    let _ = FUTEX_PRIVATE_FLAG; // documented for clarity; no behavioural use
 
     let op = futex_op & 0x7F; // Strip FUTEX_PRIVATE_FLAG and FUTEX_CLOCK_REALTIME
     let abs_realtime = (futex_op & FUTEX_CLOCK_REALTIME) != 0;
     let pid = crate::proc::current_pid_lockless();
+
+    // Per `futex(2)` (FUTEX_PRIVATE_FLAG): when the caller sets the private
+    // flag, the futex is process-private and keyed by `(mm, uaddr)` — the
+    // fast path.  When it is clear, a futex word that lives on a `MAP_SHARED`
+    // file/`memfd`-backed page is process-shared and must be keyed by its
+    // backing-object identity so two processes mapping the same object at
+    // different virtual addresses rendezvous (`resolve_futex_key`).  Mozilla's
+    // cross-process screenshot rendezvous (`CrossProcessSemaphore` on a
+    // `memfd` `MAP_SHARED` page) takes exactly this shared path: it does NOT
+    // set FUTEX_PRIVATE_FLAG, the content process WAITs and the parent WAKEs
+    // (or vice versa), and only a shared key lets the wake reach the waiter.
+    let force_private = (futex_op & FUTEX_PRIVATE_FLAG) != 0;
+    // The rendezvous key for ops that operate on `uaddr` (WAIT/WAKE/REQUEUE
+    // source/WAKE_OP first wake).  Resolved once here (one VMA lookup on the
+    // shared path; a no-op on the private fast path), then reused by every
+    // bucket operation below so waiter and waker land in the same bucket.
+    let key = crate::syscall::resolve_futex_key(pid, uaddr, force_private);
+    // The destination key for the two-address ops (REQUEUE dst, WAKE_OP second
+    // wake) is resolved lazily in those branches — `uaddr2` is unused (and may
+    // be a non-pointer count) for the single-address ops.
 
     // Read the timespec at `timeout_ptr` (NULL means "no timeout") and convert
     // it to a *relative* nanosecond duration that the rest of the handler can
@@ -9481,7 +9500,7 @@ pub fn sys_futex_linux(
             // transitioned to Blocked, so it cannot return `woken=0` while
             // we're still mid-registration.
             match crate::syscall::futex_wait_check_and_enqueue(
-                pid, uaddr, val, tid, wake_tick,
+                key, val, tid, wake_tick,
                 || unsafe { crate::syscall::user_read_u32(uaddr) },
             ) {
                 crate::syscall::FutexWaitOutcome::Enqueued     => {}
@@ -9551,13 +9570,18 @@ pub fn sys_futex_linux(
                 // requeue insert).  `take`-style: remove it so the map does
                 // not leak across this waiter's lifetime.
                 let dest = crate::syscall::FUTEX_REQUEUE_DEST.lock().remove(&(pid, tid));
-                let key = (pid, dest.unwrap_or(uaddr));
-                if let Some(list) = waiters.get_mut(&key) {
+                // The bucket the waiter actually sits in: the requeue
+                // destination key if a requeue moved it, else the key it
+                // originally enqueued under.  Both are full FutexKeys, so a
+                // shared-futex waiter (or one requeued onto a shared bucket) is
+                // scanned in the right bucket.
+                let cleanup_key = dest.unwrap_or(key);
+                if let Some(list) = waiters.get_mut(&cleanup_key) {
                     let before = list.len();
                     list.retain(|&t| t != tid);
                     if list.len() < before { timed_out = true; } // still in list → timed out; already gone → woken
                     if list.is_empty() {
-                        waiters.remove(&key);
+                        waiters.remove(&cleanup_key);
                     }
                 }
             }
@@ -9600,14 +9624,14 @@ pub fn sys_futex_linux(
 
             let tids_to_wake: Vec<u64> = {
                 let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-                if let Some(list) = waiters.get_mut(&(pid, uaddr)) {
+                if let Some(list) = waiters.get_mut(&key) {
                     let mut result = Vec::new();
                     while !list.is_empty() && woken < max_wake {
                         result.push(list.remove(0));
                         woken += 1;
                     }
                     if list.is_empty() {
-                        waiters.remove(&(pid, uaddr));
+                        waiters.remove(&key);
                     }
                     result
                 } else {
@@ -9737,18 +9761,33 @@ pub fn sys_futex_linux(
             // the per-wake scan nor the serial; `test-mode` keeps the full
             // behaviour so Test 238 (which asserts FUTEX_WAKE_GHOST_COUNT
             // advances) is unchanged.
+            // The composite-cond-var GHOST cluster is a same-address-space
+            // (PRIVATE-key) phenomenon — sibling pthread_cond_t fields within
+            // one process's enclosing object.  A SHARED-key wake has no
+            // `(pid, uaddr)` cluster to scan (its bucket identity is a backing
+            // object, not a contiguous virtual range), so the diagnostic only
+            // runs on the private path.
             #[cfg(any(feature = "firefox-test-trace", feature = "test-mode"))]
             if woken == 0 && (op == 1 || op == 10) {
+                if let crate::syscall::FutexKey::Private(_, _) = key {
                 const FUTEX_GHOST_CLUSTER: u64 = 256;
                 let cluster_lo = uaddr & !(FUTEX_GHOST_CLUSTER - 1);
                 let cluster_hi = cluster_lo + FUTEX_GHOST_CLUSTER;
                 let waiters = crate::syscall::FUTEX_WAITERS.lock();
-                // BTreeMap::range over the half-open [(pid, cluster_lo),
-                // (pid, cluster_hi)) interval lets us find sibling uaddrs
-                // in O(log n + k) without scanning the whole table.
-                for (&(wpid, wuaddr), tids) in waiters
-                    .range((pid, cluster_lo)..(pid, cluster_hi))
+                // BTreeMap::range over the half-open [Private(pid, cluster_lo),
+                // Private(pid, cluster_hi)) interval lets us find sibling
+                // uaddrs in O(log n + k) without scanning the whole table.
+                // Private(pid, _) keys for one pid are contiguous in the
+                // FutexKey ordering (the Private variant sorts before Shared
+                // and lexicographically by (pid, uaddr)).
+                use crate::syscall::FutexKey;
+                for (k, tids) in waiters
+                    .range(FutexKey::Private(pid, cluster_lo)..FutexKey::Private(pid, cluster_hi))
                 {
+                    let (wpid, wuaddr) = match k {
+                        FutexKey::Private(p, u) => (*p, *u),
+                        FutexKey::Shared { .. } => continue,
+                    };
                     if wpid != pid || wuaddr == uaddr { continue; }
                     if let Some(&first_tid) = tids.first() {
                         crate::serial_println!(
@@ -9764,6 +9803,7 @@ pub fn sys_futex_linux(
                         );
                     }
                 }
+                } // close: if let Private(_, _) = key
             }
 
             // History-mode GHOST correlation — observe-only.  This bumps
@@ -9831,12 +9871,20 @@ pub fn sys_futex_linux(
             let mut woken = 0u64;
             let mut requeued = 0u64;
 
+            // Destination rendezvous key for uaddr2.  Resolved with the same
+            // `force_private` as the source — both addresses live in the same
+            // address space and the private flag applies to the whole op.  A
+            // requeue may legitimately move waiters between a private source
+            // bucket and a shared destination bucket (or vice versa); keying
+            // both correctly is what lets the requeued waiter be found later.
+            let key2 = crate::syscall::resolve_futex_key(pid, uaddr2, force_private);
+
             let tids_to_wake: Vec<u64>;
             let tids_to_requeue: Vec<u64>;
 
             {
                 let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-                let src = waiters.remove(&(pid, uaddr)).unwrap_or_default();
+                let src = waiters.remove(&key).unwrap_or_default();
                 let mut wake_list = Vec::new();
                 let mut requeue_list = Vec::new();
                 for tid in src {
@@ -9848,21 +9896,21 @@ pub fn sys_futex_linux(
                         requeued += 1;
                     }
                 }
-                // Requeue surviving waiters to uaddr2.
+                // Requeue surviving waiters to uaddr2's key.
                 if !requeue_list.is_empty() {
-                    waiters.entry((pid, uaddr2)).or_insert_with(Vec::new).extend(requeue_list.iter());
+                    waiters.entry(key2).or_insert_with(Vec::new).extend(requeue_list.iter());
                     // Record each requeued TID's new destination key so its
                     // own FUTEX_WAIT post-`schedule()` cleanup scans the
-                    // bucket it now sits in `(pid, uaddr2)` rather than its
-                    // original `(pid, uaddr)`.  Per `futex(2)`, requeue
-                    // updates the waiter's queue key to uaddr2; without this a
-                    // timeout-after-requeue would leave an orphan in the
-                    // uaddr2 bucket and misreport ETIMEDOUT as success.  Taken
-                    // while still holding FUTEX_WAITERS to keep the single
-                    // FUTEX_WAITERS → FUTEX_REQUEUE_DEST lock order.
+                    // bucket it now sits in (`key2`) rather than its original
+                    // `key`.  Per `futex(2)`, requeue updates the waiter's
+                    // queue key to uaddr2; without this a timeout-after-requeue
+                    // would leave an orphan in the destination bucket and
+                    // misreport ETIMEDOUT as success.  Taken while still
+                    // holding FUTEX_WAITERS to keep the single FUTEX_WAITERS →
+                    // FUTEX_REQUEUE_DEST lock order.
                     let mut dest = crate::syscall::FUTEX_REQUEUE_DEST.lock();
                     for &tid in &requeue_list {
-                        dest.insert((pid, tid), uaddr2);
+                        dest.insert((pid, tid), key2);
                     }
                 }
                 tids_to_wake = wake_list;
@@ -9927,6 +9975,13 @@ pub fn sys_futex_linux(
                 oparg = 1i32 << (oparg & 31);
             }
 
+            // Resolve uaddr2's rendezvous key BEFORE taking FUTEX_WAITERS:
+            // `resolve_futex_key` acquires PROCESS_TABLE, and the established
+            // lock order is FUTEX_WAITERS → THREAD_TABLE (never FUTEX_WAITERS →
+            // PROCESS_TABLE).  Resolving up front keeps the critical section
+            // below lock-clean.
+            let key2 = crate::syscall::resolve_futex_key(pid, uaddr2, force_private);
+
             // ── Atomic modify of *uaddr2, capturing the old value ─────────
             // Read-modify-write is serialised by the FUTEX_WAITERS lock held
             // across the whole op: every wake-class futex op takes it, so no
@@ -9957,13 +10012,13 @@ pub fn sys_futex_linux(
             // ── Wake up to `val` waiters on uaddr ─────────────────────────
             let max_wake1 = if val == 0 { u64::MAX } else { val };
             let mut tids_to_wake: Vec<u64> = Vec::new();
-            if let Some(list) = waiters.get_mut(&(pid, uaddr)) {
+            if let Some(list) = waiters.get_mut(&key) {
                 let mut n = 0u64;
                 while !list.is_empty() && n < max_wake1 {
                     tids_to_wake.push(list.remove(0));
                     n += 1;
                 }
-                if list.is_empty() { waiters.remove(&(pid, uaddr)); }
+                if list.is_empty() { waiters.remove(&key); }
             }
 
             // ── Evaluate CMP(oldval, cmparg); if true wake uaddr2 too ─────
@@ -9978,13 +10033,13 @@ pub fn sys_futex_linux(
             };
             if cmp_true {
                 let max_wake2 = if val2 == 0 { u64::MAX } else { val2 };
-                if let Some(list) = waiters.get_mut(&(pid, uaddr2)) {
+                if let Some(list) = waiters.get_mut(&key2) {
                     let mut n = 0u64;
                     while !list.is_empty() && n < max_wake2 {
                         tids_to_wake.push(list.remove(0));
                         n += 1;
                     }
-                    if list.is_empty() { waiters.remove(&(pid, uaddr2)); }
+                    if list.is_empty() { waiters.remove(&key2); }
                 }
             }
             drop(waiters);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -255,49 +255,118 @@ pub(crate) unsafe fn user_read_timespec(addr: u64) -> Option<(u64, u64)> {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Futex wait queue — keyed by (pid, uaddr)
+// Futex wait queue — keyed by [`FutexKey`] (private: (pid, uaddr); shared:
+// backing-object identity)
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// Key shape: `(pid, uaddr)` — the FUTEX_PRIVATE key per `futex(2)`.
+// Per `futex(2)` (Linux man-pages, "FUTEX_PRIVATE_FLAG") a futex word names a
+// rendezvous point that must hash identically for the waiter and the waker:
 //
-// Per `futex(2)` (Linux man-pages, "FUTEX_PRIVATE_FLAG" and "Priority-inheritance
-// futexes"):
+//   * A PRIVATE futex is scoped to a single address space and identified by
+//     the tuple `(mm, virtual address)`.  We approximate `mm` with `pid` —
+//     correct because every Linux task on AstryxOS has its own page tables and
+//     no two distinct pids share an `mm`.
 //
-//   * FUTEX_PRIVATE futexes are scoped to a single process and identified by
-//     the tuple `(mm_struct, virtual address)`.  We approximate `mm_struct`
-//     with `pid` — correct because every process has its own page tables and
-//     no two processes share the `mm` of a Linux task on AstryxOS.
+//   * A SHARED (process-shared / `pshared`) futex names a *backing object*,
+//     not a virtual address.  Two processes that map the same shared object —
+//     a file, or an `memfd_create(2)` anonymous file — at DIFFERENT virtual
+//     addresses must still rendezvous: a `FUTEX_WAIT` in process A and the
+//     matching `FUTEX_WAKE` in process B operate on the same logical futex
+//     word even though their `uaddr` values differ.  Keying such a futex by
+//     `(pid, uaddr)` would place the waiter and the waker in different hash
+//     buckets and the wake would never reach the waiter.  The key is therefore
+//     the page identity of the backing object: `(mount_idx, inode, byte offset
+//     within the object)`.  See the `get_futex_key`-equivalent semantics
+//     described in `futex(2)`.
 //
-//   * FUTEX_SHARED futexes are scoped to a backing object and identified by
-//     the tuple `(inode, page offset within file)` for file-backed mappings
-//     or by an anonymous-mapping anchor for `MAP_SHARED|MAP_ANONYMOUS`.
-//     Two processes that map the same shared region at different virtual
-//     addresses must still hash to the same key, otherwise a
-//     `pthread_mutex_lock` in process A and the matching wake in process B
-//     will miss.
+// Which kind a given `(pid, uaddr)` names is resolved at futex-syscall time by
+// [`resolve_futex_key`]: it consults the VMA backing `uaddr`.  A `MAP_SHARED`
+// file/`memfd`-backed VMA yields the SHARED key; everything else (private
+// mappings, anonymous mappings — including `MAP_SHARED|MAP_ANONYMOUS`, whose
+// pinning object is the mm itself, matching `futex(2)`) yields the PRIVATE key.
+// `FUTEX_PRIVATE_FLAG`, when the caller sets it, forces the PRIVATE shape; its
+// absence over a shared VMA selects the SHARED key.  The PRIVATE path is the
+// fast path and is unchanged: a private futex resolves to `(pid, uaddr)`
+// exactly as before, and the only added cost on the shared path is one VMA
+// lookup at op entry (no extra cost once the key is in hand).
 //
-// This implementation uses the FUTEX_PRIVATE key shape for ALL futex
-// operations, including those with the FUTEX_PRIVATE_FLAG clear.  This is
-// correct in practice when:
-//
-//   (a) The futex is FUTEX_PRIVATE (FUTEX_PRIVATE_FLAG set, or implied by
-//       the caller's intent — `pthread_mutexattr_setpshared(_, PROCESS_PRIVATE)`
-//       and similar default to FUTEX_PRIVATE).
-//   (b) The futex is FUTEX_SHARED AND both processes have mapped the shared
-//       region at the same `uaddr` (common when a parent forks and the child
-//       inherits identical mappings, or when both ends explicitly request
-//       MAP_FIXED at the same VA).
-//
-// Cross-process FUTEX_SHARED synchronisation across DIFFERENT virtual
-// addresses is NOT supported.  No upstream binary on the current demo path
-// (musl-FF strace differential 2026-05-20) uses it.  When a use case
-// emerges, change `(u64, u64)` to a `FutexKey` enum with `Private(pid, va)`
-// and `Shared(mount_idx, inode, page_off)` variants, derive the shared
-// variant from `vma::lookup(pid, uaddr)` on every WAIT/WAKE/REQUEUE entry,
-// and back-fill tests with a two-process MAP_SHARED+pthread_mutex case.
-//
-// Refs: `futex(2)` Linux man-pages; POSIX.1-2017 §pthread_mutexattr_getpshared.
-pub(crate) static FUTEX_WAITERS: Mutex<BTreeMap<(u64, u64), Vec<u64>>> = Mutex::new(BTreeMap::new());
+// Refs: `futex(2)` Linux man-pages; `memfd_create(2)`;
+// POSIX.1-2017 §pthread_mutexattr_getpshared.
+
+/// Identity of a futex rendezvous point.
+///
+/// A futex word is named either by its address space + virtual address (a
+/// PRIVATE futex) or by the page identity of the shared backing object it
+/// lives on (a SHARED / `pshared` futex).  Both variants are total-ordered so
+/// the type can key the `FUTEX_WAITERS` `BTreeMap`.
+///
+/// Per `futex(2)`: a PRIVATE futex hashes on `(mm, uaddr)`; a SHARED futex
+/// hashes on the backing object so two processes mapping the same object at
+/// different virtual addresses rendezvous.  See [`resolve_futex_key`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum FutexKey {
+    /// Process-private futex: `(pid, uaddr)`.  Two operations rendezvous iff
+    /// they share both the pid (address space) and the virtual address.
+    Private(u64, u64),
+    /// Process-shared futex on a file/`memfd`-backed `MAP_SHARED` page.  Keyed
+    /// by the backing object identity + byte offset within that object, so two
+    /// processes mapping the same object at different virtual addresses
+    /// rendezvous.  `byte_off` is the absolute byte offset of the futex word
+    /// within the backing object (VMA file offset folded with the word's
+    /// distance from the VMA base); the 4-byte alignment of every futex word
+    /// keeps it well-defined.
+    Shared { mount_idx: usize, inode: u64, byte_off: u64 },
+}
+
+impl FutexKey {
+    /// The pid an operation issued for, for the diagnostic/exit paths that
+    /// still reason per-process.  For SHARED keys there is no single owning
+    /// pid; returns `None`.
+    #[inline]
+    pub(crate) fn private_pid(&self) -> Option<u64> {
+        match self {
+            FutexKey::Private(pid, _) => Some(*pid),
+            FutexKey::Shared { .. } => None,
+        }
+    }
+}
+
+/// Resolve the `(pid, uaddr)` of a futex operation to the [`FutexKey`] that
+/// names its rendezvous point.
+///
+/// The futex word at `uaddr` is SHARED iff the VMA covering it is `MAP_SHARED`
+/// and file/`memfd`-backed (`VmBacking::File`); in that case the key is the
+/// backing object identity plus the word's absolute byte offset within the
+/// object.  Every other case — private mappings, anonymous mappings (shared or
+/// private), an unmapped `uaddr`, or the absence of a resolvable VmSpace —
+/// yields the PRIVATE key `(pid, uaddr)`, which is both the fast path and the
+/// correct fallback (an anonymous shared mapping's pinning object is the mm,
+/// per `futex(2)`).
+///
+/// `force_private` is set when the caller passed `FUTEX_PRIVATE_FLAG`: per
+/// `futex(2)` that flag unconditionally selects the private key shape, so the
+/// VMA lookup is skipped entirely (the fast path the flag exists to provide).
+///
+/// Acquires `PROCESS_TABLE` briefly (via
+/// [`crate::proc::futex_backing_for`]); takes no futex lock, so it is safe to
+/// call before acquiring `FUTEX_WAITERS`.
+pub(crate) fn resolve_futex_key(pid: u64, uaddr: u64, force_private: bool) -> FutexKey {
+    if force_private {
+        return FutexKey::Private(pid, uaddr);
+    }
+    match crate::proc::futex_backing_for(pid, uaddr) {
+        Some((mount_idx, inode, vma_base, file_offset)) => {
+            // Absolute byte offset of the futex word within the backing
+            // object: the VMA's base file offset, plus the word's distance
+            // from the VMA base.  4-byte futex-word alignment keeps this exact.
+            let byte_off = file_offset.wrapping_add(uaddr.wrapping_sub(vma_base));
+            FutexKey::Shared { mount_idx, inode, byte_off }
+        }
+        None => FutexKey::Private(pid, uaddr),
+    }
+}
+
+pub(crate) static FUTEX_WAITERS: Mutex<BTreeMap<FutexKey, Vec<u64>>> = Mutex::new(BTreeMap::new());
 
 /// Destination key for waiters that a `FUTEX_REQUEUE` / `FUTEX_CMP_REQUEUE`
 /// moved off their original WAIT queue.
@@ -312,20 +381,23 @@ pub(crate) static FUTEX_WAITERS: Mutex<BTreeMap<(u64, u64), Vec<u64>>> = Mutex::
 /// for a later wake to spuriously pop, and (b) misclassify the timeout as a
 /// successful wake (returning 0 instead of ETIMEDOUT).
 ///
-/// This map records `(pid, tid) → dest_uaddr` for exactly the window between a
+/// This map records `(pid, tid) → dest_key` for exactly the window between a
 /// requeue moving the TID and that TID's WAIT branch running its post-wake
 /// cleanup.  The cleanup consults it to scan the bucket the waiter actually
 /// sits in, then removes the entry.  Keyed by `(pid, tid)`: a TID is unique
 /// within a process and at most one requeue destination is live per parked
-/// waiter.  Lock order: acquired only while NOT holding `FUTEX_WAITERS` for
-/// the requeue insert (insert happens after the `FUTEX_WAITERS` critical
-/// section in the REQUEUE branch) and acquired *inside* the `FUTEX_WAITERS`
-/// critical section in the WAIT cleanup — to keep a single, consistent order
-/// (`FUTEX_WAITERS` → `FUTEX_REQUEUE_DEST`), the requeue insert takes
-/// `FUTEX_REQUEUE_DEST` while still holding `FUTEX_WAITERS`.
+/// waiter.  The destination is a full [`FutexKey`] because a requeue may move a
+/// waiter onto a SHARED bucket (uaddr2 on a different shared backing object),
+/// not merely a different virtual address.  Lock order: acquired only while NOT
+/// holding `FUTEX_WAITERS` for the requeue insert (insert happens after the
+/// `FUTEX_WAITERS` critical section in the REQUEUE branch) and acquired
+/// *inside* the `FUTEX_WAITERS` critical section in the WAIT cleanup — to keep
+/// a single, consistent order (`FUTEX_WAITERS` → `FUTEX_REQUEUE_DEST`), the
+/// requeue insert takes `FUTEX_REQUEUE_DEST` while still holding
+/// `FUTEX_WAITERS`.
 ///
 /// Ref: `futex(2)` Linux man-pages (FUTEX_REQUEUE / FUTEX_CMP_REQUEUE).
-pub(crate) static FUTEX_REQUEUE_DEST: Mutex<BTreeMap<(u64, u64), u64>> = Mutex::new(BTreeMap::new());
+pub(crate) static FUTEX_REQUEUE_DEST: Mutex<BTreeMap<(u64, u64), FutexKey>> = Mutex::new(BTreeMap::new());
 
 /// Outcome of `futex_wait_check_and_enqueue`.
 #[derive(Debug)]
@@ -357,9 +429,13 @@ pub(crate) enum FutexWaitOutcome {
 /// path uses a kernel-mode reader so the same critical section is exercised
 /// without needing a real user mapping.  The closure must be cheap and must
 /// not acquire any kernel locks.
+///
+/// `key` is the resolved [`FutexKey`] (private or shared) naming the
+/// rendezvous; the caller resolves it once before this call (see
+/// [`resolve_futex_key`]).  All bucket operations key on it, so a shared-futex
+/// waiter lands in the same bucket a cross-process waker scans.
 pub(crate) fn futex_wait_check_and_enqueue<R>(
-    pid: u64,
-    uaddr: u64,
+    key: FutexKey,
     val: u64,
     tid: u64,
     wake_tick: u64,
@@ -392,7 +468,7 @@ where
         return FutexWaitOutcome::ValueMismatch;
     }
 
-    waiters.entry((pid, uaddr)).or_insert_with(Vec::new).push(tid);
+    waiters.entry(key).or_insert_with(Vec::new).push(tid);
 
     // Mark Blocked under THREAD_TABLE while still holding FUTEX_WAITERS.
     //
@@ -404,25 +480,24 @@ where
     // overwrite Dead with Blocked, leaving a "Blocked but not in any wait
     // queue" thread that schedule() never picks and the reaper never reaps.
     //
-    // Defensive: if state is already Dead, undo our queue push (exit_group's
-    // `futex_drain_pid` will run when we release FUTEX_WAITERS, but draining
-    // is keyed on (pid, _) and we have just made the queue non-empty under a
-    // valid key — the drain still works, but it costs an extra branch.  Pop
-    // explicitly so the queue is clean immediately).  Skip the state write.
-    // Returning Enqueued is the right outcome: the caller will call
-    // schedule(), which will skip this Dead thread, and the next pass of
-    // reap_dead_threads_sched will reclaim it.
+    // Defensive: if state is already Dead, undo our queue push so the queue is
+    // clean immediately, then skip the state write.  (exit_group's
+    // `futex_drain_pid` drains the dying process's PRIVATE buckets when we
+    // release FUTEX_WAITERS; an explicit pop here keeps the bucket clean
+    // regardless of whether `key` is private or shared.)  Returning Enqueued is
+    // the right outcome: the caller will call schedule(), which will skip this
+    // Dead thread, and the next pass of reap_dead_threads_sched will reclaim it.
     {
         let mut threads = crate::proc::THREAD_TABLE.lock();
         if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
             if t.state == crate::proc::ThreadState::Dead {
                 // Undo the queue push we just made.
-                if let Some(list) = waiters.get_mut(&(pid, uaddr)) {
+                if let Some(list) = waiters.get_mut(&key) {
                     if let Some(pos) = list.iter().rposition(|&x| x == tid) {
                         list.remove(pos);
                     }
                     if list.is_empty() {
-                        waiters.remove(&(pid, uaddr));
+                        waiters.remove(&key);
                     }
                 }
             } else {
@@ -2187,20 +2262,47 @@ pub fn write_u32_to_user_pub(cr3: u64, vaddr: u64, val: u32) {
 /// Per futex(2) NOTES: "If a process exits while threads of that process
 /// are blocked on a futex, those threads are woken (with a wake-up
 /// indicating the futex is in an inconsistent state)."  We achieve the
-/// equivalent here: the threads themselves are already Dead, so we just
-/// clean up the queue keyed by `(pid, _)`.
+/// equivalent here: the threads themselves are already Dead.
+///
+/// Two bucket classes are scrubbed:
+///   * PRIVATE buckets `Private(pid, _)` belong solely to the dying process,
+///     so the whole bucket is removed.
+///   * SHARED buckets may hold waiters from *several* processes that map the
+///     same backing object; only the dying process's TIDs are removed,
+///     leaving any other process's waiters parked.  The dying TIDs are taken
+///     from `THREAD_TABLE` (`t.pid == pid`), which still lists them as Dead at
+///     drain time (reaping happens later).
 pub fn futex_drain_pid(pid: u64) {
+    // Snapshot the dying process's TIDs so shared buckets can be scrubbed by
+    // TID membership.  THREAD_TABLE is taken and released BEFORE FUTEX_WAITERS
+    // to avoid introducing a THREAD_TABLE→FUTEX_WAITERS edge (the WAIT path
+    // takes FUTEX_WAITERS→THREAD_TABLE; holding both in the reverse order here
+    // would be a lock-order inversion).
+    let dying_tids: alloc::vec::Vec<u64> = {
+        let threads = crate::proc::THREAD_TABLE.lock();
+        threads.iter().filter(|t| t.pid == pid).map(|t| t.tid).collect()
+    };
+
     let mut waiters = FUTEX_WAITERS.lock();
-    let dead_keys: alloc::vec::Vec<(u64, u64)> = waiters
-        .keys()
-        .filter(|&&(p, _)| p == pid)
-        .copied()
-        .collect();
-    for key in dead_keys {
-        waiters.remove(&key);
+    let to_scrub: alloc::vec::Vec<FutexKey> = waiters.keys().copied().collect();
+    for key in to_scrub {
+        match key {
+            FutexKey::Private(p, _) if p == pid => {
+                waiters.remove(&key);
+            }
+            FutexKey::Shared { .. } => {
+                if let Some(list) = waiters.get_mut(&key) {
+                    list.retain(|t| !dying_tids.contains(t));
+                    if list.is_empty() {
+                        waiters.remove(&key);
+                    }
+                }
+            }
+            FutexKey::Private(..) => {} // another process's private bucket
+        }
     }
     // Drain any lingering requeue-destination records for this pid so a
-    // PID-reuse cannot inherit a stale `(pid, tid) → uaddr2` mapping.  Same
+    // PID-reuse cannot inherit a stale `(pid, tid) → dest_key` mapping.  Same
     // FUTEX_WAITERS → FUTEX_REQUEUE_DEST lock order as the requeue/WAIT paths.
     let mut dest = FUTEX_REQUEUE_DEST.lock();
     let dead_dest: alloc::vec::Vec<(u64, u64)> = dest
@@ -2215,16 +2317,26 @@ pub fn futex_drain_pid(pid: u64) {
 
 /// Wake futex waiters from the exit path (CLONE_CHILD_CLEARTID).
 /// This is called from proc::exit_thread when a thread with clear_child_tid exits.
+///
+/// The `clear_child_tid` word is a thread-local address in the exiting
+/// thread's own address space; per `clone(2)` CLONE_CHILD_CLEARTID it is a
+/// process-private futex.  We resolve the [`FutexKey`] the same way the WAIT
+/// side did (`resolve_futex_key`) so a waiter that parked on this word — even
+/// in the unlikely event the word lives on a shared mapping — is found in the
+/// bucket it actually occupies.  If the mapping has already been torn down the
+/// resolver falls back to `Private(pid, uaddr)`, which is the key a private
+/// CLEARTID waiter used.
 pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
+    let key = resolve_futex_key(pid, uaddr, false);
     #[cfg(feature = "firefox-test-core")]
     let key_present;
     let tids_to_wake: alloc::vec::Vec<u64> = {
         let mut waiters = FUTEX_WAITERS.lock();
         #[cfg(feature = "firefox-test-core")]
         {
-            key_present = waiters.contains_key(&(pid, uaddr));
+            key_present = waiters.contains_key(&key);
         }
-        if let Some(list) = waiters.get_mut(&(pid, uaddr)) {
+        if let Some(list) = waiters.get_mut(&key) {
             let mut result = alloc::vec::Vec::new();
             let mut woken = 0u64;
             while !list.is_empty() && woken < max_wake {
@@ -2232,7 +2344,7 @@ pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
                 woken += 1;
             }
             if list.is_empty() {
-                waiters.remove(&(pid, uaddr));
+                waiters.remove(&key);
             }
             result
         } else {
@@ -2243,14 +2355,14 @@ pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
     {
         // Snapshot remaining keys for diagnosis if our lookup missed.
         let waiters = FUTEX_WAITERS.lock();
-        let other_keys: alloc::vec::Vec<(u64, u64)> = waiters
+        let other_keys: alloc::vec::Vec<FutexKey> = waiters
             .keys()
-            .filter(|&&(p, _)| p == pid)
+            .filter(|k| k.private_pid() == Some(pid))
             .copied()
             .collect();
         crate::serial_println!(
-            "[FUTEX_WAKE_EXIT] pid={} uaddr={:#x} key_present={} woken={:?} remaining_pid_keys={:?}",
-            pid, uaddr, key_present, tids_to_wake, other_keys
+            "[FUTEX_WAKE_EXIT] pid={} uaddr={:#x} key={:?} key_present={} woken={:?} remaining_pid_keys={:?}",
+            pid, uaddr, key, key_present, tids_to_wake, other_keys
         );
     }
     // Wake the threads (no lock held).

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2781,6 +2781,17 @@ pub fn run() -> ! {
     total += 1;
     if test_294_epoll_edge_triggered_eventfd() { passed += 1; }
 
+    // ── Test 295: cross-process SHARED futex keying (memfd MAP_SHARED) ─────
+    // Two processes mapping the SAME memfd/file-backed MAP_SHARED page at
+    // DIFFERENT virtual addresses must rendezvous on a process-shared futex:
+    // a FUTEX_WAIT in process A and the matching FUTEX_WAKE in process B
+    // resolve to the SAME backing-object key and hash to the same bucket.
+    // Also pins the private fast path: a MAP_PRIVATE/anon word keys per-mm.
+    // This is the kernel side of the gecko cross-process screenshot
+    // rendezvous.  Refs: futex(2) FUTEX_PRIVATE_FLAG, memfd_create(2).
+    total += 1;
+    if test_295_crossproc_shared_futex_keying() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -14555,7 +14566,7 @@ fn test_futex_requeue() -> bool {
 //
 // Ref: futex(2) FUTEX_REQUEUE / FUTEX_CMP_REQUEUE (q->key = key2 invariant).
 fn test_futex_requeue_dest_tracking() -> bool {
-    use crate::syscall::{FUTEX_WAITERS, FUTEX_REQUEUE_DEST};
+    use crate::syscall::{FUTEX_WAITERS, FUTEX_REQUEUE_DEST, FutexKey};
     test_header!("futex REQUEUE destination tracking (orphan-free timeout)");
 
     // Use the CURRENT pid (the requeue syscall keys on current_pid_lockless).
@@ -14565,19 +14576,24 @@ fn test_futex_requeue_dest_tracking() -> bool {
     let uaddr2: u32 = 0;
     let a1 = &uaddr1 as *const u32 as u64;
     let a2 = &uaddr2 as *const u32 as u64;
+    // These are stack-local words (private anonymous mapping), so the futex
+    // keys are the PRIVATE shape `Private(pid, uaddr)` — the same keys the
+    // requeue syscall path resolves for them.
+    let k1 = FutexKey::Private(pid, a1);
+    let k2 = FutexKey::Private(pid, a2);
     // Synthetic waiter TID that collides with no live thread.
     let fake_tid: u64 = 0xF00D_5678;
 
     // Clean slate for these keys (a prior failed run could leak).
     {
         let mut w = FUTEX_WAITERS.lock();
-        w.remove(&(pid, a1));
-        w.remove(&(pid, a2));
+        w.remove(&k1);
+        w.remove(&k2);
         FUTEX_REQUEUE_DEST.lock().remove(&(pid, fake_tid));
     }
 
     // Step 1: register a fake waiter on uaddr1.
-    FUTEX_WAITERS.lock().entry((pid, a1))
+    FUTEX_WAITERS.lock().entry(k1)
         .or_insert_with(alloc::vec::Vec::new).push(fake_tid);
     test_println!("  registered fake waiter tid={:#x} on uaddr1", fake_tid);
 
@@ -14587,19 +14603,19 @@ fn test_futex_requeue_dest_tracking() -> bool {
             202, a1, 3, /*val=wake*/0, /*val2=requeue*/1, a2, 0)
     };
     if r != 0 {
-        FUTEX_WAITERS.lock().remove(&(pid, a1));
-        FUTEX_WAITERS.lock().remove(&(pid, a2));
+        FUTEX_WAITERS.lock().remove(&k1);
+        FUTEX_WAITERS.lock().remove(&k2);
         FUTEX_REQUEUE_DEST.lock().remove(&(pid, fake_tid));
         test_fail!("futex_requeue_dest", "REQUEUE returned {} (expected 0 woken)", r);
         return false;
     }
 
     // Step 3a: the waiter must have MOVED — gone from uaddr1, present at uaddr2.
-    let in_a1 = FUTEX_WAITERS.lock().get(&(pid, a1)).map(|v| v.contains(&fake_tid)).unwrap_or(false);
-    let in_a2 = FUTEX_WAITERS.lock().get(&(pid, a2)).map(|v| v.contains(&fake_tid)).unwrap_or(false);
+    let in_a1 = FUTEX_WAITERS.lock().get(&k1).map(|v| v.contains(&fake_tid)).unwrap_or(false);
+    let in_a2 = FUTEX_WAITERS.lock().get(&k2).map(|v| v.contains(&fake_tid)).unwrap_or(false);
     if in_a1 || !in_a2 {
-        FUTEX_WAITERS.lock().remove(&(pid, a1));
-        FUTEX_WAITERS.lock().remove(&(pid, a2));
+        FUTEX_WAITERS.lock().remove(&k1);
+        FUTEX_WAITERS.lock().remove(&k2);
         FUTEX_REQUEUE_DEST.lock().remove(&(pid, fake_tid));
         test_fail!("futex_requeue_dest",
             "after requeue: in_uaddr1={} in_uaddr2={} (expected false/true)", in_a1, in_a2);
@@ -14607,26 +14623,27 @@ fn test_futex_requeue_dest_tracking() -> bool {
     }
     test_println!("  waiter moved uaddr1→uaddr2 ✓");
 
-    // Step 3b: the destination must be recorded so the WAIT cleanup scans uaddr2.
+    // Step 3b: the destination key must be recorded so the WAIT cleanup scans
+    // uaddr2's bucket (now a full FutexKey, not a bare uaddr).
     let recorded = FUTEX_REQUEUE_DEST.lock().get(&(pid, fake_tid)).copied();
-    if recorded != Some(a2) {
-        FUTEX_WAITERS.lock().remove(&(pid, a2));
+    if recorded != Some(k2) {
+        FUTEX_WAITERS.lock().remove(&k2);
         FUTEX_REQUEUE_DEST.lock().remove(&(pid, fake_tid));
         test_fail!("futex_requeue_dest",
-            "FUTEX_REQUEUE_DEST[(pid,tid)]={:#x?} (expected {:#x})", recorded, a2);
+            "FUTEX_REQUEUE_DEST[(pid,tid)]={:#x?} (expected {:#x?})", recorded, k2);
         return false;
     }
     test_println!("  destination recorded: (pid,tid)→uaddr2 ✓ (gap #3)");
 
     // Step 4: replay the WAIT-branch timeout cleanup's bucket selection EXACTLY:
-    //   dest = FUTEX_REQUEUE_DEST.remove((pid,tid)); key = dest.unwrap_or(uaddr1)
+    //   dest = FUTEX_REQUEUE_DEST.remove((pid,tid)); key = dest.unwrap_or(k1)
     // and remove the TID from that bucket.  Pre-fix this used uaddr1 and would
     // leave the orphan in uaddr2 + misreport timeout as a wake.
     let timed_out;
     {
         let mut waiters = FUTEX_WAITERS.lock();
         let dest = FUTEX_REQUEUE_DEST.lock().remove(&(pid, fake_tid));
-        let key = (pid, dest.unwrap_or(a1));
+        let key = dest.unwrap_or(k1);
         if let Some(list) = waiters.get_mut(&key) {
             let before = list.len();
             list.retain(|&t| t != fake_tid);
@@ -14637,19 +14654,19 @@ fn test_futex_requeue_dest_tracking() -> bool {
         }
     }
     if !timed_out {
-        FUTEX_WAITERS.lock().remove(&(pid, a2));
+        FUTEX_WAITERS.lock().remove(&k2);
         test_fail!("futex_requeue_dest",
             "cleanup scanned the wrong bucket — orphan would survive (timed_out=false)");
         return false;
     }
 
     // Step 5: no orphan left anywhere, dest map cleaned.
-    let leak_a1 = FUTEX_WAITERS.lock().contains_key(&(pid, a1));
-    let leak_a2 = FUTEX_WAITERS.lock().contains_key(&(pid, a2));
+    let leak_a1 = FUTEX_WAITERS.lock().contains_key(&k1);
+    let leak_a2 = FUTEX_WAITERS.lock().contains_key(&k2);
     let leak_dest = FUTEX_REQUEUE_DEST.lock().contains_key(&(pid, fake_tid));
     if leak_a1 || leak_a2 || leak_dest {
-        FUTEX_WAITERS.lock().remove(&(pid, a1));
-        FUTEX_WAITERS.lock().remove(&(pid, a2));
+        FUTEX_WAITERS.lock().remove(&k1);
+        FUTEX_WAITERS.lock().remove(&k2);
         FUTEX_REQUEUE_DEST.lock().remove(&(pid, fake_tid));
         test_fail!("futex_requeue_dest",
             "leak after cleanup: a1={} a2={} dest={}", leak_a1, leak_a2, leak_dest);
@@ -29813,7 +29830,7 @@ fn test_access_w_ok_readonly() -> bool {
 fn test_cleartid_futex_wake() -> bool {
     test_header!("CLONE_CHILD_CLEARTID exit-time futex wake (key match + dequeue)");
 
-    use crate::syscall::{FUTEX_WAITERS, futex_wake_for_exit};
+    use crate::syscall::{FUTEX_WAITERS, FutexKey, futex_wake_for_exit};
 
     // Pick a synthetic (pid, uaddr) pair that no real thread is using.
     // The high tid value 0xFEED_1234 ensures we do not collide with any
@@ -29822,11 +29839,15 @@ fn test_cleartid_futex_wake() -> bool {
     let fake_pid: u64    = 0xDEAD_BEEF;
     let fake_uaddr: u64  = 0x7EFF_FF44_9990; // shape matches glibc joinstate addr
     let fake_tid: u64    = 0xFEED_1234;
+    // The CLEARTID word is a private thread-local; fake_pid has no VmSpace, so
+    // futex_wake_for_exit resolves it to `Private(fake_pid, fake_uaddr)` — the
+    // same key the test registers under.
+    let fk = FutexKey::Private(fake_pid, fake_uaddr);
 
     // Step 1: register a fake waiter.
     {
         let mut waiters = FUTEX_WAITERS.lock();
-        waiters.entry((fake_pid, fake_uaddr))
+        waiters.entry(fk)
             .or_insert_with(alloc::vec::Vec::new)
             .push(fake_tid);
     }
@@ -29839,13 +29860,13 @@ fn test_cleartid_futex_wake() -> bool {
     // Step 3: the (pid, uaddr) key must be gone (last waiter popped).
     {
         let waiters = FUTEX_WAITERS.lock();
-        if waiters.contains_key(&(fake_pid, fake_uaddr)) {
+        if waiters.contains_key(&fk) {
             drop(waiters);
             test_fail!("cleartid_futex_wake",
                 "FUTEX_WAITERS still contains (pid={:#x}, uaddr={:#x}) after wake",
                 fake_pid, fake_uaddr);
             // Best-effort cleanup so a failed run does not leak the entry.
-            FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+            FUTEX_WAITERS.lock().remove(&fk);
             return false;
         }
     }
@@ -29855,11 +29876,11 @@ fn test_cleartid_futex_wake() -> bool {
     futex_wake_for_exit(fake_pid, fake_uaddr, 1);
     {
         let waiters = FUTEX_WAITERS.lock();
-        if waiters.contains_key(&(fake_pid, fake_uaddr)) {
+        if waiters.contains_key(&fk) {
             drop(waiters);
             test_fail!("cleartid_futex_wake",
                 "wake-on-missing-key fabricated a stale entry");
-            FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+            FUTEX_WAITERS.lock().remove(&fk);
             return false;
         }
     }
@@ -29868,7 +29889,7 @@ fn test_cleartid_futex_wake() -> bool {
     // Step 5: queue with multiple waiters — wake 1 leaves the rest.
     {
         let mut waiters = FUTEX_WAITERS.lock();
-        let v = waiters.entry((fake_pid, fake_uaddr))
+        let v = waiters.entry(fk)
             .or_insert_with(alloc::vec::Vec::new);
         v.push(0xAAA1);
         v.push(0xAAA2);
@@ -29877,11 +29898,11 @@ fn test_cleartid_futex_wake() -> bool {
     futex_wake_for_exit(fake_pid, fake_uaddr, 1);
     let remaining = {
         let waiters = FUTEX_WAITERS.lock();
-        waiters.get(&(fake_pid, fake_uaddr)).map(|v| v.len()).unwrap_or(0)
+        waiters.get(&fk).map(|v| v.len()).unwrap_or(0)
     };
     if remaining != 2 {
         // Cleanup before failing.
-        FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+        FUTEX_WAITERS.lock().remove(&fk);
         test_fail!("cleartid_futex_wake",
             "expected 2 remaining waiters, got {}", remaining);
         return false;
@@ -29891,10 +29912,10 @@ fn test_cleartid_futex_wake() -> bool {
     futex_wake_for_exit(fake_pid, fake_uaddr, u64::MAX);
     let leftover = {
         let waiters = FUTEX_WAITERS.lock();
-        waiters.contains_key(&(fake_pid, fake_uaddr))
+        waiters.contains_key(&fk)
     };
     if leftover {
-        FUTEX_WAITERS.lock().remove(&(fake_pid, fake_uaddr));
+        FUTEX_WAITERS.lock().remove(&fk);
         test_fail!("cleartid_futex_wake", "drain wake left a stale key");
         return false;
     }
@@ -29926,7 +29947,7 @@ fn test_cleartid_write_demand_faults() -> bool {
     test_header!("CLONE_CHILD_CLEARTID write lands on non-present / COW page");
 
     use crate::mm::vmm::{read_pte, map_page_in, PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER};
-    use crate::syscall::{write_u32_to_user_pub, futex_wake_for_exit, FUTEX_WAITERS};
+    use crate::syscall::{write_u32_to_user_pub, futex_wake_for_exit, FUTEX_WAITERS, FutexKey};
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
 
     let test_pid: u64 = 9971;
@@ -30007,7 +30028,7 @@ fn test_cleartid_write_demand_faults() -> bool {
             old
         };
         if let Some(space) = old { crate::proc::free_vm_space(space); }
-        FUTEX_WAITERS.lock().remove(&(test_pid, 0)); // belt-and-braces
+        FUTEX_WAITERS.lock().remove(&FutexKey::Private(test_pid, 0)); // belt-and-braces
     };
 
     // ── Part A: write to a word on a NOT-PRESENT page ───────────────────────
@@ -30025,7 +30046,7 @@ fn test_cleartid_write_demand_faults() -> bool {
     let waiter_tid: u64 = 0x5151;
     {
         let mut waiters = FUTEX_WAITERS.lock();
-        waiters.entry((test_pid, addr_a)).or_insert_with(alloc::vec::Vec::new).push(waiter_tid);
+        waiters.entry(FutexKey::Private(test_pid, addr_a)).or_insert_with(alloc::vec::Vec::new).push(waiter_tid);
     }
 
     write_u32_to_user_pub(cr3, addr_a, 0);
@@ -30033,7 +30054,7 @@ fn test_cleartid_write_demand_faults() -> bool {
     // (a) PTE must now be present + writable + user.
     let pte_a = read_pte(cr3, addr_a);
     if pte_a & PAGE_PRESENT == 0 || pte_a & PAGE_WRITABLE == 0 || pte_a & PAGE_USER == 0 {
-        FUTEX_WAITERS.lock().remove(&(test_pid, addr_a));
+        FUTEX_WAITERS.lock().remove(&FutexKey::Private(test_pid, addr_a));
         teardown();
         test_fail!("cleartid_demand", "addr_a PTE not present/writable/user after write: {:#x}", pte_a);
         return false;
@@ -30042,7 +30063,7 @@ fn test_cleartid_write_demand_faults() -> bool {
     let phys_a = (pte_a & crate::mm::vmm::ADDR_MASK) + (addr_a & 0xFFF);
     let read_back_a = unsafe { core::ptr::read_volatile((PHYS_OFF + phys_a) as *const u32) };
     if read_back_a != 0 {
-        FUTEX_WAITERS.lock().remove(&(test_pid, addr_a));
+        FUTEX_WAITERS.lock().remove(&FutexKey::Private(test_pid, addr_a));
         teardown();
         test_fail!("cleartid_demand", "addr_a read-back {:#x}, expected 0", read_back_a);
         return false;
@@ -30053,10 +30074,10 @@ fn test_cleartid_write_demand_faults() -> bool {
     futex_wake_for_exit(test_pid, addr_a, 1);
     let still_parked = {
         let waiters = FUTEX_WAITERS.lock();
-        waiters.get(&(test_pid, addr_a)).map(|v| v.contains(&waiter_tid)).unwrap_or(false)
+        waiters.get(&FutexKey::Private(test_pid, addr_a)).map(|v| v.contains(&waiter_tid)).unwrap_or(false)
     };
     if still_parked {
-        FUTEX_WAITERS.lock().remove(&(test_pid, addr_a));
+        FUTEX_WAITERS.lock().remove(&FutexKey::Private(test_pid, addr_a));
         teardown();
         test_fail!("cleartid_demand", "waiter still parked after write+wake (lost wakeup)");
         return false;
@@ -34318,7 +34339,7 @@ fn test_rt_sigaction_flags_mask_roundtrip() -> bool {
 // the waiter sees `*uaddr != val` under the lock and returns EAGAIN.
 fn test_futex_wait_atomic_check_then_queue() -> bool {
     use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
-    use crate::syscall::{FUTEX_WAITERS, FutexWaitOutcome, futex_wait_check_and_enqueue,
+    use crate::syscall::{FUTEX_WAITERS, FutexKey, FutexWaitOutcome, futex_wait_check_and_enqueue,
                           futex_wake_for_exit};
 
     test_header!("FUTEX_WAIT atomic check-then-queue (lost-wakeup race) — issue: pre-PR");
@@ -34328,6 +34349,9 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
     // never dereferences it because we pass an in-kernel `read_u32` closure.
     const SYNTH_PID: u64    = 0xCAFE_BABE_DEAD_BEEF;
     const SYNTH_UADDR: u64  = 0x7EFF_F123_0000_0000;
+    // SYNTH_PID has no VmSpace, so both the enqueue and the wake resolve this
+    // word to the PRIVATE key — capture it once so the test keys consistently.
+    const SYNTH_KEY: FutexKey = FutexKey::Private(SYNTH_PID, SYNTH_UADDR);
     const EXPECTED_VAL: u32 = 0x4243_4445; // arbitrary sentinel
 
     // Shared kernel-mode "futex word" the closure reads under the lock.
@@ -34347,7 +34371,7 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
     WAKES_POSTED.store(0, Ordering::SeqCst);
     STOP_WAKERS.store(0, Ordering::SeqCst);
     // Remove any stale queue entry from a prior test run.
-    FUTEX_WAITERS.lock().remove(&(SYNTH_PID, SYNTH_UADDR));
+    FUTEX_WAITERS.lock().remove(&SYNTH_KEY);
 
     const N_WAITERS: u32 = 4;
     const N_WAKERS:  u32 = 2;
@@ -34362,7 +34386,7 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
         // helper returns ValueMismatch we count as "done" (a benign
         // EAGAIN — wake-side beat us via the FUTEX_WORD update).
         let outcome = futex_wait_check_and_enqueue(
-            SYNTH_PID, SYNTH_UADDR, EXPECTED_VAL as u64, tid,
+            SYNTH_KEY, EXPECTED_VAL as u64, tid,
             u64::MAX, // indefinite
             || Some(FUTEX_WORD.load(Ordering::SeqCst)),
         );
@@ -34374,10 +34398,10 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
                 // Cleanup: dequeue self if still on the list (timeout path).
                 {
                     let mut waiters = FUTEX_WAITERS.lock();
-                    if let Some(list) = waiters.get_mut(&(SYNTH_PID, SYNTH_UADDR)) {
+                    if let Some(list) = waiters.get_mut(&SYNTH_KEY) {
                         list.retain(|&t| t != tid);
                         if list.is_empty() {
-                            waiters.remove(&(SYNTH_PID, SYNTH_UADDR));
+                            waiters.remove(&SYNTH_KEY);
                         }
                     }
                 }
@@ -34474,7 +34498,7 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
     // WAITERS_DONE would be < N_WAITERS.
     if !all_done || done < N_WAITERS {
         // Best-effort cleanup so a failed run does not leak the queue entry.
-        FUTEX_WAITERS.lock().remove(&(SYNTH_PID, SYNTH_UADDR));
+        FUTEX_WAITERS.lock().remove(&SYNTH_KEY);
         test_fail!("futex_wait_atomic_check_then_queue",
             "only {}/{} waiters completed (lost wakeup — {} still parked)",
             done, N_WAITERS, N_WAITERS - done);
@@ -34484,10 +34508,10 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
     // Invariant 2: FUTEX_WAITERS must not contain a stale entry for our key.
     let leftover = {
         let waiters = FUTEX_WAITERS.lock();
-        waiters.get(&(SYNTH_PID, SYNTH_UADDR)).map(|v| v.len()).unwrap_or(0)
+        waiters.get(&SYNTH_KEY).map(|v| v.len()).unwrap_or(0)
     };
     if leftover != 0 {
-        FUTEX_WAITERS.lock().remove(&(SYNTH_PID, SYNTH_UADDR));
+        FUTEX_WAITERS.lock().remove(&SYNTH_KEY);
         test_fail!("futex_wait_atomic_check_then_queue",
             "{} waiter(s) left on FUTEX_WAITERS after drain (leaked queue entry)",
             leftover);
@@ -34517,13 +34541,15 @@ fn test_futex_wait_atomic_check_then_queue() -> bool {
 // 32 bits of `val`; when the low 32 bits differ it must report ValueMismatch.
 fn test_futex_wait_val_is_32bit() -> bool {
     use core::sync::atomic::{AtomicU32, Ordering};
-    use crate::syscall::{FUTEX_WAITERS, FutexWaitOutcome, futex_wait_check_and_enqueue};
+    use crate::syscall::{FUTEX_WAITERS, FutexKey, FutexWaitOutcome, futex_wait_check_and_enqueue};
 
     test_header!("FUTEX_WAIT 32-bit value compare (int sign-extension safe)");
 
     // Synthetic key, well clear of any live mapping.
     const SYNTH_PID:   u64 = 0xF00D_F00D_0000_0001;
     const SYNTH_UADDR: u64 = 0x7EFF_F222_0000_0000;
+    // No VmSpace for this synthetic pid → PRIVATE key.
+    const SYNTH_KEY: FutexKey = FutexKey::Private(SYNTH_PID, SYNTH_UADDR);
     // Futex word with bit 31 (musl waiters bit) set — exactly the value
     // captured live at the Firefox main-thread mutex storm (_m_lock = waiters
     // | EBUSY).
@@ -34536,14 +34562,14 @@ fn test_futex_wait_val_is_32bit() -> bool {
     FUTEX_WORD.store(WORD, Ordering::SeqCst);
 
     // Clean any stale queue entry from a prior run.
-    FUTEX_WAITERS.lock().remove(&(SYNTH_PID, SYNTH_UADDR));
+    FUTEX_WAITERS.lock().remove(&SYNTH_KEY);
 
     let tid = crate::proc::current_tid();
 
     // Case 1: low-32 bits agree, high bits all-ones (sign-extended int).
     // MUST Enqueue (pre-fix this returned ValueMismatch → the storm).
     let outcome = futex_wait_check_and_enqueue(
-        SYNTH_PID, SYNTH_UADDR, VAL_SIGN_EXTENDED, tid,
+        SYNTH_KEY, VAL_SIGN_EXTENDED, tid,
         u64::MAX,
         || Some(FUTEX_WORD.load(Ordering::SeqCst)),
     );
@@ -34553,9 +34579,9 @@ fn test_futex_wait_val_is_32bit() -> bool {
     // that so the scheduler keeps running us, and clear the queue entry.
     {
         let mut waiters = FUTEX_WAITERS.lock();
-        if let Some(list) = waiters.get_mut(&(SYNTH_PID, SYNTH_UADDR)) {
+        if let Some(list) = waiters.get_mut(&SYNTH_KEY) {
             list.retain(|&t| t != tid);
-            if list.is_empty() { waiters.remove(&(SYNTH_PID, SYNTH_UADDR)); }
+            if list.is_empty() { waiters.remove(&SYNTH_KEY); }
         }
     }
     {
@@ -34579,16 +34605,16 @@ fn test_futex_wait_val_is_32bit() -> bool {
     // the comparison legitimately exists to produce; the fix must not mask it).
     let bad_val: u64 = 0xFFFF_FFFF_8000_0011; // low32 = 0x8000_0011 != WORD
     let outcome2 = futex_wait_check_and_enqueue(
-        SYNTH_PID, SYNTH_UADDR, bad_val, tid,
+        SYNTH_KEY, bad_val, tid,
         u64::MAX,
         || Some(FUTEX_WORD.load(Ordering::SeqCst)),
     );
     // Defensive cleanup if it somehow enqueued.
     {
         let mut waiters = FUTEX_WAITERS.lock();
-        if let Some(list) = waiters.get_mut(&(SYNTH_PID, SYNTH_UADDR)) {
+        if let Some(list) = waiters.get_mut(&SYNTH_KEY) {
             list.retain(|&t| t != tid);
-            if list.is_empty() { waiters.remove(&(SYNTH_PID, SYNTH_UADDR)); }
+            if list.is_empty() { waiters.remove(&SYNTH_KEY); }
         }
         let mut threads = crate::proc::THREAD_TABLE.lock();
         if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
@@ -38423,7 +38449,7 @@ fn test_exec_from_shared_vm_child() -> bool {
 /// the supplied exit code.
 fn test_exit_group_wakes_siblings() -> bool {
     use crate::proc::{PROCESS_TABLE, THREAD_TABLE, ThreadState, ProcessState};
-    use crate::syscall::FUTEX_WAITERS;
+    use crate::syscall::{FUTEX_WAITERS, FutexKey};
 
     test_header!("exit_group wakes parked sibling threads (W59)");
 
@@ -38473,9 +38499,10 @@ fn test_exit_group_wakes_siblings() -> bool {
     // Park the two siblings on FUTEX_WAIT(uaddr_A) and FUTEX_WAIT(uaddr_B).
     {
         let mut waiters = FUTEX_WAITERS.lock();
-        waiters.entry((target_pid, UADDR_A)).or_insert_with(alloc::vec::Vec::new)
+        // Synthetic uaddrs are unmapped, so the drain path keys them PRIVATE.
+        waiters.entry(FutexKey::Private(target_pid, UADDR_A)).or_insert_with(alloc::vec::Vec::new)
                .push(sib_a_tid);
-        waiters.entry((target_pid, UADDR_B)).or_insert_with(alloc::vec::Vec::new)
+        waiters.entry(FutexKey::Private(target_pid, UADDR_B)).or_insert_with(alloc::vec::Vec::new)
                .push(sib_b_tid);
     }
     test_println!("  target PID {}: main TID {}, siblings TID {}/{} parked on futex",
@@ -38529,7 +38556,7 @@ fn test_exit_group_wakes_siblings() -> bool {
     {
         let waiters = FUTEX_WAITERS.lock();
         let lingering: alloc::vec::Vec<_> = waiters.keys()
-            .filter(|&&(p, _)| p == target_pid).copied().collect();
+            .filter(|k| k.private_pid() == Some(target_pid)).copied().collect();
         if !lingering.is_empty() {
             test_fail!("exit_group_wakes_siblings",
                 "FUTEX_WAITERS still contains entries for dead pid: {:?}",
@@ -42604,7 +42631,7 @@ fn test_238_futex_wake_ghost_cluster() -> bool {
     {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
         waiters
-            .entry((pid, uaddr_sibling))
+            .entry(crate::syscall::FutexKey::Private(pid, uaddr_sibling))
             .or_insert_with(alloc::vec::Vec::new)
             .push(fake_tid);
     }
@@ -42613,7 +42640,7 @@ fn test_238_futex_wake_ghost_cluster() -> bool {
     {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
         waiters
-            .entry((pid, uaddr_far))
+            .entry(crate::syscall::FutexKey::Private(pid, uaddr_far))
             .or_insert_with(alloc::vec::Vec::new)
             .push(fake_tid.wrapping_add(1));
     }
@@ -42634,8 +42661,8 @@ fn test_238_futex_wake_ghost_cluster() -> bool {
     // regardless of pass/fail (subsequent tests must not see fake_tid).
     {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-        let _ = waiters.remove(&(pid, uaddr_sibling));
-        let _ = waiters.remove(&(pid, uaddr_far));
+        let _ = waiters.remove(&crate::syscall::FutexKey::Private(pid, uaddr_sibling));
+        let _ = waiters.remove(&crate::syscall::FutexKey::Private(pid, uaddr_far));
     }
 
     let post = crate::subsys::linux::syscall::FUTEX_WAKE_GHOST_COUNT
@@ -42732,7 +42759,7 @@ fn test_239_futex_cluster_wake_compensation() -> bool {
     let install = |uaddr: u64, tid: u64| {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
         waiters
-            .entry((pid, uaddr))
+            .entry(crate::syscall::FutexKey::Private(pid, uaddr))
             .or_insert_with(alloc::vec::Vec::new)
             .push(tid);
     };
@@ -42740,7 +42767,7 @@ fn test_239_futex_cluster_wake_compensation() -> bool {
     // doesn't see fake TIDs in subsequent tests.
     let drain = |uaddr: u64| {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-        let _ = waiters.remove(&(pid, uaddr));
+        let _ = waiters.remove(&crate::syscall::FutexKey::Private(pid, uaddr));
     };
 
     // ── (a) Positive control: canonical-offset wake ─────────────────────
@@ -45737,8 +45764,8 @@ fn test_268_exit_group_clears_sibling_cleartid() -> bool {
     }
     {
         let waiters = crate::syscall::FUTEX_WAITERS.lock();
-        if waiters.contains_key(&(SYNTH_PID, UADDR_A))
-        || waiters.contains_key(&(SYNTH_PID, UADDR_B))
+        if waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A))
+        || waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B))
         {
             test_fail!("test268",
                 "synthetic FUTEX_WAITERS keys already present — test \
@@ -45830,11 +45857,11 @@ fn test_268_exit_group_clears_sibling_cleartid() -> bool {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
         let mut v = alloc::vec::Vec::new();
         v.push(SYNTH_WAITER);
-        waiters.insert((SYNTH_PID, UADDR_A), v);
+        waiters.insert(crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A), v);
         // A second key with NO waiters parked — proves the helper does
         // not leak per-(pid,uaddr) entries when the wake list is empty
         // (the `futex_wake_for_exit` no-op branch).
-        waiters.insert((SYNTH_PID, UADDR_B), alloc::vec::Vec::new());
+        waiters.insert(crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B), alloc::vec::Vec::new());
     }
 
     // Phase 2: exercise the helper.
@@ -45851,8 +45878,8 @@ fn test_268_exit_group_clears_sibling_cleartid() -> bool {
         let pa = find(SYNTH_SIB_A);
         let pb = find(SYNTH_SIB_B);
         let pw = find(SYNTH_WAITER);
-        let wa = waiters.contains_key(&(SYNTH_PID, UADDR_A));
-        let wb = waiters.contains_key(&(SYNTH_PID, UADDR_B));
+        let wa = waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A));
+        let wb = waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B));
         let ws = pw.map(|(_, _, _, s)| s);
         (pa, pb, pw, wa, wb, ws)
     };
@@ -45866,8 +45893,8 @@ fn test_268_exit_group_clears_sibling_cleartid() -> bool {
     }
     {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-        waiters.remove(&(SYNTH_PID, UADDR_A));
-        waiters.remove(&(SYNTH_PID, UADDR_B));
+        waiters.remove(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A));
+        waiters.remove(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B));
     }
 
     if sched_was_active { crate::sched::enable(); }
@@ -46036,8 +46063,8 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
     }
     {
         let waiters = crate::syscall::FUTEX_WAITERS.lock();
-        if waiters.contains_key(&(SYNTH_PID, UADDR_A))
-        || waiters.contains_key(&(SYNTH_PID, UADDR_B))
+        if waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A))
+        || waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B))
         {
             test_fail!("test269",
                 "synthetic FUTEX_WAITERS keys already present — test \
@@ -46100,11 +46127,11 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
         let mut v = alloc::vec::Vec::new();
         v.push(SYNTH_WAITER);
-        waiters.insert((SYNTH_PID, UADDR_A), v);
+        waiters.insert(crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A), v);
         // Empty-list key: proves the no-op wake path also removes the
         // key (mirrors Test 268; redundant validation that the helper
         // contract holds across two synthetic groups).
-        waiters.insert((SYNTH_PID, UADDR_B), alloc::vec::Vec::new());
+        waiters.insert(crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B), alloc::vec::Vec::new());
     }
 
     // Exercise: this is the EXACT call the lethal-signal path now makes
@@ -46122,8 +46149,8 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
         let pa = find(SYNTH_SIB_A);
         let pb = find(SYNTH_SIB_B);
         let pw = find(SYNTH_WAITER);
-        let wa = waiters.contains_key(&(SYNTH_PID, UADDR_A));
-        let wb = waiters.contains_key(&(SYNTH_PID, UADDR_B));
+        let wa = waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A));
+        let wb = waiters.contains_key(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B));
         let ws = pw.map(|(_, _, _, s)| s);
         (pa, pb, pw, wa, wb, ws)
     };
@@ -46137,8 +46164,8 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
     }
     {
         let mut waiters = crate::syscall::FUTEX_WAITERS.lock();
-        waiters.remove(&(SYNTH_PID, UADDR_A));
-        waiters.remove(&(SYNTH_PID, UADDR_B));
+        waiters.remove(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_A));
+        waiters.remove(&crate::syscall::FutexKey::Private(SYNTH_PID, UADDR_B));
     }
 
     if sched_was_active { crate::sched::enable(); }
@@ -49053,6 +49080,271 @@ fn test_294_epoll_edge_triggered_eventfd() -> bool {
 
     if ok {
         test_pass!("epoll EPOLLET edge-trigger on a level-ready eventfd (Test 294)");
+    }
+    ok
+}
+
+// ── Test 295: cross-process SHARED futex keying (memfd MAP_SHARED) ───────────
+//
+// Per futex(2) (FUTEX_PRIVATE_FLAG): a process-SHARED futex names a backing
+// object, not a virtual address.  Two processes that map the same file/memfd
+// MAP_SHARED page at DIFFERENT virtual addresses must rendezvous — a
+// FUTEX_WAIT in process A and the matching FUTEX_WAKE in process B operate on
+// the same logical futex word, so the kernel must key both by the backing
+// object identity (mount_idx, inode, byte offset), NOT by (pid, uaddr).  This
+// is the gecko cross-process screenshot-rendezvous case (a CrossProcessSemaphore
+// on a memfd MAP_SHARED page: content process waits, parent wakes).
+//
+// The test builds two synthetic processes whose VmSpaces each contain a
+// MAP_SHARED VMA backed by the SAME (mount_idx, inode) at DIFFERENT virtual
+// addresses, then asserts:
+//   (a) resolve_futex_key produces the SAME Shared key for both — the
+//       cross-process rendezvous identity;
+//   (b) a waiter enqueued under process A's resolved key is found and woken by
+//       a FUTEX_WAKE issued by process B (proving the cross-process bucket
+//       hit, the actual screenshot-IPC unblock);
+//   (c) the PRIVATE fast path is preserved — a MAP_PRIVATE/anon word and a
+//       FUTEX_PRIVATE_FLAG'd shared word both resolve to per-(pid, uaddr)
+//       Private keys, so two processes at the same VA do NOT collide.
+//
+// Refs: futex(2) FUTEX_PRIVATE_FLAG, memfd_create(2),
+//       POSIX.1-2017 §pthread_mutexattr_getpshared.
+fn test_295_crossproc_shared_futex_keying() -> bool {
+    use crate::syscall::{FUTEX_WAITERS, FutexKey, resolve_futex_key};
+    use crate::mm::vma::{VmArea, VmBacking, VmSpace,
+                         MAP_SHARED, MAP_PRIVATE, MAP_ANONYMOUS,
+                         PROT_READ, PROT_WRITE};
+
+    test_header!("cross-process SHARED futex keying (memfd MAP_SHARED rendezvous, Test 295)");
+
+    // Synthetic pids / shared backing identity.  The (mount_idx, inode) below
+    // names a single backing object the two processes both map.
+    const PID_A: u64 = 0xC0DE_2950;
+    const PID_B: u64 = 0xC0DE_2951;
+    const SHARED_MOUNT: usize = 0x295;
+    const SHARED_INODE: u64   = 0x2950_BEEF;
+    // The two processes map the shared object at DIFFERENT virtual addresses —
+    // the crux of the test.  Both place a 1-page MAP_SHARED VMA over the same
+    // file offset 0 so the futex word at +0x40 in each maps the same backing
+    // byte.
+    const VA_A: u64 = 0x5000_0000;   // process A's mapping VA
+    const VA_B: u64 = 0x6800_0000;   // process B's mapping VA (different!)
+    const WORD_OFF: u64 = 0x40;      // futex word offset within the shared page
+    // A private anonymous word both processes happen to place at the SAME VA —
+    // used to prove private futexes do NOT collide across processes.
+    const PRIV_VA: u64 = 0x7000_0000;
+    let fake_tid: u64 = 0x2950_F00D;
+
+    // Build a VmSpace with a MAP_SHARED file-backed VMA over [base, base+page)
+    // plus a MAP_PRIVATE anon VMA at PRIV_VA.  Returns the new cr3 or None.
+    fn build_space(base: u64) -> Option<(VmSpace, u64)> {
+        let mut vm = VmSpace::new_user()?;
+        let cr3 = vm.cr3;
+        // MAP_SHARED file/memfd-backed page.
+        vm.insert_vma(VmArea {
+            base,
+            length: 0x1000,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_SHARED,
+            backing: VmBacking::File {
+                mount_idx: SHARED_MOUNT,
+                inode: SHARED_INODE,
+                offset: 0,
+                elf_load_delta: 0,
+            },
+            name: "[test-shm]",
+        }).ok()?;
+        // MAP_PRIVATE anonymous page at the fixed PRIV_VA.
+        vm.insert_vma(VmArea {
+            base: PRIV_VA,
+            length: 0x1000,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_PRIVATE | MAP_ANONYMOUS,
+            backing: VmBacking::Anonymous,
+            name: "[test-priv]",
+        }).ok()?;
+        Some((vm, cr3))
+    }
+
+    // Register a synthetic process holding `vm` under `pid` so the resolver's
+    // PROCESS_TABLE VMA lookup succeeds.
+    fn register_proc(pid: u64, cr3: u64, vm: VmSpace) {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        procs.push(crate::proc::Process {
+            pid,
+            parent_pid: 0,
+            name: { let mut n = [0u8; 64]; n[..4].copy_from_slice(b"shm!"); n },
+            state: crate::proc::ProcessState::Active,
+            cr3,
+            threads: alloc::vec::Vec::new(),
+            exit_code: 0,
+            file_descriptors: alloc::vec::Vec::new(),
+            cwd: alloc::string::String::from("/"),
+            uid: 0, gid: 0, euid: 0, egid: 0,
+            pgid: pid as u32, sid: pid as u32,
+            no_new_privs: false,
+            cap_permitted: !0u64, cap_effective: !0u64,
+            rlimits_soft: [u64::MAX; 16],
+            supplementary_groups: alloc::vec::Vec::new(),
+            umask: 0o022,
+            vm_space: Some(vm),
+            signal_state: Some(crate::signal::SignalState::new()),
+            linux_abi: true,
+            handle_table: None,
+            subsystem: crate::win32::SubsystemType::Linux,
+            token_id: None,
+            exe_path: None,
+            epoll_sets: alloc::vec::Vec::new(),
+            auxv: alloc::vec::Vec::new(),
+            envp: alloc::vec::Vec::new(),
+            alarm_deadline_ticks: 0,
+            alarm_interval_ticks: 0,
+            pdeath_signal: 0,
+        });
+    }
+
+    // Tear down a synthetic process and reclaim its VmSpace.
+    fn teardown_proc(pid: u64) {
+        let old = {
+            let mut procs = crate::proc::PROCESS_TABLE.lock();
+            let old = procs.iter_mut().find(|p| p.pid == pid)
+                .and_then(|p| p.vm_space.take());
+            procs.retain(|p| p.pid != pid);
+            old
+        };
+        if let Some(space) = old { crate::proc::free_vm_space(space); }
+    }
+
+    // ── Setup ────────────────────────────────────────────────────────────
+    let (vm_a, cr3_a) = match build_space(VA_A) {
+        Some(x) => x,
+        None => { test_fail!("crossproc_futex", "build_space A OOM"); return false; }
+    };
+    let (vm_b, cr3_b) = match build_space(VA_B) {
+        Some(x) => x,
+        None => {
+            crate::proc::free_vm_space(vm_a);
+            test_fail!("crossproc_futex", "build_space B OOM");
+            return false;
+        }
+    };
+    register_proc(PID_A, cr3_a, vm_a);
+    register_proc(PID_B, cr3_b, vm_b);
+
+    // Clean any stale keys from a prior run.
+    {
+        let mut w = FUTEX_WAITERS.lock();
+        w.remove(&FutexKey::Shared { mount_idx: SHARED_MOUNT, inode: SHARED_INODE, byte_off: WORD_OFF });
+        w.remove(&FutexKey::Private(PID_A, PRIV_VA));
+        w.remove(&FutexKey::Private(PID_B, PRIV_VA));
+    }
+
+    let mut ok = true;
+
+    // ── (a) Same shared key for both processes despite different VAs ───────
+    let key_a = resolve_futex_key(PID_A, VA_A + WORD_OFF, /*force_private=*/false);
+    let key_b = resolve_futex_key(PID_B, VA_B + WORD_OFF, /*force_private=*/false);
+    let expected = FutexKey::Shared {
+        mount_idx: SHARED_MOUNT, inode: SHARED_INODE, byte_off: WORD_OFF,
+    };
+    if key_a != expected {
+        test_fail!("crossproc_futex",
+            "process A shared word resolved to {:#x?} (expected {:#x?})", key_a, expected);
+        ok = false;
+    }
+    if key_b != expected {
+        test_fail!("crossproc_futex",
+            "process B shared word resolved to {:#x?} (expected {:#x?})", key_b, expected);
+        ok = false;
+    }
+    if key_a != key_b {
+        test_fail!("crossproc_futex",
+            "cross-process keys DIFFER: A={:#x?} B={:#x?} (different VAs must rendezvous)",
+            key_a, key_b);
+        ok = false;
+    }
+    if ok {
+        test_println!("  (a) procA@{:#x} and procB@{:#x} → SAME shared key {:#x?} ✓",
+            VA_A + WORD_OFF, VA_B + WORD_OFF, key_a);
+    }
+
+    // ── (b) Cross-process rendezvous: WAIT under A's key, WAKE under B ─────
+    // Enqueue a synthetic waiter under process A's resolved shared key.
+    {
+        let mut w = FUTEX_WAITERS.lock();
+        w.entry(key_a).or_insert_with(alloc::vec::Vec::new).push(fake_tid);
+    }
+    // Issue a FUTEX_WAKE the way process B's syscall path would: resolve B's
+    // key and drain its bucket.  Because the keys are equal, B finds A's
+    // waiter — the wake reaches across the process boundary.
+    let woken = {
+        let mut w = FUTEX_WAITERS.lock();
+        let mut n = 0u64;
+        if let Some(list) = w.get_mut(&key_b) {
+            while let Some(_t) = list.pop() { n += 1; }
+            if list.is_empty() { w.remove(&key_b); }
+        }
+        n
+    };
+    if woken != 1 {
+        test_fail!("crossproc_futex",
+            "WAKE under process B woke {} waiters (expected 1) — cross-proc bucket miss",
+            woken);
+        ok = false;
+    } else {
+        test_println!("  (b) WAIT(procA key) woken by WAKE(procB key): woken=1 ✓");
+    }
+    // Belt-and-braces: the shared bucket must now be empty.
+    {
+        let w = FUTEX_WAITERS.lock();
+        if w.contains_key(&expected) {
+            drop(w);
+            test_fail!("crossproc_futex", "shared bucket leaked after cross-proc wake");
+            FUTEX_WAITERS.lock().remove(&expected);
+            ok = false;
+        }
+    }
+
+    // ── (c) Private fast path preserved (no cross-process collision) ───────
+    // Both processes have a MAP_PRIVATE word at the SAME VA; their keys MUST
+    // differ (per-mm), and a FUTEX_PRIVATE_FLAG'd shared word must also stay
+    // private.
+    let priv_a = resolve_futex_key(PID_A, PRIV_VA, false);
+    let priv_b = resolve_futex_key(PID_B, PRIV_VA, false);
+    if priv_a != FutexKey::Private(PID_A, PRIV_VA) {
+        test_fail!("crossproc_futex", "private word A resolved to {:#x?} (expected Private)", priv_a);
+        ok = false;
+    }
+    if priv_a == priv_b {
+        test_fail!("crossproc_futex",
+            "two processes' private words at the same VA collided: {:#x?} — fast path broken",
+            priv_a);
+        ok = false;
+    }
+    // FUTEX_PRIVATE_FLAG forces the shared word to a private key even though
+    // its VMA is MAP_SHARED (per futex(2): the flag selects the private shape).
+    let forced = resolve_futex_key(PID_A, VA_A + WORD_OFF, /*force_private=*/true);
+    if forced != FutexKey::Private(PID_A, VA_A + WORD_OFF) {
+        test_fail!("crossproc_futex",
+            "FUTEX_PRIVATE_FLAG over MAP_SHARED resolved to {:#x?} (expected Private)", forced);
+        ok = false;
+    }
+    if ok {
+        test_println!("  (c) private words key per-(pid,uaddr); PRIVATE_FLAG forces private ✓");
+    }
+
+    // ── Teardown ──────────────────────────────────────────────────────────
+    {
+        let mut w = FUTEX_WAITERS.lock();
+        w.remove(&expected);
+        w.remove(&FutexKey::Private(PID_A, PRIV_VA));
+        w.remove(&FutexKey::Private(PID_B, PRIV_VA));
+    }
+    teardown_proc(PID_A);
+    teardown_proc(PID_B);
+
+    if ok {
+        test_pass!("cross-process SHARED futex keying (memfd MAP_SHARED rendezvous, Test 295)");
     }
     ok
 }


### PR DESCRIPTION
Two kernel fixes on the render-ladder branch.

## 1. Cross-process SHARED futex keying (the render unblock)

Per `futex(2)` (FUTEX_PRIVATE_FLAG), a process-shared (`pshared`) futex names a
*backing object*, not a virtual address: two processes that map the same
file/memfd `MAP_SHARED` page at **different** virtual addresses must rendezvous
on the same logical futex word. The kernel keyed **all** futexes by
`(pid, uaddr)`, so a `FUTEX_WAIT` in one process and the matching `FUTEX_WAKE`
in another hashed to different buckets — the wake never reached the waiter. This
wedges any cross-process pshared primitive (a `CrossProcessSemaphore` / pthread
pshared mutex/cond on a shared `memfd` page): the waiter parks forever.

**Fix:** introduce a `FutexKey` enum — `Private(pid, uaddr)` (the unchanged fast
path) and `Shared { mount_idx, inode, byte_off }` (keyed by backing-object
identity + byte offset, so different VAs over the same object rendezvous).
`resolve_futex_key` selects which at syscall time from the VMA backing `uaddr`
(MAP_SHARED + `VmBacking::File` → Shared; everything else → Private;
`FUTEX_PRIVATE_FLAG` forces Private and skips the VMA lookup). Every futex op is
routed through the unified key: WAIT enqueue + cleanup, WAKE, REQUEUE/CMP_REQUEUE
(source + uaddr2 dest), WAKE_OP (both targets), the CLEARTID exit-wake, and the
process-exit drain (now scrubs shared buckets by the dying pid's TIDs only).
Lock order preserved (`FUTEX_WAITERS → THREAD_TABLE`).

Adds **Test 295**: two processes mapping the same memfd `MAP_SHARED` page at
different VAs (a) resolve to the **same** shared key, (b) a WAIT under process
A's key is woken by a WAKE under process B's key (the cross-process rendezvous),
and (c) the private fast path is preserved. All existing futex tests pass.

## 2. Reserve the UEFI bootstrap stack in PMM init (recurring `switch_context_asm` #GP)

The BSP main/idle thread (TID 0) runs on the UEFI bootstrap stack for the
kernel's lifetime, but `pmm::init` never reserved that region — after
ExitBootServices UEFI reports it as `Available`, so the PMM marked it free.
Under heavy clone/pthread kernel-stack churn (the Firefox launch path), a later
`alloc_pages` could hand out the live bootstrap-stack frames; the new thread
clobbered TID 0's saved callee-saved frame, and the next switch into TID 0
`ret`-ed to a non-canonical address — a recurring, flaky bugcheck
(`KERNEL_GPF` / `UNEXPECTED_KERNEL_MODE_TRAP`) inside `switch_context_asm`.

**Fix:** reserve the live bootstrap stack in `pmm::init` while still executing on
it (read RSP, reserve a 128 KiB downward guard + the rest of the current page),
mirroring the existing BootInfo reservation that closes the identical
UEFI-reclamation hole. The `[PMM] Bootstrap-stack reservation` line confirms it
armed; the reserved window brackets the observed fault RSPs.

## Verification

`scripts/qemu-harness.py` test-mode boot: Test 295 PASS (all 3 sub-assertions),
all existing futex tests PASS (195/195b/238/239/240/268/269, REQUEUE/WAKE_OP,
CLEARTID, errno contract), **zero bugchecks** — the suite now runs past the
Firefox launch oracle that reliably triggered the #GP. The 16 unrelated failures
are pre-existing environmental issues (missing `/disk/bin` binaries, etc.).

Refs: `futex(2)`, `memfd_create(2)`, POSIX.1-2017; UEFI §7.2, Intel SDM Vol. 3A
§4.10.5, System V AMD64 ABI §3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)