### PR TITLE
vfs/ramfs+tmpfs+memfd: read(2) coherent with MAP_SHARED stores (page-cache read-through)

### DIFF
--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -586,6 +586,87 @@ pub fn update_range(mount_idx: usize, inode: u64, offset: u64, data: &[u8]) {
     }
 }
 
+/// Overlay cache-resident bytes onto a buffer that already holds the
+/// backing-filesystem's bytes for the file range `[offset, offset + buf.len())`.
+///
+/// This is the read-side symmetric counterpart of [`update_range`] and closes
+/// the *reverse* coherence direction for in-memory filesystems (ramfs / tmpfs /
+/// memfd).  On those backends the inode keeps its own `Vec<u8>` storage AND, once
+/// a page has been demand-faulted by an `mmap(MAP_SHARED)`, a page-cache frame.
+/// A store through the shared mapping lands in the page-cache frame but never
+/// touches the inode `Vec`; a subsequent `read(2)` that consulted only the `Vec`
+/// would observe stale (pre-store) bytes.  Per POSIX:
+///
+///   * mmap(2) (IEEE Std 1003.1-2017): "The application shall ensure ... write
+///     references to a memory region mapped with MAP_SHARED are visible ... to
+///     other processes ... that have mapped the same portion of the file."
+///   * read(2): "After a write() to a regular file has successfully returned ...
+///     any subsequent ... read() ... shall return the data written."  A store
+///     through a MAP_SHARED region IS a write to the underlying file object, so
+///     it must be visible to a later `read(2)` of the same file.
+///
+/// The two contracts compose: the page-cache frame is the only handle through
+/// which a MAP_SHARED store is recorded, so `read(2)` must consult it.  For any
+/// page in `[offset, offset + buf.len())` that has a live cache entry, copy the
+/// overlapping slice of the cache frame over the corresponding slice of `buf`.
+/// Pages with no cache entry are left as the FS already filled them (the
+/// authoritative `Vec`/disk content, which the `write(2)` path keeps current via
+/// [`update_range`]).  This makes a cache-resident inode present ONE source of
+/// truth — the cache frame — to both mmap mappers and `read(2)`, exactly as a
+/// unified-page-cache tmpfs does.
+///
+/// Block-backed filesystems (ext2 / fat32 / ntfs) are unaffected in practice:
+/// their `write(2)` path already calls `update_range`, so a cache page and the
+/// on-disk bytes agree, and overlaying agreeing bytes is a no-op.  The overlay
+/// is therefore safe for every backend and only *changes* observed bytes for the
+/// in-memory backends, where it is exactly the missing coherence.
+///
+/// `offset` is the file offset of `buf[0]`; only `buf[..valid]` need hold
+/// meaningful FS bytes, but the overlay is applied to the whole `buf` span the
+/// caller passes (callers pass the exact `[offset, offset+n)` they intend to
+/// return to userspace).
+///
+/// Safety: each cache entry's `phys` is alive while the cache lock is held (the
+/// cache holds a reference), so the `PHYS_OFF + phys` read lands in valid memory
+/// (Intel SDM Vol. 3A §4.10.5 higher-half identity map).  The cache lock is held
+/// across the small per-page copies; no FS or PMM dispatch happens under it.
+pub fn read_through(mount_idx: usize, inode: u64, offset: u64, buf: &mut [u8]) {
+    if buf.is_empty() {
+        return;
+    }
+    const PAGE: u64 = 4096;
+    const PHYS_OFFSET: u64 = 0xFFFF_8000_0000_0000;
+
+    let start = offset;
+    let end = offset.saturating_add(buf.len() as u64);
+    let first_page = start & !(PAGE - 1);
+    let last_page_exclusive = (end + PAGE - 1) & !(PAGE - 1);
+
+    let cache = PAGE_CACHE.lock();
+    let mut page = first_page;
+    while page < last_page_exclusive {
+        if let Some(entry) = cache.get(&(mount_idx, inode, page)) {
+            // [page, page+PAGE) ∩ [start, end) in file coordinates.
+            let slice_start = core::cmp::max(page, start);
+            let slice_end = core::cmp::min(page + PAGE, end);
+            debug_assert!(slice_start < slice_end);
+            let cache_off = (slice_start - page) as usize;
+            let buf_off = (slice_start - start) as usize;
+            let n = (slice_end - slice_start) as usize;
+            let src = (PHYS_OFFSET + entry.phys + cache_off as u64) as *const u8;
+            let dst = unsafe { buf.as_mut_ptr().add(buf_off) };
+            // SAFETY: cache page is 4 KiB; cache_off + n ≤ PAGE by construction.
+            // `buf[buf_off..buf_off+n]` is in-bounds because slice_end ≤ end =
+            // start + buf.len().  Source (PMM frame) and destination (caller
+            // buffer) are distinct allocations.
+            unsafe {
+                core::ptr::copy_nonoverlapping(src, dst, n);
+            }
+        }
+        page += PAGE;
+    }
+}
+
 /// Bring the page cache into coherence with a file that has just been
 /// resized from `old_size` to `new_size` bytes.
 ///

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2243,6 +2243,8 @@ pub fn run() -> ! {
         if test_234_cache_update_range_boundaries() { passed += 1; }
         total += 1;
         if test_240_vfs_truncate_page_cache_coherency() { passed += 1; }
+        total += 1;
+        if test_241_ramfs_mmap_read_coherency() { passed += 1; }
     }
 
     // ── Test 235: ELF loader hardening (H4) ──────────────────────────────
@@ -42338,6 +42340,167 @@ fn test_234_cache_update_range_boundaries() -> bool {
     }
     let _ = crate::vfs::remove(path);
     test_pass!("mm::cache::update_range — page-boundary arithmetic");
+    true
+}
+
+// ── Test 241: ramfs/tmpfs/memfd mmap ↔ read(2) coherency ──────────────────
+//
+// Regression guard for the REVERSE-direction page-cache coherence bug on the
+// in-memory backends (ramfs / tmpfs / memfd).  On those backends an inode keeps
+// its own `Vec<u8>` storage, and once a page is demand-faulted by an
+// `mmap(MAP_SHARED)` the file ALSO has a page-cache frame.  A store through the
+// shared mapping lands in the page-cache frame but never touches the inode
+// `Vec`.  Before `mm::cache::read_through`, `read(2)` consulted only the `Vec`
+// (`fs.read`), so it returned stale (pre-store) bytes — Mozilla's `/dev/shm`
+// IPC SharedMemory stages bytes through the mapping that the peer reads back via
+// `read(2)`, so the peer saw zeros and dereferenced a NULL IPC object pointer.
+//
+// This test models the bug at the kernel API without a full userspace process:
+//   1. Create a tmpfs/ramfs file and `write_file` a known pattern (populates the
+//      inode `Vec`).
+//   2. Allocate a page-cache frame for page 0, seed it from the `Vec` (mirrors
+//      the mmap demand-fault seeding from `fs.read`), and `cache::insert` it —
+//      the file is now "mmap'd": one shared cache frame backs page 0.
+//   3. Store a DIFFERENT pattern directly into the cache frame through the
+//      higher-half map — this is exactly what a `MAP_SHARED`+`PROT_WRITE` store
+//      does (it writes the mapped physical frame, NOT the inode `Vec`).
+//   4. `read(2)` the file via `fd_read` and assert it returns the STORE pattern,
+//      not the original `write_file` pattern.
+//
+// Pre-fix: step 4 returns the original pattern (FAIL — `fs.read` reads the
+// stale `Vec`).  Post-fix: `read_through` overlays the cache frame, so step 4
+// returns the store pattern (PASS).
+//
+// POSIX mmap(2): a write through a MAP_SHARED region is a write to the
+// underlying file object and shall be visible to a subsequent `read(2)` of the
+// same file.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_241_ramfs_mmap_read_coherency() -> bool {
+    test_header!("ramfs/tmpfs mmap ↔ read(2) coherency (reverse direction)");
+
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    let path = "/tmp/test241_mmap_read.bin";
+    let pid = crate::proc::current_pid();
+
+    let _ = crate::vfs::remove(path);
+    if let Err(e) = crate::vfs::create_file(path) {
+        test_fail!("test241", "create_file failed: {:?}", e);
+        return false;
+    }
+
+    // (1) Seed the inode Vec with the ORIGINAL pattern (one full page of 'A').
+    let original: alloc::vec::Vec<u8> = alloc::vec![b'A'; 4096];
+    if let Err(e) = crate::vfs::write_file(path, &original) {
+        test_fail!("test241", "write_file failed: {:?}", e);
+        let _ = crate::vfs::remove(path);
+        return false;
+    }
+
+    let (mount_idx, inode) = match crate::vfs::resolve_path(path) {
+        Ok(r) => r,
+        Err(e) => {
+            test_fail!("test241", "resolve_path failed: {:?}", e);
+            let _ = crate::vfs::remove(path);
+            return false;
+        }
+    };
+
+    // (2) "Demand-fault" page 0: allocate a frame, seed it from the Vec (as the
+    //     mmap fault path does via fs.read), and install it in the cache.  The
+    //     file is now mmap-resident: this frame is the shared MAP_SHARED page.
+    let phys = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => {
+            test_fail!("test241", "pmm alloc_page failed");
+            let _ = crate::vfs::remove(path);
+            return false;
+        }
+    };
+    let frame = (PHYS_OFF + phys) as *mut u8;
+    unsafe { core::ptr::copy_nonoverlapping(original.as_ptr(), frame, 4096); }
+    crate::mm::cache::insert(mount_idx, inode, 0, phys);
+
+    // (3) Store a DIFFERENT pattern ('B') through the shared frame — exactly
+    //     what a MAP_SHARED+PROT_WRITE store does (writes the frame, not the Vec).
+    unsafe { core::ptr::write_bytes(frame, b'B', 4096); }
+
+    // (4) read(2) the file and require the mmap'd store to be visible.
+    let fd = match crate::vfs::open(pid, path, 0 /*O_RDONLY*/) {
+        Ok(f) => f,
+        Err(e) => {
+            test_fail!("test241", "open failed: {:?}", e);
+            let _ = crate::mm::cache::evict(mount_idx, inode, 0);
+            let _ = crate::vfs::remove(path);
+            return false;
+        }
+    };
+    let mut readbuf = [0u8; 4096];
+    let n = crate::vfs::fd_read(pid, fd, readbuf.as_mut_ptr(), readbuf.len());
+    let _ = crate::vfs::close(pid, fd);
+
+    let read_ok = match n {
+        Ok(got) => got == 4096 && readbuf.iter().all(|&b| b == b'B'),
+        Err(e) => {
+            test_fail!("test241", "fd_read failed: {:?}", e);
+            false
+        }
+    };
+
+    // Cleanup: the cache holds a reference on `phys`; evict releases it.
+    if let Some(p) = crate::mm::cache::evict(mount_idx, inode, 0) {
+        crate::mm::pmm::free_page(p);
+    }
+    let _ = crate::vfs::remove(path);
+
+    if !read_ok {
+        // Report what the read returned so a regression is diagnosable: a 'A'
+        // page is the stale-Vec (pre-fix) failure; anything else is a deeper bug.
+        let first = readbuf[0];
+        let last = readbuf[4095];
+        test_fail!("test241",
+            "read(2) did not observe the MAP_SHARED store: buf[0]={:#x} buf[4095]={:#x} \
+             (expected all 'B' {:#x}; 'A' {:#x} means read still served the stale inode Vec)",
+            first, last, b'B', b'A');
+        return false;
+    }
+    test_println!("  store-through-mapping ('B') visible to read(2) ✓");
+
+    // Forward-direction regression guard: a write(2) to the same file must also
+    // remain visible (update_range keeps the cache frame coherent on writes).
+    // Re-create, re-seed a cache page, write through fd_write, read back.
+    let _ = crate::vfs::create_file(path);
+    let _ = crate::vfs::write_file(path, &original); // page of 'A'
+    let (mi2, in2) = match crate::vfs::resolve_path(path) {
+        Ok(r) => r,
+        Err(_) => { let _ = crate::vfs::remove(path); test_pass!("ramfs mmap ↔ read(2) coherency"); return true; }
+    };
+    if let Some(phys2) = crate::mm::pmm::alloc_page() {
+        let f2 = (PHYS_OFF + phys2) as *mut u8;
+        unsafe { core::ptr::write_bytes(f2, b'A', 4096); }
+        crate::mm::cache::insert(mi2, in2, 0, phys2);
+        // write(2) 'C' over the first 100 bytes via fd_write.
+        let cbytes: alloc::vec::Vec<u8> = alloc::vec![b'C'; 100];
+        if let Ok(wfd) = crate::vfs::open(pid, path, 0x1 /*O_WRONLY*/) {
+            let _ = crate::vfs::fd_write(pid, wfd, cbytes.as_ptr(), cbytes.len());
+            let _ = crate::vfs::close(pid, wfd);
+        }
+        // The cache frame must now show 'C' in [0,100) (update_range) and the
+        // overlaid read must agree.
+        let cache_c = unsafe { *f2 } == b'C' && unsafe { *f2.add(99) } == b'C'
+            && unsafe { *f2.add(100) } == b'A';
+        if let Some(p) = crate::mm::cache::evict(mi2, in2, 0) {
+            crate::mm::pmm::free_page(p);
+        }
+        if !cache_c {
+            test_fail!("test241", "forward direction: write(2) did not propagate to cache frame");
+            let _ = crate::vfs::remove(path);
+            return false;
+        }
+        test_println!("  write(2) ('C') propagated into cache frame ✓");
+    }
+    let _ = crate::vfs::remove(path);
+
+    test_pass!("ramfs mmap ↔ read(2) coherency");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2170,16 +2170,23 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
 
 /// Read from a file descriptor.
 ///
-/// Forward-direction coherency (write(2) visible to a subsequent read or
-/// mmap reader) is maintained by `fd_write` / `write_file` via
-/// `mm::cache::update_range`.  The reverse direction — a write through a
-/// MAP_SHARED+PROT_WRITE PTE visible to a subsequent `read(2)` — is not
-/// currently served from the page cache; this path goes straight to
-/// `fs.read`, which on tmpfs/ramfs returns the in-memory file content
-/// (consistent with mmap'd writes IF those writes have also been flushed
-/// back to FS storage).  Adding a read-through cache lookup here is a
-/// follow-up — see W215 docs/W215_CRC_MISMATCH_INVESTIGATION_*.md for the
-/// scope discussion.
+/// Page-cache coherency is maintained in BOTH directions for FS-backed fds:
+///
+///   * Forward — a `write(2)` visible to a subsequent `read(2)` or mmap reader —
+///     is maintained by `fd_write` / `write_file` via `mm::cache::update_range`,
+///     which copies the written bytes into every overlapping cache-resident page.
+///   * Reverse — a store through a `MAP_SHARED`+`PROT_WRITE` PTE visible to a
+///     subsequent `read(2)` — is maintained here: after `fs.read` returns the
+///     filesystem's own bytes, `mm::cache::read_through` overlays any
+///     cache-resident page on top, so a store that landed in the page-cache frame
+///     (the only handle a MAP_SHARED store records on the in-memory ramfs/tmpfs/
+///     memfd backends, where the inode keeps a separate `Vec<u8>`) is observed by
+///     `read(2)`.
+///
+/// Together these make a cache-resident inode present one source of truth — the
+/// page-cache frame — to mmap mappers, `read(2)`, and `write(2)` alike, matching
+/// the unified-page-cache semantics POSIX mmap(2)/read(2) require (see
+/// `mm::cache::read_through` / `update_range` for the citations).
 pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize) -> VfsResult<usize> {
     // SMAP bracket — fd_read writes data into `buf` which is typically
     // a user-VA from the syscall path.  The function does not call
@@ -2383,6 +2390,23 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                 let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
                 fs.read(inode, offset, &mut buffer)?
             };
+
+            // Reverse-direction page-cache coherency (closes the ramfs/tmpfs/
+            // memfd incoherence).  `fs.read` above returned the bytes from the
+            // filesystem's own storage (the inode `Vec<u8>` for an in-memory FS).
+            // For a file that has been mmap(MAP_SHARED)'d, a store through the
+            // shared mapping landed in the page-cache frame — NOT the inode
+            // `Vec` — so the `Vec` (and thus `fs.read`) is stale for those
+            // pages.  Overlay the cache-resident bytes on top of `buffer` so the
+            // value `read(2)` returns reflects the mapping's current content.
+            // Per POSIX mmap(2)/read(2): a write through a MAP_SHARED region is a
+            // write to the underlying file object and must be visible to a later
+            // `read(2)`.  Block-backed filesystems are unaffected (their cache and
+            // on-disk bytes already agree via `cache::update_range`, so the
+            // overlay copies identical bytes).  See `mm::cache::read_through`.
+            if n > 0 && mount_idx != usize::MAX {
+                crate::mm::cache::read_through(mount_idx, inode, offset, &mut buffer[..n]);
+            }
 
             // Update offset.
             {


### PR DESCRIPTION
## The bug (OUR-kernel divergence)

In-memory filesystems (ramfs / tmpfs / memfd) keep **two distinct storages** for a file once it has been `mmap`'d `MAP_SHARED`:

- the inode's own `Vec<u8>` (`RamFs::read`/`RamFs::write` — what `read(2)`/`write(2)` touch), and
- a **page-cache frame** seeded from `fs.read` at the demand-fault site — the physical frame every `MAP_SHARED` mapper aliases.

The **forward** direction was already coherent (`fd_write`/`write_file` → `mm::cache::update_range` copies written bytes into overlapping cache pages, so `write(2)` is visible to mappers). The **reverse** direction was not: a store through a `MAP_SHARED`+`PROT_WRITE` region lands in the page-cache frame but never touches the inode `Vec`, and `fd_read` went straight to `fs.read` (the `Vec`) — so a later `read(2)` observed **stale (pre-store) bytes**. The gap was documented in `fd_read` as an unimplemented follow-up.

This corrupts any program that stages bytes through a `/dev/shm` or `memfd` mapping and reads them back through the fd — e.g. Mozilla's `org.mozilla.ipc.*` IPC SharedMemory: the reader sees zeros where the writer stored data, yielding a NULL IPC object pointer and a content-process crash at IPC-init.

## POSIX anchor

- **mmap(2)** (IEEE Std 1003.1-2017): writes to a `MAP_SHARED` region are visible to other processes that have mapped the same portion of the file.
- **read(2)**: after a successful write to a regular file, a subsequent `read` shall return the data written. A store through a `MAP_SHARED` region is a write to the underlying file object, so it must be observed by a later `read(2)`.

## Fix

Add `mm::cache::read_through` — the read-side symmetric counterpart of `update_range`. After `fs.read` fills the buffer with the FS's own bytes, `fd_read` overlays any cache-resident page on top, so a store recorded in the page-cache frame is observed by `read(2)`. A cache-resident inode now presents **one source of truth** (the page-cache frame) to mmap mappers, `read(2)`, and `write(2)` alike — unified-page-cache tmpfs semantics.

Block-backed filesystems (ext2 / fat32 / ntfs) are unaffected: their `write(2)` path already keeps the cache and on-disk bytes in agreement via `update_range`, so the overlay copies identical bytes. Same coherence class as the ext2 write-path fix (`cache::update_range`/`truncate_range`).

## Test (test_runner.rs test 241)

Models the incoherence at the kernel API without a full userspace process:
write a pattern to a tmpfs file (populates the inode `Vec`) → promote a cache page → store a **different** pattern directly into the cache frame (a `MAP_SHARED` store) → `read(2)` and require the store visible. Plus a forward-direction guard (`write(2)` still propagates into the cache frame).

- **Verified FAILS without the fix**: `read(2)` returns the stale `Vec` content — `buf[0]=0x41 'A'` instead of `0x42 'B'`.
- **Verified PASSES with the fix**: `store-through-mapping ('B') visible to read(2) ✓` and `write(2) ('C') propagated into cache frame ✓`.

## FF impact (harness, file:///tmp/hello.html, `firefox-test-core,kdb` + `firefox-test,kdb`)

The IPC-init crash class is **gone** in both profiles — no `CR2=0xd0` / `SIGSEGV` / `MOZ_CRASH` / `channel-error` in either serial log. The content tree advances well past IPC-init (ICU load, sandbox setup via sysfs, multi-process tree with live content procs; the `firefox-test` profile reaches the screenshot-extension load and the screenshot-IPC condvar wait). The PNG is not yet reached — the next terminal gate is the downstream **screenshot-IPC poll/condvar readiness** edge (a separate, already-tracked class), not this FS-coherence bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)