### PR TITLE
harness: default-on host pcap capture for Firefox-render boots (--no-pcap opt-out)

### DIFF
--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -1099,12 +1099,17 @@ def run_pcap_argv_check():
     No QEMU launched (< 2s).  Locks down the host-side packet-capture surface
     so a future refactor cannot silently regress it:
 
-      * `start --pcap` is advertised and parses to pcap=True
+      * `start --pcap` and `start --no-pcap` are advertised and parse
       * the filter-dump `-object` references the e1000/SLIRP netdev id (net0)
         and a per-session pcap file, and is emitted AFTER `-netdev` so QEMU's
         object resolver finds the netdev (QEMU networking docs)
       * the in-place kdb-hostfwd patch (which mutates the `-netdev` arg, not
         its id) leaves the filter-dump binding intact
+      * the default-ON / opt-out decision precedence (`_resolve_pcap_decision`,
+        the helper cmd_start drives): --no-pcap > --pcap > FF-feature-set > off
+        — an FF-render feature set captures by default, --no-pcap suppresses it
+        even on FF, a non-FF boot stays off, and --pcap force-enables any boot;
+        each on/off decision is cross-checked against the composed cmdline
       * serial-web serves the raw .pcap (application/vnd.tcpdump.pcap,
         attachment) byte-identically, and /api/wire returns a stable envelope
         (decode_available bool + pcap_url) whether or not the wire decoder
@@ -1116,10 +1121,12 @@ def run_pcap_argv_check():
     import importlib.util, tempfile, os as _os, struct, urllib.request, json as _json
     import http.server, socketserver, threading
 
-    # ── start --pcap advertised + parses ──────────────────────────────────────
+    # ── start --pcap / --no-pcap advertised + parse ───────────────────────────
     _, raw, _ = _h("start", "--help")
     check("start --pcap advertised in --help",
           "--pcap" in raw, "flag missing from start --help")
+    check("start --no-pcap advertised in --help",
+          "--no-pcap" in raw, "opt-out flag missing from start --help")
 
     # ── filter-dump arg composes correctly through build_qemu_cmd ──────────────
     aq_path = Path(__file__).resolve().parent / "astryx_qemu.py"
@@ -1159,6 +1166,81 @@ def run_pcap_argv_check():
     except StopIteration:
         check("filter-dump -object present", False,
               "no -object in composed cmdline")
+
+    # ── pcap default-ON / opt-out decision + cmdline composition ───────────────
+    # Lock down the precedence introduced by tools/pcap-default-ff:
+    #   --no-pcap > --pcap > FF-feature-set > off.  We drive the SAME decision
+    #   helper cmd_start uses (`_resolve_pcap_decision`), then — for the on/off
+    #   cases — replicate cmd_start's filter-dump injection and feed it through
+    #   build_qemu_cmd to confirm the -object lands (or doesn't) and stays
+    #   ordered after -netdev, exactly as the live `start` path does.
+    qh_spec = importlib.util.spec_from_file_location("qh_pcap_smoke", HARNESS)
+    qh = importlib.util.module_from_spec(qh_spec)
+    qh_spec.loader.exec_module(qh)
+    resolve = qh._resolve_pcap_decision
+
+    def _compose_has_filterdump(enabled):
+        """Replicate cmd_start's injection for a decision, return (has, ok_ordered)."""
+        di = tempfile.NamedTemporaryFile(suffix=".img", delete=False)
+        di.write(b"\0" * 4096); di.close()
+        try:
+            ex = []
+            if enabled:
+                ex = ["-object",
+                      f"filter-dump,id=netdump,netdev=net0,file=/x/harness/s.pcap"]
+            c = aq.build_qemu_cmd("", di.name, "/x/s.log", mode="test",
+                                  ovmf_code="/x/code.fd", ovmf_vars="/x/vars",
+                                  esp_dir="/x/esp", qmp_sock="/x/q.sock",
+                                  kvm=False, extra_args=ex)
+            has = any(a == "-object" and "filter-dump" in c[i + 1]
+                      for i, a in enumerate(c[:-1]))
+            ok_order = True
+            if has:
+                ndi = next(i for i, a in enumerate(c) if a == "-netdev")
+                oi = next(i for i, a in enumerate(c)
+                          if a == "-object" and "filter-dump" in c[i + 1])
+                ok_order = ndi < oi and "netdev=net0" in c[oi + 1]
+            return has, ok_order
+        finally:
+            try:
+                _os.unlink(di.name)
+            except OSError:
+                pass
+
+    # 1) firefox-test-core (no flags) -> ON by default ("ff-default"), -object lands.
+    en, rs = resolve(["firefox-test-core"], False, False)
+    has, ordered = _compose_has_filterdump(en)
+    check("FF-render boot defaults pcap ON",
+          en is True and rs == "ff-default", f"enabled={en} reason={rs}")
+    check("FF-default cmdline carries filter-dump after -netdev",
+          has and ordered, f"has={has} ordered={ordered}")
+
+    # 2) firefox-test-core --no-pcap -> OFF ("no-pcap-optout"), NO -object.
+    en, rs = resolve(["firefox-test-core"], False, True)
+    has, _o = _compose_has_filterdump(en)
+    check("FF boot + --no-pcap disables pcap",
+          en is False and rs == "no-pcap-optout", f"enabled={en} reason={rs}")
+    check("--no-pcap cmdline has NO filter-dump", not has, f"has={has}")
+
+    # 3) test-mode (non-FF, no flags) -> OFF by default ("non-ff-default"), NO -object.
+    en, rs = resolve(["test-mode"], False, False)
+    has, _o = _compose_has_filterdump(en)
+    check("non-FF boot defaults pcap OFF",
+          en is False and rs == "non-ff-default", f"enabled={en} reason={rs}")
+    check("non-FF-default cmdline has NO filter-dump", not has, f"has={has}")
+
+    # 4) test-mode --pcap -> force ON ("pcap-forced"), -object lands.
+    en, rs = resolve(["test-mode"], True, False)
+    has, ordered = _compose_has_filterdump(en)
+    check("non-FF boot + --pcap forces pcap ON",
+          en is True and rs == "pcap-forced", f"enabled={en} reason={rs}")
+    check("--pcap-on-non-FF cmdline carries filter-dump after -netdev",
+          has and ordered, f"has={has} ordered={ordered}")
+
+    # 5) precedence: --no-pcap beats an explicit --pcap on an FF boot.
+    en, rs = resolve(["firefox-test-core"], True, True)
+    check("--no-pcap wins over --pcap (precedence)",
+          en is False and rs == "no-pcap-optout", f"enabled={en} reason={rs}")
 
     try:
         _os.unlink(data_img)

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -53,9 +53,23 @@ Tier 1 — session management:
                                           [--gdb-port PORT] [--gdb-wait]
                                           [--firefox-variant musl|glibc]
                                           [--snapshottable]
+                                          [--pcap] [--no-pcap]
                                           [--livelock-reap-sc N]
                                           [--livelock-reap-secs SECS]
                                           [--no-livelock-reap]
+        Host-side packet capture (default ON for FF-render boots): every
+        Firefox-render boot (features firefox-test / firefox-test-core /
+        firefox-test-trace) automatically captures its VM<->internet traffic to
+        ~/.astryx-harness/<sid>.pcap via a host-side QEMU `-object filter-dump`
+        (ZERO guest VM-exits — only a host fwrite per frame).  serial-web serves
+        it at /api/pcap?sid=<sid> and a decoded wire summary at
+        /api/wire?sid=<sid>.  Non-FF boots (test-mode, default desktop) have no
+        network worth capturing, so capture stays OFF for them.  --pcap
+        force-enables capture on ANY boot (incl. non-FF); --no-pcap disables it
+        even on an FF boot (for a clean perf-timing run).  Precedence: --no-pcap
+        > --pcap > FF-default > off.  The effective path + decision land in the
+        session JSON and `start`/`status` output as pcap_path (source of truth,
+        "" when disabled), pcap_enabled, and pcap_reason.
         Livelock auto-reap (default ON): a spinning FF render boot — pid 1
         busy-looping (waitpid/futex) while the deepest gate is frozen — drives
         the pid=1 syscall count into the hundreds-of-millions/billions at ~100%
@@ -943,6 +957,47 @@ _PROC_METRICS_PID1_SC_RE = re.compile(rb"PROC-METRICS\] .*?\bpid=1\b.*?\bsc=(\d+
 # guard is disabled with `start --no-livelock-reap`.
 LIVELOCK_REAP_SC_DEFAULT   = 50_000_000
 LIVELOCK_REAP_SECS_DEFAULT = 180.0
+
+# Feature flags that mark a boot as a "Firefox-render" boot (the profiles that
+# exercise the network: a real HTTPS page load over the e1000/SLIRP netdev).
+# `firefox-test` is the back-compat super-feature; `firefox-test-core` is the
+# perf/render profile; `firefox-test-trace` is the dense-trace add-on. When the
+# resolved feature set intersects this set, host-side pcap capture defaults ON
+# (see `_resolve_pcap_decision`) — every FF boot's VM↔internet traffic is
+# captured automatically. Non-FF boots (test-mode, default desktop) have no
+# network worth capturing, so capture stays OFF for them by default.
+FF_RENDER_FEATURES = frozenset({
+    "firefox-test",
+    "firefox-test-core",
+    "firefox-test-trace",
+})
+
+
+def _resolve_pcap_decision(feats, pcap_flag, no_pcap_flag):
+    """Decide whether host-side pcap capture is enabled for this boot.
+
+    Pure (no I/O) so the smoke suite can exercise every branch without a boot.
+
+    Precedence (highest first):
+      1. ``--no-pcap``  → OFF unconditionally (wins over everything; lets a
+         clean perf-timing FF run suppress even the host fwrite).
+      2. ``--pcap``     → ON unconditionally (force-on for ANY boot, incl. the
+         non-FF / no-network ones).
+      3. FF-render feature set present → ON (the new default: every Firefox
+         boot captures its VM↔internet traffic automatically).
+      4. otherwise      → OFF (non-FF boots have no network worth capturing).
+
+    `feats` is the fully-resolved feature list (post `--trace` expansion).
+    Returns ``(enabled: bool, reason: str)`` where reason is one of
+    ``"no-pcap-optout" | "pcap-forced" | "ff-default" | "non-ff-default"``.
+    """
+    if no_pcap_flag:
+        return False, "no-pcap-optout"
+    if pcap_flag:
+        return True, "pcap-forced"
+    if any(f in FF_RENDER_FEATURES for f in feats):
+        return True, "ff-default"
+    return False, "non-ff-default"
 
 
 class LivelockDetector:
@@ -3756,7 +3811,7 @@ def cmd_start(args):
     if "xeyes-test" in feats and not any(a == "-vga" for a in extra_qemu_args):
         extra_qemu_args += ["-vga", "vmware"]
 
-    # --pcap: host-side packet capture on the e1000/SLIRP netdev (net0).
+    # Host-side packet capture on the e1000/SLIRP netdev (net0).
     #
     # `-object filter-dump,id=netdump,netdev=net0,file=<sid>.pcap` taps the
     # netdev frontend on the HOST side (QEMU networking docs: filter-dump
@@ -3770,13 +3825,29 @@ def cmd_start(args):
     # the netdev by id (`net0`) so the in-place hostfwd patching in
     # `_launch_qemu_harness` (which mutates the `-netdev` arg, not its id)
     # leaves the filter-dump binding intact.
+    #
+    # Capture defaults ON for Firefox-render boots (the FF profiles exercise a
+    # real network load), so every FF boot's VM↔internet traffic is captured
+    # automatically with no opt-in.  `--pcap` force-enables it for ANY boot
+    # (incl. non-FF); `--no-pcap` disables it even on FF boots (for a clean
+    # perf-timing run).  Precedence and the decision live in
+    # `_resolve_pcap_decision`; `pcap_reason` records which rule fired.
+    pcap_enabled, pcap_reason = _resolve_pcap_decision(
+        feats,
+        bool(getattr(args, "pcap", False)),
+        bool(getattr(args, "no_pcap", False)),
+    )
     pcap_path = ""
-    if bool(getattr(args, "pcap", False)):
+    if pcap_enabled:
         pcap_path = str(HARNESS_DIR / f"{sid}.pcap")
         extra_qemu_args += [
             "-object",
             f"filter-dump,id=netdump,netdev=net0,file={pcap_path}",
         ]
+        print(f"[HARNESS] pcap capture: {pcap_path}", file=sys.stderr)
+    else:
+        print(f"[HARNESS] pcap capture: disabled ({pcap_reason})",
+              file=sys.stderr)
 
     # snap-gate (--snapshottable): build the savevm/loadvm-compatible device
     # topology so the running guest can be snapshotted live.  The default
@@ -3821,12 +3892,17 @@ def cmd_start(args):
         "kdb_host_port": kdb_host_port,
         "http_host_port": http_host_port,
         "ssh_host_port": ssh_host_port,
-        # --pcap host-side network capture (off by default).  Empty string
-        # when not requested; otherwise the libpcap file QEMU's filter-dump
-        # object writes every guest netdev frame to.  serial-web serves it at
-        # /api/pcap?sid=<sid> and decodes it at /api/wire?sid=<sid>.  Additive
-        # — never present on sessions started before --pcap landed.
-        "pcap_path": pcap_path,
+        # Host-side network capture.  `pcap_path` is the source of truth —
+        # the libpcap file QEMU's filter-dump object writes every guest netdev
+        # frame to, or "" when capture is disabled.  serial-web serves it at
+        # /api/pcap?sid=<sid> and decodes it at /api/wire?sid=<sid>.  Defaults
+        # ON for FF-render boots, OFF otherwise; `--pcap` force-on, `--no-pcap`
+        # force-off (precedence in `_resolve_pcap_decision`).  `pcap_enabled`
+        # mirrors `bool(pcap_path)`; `pcap_reason` records which rule decided.
+        # All additive — never present on sessions started before they landed.
+        "pcap_path":    pcap_path,
+        "pcap_enabled": pcap_enabled,
+        "pcap_reason":  pcap_reason,
         # PIVOT-I2 Phase D — host stub Conflux for oracle-daemon-test.
         # If oracle_stub_pid is 0 the stub wasn't launched (default).
         "oracle_stub_port": oracle_stub_port,
@@ -3977,8 +4053,13 @@ def cmd_start(args):
           "gdb_port": gdb_port, "kdb_host_port": kdb_host_port,
           "http_host_port": http_host_port,
           "ssh_host_port": ssh_host_port,
-          # --pcap host-side capture path ("" when not requested).
-          "pcap_path": pcap_path,
+          # Host-side capture: path ("" when disabled) is the source of truth;
+          # `pcap_enabled` mirrors bool(path); `pcap_reason` is the rule that
+          # fired ("ff-default" | "pcap-forced" | "no-pcap-optout" |
+          # "non-ff-default").  Additive.
+          "pcap_path":    pcap_path,
+          "pcap_enabled": pcap_enabled,
+          "pcap_reason":  pcap_reason,
           # W106: structured CPU-model fields. `cpu_model_resolved` is
           # the literal string passed to QEMU `-cpu`; `cpu_model_reason`
           # is one of "override" | "kvm-host" | "tcg-safe".
@@ -4544,10 +4625,15 @@ def cmd_status(args):
     stored_terminal = sess.get("terminal_cause")
     terminal_cause = stored_terminal or (None if alive else exit_cause)
 
-    # --pcap host-side capture.  Report path + whether QEMU has started
-    # writing frames (file present + byte size).  pcap_path is "" on sessions
-    # not launched with --pcap (and absent entirely on pre-feature sessions).
+    # Host-side capture.  Report path + whether QEMU has started writing frames
+    # (file present + byte size), plus the decision metadata.  pcap_path is ""
+    # when capture was disabled for this session (and absent entirely on
+    # sessions that predate the feature).  `pcap_reason` records which rule
+    # enabled/disabled it; older sessions fall back to deriving it from path.
     pcap_path = sess.get("pcap_path") or ""
+    pcap_enabled = bool(sess.get("pcap_enabled", bool(pcap_path)))
+    # None on sessions that predate the field (decision rule unknown).
+    pcap_reason = sess.get("pcap_reason")
     pcap_size = 0
     if pcap_path:
         try:
@@ -4578,10 +4664,15 @@ def cmd_status(args):
         # filled in by the post-boot verifier once the [FFTEST] probe line
         # is parsed; until then they remain None.
         "firefox_variant_info": sess.get("firefox_variant_info"),
-        # --pcap host-side capture.  `pcap_path` is "" when not enabled;
+        # Host-side capture.  `pcap_path` is "" when capture was disabled;
         # `pcap_size` > 0 confirms QEMU's filter-dump is writing frames.
+        # `pcap_enabled` mirrors bool(path); `pcap_reason` is the rule that
+        # decided ("ff-default" | "pcap-forced" | "no-pcap-optout" |
+        # "non-ff-default"), or None on pre-feature sessions.  Additive.
         "pcap_path":       pcap_path,
         "pcap_size":       pcap_size,
+        "pcap_enabled":    pcap_enabled,
+        "pcap_reason":     pcap_reason,
     })
 
 
@@ -11669,20 +11760,32 @@ def main():
                                "session entirely. Use for a debugging/autopsy "
                                "hold you WANT to keep spinning for inspection.")
     p_start.add_argument("--pcap", action="store_true", dest="pcap",
-                          help="Capture ALL guest network traffic on the "
-                               "e1000/SLIRP netdev (net0) to a libpcap file at "
+                          help="FORCE host-side packet capture ON for this "
+                               "boot, even a non-FF one.  Captures ALL guest "
+                               "network traffic on the e1000/SLIRP netdev "
+                               "(net0) to a libpcap file at "
                                "~/.astryx-harness/<sid>.pcap via a HOST-SIDE "
-                               "QEMU `-object filter-dump`.  Off by default. "
-                               "This taps the netdev on the host side — the "
-                               "guest is unaware, so there are ZERO guest "
-                               "VM-exits and negligible guest perf cost (only "
-                               "host disk writes bounded by traffic volume, a "
-                               "few MB for a page load).  Unlike the serial "
-                               "firehose (per-byte PIO VM-exits), this is "
-                               "free on the guest path.  The pcap opens in "
-                               "Wireshark; serial-web serves it at "
-                               "/api/pcap?sid=<sid> and a decoded wire summary "
-                               "at /api/wire?sid=<sid>.")
+                               "QEMU `-object filter-dump`.  Capture already "
+                               "DEFAULTS ON for Firefox-render boots (features "
+                               "firefox-test / firefox-test-core / "
+                               "firefox-test-trace) — this flag is only needed "
+                               "to force it on a non-FF boot.  The tap lives on "
+                               "the host side — the guest is unaware, so there "
+                               "are ZERO guest VM-exits and negligible guest "
+                               "perf cost (only host disk writes bounded by "
+                               "traffic volume, a few MB for a page load).  "
+                               "Unlike the serial firehose (per-byte PIO "
+                               "VM-exits), this is free on the guest path.  The "
+                               "pcap opens in Wireshark; serial-web serves it "
+                               "at /api/pcap?sid=<sid> and a decoded wire "
+                               "summary at /api/wire?sid=<sid>.")
+    p_start.add_argument("--no-pcap", action="store_true", dest="no_pcap",
+                          help="Disable host-side packet capture for this boot "
+                               "even when it would otherwise default ON (an "
+                               "FF-render boot).  Use for a clean perf-timing "
+                               "run where even the per-frame host fwrite is "
+                               "unwanted.  Wins over both the FF-default and an "
+                               "explicit --pcap.")
 
     # stop
     p_stop = sub.add_parser("stop", help="Kill a QEMU session")


### PR DESCRIPTION
## Summary

Makes #529's host-side packet capture (`--pcap`, a QEMU `-object filter-dump` on the e1000/SLIRP netdev) **default-ON for Firefox-render boots**, so every FF boot's VM↔internet traffic is captured automatically — viewable on serial-web's `/api/wire` panel and downloadable as a `.pcap` from `/api/pcap` — with no opt-in.

The capture is essentially free: the filter-dump taps the netdev frontend on the **host** side, so the guest takes **ZERO** extra VM-exits; the only cost is a host `fwrite` per frame, bounded by traffic volume (a few MB for a page load). That makes default-on safe for FF boots. Non-FF boots (test-mode, default desktop) have no network worth capturing, so capture stays **OFF** for them by default.

## Precedence logic

The decision is centralised in a pure, unit-testable helper `_resolve_pcap_decision(feats, pcap_flag, no_pcap_flag)` → `(enabled, reason)`:

```
--no-pcap   →  OFF   (reason "no-pcap-optout")   wins over everything
--pcap      →  ON    (reason "pcap-forced")      force-on for ANY boot
FF feature  →  ON    (reason "ff-default")       the new default
otherwise   →  OFF   (reason "non-ff-default")
```

"FF feature" = the resolved `--features` set (post `--trace` expansion) intersects `{firefox-test, firefox-test-core, firefox-test-trace}`.

## The new `--no-pcap` flag

Opt-out that disables capture even on an FF-render boot — for a clean perf-timing run where even the per-frame host `fwrite` is unwanted. It wins over both the FF-default and an explicit `--pcap`.

The existing `--pcap` keeps its force-on semantics (now mainly useful to enable capture on a **non-FF** boot).

A one-line `[HARNESS] pcap capture: <path>` (or `disabled (<reason>)`) is logged to stderr at `start` so the decision is always visible.

## JSON changes (all additive)

- `pcap_path` stays the **source of truth** — `""`/null when disabled. Unchanged semantics, never renamed.
- New additive `pcap_enabled` (bool, mirrors `bool(pcap_path)`) and `pcap_reason` (`ff-default` | `pcap-forced` | `no-pcap-optout` | `non-ff-default`, null on pre-feature sessions) in the session JSON and in `start` + `status` output.

No existing flags or JSON fields were renamed.

## Validation (host-only, no boot)

Extended `qemu-harness-smoke.py`'s `run_pcap_argv_check` (#529's host-only check) with the default-on/opt-out matrix, each cross-checked against the composed cmdline through `build_qemu_cmd`:

- `firefox-test-core` → `ff-default`, cmdline carries the filter-dump `-object` after `-netdev`.
- `firefox-test-core --no-pcap` → `no-pcap-optout`, **no** filter-dump.
- `test-mode` → `non-ff-default`, **no** filter-dump.
- `test-mode --pcap` → `pcap-forced`, cmdline carries the filter-dump after `-netdev`.
- `firefox-test-core --pcap --no-pcap` → `no-pcap-optout` (precedence).
- The filter-dump still survives the in-place kdb-hostfwd `-netdev` patch (existing check retained).

`python3 scripts/qemu-harness-smoke.py --staleness-only` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)