### PR TITLE
harness: expose the already-wired epoll-watch kdb op on the CLI

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -11575,6 +11575,11 @@ def main():
         # struct dump + parked waiters + recent wakes + holder + verdict.
         # See subsys/linux/futex_cluster.rs::recent_wakes_near + op_cond_autopsy.
         "cond-autopsy",
+        # epoll-watch: live epoll interest-set + per-fd readiness/delivered dump
+        # for one (pid, epfd).  Tests "fd POLLIN-ready but epoll_wait never
+        # delivers it" (reactor-starvation vs kernel readiness-drop).  Request
+        # builder + op_epoll_watch already wired; this just enables the CLI op.
+        "epoll-watch",
         # Terse file-backed VMA map; one entry per VMA with first_page_phys.
         "procmaps",
         # FUTEX_WAKE cluster-wake compensation (firefox-test/test-mode only).


### PR DESCRIPTION
## What

The kdb op `epoll-watch` (kernel `op_epoll_watch`) and the harness request-builder for it were both already present in `scripts/qemu-harness.py`, but `epoll-watch` was missing from the `kdb` subcommand's argparse `choices` list — so the CLI rejected it with `invalid choice: 'epoll-watch'` and the op was only reachable via a hand-rolled JSON request to the kdb port.

This adds `epoll-watch` to the choices list (one line + comment). No behaviour change beyond making the existing op reachable.

## Why

`epoll-watch <pid> <epfd>` dumps, for one (pid, epfd), every fd in the epoll interest set with its subscribed mask, live readiness (`revents`), and what `epoll_wait(2)` would deliver (`delivered`/`ready`) — computed via the same path the wait loop uses. It is the decisive probe for distinguishing:

- **kernel readiness-drop** — an fd is POLLIN-ready but `epoll_wait` never returns it, or returns wrong revents; vs
- **producer-side stall** — `epoll_wait` faithfully has nothing to deliver because no peer produced data,

per `epoll(7)` / `epoll_wait(2)` level-vs-edge semantics. It was used to settle the FF screenshot-IPC gate (all four parent epoll sets confirmed to have zero EPOLLIN-ready fds — refuting an epoll-return bug as the gate).

## Test

- `python3 -c "import ast; ast.parse(open('scripts/qemu-harness.py').read())"` — syntax OK
- `kdb <sid> epoll-watch <pid> <epfd>` now accepted; returns the documented JSON for a live FF parent's IPC epoll set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)