### PR TITLE
harness: default-on host pcap capture for Firefox-render boots (--no-pcap opt-out)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,8 @@ jobs:
           python-version: "3.x"
       - name: serial-web smoke (serial monitor + per-gate timing)
         run: python3 scripts/serial-web-smoke.py
+      - name: pcap_decode selftest (wire decoder the /api/wire panel depends on)
+        run: python3 scripts/pcap_decode.py --selftest
       - name: perf-bench smoke (taxonomy + ingest-marks bridge)
         run: python3 scripts/perf-bench-smoke.py
       - name: perf baseline-linux smoke (record shape)

--- a/scripts/pcap_decode.py
+++ b/scripts/pcap_decode.py
@@ -1,0 +1,1419 @@
+#!/usr/bin/env python3
+"""pcap_decode.py — decode a libpcap capture into a human-readable "what's on
+the wire" summary, for the AstryxOS serial monitor's /api/wire endpoint.
+
+The capture is produced HOST-SIDE by a QEMU `filter-dump` object tapping the
+e1000/SLIRP netdev (`-object filter-dump,id=netdump,netdev=net0,file=…`). That
+tap is invisible to the guest, so this module never touches the VM — it only
+parses bytes that QEMU already wrote to disk.
+
+What it surfaces (the "what happened on the wire" view):
+  * DNS    — queries + responses (names, A/AAAA addrs, the resolver)
+  * TCP    — each 4-tuple connection: handshake (SYN/SYN-ACK/ACK), close
+             (FIN/RST), retransmits, dup-ACKs, bytes each way, final state
+  * TLS    — ClientHello SNI + offered versions + ALPN, ServerHello, whether
+             the handshake completed (Finished / appdata) or where it stalled
+  * HTTP   — cleartext request lines (method/host/path) + response status
+             (HTTPS payload is encrypted: we summarize TLS metadata only)
+  * ANOMALIES useful for debugging an OUR-kernel network divergence:
+             out-of-order, dup-ACKs, zero-window, premature RST, unanswered
+             SYN, half-open connections, retransmissions.
+
+Usage as a library (what /api/wire calls):
+    import pcap_decode
+    summary = pcap_decode.decode("/path/to/capture.pcap")   # -> dict (JSON-able)
+
+Usage as a CLI (non-interactive, one-shot, JSON to stdout — harness convention):
+    python3 scripts/pcap_decode.py <capture.pcap> [--max-packets N] [--pretty]
+    python3 scripts/pcap_decode.py --selftest          # craft + decode a tiny
+                                                          synthetic pcap, exit 0
+
+Robustness contract (the capture may be PARTIAL / still being written):
+  * A truncated final record is dropped, not fatal.
+  * A bad/garbled packet is recorded as a parse anomaly and skipped; decoding
+    continues.
+  * An empty or header-only file yields a valid (empty) summary, never an
+    exception. The raw .pcap download path is independent of this module.
+
+Pure Python standard library only. No tshark/scapy dependency. (If a future
+caller wants tshark when present, it can shell out separately; this module is
+the always-available fallback and the canonical structured view.)
+
+Spec anchors (public only): libpcap savefile format; RFC 791 (IPv4),
+RFC 8200 (IPv6), RFC 768 (UDP), RFC 793 (TCP), RFC 826 (ARP), RFC 1035 (DNS),
+RFC 8446 + RFC 6066 (TLS 1.3 / SNI / ALPN), RFC 9110 (HTTP semantics),
+RFC 894 (Ethernet II framing).
+"""
+import io
+import os
+import struct
+import sys
+import json
+import argparse
+
+# ---------------------------------------------------------------------------
+# libpcap savefile constants
+# ---------------------------------------------------------------------------
+PCAP_MAGIC_LE = 0xA1B2C3D4   # microsecond ts, little-endian on-disk
+PCAP_MAGIC_BE = 0xD4C3B2A1   # microsecond ts, big-endian on-disk
+PCAP_MAGIC_NS_LE = 0xA1B23C4D  # nanosecond ts, little-endian
+PCAP_MAGIC_NS_BE = 0x4D3CB2A1  # nanosecond ts, big-endian
+# pcapng uses 0x0A0D0D0A as the first block type — we detect and report it but
+# do not parse it (the filter-dump tap writes classic pcap).
+PCAPNG_MAGIC = 0x0A0D0D0A
+
+GLOBAL_HDR_LEN = 24
+RECORD_HDR_LEN = 16
+
+# DLT / LINKTYPE values we handle.
+LINKTYPE_NULL = 0       # BSD loopback: 4-byte AF_* header
+LINKTYPE_ETHERNET = 1   # Ethernet II
+LINKTYPE_RAW = 101      # raw IP, no link header (some SLIRP dumps)
+LINKTYPE_LINUX_SLL = 113  # Linux cooked capture v1
+LINKTYPE_LINUX_SLL2 = 276
+
+ETH_P_IPV4 = 0x0800
+ETH_P_IPV6 = 0x86DD
+ETH_P_ARP = 0x0806
+ETH_P_VLAN = 0x8100
+ETH_P_VLAN_QINQ = 0x88A8
+
+IPPROTO_ICMP = 1
+IPPROTO_TCP = 6
+IPPROTO_UDP = 17
+IPPROTO_ICMPV6 = 58
+
+# Sanity caps so a corrupt length field can't make us allocate gigabytes.
+MAX_SNAPLEN = 262144
+DEFAULT_MAX_PACKETS = 200000
+
+
+# ---------------------------------------------------------------------------
+# Address formatting
+# ---------------------------------------------------------------------------
+def _ipv4_str(b):
+    return ".".join(str(x) for x in b)
+
+
+def _ipv6_str(b):
+    # RFC 5952-ish compaction is nice-to-have; a plain hextet form is enough
+    # for a debugging summary and avoids edge-case bugs.
+    parts = [f"{(b[i] << 8) | b[i + 1]:x}" for i in range(0, 16, 2)]
+    s = ":".join(parts)
+    # collapse the longest run of :0: groups into ::
+    import re as _re
+    best = None
+    for m in _re.finditer(r"(?:^|:)(0(?::0)+)(?::|$)", s):
+        run = m.group(1)
+        if best is None or len(run) > len(best[0]):
+            best = (run, m.start(1), m.end(1))
+    if best:
+        run, a, c = best
+        s = (s[:a].rstrip(":") + "::" + s[c:].lstrip(":"))
+        s = s.replace(":::", "::")
+    return s
+
+
+def _mac_str(b):
+    return ":".join(f"{x:02x}" for x in b)
+
+
+# ---------------------------------------------------------------------------
+# pcap file reader (byte-order + ts-precision aware, partial-safe)
+# ---------------------------------------------------------------------------
+class PcapError(Exception):
+    pass
+
+
+class PcapReader:
+    """Iterates (ts_float, linktype, packet_bytes, truncated_flag) records.
+
+    Stops cleanly at EOF or at the first torn record (a partial capture in
+    progress) and records that in `self.truncated`. Never raises on a short
+    final record."""
+
+    def __init__(self, fileobj):
+        self.f = fileobj
+        self.truncated = False
+        self.ts_div = 1_000_000  # us by default
+        hdr = self.f.read(GLOBAL_HDR_LEN)
+        if len(hdr) < 4:
+            raise PcapError("file too short for a pcap global header")
+        magic = struct.unpack("<I", hdr[:4])[0]
+        if magic == PCAPNG_MAGIC:
+            raise PcapError("pcapng format is not supported by this decoder "
+                            "(expected classic libpcap)")
+        if magic in (PCAP_MAGIC_LE, PCAP_MAGIC_NS_LE):
+            self.endian = "<"
+        elif magic in (PCAP_MAGIC_BE, PCAP_MAGIC_NS_BE):
+            self.endian = ">"
+        else:
+            raise PcapError(f"not a libpcap file (bad magic 0x{magic:08x})")
+        if magic in (PCAP_MAGIC_NS_LE, PCAP_MAGIC_NS_BE):
+            self.ts_div = 1_000_000_000
+        if len(hdr) < GLOBAL_HDR_LEN:
+            raise PcapError("truncated pcap global header")
+        (self.ver_major, self.ver_minor, self.thiszone,
+         self.sigfigs, self.snaplen, self.linktype) = struct.unpack(
+            self.endian + "HHiIII", hdr[4:GLOBAL_HDR_LEN])
+
+    def __iter__(self):
+        ep = self.endian
+        while True:
+            rh = self.f.read(RECORD_HDR_LEN)
+            if not rh:
+                return  # clean EOF
+            if len(rh) < RECORD_HDR_LEN:
+                self.truncated = True
+                return  # torn record header (capture still being written)
+            ts_sec, ts_frac, incl_len, orig_len = struct.unpack(ep + "IIII", rh)
+            if incl_len > MAX_SNAPLEN:
+                # corrupt length — refuse to read it, flag and stop.
+                self.truncated = True
+                return
+            data = self.f.read(incl_len)
+            if len(data) < incl_len:
+                self.truncated = True
+                return  # torn packet body
+            ts = ts_sec + (ts_frac / self.ts_div)
+            yield (ts, self.linktype, data, orig_len)
+
+
+# ---------------------------------------------------------------------------
+# Link / network / transport dissection -> a normalised packet dict
+# ---------------------------------------------------------------------------
+def _strip_link(linktype, data):
+    """Return (l3_proto, l3_bytes) where l3_proto is 'ipv4'/'ipv6'/'arp'/None."""
+    if linktype == LINKTYPE_ETHERNET:
+        if len(data) < 14:
+            return (None, b"", {})
+        eth = {"dst_mac": _mac_str(data[0:6]), "src_mac": _mac_str(data[6:12])}
+        et = (data[12] << 8) | data[13]
+        off = 14
+        # peel VLAN tags (RFC 802.1Q) — they sit between MACs and ethertype.
+        while et in (ETH_P_VLAN, ETH_P_VLAN_QINQ) and len(data) >= off + 4:
+            et = (data[off + 2] << 8) | data[off + 3]
+            off += 4
+        rest = data[off:]
+        if et == ETH_P_IPV4:
+            return ("ipv4", rest, eth)
+        if et == ETH_P_IPV6:
+            return ("ipv6", rest, eth)
+        if et == ETH_P_ARP:
+            return ("arp", rest, eth)
+        return (None, rest, eth)
+    if linktype == LINKTYPE_RAW:
+        if not data:
+            return (None, b"", {})
+        ver = data[0] >> 4
+        if ver == 4:
+            return ("ipv4", data, {})
+        if ver == 6:
+            return ("ipv6", data, {})
+        return (None, data, {})
+    if linktype == LINKTYPE_NULL:
+        if len(data) < 4:
+            return (None, b"", {})
+        # 4-byte host-order AF_ family; AF_INET=2 typically, AF_INET6 varies.
+        fam = struct.unpack("<I", data[0:4])[0]
+        rest = data[4:]
+        if fam == 2:
+            return ("ipv4", rest, {})
+        if fam in (10, 23, 28, 30):
+            return ("ipv6", rest, {})
+        if rest and (rest[0] >> 4) == 4:
+            return ("ipv4", rest, {})
+        if rest and (rest[0] >> 4) == 6:
+            return ("ipv6", rest, {})
+        return (None, rest, {})
+    if linktype in (LINKTYPE_LINUX_SLL, LINKTYPE_LINUX_SLL2):
+        hlen = 16 if linktype == LINKTYPE_LINUX_SLL else 20
+        if len(data) < hlen:
+            return (None, b"", {})
+        if linktype == LINKTYPE_LINUX_SLL:
+            et = (data[14] << 8) | data[15]
+        else:
+            et = (data[0] << 8) | data[1]
+        rest = data[hlen:]
+        if et == ETH_P_IPV4:
+            return ("ipv4", rest, {})
+        if et == ETH_P_IPV6:
+            return ("ipv6", rest, {})
+        if et == ETH_P_ARP:
+            return ("arp", rest, {})
+        return (None, rest, {})
+    return (None, data, {})
+
+
+def _parse_ipv4(b):
+    if len(b) < 20:
+        return None
+    ihl = (b[0] & 0x0F) * 4
+    if ihl < 20 or len(b) < ihl:
+        return None
+    total = (b[2] << 8) | b[3]
+    proto = b[9]
+    src = _ipv4_str(b[12:16])
+    dst = _ipv4_str(b[16:20])
+    # frag offset / MF — note fragmentation but still hand over what we have.
+    flags_frag = (b[6] << 8) | b[7]
+    frag_off = flags_frag & 0x1FFF
+    mf = bool(flags_frag & 0x2000)
+    payload = b[ihl:total] if 0 < total <= len(b) else b[ihl:]
+    return {"ver": 4, "src": src, "dst": dst, "proto": proto,
+            "payload": payload, "fragmented": (frag_off != 0 or mf)}
+
+
+def _parse_ipv6(b):
+    if len(b) < 40:
+        return None
+    plen = (b[4] << 8) | b[5]
+    nexthdr = b[6]
+    src = _ipv6_str(b[8:24])
+    dst = _ipv6_str(b[24:40])
+    off = 40
+    # Walk the extension-header chain (RFC 8200 §4) to the upper-layer proto.
+    EXT = {0, 43, 44, 51, 60}  # hop-by-hop, routing, fragment, AH, dest-opts
+    fragmented = False
+    guard = 0
+    while nexthdr in EXT and len(b) >= off + 2 and guard < 16:
+        guard += 1
+        if nexthdr == 44:
+            fragmented = True
+            ext_len = 8
+        elif nexthdr == 51:  # AH length is in 4-byte units, +2
+            ext_len = (b[off + 1] + 2) * 4
+        else:
+            ext_len = (b[off + 1] + 1) * 8
+        nexthdr = b[off]
+        off += ext_len
+    payload = b[off:40 + plen] if plen and (40 + plen) <= len(b) else b[off:]
+    return {"ver": 6, "src": src, "dst": dst, "proto": nexthdr,
+            "payload": payload, "fragmented": fragmented}
+
+
+def _parse_tcp(b):
+    if len(b) < 20:
+        return None
+    sport = (b[0] << 8) | b[1]
+    dport = (b[2] << 8) | b[3]
+    seq = struct.unpack(">I", b[4:8])[0]
+    ack = struct.unpack(">I", b[8:12])[0]
+    data_off = (b[12] >> 4) * 4
+    if data_off < 20 or len(b) < data_off:
+        data_off = 20
+    flags = b[13]
+    window = (b[14] << 8) | b[15]
+    payload = b[data_off:]
+    return {
+        "sport": sport, "dport": dport, "seq": seq, "ack": ack,
+        "window": window, "payload": payload,
+        "fin": bool(flags & 0x01), "syn": bool(flags & 0x02),
+        "rst": bool(flags & 0x04), "psh": bool(flags & 0x08),
+        "ack_flag": bool(flags & 0x10), "urg": bool(flags & 0x20),
+    }
+
+
+def _parse_udp(b):
+    if len(b) < 8:
+        return None
+    sport = (b[0] << 8) | b[1]
+    dport = (b[2] << 8) | b[3]
+    ulen = (b[4] << 8) | b[5]
+    payload = b[8:ulen] if 8 <= ulen <= len(b) else b[8:]
+    return {"sport": sport, "dport": dport, "payload": payload}
+
+
+# ---------------------------------------------------------------------------
+# DNS (RFC 1035) — names with compression, A/AAAA/CNAME/PTR answers
+# ---------------------------------------------------------------------------
+_DNS_TYPES = {1: "A", 2: "NS", 5: "CNAME", 6: "SOA", 12: "PTR", 15: "MX",
+              16: "TXT", 28: "AAAA", 33: "SRV", 43: "DS", 65: "HTTPS",
+              64: "SVCB", 257: "CAA"}
+_DNS_RCODES = {0: "NOERROR", 1: "FORMERR", 2: "SERVFAIL", 3: "NXDOMAIN",
+               4: "NOTIMP", 5: "REFUSED"}
+
+
+def _dns_name(b, off):
+    """Decode a (possibly compressed) DNS name. Returns (name, next_off)."""
+    labels = []
+    jumped = False
+    next_off = off
+    guard = 0
+    while True:
+        if off >= len(b) or guard > 128:
+            break
+        guard += 1
+        ln = b[off]
+        if ln == 0:
+            off += 1
+            if not jumped:
+                next_off = off
+            break
+        if (ln & 0xC0) == 0xC0:  # compression pointer (RFC 1035 §4.1.4)
+            if off + 1 >= len(b):
+                break
+            ptr = ((ln & 0x3F) << 8) | b[off + 1]
+            if not jumped:
+                next_off = off + 2
+            jumped = True
+            off = ptr
+            continue
+        if off + 1 + ln > len(b):
+            break
+        labels.append(b[off + 1:off + 1 + ln].decode("ascii", "replace"))
+        off += 1 + ln
+    if not jumped:
+        next_off = off
+    return (".".join(labels), next_off)
+
+
+def _parse_dns(payload):
+    b = payload
+    if len(b) < 12:
+        return None
+    tid = (b[0] << 8) | b[1]
+    flags = (b[2] << 8) | b[3]
+    qr = (flags >> 15) & 1
+    opcode = (flags >> 11) & 0xF
+    rcode = flags & 0xF
+    qd = (b[4] << 8) | b[5]
+    an = (b[6] << 8) | b[7]
+    off = 12
+    questions = []
+    for _ in range(min(qd, 64)):
+        name, off = _dns_name(b, off)
+        if off + 4 > len(b):
+            break
+        qtype = (b[off] << 8) | b[off + 1]
+        off += 4
+        questions.append({"name": name, "type": _DNS_TYPES.get(qtype, str(qtype))})
+    answers = []
+    if qr == 1:
+        for _ in range(min(an, 128)):
+            name, off = _dns_name(b, off)
+            if off + 10 > len(b):
+                break
+            atype = (b[off] << 8) | b[off + 1]
+            rdlen = (b[off + 8] << 8) | b[off + 9]
+            off += 10
+            if off + rdlen > len(b):
+                break
+            rdata = b[off:off + rdlen]
+            val = None
+            if atype == 1 and rdlen == 4:
+                val = _ipv4_str(rdata)
+            elif atype == 28 and rdlen == 16:
+                val = _ipv6_str(rdata)
+            elif atype in (5, 2, 12):
+                val, _ = _dns_name(b, off)
+            answers.append({"name": name,
+                            "type": _DNS_TYPES.get(atype, str(atype)),
+                            "data": val})
+            off += rdlen
+    return {"tid": tid, "qr": qr, "opcode": opcode,
+            "rcode": _DNS_RCODES.get(rcode, str(rcode)),
+            "questions": questions, "answers": answers}
+
+
+# ---------------------------------------------------------------------------
+# TLS (RFC 8446) — ClientHello SNI/ALPN/versions, ServerHello, record types
+# ---------------------------------------------------------------------------
+_TLS_VERS = {0x0300: "SSL3.0", 0x0301: "TLS1.0", 0x0302: "TLS1.1",
+             0x0303: "TLS1.2", 0x0304: "TLS1.3"}
+_TLS_CONTENT = {20: "ChangeCipherSpec", 21: "Alert", 22: "Handshake",
+                23: "ApplicationData", 24: "Heartbeat"}
+
+
+def _tls_version_name(v):
+    return _TLS_VERS.get(v, f"0x{v:04x}")
+
+
+def _parse_tls_records(payload):
+    """Walk the TLS record layer of one TCP segment. Returns a list of records
+    [{type, version, len, handshake?}], best-effort across a single segment.
+
+    NOTE: a TLS record can span TCP segments; we decode what is present in this
+    segment and mark a record as 'spanning' if its declared length exceeds the
+    bytes we hold. The per-connection assembler upgrades this where it can."""
+    b = payload
+    out = []
+    off = 0
+    while off + 5 <= len(b):
+        ctype = b[off]
+        ver = (b[off + 1] << 8) | b[off + 2]
+        rlen = (b[off + 3] << 8) | b[off + 4]
+        if ctype not in _TLS_CONTENT:
+            break  # not TLS (or mid-stream encrypted) — stop scanning
+        if ver not in _TLS_VERS:
+            break
+        rec = {"type": _TLS_CONTENT[ctype], "version": _tls_version_name(ver),
+               "len": rlen}
+        body = b[off + 5:off + 5 + rlen]
+        if len(body) < rlen:
+            rec["spanning"] = True
+        if ctype == 22 and body:
+            hs = _parse_tls_handshake(body)
+            if hs:
+                rec.update(hs)
+        out.append(rec)
+        off += 5 + rlen
+    return out
+
+
+def _parse_tls_handshake(body):
+    if len(body) < 4:
+        return None
+    htype = body[0]
+    hlen = (body[1] << 16) | (body[2] << 8) | body[3]
+    if htype == 1:  # ClientHello
+        return _parse_client_hello(body[4:4 + hlen] if hlen else body[4:])
+    if htype == 2:  # ServerHello
+        return _parse_server_hello(body[4:4 + hlen] if hlen else body[4:])
+    names = {11: "Certificate", 12: "ServerKeyExchange",
+             13: "CertificateRequest", 14: "ServerHelloDone",
+             15: "CertificateVerify", 16: "ClientKeyExchange",
+             20: "Finished", 4: "NewSessionTicket", 8: "EncryptedExtensions"}
+    return {"handshake": names.get(htype, f"hs_type_{htype}")}
+
+
+def _parse_hello_extensions(b, off, info):
+    """Shared SNI/ALPN/supported_versions extension walk (RFC 6066, RFC 7301,
+    RFC 8446 §4.2)."""
+    if off + 2 > len(b):
+        return
+    ext_total = (b[off] << 8) | b[off + 1]
+    off += 2
+    end = min(len(b), off + ext_total)
+    while off + 4 <= end:
+        etype = (b[off] << 8) | b[off + 1]
+        elen = (b[off + 2] << 8) | b[off + 3]
+        off += 4
+        edata = b[off:off + elen]
+        off += elen
+        if etype == 0 and len(edata) >= 5:  # server_name (SNI)
+            # server_name_list -> entry: type(1)=host_name + len(2) + name
+            p = 2
+            if p + 3 <= len(edata) and edata[p] == 0:
+                nlen = (edata[p + 1] << 8) | edata[p + 2]
+                info["sni"] = edata[p + 3:p + 3 + nlen].decode("ascii", "replace")
+        elif etype == 16 and len(edata) >= 2:  # ALPN (RFC 7301)
+            alpn = []
+            p = 2
+            while p < len(edata):
+                ln = edata[p]
+                p += 1
+                if p + ln > len(edata):
+                    break
+                alpn.append(edata[p:p + ln].decode("ascii", "replace"))
+                p += ln
+            if alpn:
+                info["alpn"] = alpn
+        elif etype == 43 and len(edata) >= 1:  # supported_versions (1.3)
+            vers = []
+            if info.get("_is_server"):
+                if len(edata) >= 2:
+                    vers.append(_tls_version_name((edata[0] << 8) | edata[1]))
+            else:
+                ln = edata[0]
+                p = 1
+                while p + 1 < 1 + ln and p + 1 < len(edata):
+                    vers.append(_tls_version_name((edata[p] << 8) | edata[p + 1]))
+                    p += 2
+            if vers:
+                info["supported_versions"] = vers
+
+
+def _parse_client_hello(b):
+    info = {"handshake": "ClientHello", "_is_server": False}
+    if len(b) < 38:
+        info.pop("_is_server", None)
+        return info
+    legacy_ver = (b[0] << 8) | b[1]
+    info["legacy_version"] = _tls_version_name(legacy_ver)
+    off = 2 + 32  # client_version + random
+    if off >= len(b):
+        info.pop("_is_server", None)
+        return info
+    sid_len = b[off]; off += 1 + sid_len
+    if off + 2 > len(b):
+        info.pop("_is_server", None)
+        return info
+    cs_len = (b[off] << 8) | b[off + 1]; off += 2 + cs_len  # cipher_suites
+    if off >= len(b):
+        info.pop("_is_server", None)
+        return info
+    comp_len = b[off]; off += 1 + comp_len  # compression_methods
+    _parse_hello_extensions(b, off, info)
+    info.pop("_is_server", None)
+    return info
+
+
+def _parse_server_hello(b):
+    info = {"handshake": "ServerHello", "_is_server": True}
+    if len(b) < 38:
+        info.pop("_is_server", None)
+        return info
+    legacy_ver = (b[0] << 8) | b[1]
+    info["legacy_version"] = _tls_version_name(legacy_ver)
+    off = 2 + 32
+    if off >= len(b):
+        info.pop("_is_server", None)
+        return info
+    sid_len = b[off]; off += 1 + sid_len
+    if off + 3 > len(b):
+        info.pop("_is_server", None)
+        return info
+    cipher = (b[off] << 8) | b[off + 1]; off += 2
+    info["cipher_suite"] = f"0x{cipher:04x}"
+    off += 1  # compression method
+    _parse_hello_extensions(b, off, info)
+    info.pop("_is_server", None)
+    return info
+
+
+# ---------------------------------------------------------------------------
+# HTTP (RFC 9110) — cleartext request/response first lines only
+# ---------------------------------------------------------------------------
+_HTTP_METHODS = (b"GET", b"POST", b"HEAD", b"PUT", b"DELETE", b"OPTIONS",
+                 b"PATCH", b"CONNECT", b"TRACE")
+
+
+def _parse_http(payload):
+    if not payload:
+        return None
+    line0, _, rest = payload.partition(b"\r\n")
+    if payload.startswith(b"HTTP/"):
+        parts = line0.split(b" ", 2)
+        if len(parts) >= 2 and parts[1].isdigit():
+            return {"kind": "response", "status": int(parts[1]),
+                    "reason": (parts[2].decode("ascii", "replace")
+                               if len(parts) > 2 else "")}
+        return None
+    for m in _HTTP_METHODS:
+        if payload.startswith(m + b" "):
+            parts = line0.split(b" ")
+            if len(parts) >= 2:
+                host = ""
+                for hl in rest.split(b"\r\n"):
+                    if hl.lower().startswith(b"host:"):
+                        host = hl[5:].strip().decode("ascii", "replace")
+                        break
+                return {"kind": "request",
+                        "method": m.decode(),
+                        "path": parts[1].decode("ascii", "replace"),
+                        "host": host}
+    return None
+
+
+# ---------------------------------------------------------------------------
+# TCP connection tracking (RFC 793 state inference) + anomaly detection
+# ---------------------------------------------------------------------------
+class _Conn:
+    __slots__ = ("a", "b", "first_ts", "last_ts",
+                 "syn", "synack", "established", "fin_a", "fin_b", "rst",
+                 "bytes_ab", "bytes_ba", "segs_ab", "segs_ba",
+                 "retransmits", "dup_acks", "zero_window", "out_of_order",
+                 "tls_client_hello", "tls_server_hello", "tls_complete",
+                 "tls_sni", "tls_alpn", "tls_client_versions",
+                 "tls_server_version", "http_reqs", "http_resps",
+                 "_seen_seqs_ab", "_seen_seqs_ba", "_max_seq_ab", "_max_seq_ba",
+                 "_last_ack_a", "_last_ack_a_n", "_last_ack_b", "_last_ack_b_n")
+
+    def __init__(self, a, b, ts):
+        self.a = a            # the endpoint that sent the first SYN (client)
+        self.b = b            # the other endpoint (server)
+        self.first_ts = ts
+        self.last_ts = ts
+        self.syn = False
+        self.synack = False
+        self.established = False
+        self.fin_a = False
+        self.fin_b = False
+        self.rst = False
+        self.bytes_ab = 0     # a -> b payload bytes
+        self.bytes_ba = 0
+        self.segs_ab = 0
+        self.segs_ba = 0
+        self.retransmits = 0
+        self.dup_acks = 0
+        self.zero_window = 0
+        self.out_of_order = 0
+        self.tls_client_hello = False
+        self.tls_server_hello = False
+        self.tls_complete = False
+        self.tls_sni = None
+        self.tls_alpn = None
+        self.tls_client_versions = None
+        self.tls_server_version = None
+        self.http_reqs = []
+        self.http_resps = []
+        self._seen_seqs_ab = set()
+        self._seen_seqs_ba = set()
+        self._max_seq_ab = None
+        self._max_seq_ba = None
+        self._last_ack_a = None
+        self._last_ack_a_n = 0
+        self._last_ack_b = None
+        self._last_ack_b_n = 0
+
+
+def _conn_key(src, sp, dst, dp):
+    """Order-independent 4-tuple key (so both directions map to one conn)."""
+    x, y = (src, sp), (dst, dp)
+    return (x, y) if x <= y else (y, x)
+
+
+class _Tracker:
+    def __init__(self):
+        self.conns = {}      # key -> _Conn
+        self.dns = []        # list of dns event dicts
+        self.anomalies = []  # global anomaly list
+        self.counts = {"total": 0, "ipv4": 0, "ipv6": 0, "tcp": 0, "udp": 0,
+                       "dns": 0, "arp": 0, "tls": 0, "http": 0, "icmp": 0,
+                       "other": 0, "parse_errors": 0}
+        self._ts_lo = None
+        self._ts_hi = None
+
+    def _note_ts(self, ts):
+        if self._ts_lo is None or ts < self._ts_lo:
+            self._ts_lo = ts
+        if self._ts_hi is None or ts > self._ts_hi:
+            self._ts_hi = ts
+
+    def feed(self, ts, l3proto, ip):
+        proto = ip["proto"]
+        src, dst = ip["src"], ip["dst"]
+        if proto == IPPROTO_TCP:
+            tcp = _parse_tcp(ip["payload"])
+            if tcp:
+                self.counts["tcp"] += 1
+                self._tcp(ts, src, dst, tcp)
+            else:
+                self.counts["parse_errors"] += 1
+        elif proto == IPPROTO_UDP:
+            udp = _parse_udp(ip["payload"])
+            if udp:
+                self.counts["udp"] += 1
+                self._udp(ts, src, dst, udp)
+            else:
+                self.counts["parse_errors"] += 1
+        elif proto in (IPPROTO_ICMP, IPPROTO_ICMPV6):
+            self.counts["icmp"] += 1
+        else:
+            self.counts["other"] += 1
+
+    def _udp(self, ts, src, dst, udp):
+        if udp["sport"] == 53 or udp["dport"] == 53:
+            dns = None
+            try:
+                dns = _parse_dns(udp["payload"])
+            except Exception:
+                self.counts["parse_errors"] += 1
+            if dns:
+                self.counts["dns"] += 1
+                ev = {"ts": round(ts, 6),
+                      "resolver": (dst if udp["dport"] == 53 else src),
+                      "client": (src if udp["dport"] == 53 else dst)}
+                if dns["qr"] == 0:
+                    ev["kind"] = "query"
+                    ev["questions"] = dns["questions"]
+                else:
+                    ev["kind"] = "response"
+                    ev["rcode"] = dns["rcode"]
+                    ev["questions"] = dns["questions"]
+                    ev["answers"] = dns["answers"]
+                self.dns.append(ev)
+
+    def _tcp(self, ts, src, dst, tcp):
+        sp, dp = tcp["sport"], tcp["dport"]
+        key = _conn_key(src, sp, dst, dp)
+        c = self.conns.get(key)
+        if c is None:
+            # The first packet seen defines "a" (client) heuristically: a pure
+            # SYN's sender is the client; otherwise the current src is "a".
+            if tcp["syn"] and not tcp["ack_flag"]:
+                c = _Conn((src, sp), (dst, dp), ts)
+            else:
+                c = _Conn((src, sp), (dst, dp), ts)
+            self.conns[key] = c
+        c.last_ts = ts
+        from_a = ((src, sp) == c.a)
+
+        # --- handshake / teardown flags (RFC 793 §3.4, §3.5) ---
+        if tcp["syn"] and not tcp["ack_flag"]:
+            c.syn = True
+            if not from_a:
+                # SYN came from the side we tagged as server: re-tag so "a" is
+                # always the active opener.
+                c.a, c.b = c.b, c.a
+                from_a = True
+        if tcp["syn"] and tcp["ack_flag"]:
+            c.synack = True
+        if tcp["ack_flag"] and c.syn and c.synack:
+            c.established = True
+        if tcp["fin"]:
+            if from_a:
+                c.fin_a = True
+            else:
+                c.fin_b = True
+        if tcp["rst"]:
+            if not c.rst:
+                # premature RST before established is the interesting anomaly.
+                if not c.established:
+                    self.anomalies.append({
+                        "type": "premature_rst",
+                        "conn": _fmt_endpoints(c),
+                        "detail": "RST before connection established"})
+            c.rst = True
+
+        # --- zero window (RFC 793 flow control: receiver advertised 0) ---
+        if tcp["window"] == 0 and tcp["ack_flag"] and not tcp["rst"]:
+            c.zero_window += 1
+
+        # --- payload accounting + retransmit/out-of-order/dup-ACK ---
+        plen = len(tcp["payload"])
+        seq = tcp["seq"]
+        if from_a:
+            c.segs_ab += 1
+            c.bytes_ab += plen
+            if plen > 0:
+                if seq in c._seen_seqs_ab:
+                    c.retransmits += 1
+                else:
+                    c._seen_seqs_ab.add(seq)
+                    if c._max_seq_ab is not None and seq < c._max_seq_ab:
+                        c.out_of_order += 1
+                    if c._max_seq_ab is None or seq > c._max_seq_ab:
+                        c._max_seq_ab = seq
+            self._dup_ack(c, tcp, "a")
+        else:
+            c.segs_ba += 1
+            c.bytes_ba += plen
+            if plen > 0:
+                if seq in c._seen_seqs_ba:
+                    c.retransmits += 1
+                else:
+                    c._seen_seqs_ba.add(seq)
+                    if c._max_seq_ba is not None and seq < c._max_seq_ba:
+                        c.out_of_order += 1
+                    if c._max_seq_ba is None or seq > c._max_seq_ba:
+                        c._max_seq_ba = seq
+            self._dup_ack(c, tcp, "b")
+
+        # --- L7 over this segment ---
+        if plen > 0:
+            self._l7(c, tcp["payload"], from_a)
+
+    def _dup_ack(self, c, tcp, side):
+        """Duplicate-ACK heuristic (RFC 5681 §2): same ACK number repeated with
+        no new payload is the fast-retransmit trigger and a loss signal."""
+        if not tcp["ack_flag"]:
+            return
+        ackn = tcp["ack"]
+        empty = (len(tcp["payload"]) == 0 and not tcp["syn"] and not tcp["fin"])
+        if side == "a":
+            if empty and ackn == c._last_ack_a:
+                c._last_ack_a_n += 1
+                if c._last_ack_a_n >= 2:  # 3rd identical ACK = dup-ACK event
+                    c.dup_acks += 1
+            else:
+                c._last_ack_a = ackn
+                c._last_ack_a_n = 1 if empty else 0
+        else:
+            if empty and ackn == c._last_ack_b:
+                c._last_ack_b_n += 1
+                if c._last_ack_b_n >= 2:
+                    c.dup_acks += 1
+            else:
+                c._last_ack_b = ackn
+                c._last_ack_b_n = 1 if empty else 0
+
+    def _l7(self, c, payload, from_a):
+        # TLS first (port 443 is the FF real-website path).
+        dport = c.b[1] if from_a else c.a[1]
+        sport = c.a[1] if from_a else c.b[1]
+        looks_tls = (443 in (sport, dport)) or (payload[:1] in (b"\x16", b"\x17",
+                                                                b"\x14", b"\x15"))
+        if looks_tls:
+            try:
+                recs = _parse_tls_records(payload)
+            except Exception:
+                recs = []
+            if recs:
+                self.counts["tls"] += 1
+                for r in recs:
+                    hs = r.get("handshake")
+                    if hs == "ClientHello":
+                        c.tls_client_hello = True
+                        c.tls_sni = r.get("sni") or c.tls_sni
+                        c.tls_alpn = r.get("alpn") or c.tls_alpn
+                        c.tls_client_versions = (r.get("supported_versions")
+                                                 or c.tls_client_versions
+                                                 or [r.get("legacy_version")])
+                    elif hs == "ServerHello":
+                        c.tls_server_hello = True
+                        sv = r.get("supported_versions")
+                        c.tls_server_version = (sv[0] if sv else
+                                                r.get("legacy_version"))
+                    if r.get("type") == "ApplicationData":
+                        # Encrypted app data flowing => handshake completed.
+                        if c.tls_server_hello:
+                            c.tls_complete = True
+                return
+        # Cleartext HTTP (port 80 or anything that parses as a request/status).
+        try:
+            h = _parse_http(payload)
+        except Exception:
+            h = None
+        if h:
+            self.counts["http"] += 1
+            if h["kind"] == "request":
+                c.http_reqs.append({"method": h["method"], "host": h["host"],
+                                    "path": h["path"]})
+            else:
+                c.http_resps.append({"status": h["status"],
+                                     "reason": h["reason"]})
+
+    # ----- finalisation: derive per-conn state + global anomalies -----
+    def finalize(self):
+        conns_out = []
+        for c in self.conns.values():
+            state = self._infer_state(c)
+            # half-open: SYN seen, no SYN-ACK, never established, no RST.
+            if c.syn and not c.synack and not c.established and not c.rst:
+                self.anomalies.append({
+                    "type": "unanswered_syn",
+                    "conn": _fmt_endpoints(c),
+                    "detail": "SYN sent, no SYN-ACK observed (server silent "
+                              "or capture truncated)"})
+            if c.established and (c.fin_a ^ c.fin_b) and not c.rst:
+                self.anomalies.append({
+                    "type": "half_open",
+                    "conn": _fmt_endpoints(c),
+                    "detail": "one side sent FIN, the other never closed"})
+            if c.retransmits:
+                self.anomalies.append({
+                    "type": "retransmission", "conn": _fmt_endpoints(c),
+                    "detail": f"{c.retransmits} retransmitted segment(s)"})
+            if c.out_of_order:
+                self.anomalies.append({
+                    "type": "out_of_order", "conn": _fmt_endpoints(c),
+                    "detail": f"{c.out_of_order} out-of-order segment(s)"})
+            if c.dup_acks:
+                self.anomalies.append({
+                    "type": "dup_acks", "conn": _fmt_endpoints(c),
+                    "detail": f"{c.dup_acks} duplicate-ACK event(s)"})
+            if c.zero_window:
+                self.anomalies.append({
+                    "type": "zero_window", "conn": _fmt_endpoints(c),
+                    "detail": f"receiver advertised zero window "
+                              f"{c.zero_window} time(s)"})
+            if c.tls_client_hello and not c.tls_server_hello:
+                self.anomalies.append({
+                    "type": "tls_stalled", "conn": _fmt_endpoints(c),
+                    "detail": "ClientHello sent, no ServerHello "
+                              f"(SNI={c.tls_sni or '?'})"})
+            co = {
+                "client": f"{c.a[0]}:{c.a[1]}",
+                "server": f"{c.b[0]}:{c.b[1]}",
+                "state": state,
+                "handshake": {
+                    "syn": c.syn, "syn_ack": c.synack,
+                    "established": c.established},
+                "close": {"fin_client": c.fin_a, "fin_server": c.fin_b,
+                          "rst": c.rst},
+                "bytes_c2s": c.bytes_ab, "bytes_s2c": c.bytes_ba,
+                "segs_c2s": c.segs_ab, "segs_s2c": c.segs_ba,
+                "retransmits": c.retransmits, "dup_acks": c.dup_acks,
+                "out_of_order": c.out_of_order, "zero_window": c.zero_window,
+                "duration_s": round(c.last_ts - c.first_ts, 6),
+            }
+            if c.tls_client_hello or c.tls_server_hello:
+                co["tls"] = {
+                    "client_hello": c.tls_client_hello,
+                    "server_hello": c.tls_server_hello,
+                    "completed": c.tls_complete,
+                    "sni": c.tls_sni,
+                    "alpn": c.tls_alpn,
+                    "client_versions": c.tls_client_versions,
+                    "negotiated_version": c.tls_server_version,
+                }
+            if c.http_reqs or c.http_resps:
+                co["http"] = {"requests": c.http_reqs,
+                              "responses": c.http_resps}
+            conns_out.append(co)
+        # Stable, useful ordering: by start time (clients first), most bytes.
+        conns_out.sort(key=lambda x: (-(x["bytes_c2s"] + x["bytes_s2c"])))
+        return conns_out
+
+    @staticmethod
+    def _infer_state(c):
+        # RFC 793 §3.2 state inference from observed flags.
+        if c.rst:
+            return "RESET"
+        if c.fin_a and c.fin_b:
+            return "CLOSED"
+        if c.fin_a or c.fin_b:
+            return "CLOSING"
+        if c.established:
+            return "ESTABLISHED"
+        if c.synack:
+            return "SYN_RCVD"
+        if c.syn:
+            return "SYN_SENT"
+        return "UNKNOWN"
+
+
+def _fmt_endpoints(c):
+    return f"{c.a[0]}:{c.a[1]} <-> {c.b[0]}:{c.b[1]}"
+
+
+# ---------------------------------------------------------------------------
+# Top-level decode()
+# ---------------------------------------------------------------------------
+def decode(pcap_path, max_packets=DEFAULT_MAX_PACKETS):
+    """Decode a libpcap capture into a JSON-able wire summary.
+
+    Returns a dict:
+      { ok, error?, file, file_size, truncated, linktype,
+        capture: {packets, duration_s, first_ts, last_ts},
+        counts: {...protocol tallies...},
+        dns: [ {kind, resolver, client, questions, answers?, rcode?} ],
+        connections: [ {client, server, state, handshake, close, bytes_*,
+                        retransmits, dup_acks, tls?, http?} ],
+        anomalies: [ {type, conn, detail} ] }
+
+    Never raises on a malformed/partial capture: structural problems land in
+    `error` with ok=False but a still-usable partial summary; per-packet
+    problems are tallied in counts.parse_errors and as anomalies."""
+    result = {
+        "ok": True, "error": None,
+        "file": os.path.basename(pcap_path),
+        "file_size": None, "truncated": False, "linktype": None,
+        "capture": {"packets": 0, "duration_s": 0.0,
+                    "first_ts": None, "last_ts": None},
+        "counts": {}, "dns": [], "connections": [], "anomalies": [],
+    }
+    try:
+        result["file_size"] = os.path.getsize(pcap_path)
+    except OSError:
+        pass
+
+    try:
+        f = open(pcap_path, "rb")
+    except OSError as e:
+        result["ok"] = False
+        result["error"] = f"cannot open capture: {e}"
+        return result
+
+    tr = _Tracker()
+    n = 0
+    with f:
+        try:
+            reader = PcapReader(f)
+        except PcapError as e:
+            result["ok"] = False
+            result["error"] = str(e)
+            return result
+        result["linktype"] = reader.linktype
+        result["snaplen"] = reader.snaplen
+        result["pcap_version"] = f"{reader.ver_major}.{reader.ver_minor}"
+        for ts, linktype, data, orig_len in reader:
+            n += 1
+            tr.counts_total = n
+            tr._note_ts(ts)
+            if n > max_packets:
+                tr.anomalies.append({
+                    "type": "capture_capped", "conn": "-",
+                    "detail": f"stopped after {max_packets} packets "
+                              "(file larger; raise --max-packets to see all)"})
+                break
+            try:
+                l3, l3bytes, _eth = _strip_link(linktype, data)
+                if l3 == "ipv4":
+                    tr.counts["ipv4"] += 1
+                    ip = _parse_ipv4(l3bytes)
+                elif l3 == "ipv6":
+                    tr.counts["ipv6"] += 1
+                    ip = _parse_ipv6(l3bytes)
+                elif l3 == "arp":
+                    tr.counts["arp"] += 1
+                    ip = None
+                else:
+                    tr.counts["other"] += 1
+                    ip = None
+                if ip and ip.get("payload") is not None:
+                    if ip.get("fragmented"):
+                        # We don't reassemble IP fragments; note and skip L4.
+                        tr.anomalies.append({
+                            "type": "ip_fragment", "conn": "-",
+                            "detail": f"IP fragment {ip['src']}->{ip['dst']} "
+                                      "(L4 not reassembled)"})
+                    else:
+                        tr.feed(ts, l3, ip)
+            except Exception as e:  # never let one bad packet kill the decode
+                tr.counts["parse_errors"] += 1
+                if len([a for a in tr.anomalies
+                        if a["type"] == "parse_error"]) < 5:
+                    tr.anomalies.append({
+                        "type": "parse_error", "conn": "-",
+                        "detail": f"packet #{n}: {type(e).__name__}: {e}"})
+        result["truncated"] = reader.truncated
+
+    tr.counts["total"] = n
+    result["counts"] = tr.counts
+    result["capture"]["packets"] = n
+    if tr._ts_lo is not None:
+        result["capture"]["first_ts"] = round(tr._ts_lo, 6)
+        result["capture"]["last_ts"] = round(tr._ts_hi, 6)
+        result["capture"]["duration_s"] = round(tr._ts_hi - tr._ts_lo, 6)
+    result["dns"] = tr.dns
+    result["connections"] = tr.finalize()
+    result["anomalies"] = tr.anomalies
+    if result["truncated"]:
+        result["anomalies"].insert(0, {
+            "type": "capture_in_progress", "conn": "-",
+            "detail": "capture appears to be still being written or was "
+                      "truncated; final record dropped (this is normal for a "
+                      "live filter-dump)"})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# decode_pcap() — serial-web /api/wire adapter
+# ---------------------------------------------------------------------------
+# The serial-web wire panel (scripts/serial-web.py) consumes a flat,
+# UI-oriented summary: top-level `packets`/`bytes` counters and four parallel
+# arrays — `dns` ({name,type,answer}), `tls` ({sni,version,dst}),
+# `http` ({method,host,path}), `flows` ({dst,bytes,pkts}).  The rich decode()
+# output is nested (TLS/HTTP live inside each connection), so this adapter
+# projects the connection-centric view onto the UI's flat per-event view while
+# passing the full structured detail through verbatim (additive keys) so the
+# `wire_summary` / Wireshark-equivalent inspection still has handshake state,
+# RFC-793 connection state, and the anomaly list.
+def decode_pcap(path, max_packets=None):
+    """Adapter to the serial-web /api/wire contract.
+
+    Returns a dict whose flat top-level keys (packets, bytes, dns, tls, http,
+    flows) drive the dashboard wire panel, and which also carries the full
+    decode() detail (connections, anomalies, counts, capture) so the textual
+    wire summary is complete.  Never raises on a partial/torn capture."""
+    if max_packets is None:
+        d = decode(path)
+    else:
+        d = decode(path, max_packets=max_packets)
+
+    flows, tls, http = [], [], []
+    total_bytes = 0
+    for c in d.get("connections", []):
+        b = int(c.get("bytes_c2s", 0)) + int(c.get("bytes_s2c", 0))
+        pk = int(c.get("segs_c2s", 0)) + int(c.get("segs_s2c", 0))
+        total_bytes += b
+        dst = c.get("server", "?")
+        flows.append({
+            "dst": dst,
+            "src": c.get("client", "?"),
+            "bytes": b,
+            "pkts": pk,
+            "state": c.get("state", "?"),
+        })
+        t = c.get("tls")
+        if t:
+            # RFC 8446 §4.1.2 ClientHello / RFC 6066 §3 SNI.  Surface the SNI,
+            # the negotiated (or, if the handshake stalled, the offered) TLS
+            # version, and the server endpoint the ClientHello targeted.
+            ver = t.get("negotiated_version") or (
+                (t.get("client_versions") or ["?"])[0])
+            tls.append({
+                "sni": t.get("sni") or "(no SNI)",
+                "version": ver,
+                "dst": dst,
+                "alpn": t.get("alpn") or [],
+                "completed": bool(t.get("completed")),
+            })
+        h = c.get("http")
+        if h:
+            # RFC 9110 §9 request lines.  decode() stores each request as
+            # {method, host, path}; surface them as the UI's method/host/path
+            # columns (host falls back to the connection's server endpoint when
+            # the request carried no Host header, e.g. cleartext HTTP/1.0).
+            for req in (h.get("requests") or []):
+                if isinstance(req, dict):
+                    http.append({
+                        "method": req.get("method", "?"),
+                        "host": req.get("host") or dst,
+                        "path": req.get("path", "/"),
+                    })
+                else:
+                    method, host, pth = _split_http_req(req)
+                    http.append({"method": method, "host": host or dst,
+                                 "path": pth})
+
+    dns_out = []
+    for ev in d.get("dns", []):
+        # RFC 1035 §4.1.  One UI row per question, annotated with the first
+        # answer (if this is a response) so DNS A/AAAA results are visible.
+        qs = ev.get("questions") or []
+        ans = ev.get("answers") or []
+        first_answer = None
+        for a in ans:
+            if isinstance(a, dict) and a.get("data"):
+                first_answer = a.get("data")
+                break
+        if not qs:
+            dns_out.append({"name": "?", "type": ev.get("kind", "?"),
+                            "answer": first_answer})
+        for q in qs:
+            qname = q.get("name") if isinstance(q, dict) else str(q)
+            qtype = q.get("type") if isinstance(q, dict) else "?"
+            dns_out.append({
+                "name": qname,
+                "type": qtype if ev.get("kind") == "query"
+                        else (qtype),
+                "kind": ev.get("kind"),
+                "answer": first_answer,
+            })
+
+    out = dict(d)  # pass full structured detail through (connections, etc.)
+    out["packets"] = d.get("capture", {}).get("packets", 0)
+    out["bytes"] = total_bytes
+    out["dns"] = dns_out
+    out["tls"] = tls
+    out["http"] = http
+    out["flows"] = flows
+    return out
+
+
+def _split_http_req(req):
+    """Best-effort split of a raw HTTP request line into (method, host, path).
+
+    `req` is typically a request-line string like "GET /index.html HTTP/1.1"
+    optionally with a Host: captured.  Returns ('?', None, raw) when it cannot
+    be parsed — never raises (RFC 9110 §9 request line syntax)."""
+    try:
+        s = req if isinstance(req, str) else str(req)
+        parts = s.split()
+        if len(parts) >= 2 and parts[0].isupper():
+            return parts[0], None, parts[1]
+        return "?", None, s
+    except Exception:
+        return "?", None, str(req)
+
+
+# ---------------------------------------------------------------------------
+# Self-test: craft a tiny synthetic pcap (DNS query + TLS ClientHello) and
+# decode it, asserting the structured summary comes out. No external file.
+# ---------------------------------------------------------------------------
+def _u16(v):
+    return struct.pack(">H", v)
+
+
+def _build_eth_ipv4(src_ip, dst_ip, proto, l4):
+    ip_hdr = bytearray(20)
+    ip_hdr[0] = 0x45
+    total = 20 + len(l4)
+    ip_hdr[2:4] = _u16(total)
+    ip_hdr[8] = 64
+    ip_hdr[9] = proto
+    ip_hdr[12:16] = bytes(int(x) for x in src_ip.split("."))
+    ip_hdr[16:20] = bytes(int(x) for x in dst_ip.split("."))
+    eth = (b"\x52\x55\x0a\x00\x02\x02" + b"\x52\x54\x00\x12\x34\x56"
+           + _u16(ETH_P_IPV4))
+    return eth + bytes(ip_hdr) + l4
+
+
+def _build_udp(sp, dp, payload):
+    return _u16(sp) + _u16(dp) + _u16(8 + len(payload)) + _u16(0) + payload
+
+
+def _build_tcp(sp, dp, seq, ack, flags, payload=b"", window=64240):
+    hdr = bytearray(20)
+    hdr[0:2] = _u16(sp)
+    hdr[2:4] = _u16(dp)
+    hdr[4:8] = struct.pack(">I", seq)
+    hdr[8:12] = struct.pack(">I", ack)
+    hdr[12] = 0x50  # data offset = 5 words
+    hdr[13] = flags
+    hdr[14:16] = _u16(window)
+    return bytes(hdr) + payload
+
+
+def _build_dns_query(name="example.com"):
+    q = bytearray()
+    q += _u16(0x1234) + _u16(0x0100) + _u16(1) + _u16(0) + _u16(0) + _u16(0)
+    for label in name.split("."):
+        q += bytes([len(label)]) + label.encode()
+    q += b"\x00" + _u16(1) + _u16(1)  # type A, class IN
+    return bytes(q)
+
+
+def _build_client_hello(sni="example.com"):
+    # Minimal but spec-shaped TLS record -> handshake -> ClientHello with SNI.
+    server_name = sni.encode()
+    sni_entry = b"\x00" + _u16(len(server_name)) + server_name  # host_name
+    sni_list = _u16(len(sni_entry)) + sni_entry
+    ext_sni = _u16(0) + _u16(len(sni_list)) + sni_list
+    alpn_protos = b"\x02h2\x08http/1.1"
+    alpn = _u16(len(alpn_protos)) + alpn_protos
+    ext_alpn = _u16(16) + _u16(len(alpn)) + alpn
+    exts = ext_sni + ext_alpn
+    body = bytearray()
+    body += _u16(0x0303)          # legacy_version TLS1.2
+    body += b"\x00" * 32          # random
+    body += b"\x00"               # session_id len 0
+    body += _u16(2) + _u16(0x1301)  # cipher_suites: TLS_AES_128_GCM_SHA256
+    body += b"\x01\x00"           # compression: null
+    body += _u16(len(exts)) + exts
+    hs = b"\x01" + struct.pack(">I", len(body))[1:] + bytes(body)
+    rec = b"\x16" + _u16(0x0303) + _u16(len(hs)) + hs
+    return rec
+
+
+def _write_pcap(records, linktype=LINKTYPE_ETHERNET):
+    """records: list of (ts_sec, ts_usec, frame_bytes). Returns pcap bytes."""
+    out = io.BytesIO()
+    out.write(struct.pack("<IHHiIII", PCAP_MAGIC_LE, 2, 4, 0, 0,
+                          65535, linktype))
+    for ts_sec, ts_usec, frame in records:
+        out.write(struct.pack("<IIII", ts_sec, ts_usec, len(frame), len(frame)))
+        out.write(frame)
+    return out.getvalue()
+
+
+def _selftest():
+    import tempfile
+    cli = "10.0.2.15"
+    res = "10.0.2.3"
+    srv = "93.184.216.34"
+    frames = []
+    # 1. DNS query example.com -> resolver
+    frames.append((1, 0, _build_eth_ipv4(cli, res, IPPROTO_UDP,
+                   _build_udp(40000, 53, _build_dns_query("example.com")))))
+    # 2. DNS response with an A record
+    dns_resp = bytearray()
+    dns_resp += _u16(0x1234) + _u16(0x8180) + _u16(1) + _u16(1) + _u16(0) + _u16(0)
+    for label in "example.com".split("."):
+        dns_resp += bytes([len(label)]) + label.encode()
+    dns_resp += b"\x00" + _u16(1) + _u16(1)
+    dns_resp += b"\xc0\x0c" + _u16(1) + _u16(1) + struct.pack(">I", 300)
+    dns_resp += _u16(4) + bytes(int(x) for x in srv.split("."))
+    frames.append((1, 5000, _build_eth_ipv4(res, cli, IPPROTO_UDP,
+                   _build_udp(53, 40000, bytes(dns_resp)))))
+    # 3. TCP SYN cli->srv:443
+    frames.append((1, 10000, _build_eth_ipv4(cli, srv, IPPROTO_TCP,
+                   _build_tcp(50000, 443, 1000, 0, 0x02))))
+    # 4. SYN-ACK srv->cli
+    frames.append((1, 12000, _build_eth_ipv4(srv, cli, IPPROTO_TCP,
+                   _build_tcp(443, 50000, 9000, 1001, 0x12))))
+    # 5. ACK cli->srv
+    frames.append((1, 13000, _build_eth_ipv4(cli, srv, IPPROTO_TCP,
+                   _build_tcp(50000, 443, 1001, 9001, 0x10))))
+    # 6. TLS ClientHello cli->srv
+    ch = _build_client_hello("example.com")
+    frames.append((1, 14000, _build_eth_ipv4(cli, srv, IPPROTO_TCP,
+                   _build_tcp(50000, 443, 1001, 9001, 0x18, ch))))
+    # 7. ServerHello (minimal) srv->cli
+    sh_body = bytearray()
+    sh_body += _u16(0x0303) + b"\x00" * 32 + b"\x00"
+    sh_body += _u16(0x1301) + b"\x00"
+    sh_body += _u16(0)  # no extensions
+    sh_hs = b"\x02" + struct.pack(">I", len(sh_body))[1:] + bytes(sh_body)
+    sh_rec = b"\x16" + _u16(0x0303) + _u16(len(sh_hs)) + sh_hs
+    frames.append((1, 16000, _build_eth_ipv4(srv, cli, IPPROTO_TCP,
+                   _build_tcp(443, 50000, 9001, 1001 + len(ch), 0x18, sh_rec))))
+    # 8. Application data srv->cli (=> handshake complete)
+    appdata = b"\x17\x03\x03" + _u16(32) + b"\xaa" * 32
+    frames.append((1, 18000, _build_eth_ipv4(srv, cli, IPPROTO_TCP,
+                   _build_tcp(443, 50000, 9001 + len(sh_rec), 1001 + len(ch),
+                              0x18, appdata))))
+    # 9. A retransmit of the ClientHello segment (same seq + payload) -> anomaly
+    frames.append((1, 20000, _build_eth_ipv4(cli, srv, IPPROTO_TCP,
+                   _build_tcp(50000, 443, 1001, 9001, 0x18, ch))))
+    # 10. FIN both ways
+    frames.append((1, 22000, _build_eth_ipv4(cli, srv, IPPROTO_TCP,
+                   _build_tcp(50000, 443, 9999, 9001, 0x11))))
+    frames.append((1, 23000, _build_eth_ipv4(srv, cli, IPPROTO_TCP,
+                   _build_tcp(443, 50000, 9001, 10000, 0x11))))
+
+    pcap = _write_pcap(frames)
+    with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as tf:
+        tf.write(pcap)
+        path = tf.name
+    try:
+        summary = decode(path)
+    finally:
+        os.unlink(path)
+
+    # Assertions: prove the structured summary captured the wire facts.
+    errs = []
+    if not summary["ok"]:
+        errs.append(f"ok=False: {summary['error']}")
+    if summary["capture"]["packets"] != len(frames):
+        errs.append(f"packet count {summary['capture']['packets']} != "
+                    f"{len(frames)}")
+    qnames = [q["name"] for ev in summary["dns"]
+              for q in ev.get("questions", [])]
+    if "example.com" not in qnames:
+        errs.append("DNS query name example.com not found")
+    answers = [a["data"] for ev in summary["dns"] for a in ev.get("answers", [])]
+    if srv not in answers:
+        errs.append(f"DNS A answer {srv} not found (got {answers})")
+    if len(summary["connections"]) != 1:
+        errs.append(f"expected 1 TCP connection, got "
+                    f"{len(summary['connections'])}")
+    else:
+        conn = summary["connections"][0]
+        if not conn["handshake"]["established"]:
+            errs.append("TCP handshake not marked established")
+        tls = conn.get("tls", {})
+        if tls.get("sni") != "example.com":
+            errs.append(f"TLS SNI not parsed (got {tls.get('sni')})")
+        if tls.get("alpn") != ["h2", "http/1.1"]:
+            errs.append(f"TLS ALPN not parsed (got {tls.get('alpn')})")
+        if not tls.get("server_hello"):
+            errs.append("ServerHello not detected")
+        if not tls.get("completed"):
+            errs.append("TLS handshake not marked completed")
+        if conn["retransmits"] < 1:
+            errs.append("retransmit not detected")
+        if conn["state"] != "CLOSED":
+            errs.append(f"TCP state expected CLOSED, got {conn['state']}")
+    atypes = {a["type"] for a in summary["anomalies"]}
+    if "retransmission" not in atypes:
+        errs.append("retransmission anomaly missing")
+
+    print(json.dumps(summary, indent=2))
+    if errs:
+        print("\nSELFTEST FAILED:", file=sys.stderr)
+        for e in errs:
+            print("  -", e, file=sys.stderr)
+        return 1
+    print("\nSELFTEST PASSED: all wire facts decoded "
+          f"({len(frames)} packets, 1 TCP conn, DNS A, TLS SNI/ALPN, "
+          "retransmit, CLOSED).", file=sys.stderr)
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Decode a libpcap capture into a wire summary (JSON).")
+    ap.add_argument("pcap", nargs="?", help="path to a .pcap capture")
+    ap.add_argument("--max-packets", type=int, default=DEFAULT_MAX_PACKETS,
+                    help="cap packets processed (default %(default)s)")
+    ap.add_argument("--pretty", action="store_true",
+                    help="indent the JSON output")
+    ap.add_argument("--selftest", action="store_true",
+                    help="craft + decode a synthetic pcap, assert, exit")
+    args = ap.parse_args(argv)
+    if args.selftest:
+        return _selftest()
+    if not args.pcap:
+        ap.error("a pcap path is required (or use --selftest)")
+    summary = decode(args.pcap, max_packets=args.max_packets)
+    print(json.dumps(summary, indent=2 if args.pretty else None))
+    return 0 if summary["ok"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -971,6 +971,237 @@ def run_blk_trace_argv_check():
     print()
 
 
+def run_pcap_argv_check():
+    """
+    Tier 1.5 host-only check: `start --pcap` filter-dump composition +
+    serial-web /api/pcap + /api/wire endpoints.
+
+    No QEMU launched (< 2s).  Locks down the host-side packet-capture surface
+    so a future refactor cannot silently regress it:
+
+      * `start --pcap` and `start --no-pcap` are advertised and parse
+      * the filter-dump `-object` references the e1000/SLIRP netdev id (net0)
+        and a per-session pcap file, and is emitted AFTER `-netdev` so QEMU's
+        object resolver finds the netdev (QEMU networking docs)
+      * the in-place kdb-hostfwd patch (which mutates the `-netdev` arg, not
+        its id) leaves the filter-dump binding intact
+      * the default-ON / opt-out decision precedence (`_resolve_pcap_decision`,
+        the helper cmd_start drives): --no-pcap > --pcap > FF-feature-set > off
+        — an FF-render feature set captures by default, --no-pcap suppresses it
+        even on FF, a non-FF boot stays off, and --pcap force-enables any boot;
+        each on/off decision is cross-checked against the composed cmdline
+      * serial-web serves the raw .pcap (application/vnd.tcpdump.pcap,
+        attachment) byte-identically, and /api/wire returns a stable envelope
+        (decode_available bool + pcap_url) whether or not the wire decoder
+        scripts/pcap_decode.py is present on the checkout
+    """
+    print("=== Tier 1.5: --pcap filter-dump + serial-web wire (host-only) ===")
+    print()
+
+    import importlib.util, tempfile, os as _os, struct, urllib.request, json as _json
+    import http.server, socketserver, threading
+
+    # ── start --pcap / --no-pcap advertised + parse ───────────────────────────
+    _, raw, _ = _h("start", "--help")
+    check("start --pcap advertised in --help",
+          "--pcap" in raw, "flag missing from start --help")
+    check("start --no-pcap advertised in --help",
+          "--no-pcap" in raw, "opt-out flag missing from start --help")
+
+    # ── filter-dump arg composes correctly through build_qemu_cmd ──────────────
+    aq_path = Path(__file__).resolve().parent / "astryx_qemu.py"
+    spec = importlib.util.spec_from_file_location("astryx_qemu_pcap_smoke", aq_path)
+    aq = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(aq)
+
+    _di = tempfile.NamedTemporaryFile(suffix=".img", delete=False)
+    _di.write(b"\0" * 4096); _di.close()
+    data_img = _di.name
+    sid = "smoke0000pcap"
+    pcap_path = f"/x/harness/{sid}.pcap"
+    # This is the exact extra_args cmd_start injects for --pcap.
+    extra = ["-object", f"filter-dump,id=netdump,netdev=net0,file={pcap_path}"]
+    cmd = aq.build_qemu_cmd("", data_img, "/x/s.log", mode="test",
+                            ovmf_code="/x/code.fd", ovmf_vars="/x/vars",
+                            esp_dir="/x/esp", qmp_sock="/x/q.sock", kvm=False,
+                            extra_args=extra)
+    try:
+        netdev_i = next(i for i, a in enumerate(cmd) if a == "-netdev")
+        obj_i = next(i for i, a in enumerate(cmd) if a == "-object")
+        check("filter-dump -object present", True, "")
+        check("filter-dump references netdev=net0",
+              "netdev=net0" in cmd[obj_i + 1], cmd[obj_i + 1])
+        check("filter-dump writes per-session pcap file",
+              f"file={pcap_path}" in cmd[obj_i + 1], cmd[obj_i + 1])
+        check("netdev emitted before filter-dump object",
+              netdev_i < obj_i, f"netdev@{netdev_i} object@{obj_i}")
+        # Replicate the kdb-hostfwd in-place patch from _launch_qemu_harness.
+        for i, a in enumerate(cmd):
+            if a == "-netdev" and cmd[i + 1].startswith("user,id=net0"):
+                cmd[i + 1] = cmd[i + 1] + ",hostfwd=tcp:127.0.0.1:9991-:9999"
+                break
+        obj_i2 = next(i for i, a in enumerate(cmd) if a == "-object")
+        check("filter-dump binding survives kdb-hostfwd patch",
+              "netdev=net0" in cmd[obj_i2 + 1], cmd[obj_i2 + 1])
+    except StopIteration:
+        check("filter-dump -object present", False,
+              "no -object in composed cmdline")
+
+    # ── pcap default-ON / opt-out decision + cmdline composition ───────────────
+    # Lock down the precedence introduced by tools/pcap-default-ff:
+    #   --no-pcap > --pcap > FF-feature-set > off.  We drive the SAME decision
+    #   helper cmd_start uses (`_resolve_pcap_decision`), then — for the on/off
+    #   cases — replicate cmd_start's filter-dump injection and feed it through
+    #   build_qemu_cmd to confirm the -object lands (or doesn't) and stays
+    #   ordered after -netdev, exactly as the live `start` path does.
+    qh_spec = importlib.util.spec_from_file_location("qh_pcap_smoke", HARNESS)
+    qh = importlib.util.module_from_spec(qh_spec)
+    qh_spec.loader.exec_module(qh)
+    resolve = qh._resolve_pcap_decision
+
+    def _compose_has_filterdump(enabled):
+        """Replicate cmd_start's injection for a decision, return (has, ok_ordered)."""
+        di = tempfile.NamedTemporaryFile(suffix=".img", delete=False)
+        di.write(b"\0" * 4096); di.close()
+        try:
+            ex = []
+            if enabled:
+                ex = ["-object",
+                      f"filter-dump,id=netdump,netdev=net0,file=/x/harness/s.pcap"]
+            c = aq.build_qemu_cmd("", di.name, "/x/s.log", mode="test",
+                                  ovmf_code="/x/code.fd", ovmf_vars="/x/vars",
+                                  esp_dir="/x/esp", qmp_sock="/x/q.sock",
+                                  kvm=False, extra_args=ex)
+            has = any(a == "-object" and "filter-dump" in c[i + 1]
+                      for i, a in enumerate(c[:-1]))
+            ok_order = True
+            if has:
+                ndi = next(i for i, a in enumerate(c) if a == "-netdev")
+                oi = next(i for i, a in enumerate(c)
+                          if a == "-object" and "filter-dump" in c[i + 1])
+                ok_order = ndi < oi and "netdev=net0" in c[oi + 1]
+            return has, ok_order
+        finally:
+            try:
+                _os.unlink(di.name)
+            except OSError:
+                pass
+
+    # 1) firefox-test-core (no flags) -> ON by default ("ff-default"), -object lands.
+    en, rs = resolve(["firefox-test-core"], False, False)
+    has, ordered = _compose_has_filterdump(en)
+    check("FF-render boot defaults pcap ON",
+          en is True and rs == "ff-default", f"enabled={en} reason={rs}")
+    check("FF-default cmdline carries filter-dump after -netdev",
+          has and ordered, f"has={has} ordered={ordered}")
+
+    # 2) firefox-test-core --no-pcap -> OFF ("no-pcap-optout"), NO -object.
+    en, rs = resolve(["firefox-test-core"], False, True)
+    has, _o = _compose_has_filterdump(en)
+    check("FF boot + --no-pcap disables pcap",
+          en is False and rs == "no-pcap-optout", f"enabled={en} reason={rs}")
+    check("--no-pcap cmdline has NO filter-dump", not has, f"has={has}")
+
+    # 3) test-mode (non-FF, no flags) -> OFF by default ("non-ff-default"), NO -object.
+    en, rs = resolve(["test-mode"], False, False)
+    has, _o = _compose_has_filterdump(en)
+    check("non-FF boot defaults pcap OFF",
+          en is False and rs == "non-ff-default", f"enabled={en} reason={rs}")
+    check("non-FF-default cmdline has NO filter-dump", not has, f"has={has}")
+
+    # 4) test-mode --pcap -> force ON ("pcap-forced"), -object lands.
+    en, rs = resolve(["test-mode"], True, False)
+    has, ordered = _compose_has_filterdump(en)
+    check("non-FF boot + --pcap forces pcap ON",
+          en is True and rs == "pcap-forced", f"enabled={en} reason={rs}")
+    check("--pcap-on-non-FF cmdline carries filter-dump after -netdev",
+          has and ordered, f"has={has} ordered={ordered}")
+
+    # 5) precedence: --no-pcap beats an explicit --pcap on an FF boot.
+    en, rs = resolve(["firefox-test-core"], True, True)
+    check("--no-pcap wins over --pcap (precedence)",
+          en is False and rs == "no-pcap-optout", f"enabled={en} reason={rs}")
+
+    try:
+        _os.unlink(data_img)
+    except OSError:
+        pass
+
+    # ── serial-web /api/pcap + /api/wire against a fixture ─────────────────────
+    # Build a tiny valid libpcap fixture (global header + 1 ethernet frame) in a
+    # throwaway HARNESS_DIR, then serve it through serial-web's handler.
+    tmpdir = tempfile.mkdtemp(prefix="pcap-smoke-")
+    fsid = "fixt0000pcap"
+    fpcap = _os.path.join(tmpdir, fsid + ".pcap")
+    with open(fpcap, "wb") as f:
+        # classic pcap global header, LINKTYPE_ETHERNET (1), snaplen 65535
+        f.write(struct.pack("<IHHiIII", 0xa1b2c3d4, 2, 4, 0, 0, 65535, 1))
+        frame = bytes(14) + b"\x45" + bytes(19)   # 34-byte stub ethernet+ipv4
+        f.write(struct.pack("<IIII", 1780000000, 0, len(frame), len(frame)))
+        f.write(frame)
+    with open(_os.path.join(tmpdir, fsid + ".serial.log"), "w") as f:
+        f.write("[boot] pcap smoke fixture\n")
+    with open(_os.path.join(tmpdir, fsid + ".json"), "w") as f:
+        _json.dump({"sid": fsid, "pid": 0, "pcap_path": fpcap,
+                    "serial_log": _os.path.join(tmpdir, fsid + ".serial.log")}, f)
+
+    sw_path = Path(__file__).resolve().parent / "serial-web.py"
+    spec2 = importlib.util.spec_from_file_location("serial_web_pcap_smoke", sw_path)
+    sw = importlib.util.module_from_spec(spec2)
+    spec2.loader.exec_module(sw)
+    sw.HARNESS_DIR = tmpdir   # point the handler at the throwaway dir
+
+    srv = socketserver.TCPServer(("127.0.0.1", 0), sw.H)
+    srv.allow_reuse_address = True
+    port = srv.server_address[1]
+    th = threading.Thread(target=srv.serve_forever, daemon=True)
+    th.start()
+    try:
+        base = f"http://127.0.0.1:{port}"
+        with urllib.request.urlopen(f"{base}/api/pcap?sid={fsid}") as r:
+            ct = r.headers.get("Content-Type")
+            cd = r.headers.get("Content-Disposition")
+            body = r.read()
+        with open(fpcap, "rb") as f:
+            orig = f.read()
+        check("/api/pcap Content-Type is libpcap",
+              ct == "application/vnd.tcpdump.pcap", str(ct))
+        check("/api/pcap is an attachment download",
+              cd and "attachment" in cd and f"{fsid}.pcap" in cd, str(cd))
+        check("/api/pcap bytes match capture file",
+              body == orig, f"{len(body)} vs {len(orig)} bytes")
+
+        wreq = urllib.request.urlopen(f"{base}/api/wire?sid={fsid}")
+        wj = _json.loads(wreq.read())
+        # /api/wire is correct in BOTH worlds: with scripts/pcap_decode.py on
+        # the checkout it returns a decoded summary (decode_available:true);
+        # without it, it degrades to decode_available:false. Either way the
+        # envelope must carry pcap_url so the UI can still offer the raw
+        # download. (The decoder's own parsing is gated by its --selftest and
+        # by serial-web-smoke.py's decoded-fixture checks.)
+        check("/api/wire envelope carries decode_available + pcap_url",
+              isinstance(wj.get("decode_available"), bool)
+              and wj.get("pcap_url") == f"/api/pcap?sid={fsid}",
+              _json.dumps(wj)[:140])
+
+        # missing-capture session -> structured 404, never a 500
+        try:
+            urllib.request.urlopen(f"{base}/api/pcap?sid=nopcap00000a")
+            code = 200
+        except urllib.error.HTTPError as e:
+            code = e.code
+            err = _json.loads(e.read())
+        check("/api/pcap missing capture -> 404 JSON",
+              code == 404 and err.get("error") == "no_pcap", f"code={code}")
+    except Exception as e:
+        check("serial-web pcap/wire endpoints serve", False, repr(e))
+    finally:
+        srv.shutdown(); srv.server_close()
+        import shutil as _sh
+        _sh.rmtree(tmpdir, ignore_errors=True)
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="AstryxOS qemu-harness smoke test")
@@ -1004,6 +1235,7 @@ def main():
     run_read_ff_png_check()
     run_kdb_read_png_check()
     run_blk_trace_argv_check()
+    run_pcap_argv_check()
 
     if args.staleness_only:
         # Early exit for CI cycles that just want the cheap host-only checks.

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -2846,6 +2846,48 @@ def _make_snap_topology(sid: str, data_img: str) -> dict:
             "data_img": str(data_img)}
 
 
+# Feature flags that mark a boot as a "Firefox-render" boot (the profiles that
+# exercise the network: a real HTTPS page load over the e1000/SLIRP netdev).
+# `firefox-test` is the back-compat super-feature; `firefox-test-core` is the
+# perf/render profile; `firefox-test-trace` is the dense-trace add-on. When the
+# resolved feature set intersects this set, host-side pcap capture defaults ON
+# (see `_resolve_pcap_decision`) — every FF boot's VM<->internet traffic is
+# captured automatically. Non-FF boots (test-mode, default desktop) have no
+# network worth capturing, so capture stays OFF for them by default.
+FF_RENDER_FEATURES = frozenset({
+    "firefox-test",
+    "firefox-test-core",
+    "firefox-test-trace",
+})
+
+
+def _resolve_pcap_decision(feats, pcap_flag, no_pcap_flag):
+    """Decide whether host-side pcap capture is enabled for this boot.
+
+    Pure (no I/O) so the smoke suite can exercise every branch without a boot.
+
+    Precedence (highest first):
+      1. ``--no-pcap``  -> OFF unconditionally (wins over everything; lets a
+         clean perf-timing FF run suppress even the host fwrite).
+      2. ``--pcap``     -> ON unconditionally (force-on for ANY boot, incl. the
+         non-FF / no-network ones).
+      3. FF-render feature set present -> ON (the default: every Firefox boot
+         captures its VM<->internet traffic automatically).
+      4. otherwise      -> OFF (non-FF boots have no network worth capturing).
+
+    `feats` is the fully-resolved feature list (post `--trace` expansion).
+    Returns ``(enabled: bool, reason: str)`` where reason is one of
+    ``"no-pcap-optout" | "pcap-forced" | "ff-default" | "non-ff-default"``.
+    """
+    if no_pcap_flag:
+        return False, "no-pcap-optout"
+    if pcap_flag:
+        return True, "pcap-forced"
+    if any(f in FF_RENDER_FEATURES for f in feats):
+        return True, "ff-default"
+    return False, "non-ff-default"
+
+
 def cmd_start(args):
     sid = uuid.uuid4().hex[:12]
     serial_log  = str(HARNESS_DIR / f"{sid}.serial.log")
@@ -3466,6 +3508,44 @@ def cmd_start(args):
     if "xeyes-test" in feats and not any(a == "-vga" for a in extra_qemu_args):
         extra_qemu_args += ["-vga", "vmware"]
 
+    # Host-side packet capture on the e1000/SLIRP netdev (net0).
+    #
+    # `-object filter-dump,id=netdump,netdev=net0,file=<sid>.pcap` taps the
+    # netdev frontend on the HOST side (QEMU networking docs: filter-dump
+    # records every packet on the named netdev to a libpcap file, classic
+    # pcap file format).  Because the tap lives in the host QEMU process
+    # — not the guest — the guest takes ZERO extra VM-exits; the only cost
+    # is a host fwrite per frame, bounded by traffic volume (~MB per page
+    # load).  This is fundamentally cheaper than the serial firehose, where
+    # every emitted byte was a synchronous PIO VM-exit (Intel SDM Vol. 3C
+    # §25).  The `-object` is appended via extra_qemu_args; it references
+    # the netdev by id (`net0`) so the in-place hostfwd patching in
+    # `_launch_qemu_harness` (which mutates the `-netdev` arg, not its id)
+    # leaves the filter-dump binding intact.
+    #
+    # Capture defaults ON for Firefox-render boots (the FF profiles exercise a
+    # real network load), so every FF boot's VM<->internet traffic is captured
+    # automatically with no opt-in.  `--pcap` force-enables it for ANY boot
+    # (incl. non-FF); `--no-pcap` disables it even on FF boots (for a clean
+    # perf-timing run).  Precedence and the decision live in
+    # `_resolve_pcap_decision`; `pcap_reason` records which rule fired.
+    pcap_enabled, pcap_reason = _resolve_pcap_decision(
+        feats,
+        bool(getattr(args, "pcap", False)),
+        bool(getattr(args, "no_pcap", False)),
+    )
+    pcap_path = ""
+    if pcap_enabled:
+        pcap_path = str(HARNESS_DIR / f"{sid}.pcap")
+        extra_qemu_args += [
+            "-object",
+            f"filter-dump,id=netdump,netdev=net0,file={pcap_path}",
+        ]
+        print(f"[HARNESS] pcap capture: {pcap_path}", file=sys.stderr)
+    else:
+        print(f"[HARNESS] pcap capture: disabled ({pcap_reason})",
+              file=sys.stderr)
+
     # snap-gate (--snapshottable): build the savevm/loadvm-compatible device
     # topology so the running guest can be snapshotted live.  The default
     # firefox-test boot disk (writable vvfat) + writable OVMF_VARS pflash
@@ -3510,6 +3590,17 @@ def cmd_start(args):
         "kdb_host_port": kdb_host_port,
         "http_host_port": http_host_port,
         "ssh_host_port": ssh_host_port,
+        # Host-side network capture.  `pcap_path` is the source of truth —
+        # the libpcap file QEMU's filter-dump object writes every guest netdev
+        # frame to, or "" when capture is disabled.  serial-web serves it at
+        # /api/pcap?sid=<sid> and decodes it at /api/wire?sid=<sid>.  Defaults
+        # ON for FF-render boots, OFF otherwise; `--pcap` force-on, `--no-pcap`
+        # force-off (precedence in `_resolve_pcap_decision`).  `pcap_enabled`
+        # mirrors `bool(pcap_path)`; `pcap_reason` records which rule decided.
+        # All additive — never present on sessions started before they landed.
+        "pcap_path":    pcap_path,
+        "pcap_enabled": pcap_enabled,
+        "pcap_reason":  pcap_reason,
         # PIVOT-I2 Phase D — host stub Conflux for oracle-daemon-test.
         # If oracle_stub_pid is 0 the stub wasn't launched (default).
         "oracle_stub_port": oracle_stub_port,
@@ -3645,6 +3736,13 @@ def cmd_start(args):
           "gdb_port": gdb_port, "kdb_host_port": kdb_host_port,
           "http_host_port": http_host_port,
           "ssh_host_port": ssh_host_port,
+          # Host-side capture: path ("" when disabled) is the source of truth;
+          # `pcap_enabled` mirrors bool(path); `pcap_reason` is the rule that
+          # fired ("ff-default" | "pcap-forced" | "no-pcap-optout" |
+          # "non-ff-default").  Additive.
+          "pcap_path":    pcap_path,
+          "pcap_enabled": pcap_enabled,
+          "pcap_reason":  pcap_reason,
           # W106: structured CPU-model fields. `cpu_model_resolved` is
           # the literal string passed to QEMU `-cpu`; `cpu_model_reason`
           # is one of "override" | "kvm-host" | "tcg-safe".
@@ -4195,6 +4293,22 @@ def cmd_status(args):
 
     exit_cause = _classify_exit_cause(sess["serial_log"], alive)
 
+    # Host-side capture.  Report path + whether QEMU has started writing frames
+    # (file present + byte size), plus the decision metadata.  pcap_path is ""
+    # when capture was disabled for this session (and absent entirely on
+    # sessions that predate the feature).  `pcap_reason` records which rule
+    # enabled/disabled it; older sessions fall back to deriving it from path.
+    pcap_path = sess.get("pcap_path") or ""
+    pcap_enabled = bool(sess.get("pcap_enabled", bool(pcap_path)))
+    # None on sessions that predate the field (decision rule unknown).
+    pcap_reason = sess.get("pcap_reason")
+    pcap_size = 0
+    if pcap_path:
+        try:
+            pcap_size = Path(pcap_path).stat().st_size
+        except OSError:
+            pass
+
     _out({
         "running":         alive,
         "sid":             sid,
@@ -4208,6 +4322,15 @@ def cmd_status(args):
         # filled in by the post-boot verifier once the [FFTEST] probe line
         # is parsed; until then they remain None.
         "firefox_variant_info": sess.get("firefox_variant_info"),
+        # Host-side capture.  `pcap_path` is "" when capture was disabled;
+        # `pcap_size` > 0 confirms QEMU's filter-dump is writing frames.
+        # `pcap_enabled` mirrors bool(path); `pcap_reason` is the rule that
+        # decided ("ff-default" | "pcap-forced" | "no-pcap-optout" |
+        # "non-ff-default"), or None on pre-feature sessions.  Additive.
+        "pcap_path":       pcap_path,
+        "pcap_size":       pcap_size,
+        "pcap_enabled":    pcap_enabled,
+        "pcap_reason":     pcap_reason,
     })
 
 
@@ -11357,6 +11480,33 @@ def main():
                                "Suppress the auto-restage with "
                                "--no-regen-data-img — the mismatch is still "
                                "warned about on stderr.")
+    p_start.add_argument("--pcap", action="store_true", dest="pcap",
+                          help="FORCE host-side packet capture ON for this "
+                               "boot, even a non-FF one.  Captures ALL guest "
+                               "network traffic on the e1000/SLIRP netdev "
+                               "(net0) to a libpcap file at "
+                               "~/.astryx-harness/<sid>.pcap via a HOST-SIDE "
+                               "QEMU `-object filter-dump`.  Capture already "
+                               "DEFAULTS ON for Firefox-render boots (features "
+                               "firefox-test / firefox-test-core / "
+                               "firefox-test-trace) — this flag is only needed "
+                               "to force it on a non-FF boot.  The tap lives on "
+                               "the host side — the guest is unaware, so there "
+                               "are ZERO guest VM-exits and negligible guest "
+                               "perf cost (only host disk writes bounded by "
+                               "traffic volume, a few MB for a page load).  "
+                               "Unlike the serial firehose (per-byte PIO "
+                               "VM-exits), this is free on the guest path.  The "
+                               "pcap opens in Wireshark; serial-web serves it "
+                               "at /api/pcap?sid=<sid> and a decoded wire "
+                               "summary at /api/wire?sid=<sid>.")
+    p_start.add_argument("--no-pcap", action="store_true", dest="no_pcap",
+                          help="Disable host-side packet capture for this boot "
+                               "even when it would otherwise default ON (an "
+                               "FF-render boot).  Use for a clean perf-timing "
+                               "run where even the per-frame host fwrite is "
+                               "unwanted.  Wins over both the FF-default and an "
+                               "explicit --pcap.")
 
     # stop
     p_stop = sub.add_parser("stop", help="Kill a QEMU session")

--- a/scripts/serial-web-smoke.py
+++ b/scripts/serial-web-smoke.py
@@ -27,14 +27,18 @@ Covers (matches the operator-requested feature set):
                       kernel-tick derivation (APPROX historical), incl. the
                       monotone/forward-ordered delta invariant.
 """
+import base64
 import importlib.util
 import json
 import os
+import struct
 import sys
 import tempfile
 import threading
 import time
+import urllib.error
 import urllib.request
+import zlib
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PASS = "\033[32mPASS\033[0m"
@@ -55,6 +59,28 @@ def load_module(harness_dir):
     spec.loader.exec_module(sw)
     sw.HARNESS_DIR = harness_dir
     return sw
+
+
+def _build_pcap_fixture():
+    """Return bytes of a tiny but spec-faithful libpcap capture for the wire
+    endpoints. Reuses pcap_decode's own frame builders (the same ones its
+    --selftest exercises) so the fixture is a real Ethernet/IPv4/UDP DNS query
+    plus a TCP+TLS ClientHello carrying an SNI — i.e. /api/wire must decode a
+    DNS question and a TLS SNI out of it. Imported lazily so a checkout missing
+    pcap_decode.py degrades to the decode_available=False path instead of
+    erroring the whole smoke run."""
+    pd_spec = importlib.util.spec_from_file_location(
+        "pcap_decode_fixture", os.path.join(HERE, "pcap_decode.py"))
+    pd = importlib.util.module_from_spec(pd_spec)
+    pd_spec.loader.exec_module(pd)
+    dns = pd._build_eth_ipv4("10.0.2.15", "10.0.2.3", pd.IPPROTO_UDP,
+                             pd._build_udp(50000, 53, pd._build_dns_query("example.com")))
+    ch = pd._build_eth_ipv4("10.0.2.15", "93.184.216.34", pd.IPPROTO_TCP,
+                            pd._build_tcp(50001, 443, 1, 0, 0x02))  # SYN
+    hello = pd._build_eth_ipv4("10.0.2.15", "93.184.216.34", pd.IPPROTO_TCP,
+                               pd._build_tcp(50001, 443, 2, 1, 0x18,
+                                             pd._build_client_hello("example.com")))
+    return pd._write_pcap([(1, 0, dns), (1, 1000, ch), (1, 2000, hello)])
 
 
 # ── synthetic fixtures ────────────────────────────────────────────────────────
@@ -263,6 +289,212 @@ def _core_profile_gate_checks(sw, tmp):
           fire == 0, fire)
 
 
+# ── screenshot streams: base64 PNG decode (VGA framebuffer + Firefox render) ──
+PNG_SIG = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+
+def _make_png(w, h):
+    """A real, valid PNG built with stdlib zlib only (NO Pillow). 8-bit RGBA,
+    one IDAT, one IEND. Its IHDR carries w/h so the dimension parse is exercised."""
+    def chunk(typ, data):
+        c = typ + data
+        return struct.pack(">I", len(data)) + c + struct.pack(
+            ">I", zlib.crc32(c) & 0xFFFFFFFF)
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0)   # 8-bit, colour-type 6
+    # filter byte 0 + RGBA scanlines (a flat colour compresses small/fast)
+    raw = b"".join(b"\x00" + b"\x39\xd3\x53\xff" * w for _ in range(h))
+    return (PNG_SIG + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(raw, 6)) + chunk(b"IEND", b""))
+
+
+def _emit_stream(png, kind, drop_tail=0, end=True):
+    """Render `png` as the chunked base64 serial stream for `kind` (vga|ff). When
+    drop_tail>0, omit the last `drop_tail` chunks (and the END marker) to model
+    an in-progress/partial stream. Mirrors the kernel's 76-char chunk width."""
+    b64 = base64.b64encode(png).decode()
+    parts = [b64[i:i + 76] for i in range(0, len(b64), 76)]
+    M = len(parts)
+    keep = M - drop_tail
+    lines = []
+    if kind == "ff":
+        lines.append(f"[FF-OUT-PNG:path=/tmp/out.png size={len(png)} sig_ok=true]")
+        tag = "FF-OUT-PNG-B64"
+        endtag = "[FF-OUT-PNG-END]"
+    else:
+        tag = "SCREENSHOT-B64"
+        endtag = "[SCREENSHOT-B64-END]"
+    for i in range(keep):
+        lines.append(f"[{tag}:{i}/{M}] {parts[i]}")
+    if end and drop_tail == 0:
+        lines.append(endtag)
+    return "\n".join(lines) + "\n", M, keep
+
+
+def _screenshot_checks(sw, tmp):
+    """The screenshot decode endpoint: complete + partial streams for BOTH the
+    VGA framebuffer (kind=vga) and the Firefox render (kind=ff). Validates the
+    decoded PNG signature/dimensions, completeness flags, partial-pct, the
+    metadata endpoint, and graceful degradation (no 500 on a torn stream; a
+    clean JSON 404 when absent). All synthetic — CI-safe, no real logs needed."""
+    # ---- complete VGA + complete FF in one log ----
+    png_vga = _make_png(800, 450)        # matches the real fixture dimensions
+    png_ff = _make_png(64, 48)
+    sid = "shots01"
+    log = os.path.join(tmp, sid + ".serial.log")
+    vga_txt, vgaM, _ = _emit_stream(png_vga, "vga")
+    ff_txt, ffM, _ = _emit_stream(png_ff, "ff")
+    with open(log, "w") as f:
+        f.write("[BOOT] AstryxOS kernel\n" + vga_txt + ff_txt)
+
+    dv = sw._decode_shot(log, "vga")
+    check("shots vga decodes to valid PNG", dv["sig_ok"] and dv["png"][:8] == PNG_SIG)
+    check("shots vga complete", dv["complete"] is True, dv["complete"])
+    check("shots vga dims 800x450", dv["w"] == 800 and dv["h"] == 450, (dv["w"], dv["h"]))
+    check("shots vga byte-exact", dv["bytes"] == len(png_vga), (dv["bytes"], len(png_vga)))
+    check("shots vga chunks==total", dv["chunks"] == vgaM and dv["total"] == vgaM)
+
+    df = sw._decode_shot(log, "ff")
+    check("shots ff decodes to valid PNG", df["sig_ok"] and df["png"][:8] == PNG_SIG)
+    check("shots ff complete", df["complete"] is True, df["complete"])
+    check("shots ff dims 64x48", df["w"] == 64 and df["h"] == 48, (df["w"], df["h"]))
+    check("shots ff byte-exact + guest_size cross-check",
+          df["bytes"] == len(png_ff) == df["guest_size"],
+          (df["bytes"], len(png_ff), df["guest_size"]))
+
+    # ---- metadata endpoint: both present, no png bytes shipped ----
+    md = sw.scan_screenshots(log)
+    check("scan_screenshots vga present+complete",
+          md["vga"]["present"] and md["vga"]["complete"])
+    check("scan_screenshots ff present+complete",
+          md["ff"]["present"] and md["ff"]["complete"])
+    check("scan_screenshots strips png bytes (metadata only)",
+          "png" not in md["vga"] and "png" not in md["ff"])
+    check("scan_screenshots consistent schema (both branches have end_seen/received)",
+          all(k in md["vga"] for k in ("end_seen", "received", "first_gap", "partial_pct")))
+
+    # ---- PARTIAL VGA: drop ~33% of the tail + the END marker ----
+    sidp = "shotspart01"
+    logp = os.path.join(tmp, sidp + ".serial.log")
+    drop = vgaM // 3
+    vpart, _, vkeep = _emit_stream(png_vga, "vga", drop_tail=drop)
+    with open(logp, "w") as f:
+        f.write(vpart)
+    dp = sw._decode_shot(logp, "vga")
+    check("shots PARTIAL does not error (graceful)", dp["error"] is None, dp["error"])
+    check("shots PARTIAL present but not complete",
+          dp["present"] and dp["complete"] is False, (dp["present"], dp["complete"]))
+    check("shots PARTIAL still a valid PNG prefix (IHDR present)",
+          dp["sig_ok"] and dp["png"][:8] == PNG_SIG)
+    check("shots PARTIAL keeps IHDR dims (800x450)",
+          dp["w"] == 800 and dp["h"] == 450, (dp["w"], dp["h"]))
+    check("shots PARTIAL pct == int(100*keep/total)",
+          dp["partial_pct"] == int(100 * vkeep / vgaM),
+          (dp["partial_pct"], vkeep, vgaM))
+    check("shots PARTIAL end_seen False (no END marker)", dp["end_seen"] is False)
+
+    # ---- absent stream: clean 'present:false', no crash ----
+    sidn = "shotsnone01"
+    logn = os.path.join(tmp, sidn + ".serial.log")
+    with open(logn, "w") as f:
+        f.write("[BOOT] AstryxOS kernel\n[FFTEST] no screenshot here\n")
+    dn = sw._decode_shot(logn, "vga")
+    check("shots absent -> present False, no error", not dn["present"] and dn["error"] is None)
+
+    # ---- HTTP layer: serve PNG bytes, headers, JSON 404 on absent ----
+    from http.server import ThreadingHTTPServer
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), sw.H)
+    srv.daemon_threads = True
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        # complete VGA -> 200 image/png, PNG magic, complete header
+        req = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/screenshot?sid={sid}&kind=vga", timeout=5)
+        body = req.read()
+        check("GET /api/screenshot vga 200 image/png",
+              req.status == 200 and req.headers.get("Content-Type") == "image/png")
+        check("GET /api/screenshot vga returns PNG bytes", body[:8] == PNG_SIG)
+        check("GET /api/screenshot vga X-Screenshot-Complete true",
+              req.headers.get("X-Screenshot-Complete") == "true")
+        check("GET /api/screenshot vga X-Screenshot-Dimensions 800x450",
+              req.headers.get("X-Screenshot-Dimensions") == "800x450")
+        # complete FF -> 200 image/png
+        reqf = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/screenshot?sid={sid}&kind=ff", timeout=5)
+        bodyf = reqf.read()
+        check("GET /api/screenshot ff 200 PNG bytes",
+              reqf.status == 200 and bodyf[:8] == PNG_SIG)
+        # partial VGA -> 200 but Complete:false (degrades, not 500)
+        reqp = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/api/screenshot?sid={sidp}&kind=vga", timeout=5)
+        bodyp = reqp.read()
+        check("GET /api/screenshot PARTIAL 200 (not 500) + PNG bytes",
+              reqp.status == 200 and bodyp[:8] == PNG_SIG)
+        check("GET /api/screenshot PARTIAL Complete header false",
+              reqp.headers.get("X-Screenshot-Complete") == "false")
+        # absent FF on a vga-only log -> JSON 404
+        try:
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/screenshot?sid={sidp}&kind=ff", timeout=5)
+            absent404 = False
+        except urllib.error.HTTPError as e:
+            absent404 = (e.code == 404
+                         and e.headers.get("Content-Type") == "application/json")
+        check("GET /api/screenshot absent -> JSON 404 (no 500)", absent404)
+        # bad kind -> 400 JSON
+        try:
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/screenshot?sid={sid}&kind=bogus", timeout=5)
+            bad400 = False
+        except urllib.error.HTTPError as e:
+            bad400 = e.code == 400
+        check("GET /api/screenshot bad kind -> 400", bad400)
+        # metadata endpoint
+        with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/screenshots?sid={sid}", timeout=5) as r:
+            mbody = json.loads(r.read())
+        check("GET /api/screenshots both kinds + no png bytes",
+              mbody["vga"]["complete"] and mbody["ff"]["complete"]
+              and "png" not in mbody["vga"])
+        # the dashboard HTML wires up the screenshots panel + endpoint
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=5) as r:
+            page = r.read()
+        check("dashboard HTML references screenshots panel",
+              b"id=shots" in page and b"/api/screenshot?" in page
+              and b"VGA framebuffer" in page and b"Firefox render" in page)
+    finally:
+        srv.shutdown()
+
+
+def _real_fixture_checks(sw):
+    """Opportunistic check against the REAL operator fixtures, only when this
+    host has them (skipped silently in CI, which has no ~/.astryx-harness logs).
+    fcc3cb95d128 = a COMPLETE [SCREENSHOT-B64] (25275/25275 -> 800x450 PNG);
+    137d5d460cc0 = a PARTIAL one (16990/25275)."""
+    hd = os.path.expanduser("~/.astryx-harness")
+    comp = os.path.join(hd, "fcc3cb95d128.serial.log")
+    part = os.path.join(hd, "137d5d460cc0.serial.log")
+    if not (os.path.exists(comp) and os.path.exists(part)):
+        print("  (real fixtures absent — host-fixture checks skipped)")
+        return
+    old = sw.HARNESS_DIR
+    sw.HARNESS_DIR = hd
+    try:
+        dc = sw._decode_shot(comp, "vga")
+        check("REAL complete fixture -> valid 800x450 PNG",
+              dc["complete"] and dc["sig_ok"] and dc["w"] == 800 and dc["h"] == 450,
+              (dc["complete"], dc["w"], dc["h"]))
+        check("REAL complete fixture 25275 chunks",
+              dc["total"] == 25275 and dc["chunks"] == 25275, (dc["chunks"], dc["total"]))
+        dp = sw._decode_shot(part, "vga")
+        check("REAL partial fixture decodes gracefully (no error, valid prefix)",
+              dp["error"] is None and dp["sig_ok"] and dp["present"], dp["error"])
+        check("REAL partial fixture not complete + pct ~67",
+              dp["complete"] is False and dp["partial_pct"] == 67, dp["partial_pct"])
+    finally:
+        sw.HARNESS_DIR = old
+
+
 def main():
     tmp = tempfile.mkdtemp(prefix="serialweb-smoke-")
     sid = "smoketest1234"
@@ -278,6 +510,22 @@ def main():
     log2 = os.path.join(tmp, sid2 + ".serial.log")
     with open(log2, "w") as f:
         f.write("[BOOT] AstryxOS kernel\n")
+    # a third session WITH a --pcap capture — exercises /api/pcap (raw libpcap
+    # download) + /api/wire (decoded DNS/TCP/TLS/HTTP summary). The fixture pcap
+    # is built spec-faithfully via pcap_decode's own frame builders (DNS query +
+    # TLS ClientHello with SNI), so the wire summary must surface them.
+    sid3 = "pcapsess9012"
+    log3 = os.path.join(tmp, sid3 + ".serial.log")
+    with open(log3, "w") as f:
+        f.write("[BOOT] AstryxOS kernel (pcap session)\n")
+    pcap_fixture = _build_pcap_fixture()
+    pcap_path = os.path.join(tmp, sid3 + ".pcap")
+    with open(pcap_path, "wb") as f:
+        f.write(pcap_fixture)
+    with open(os.path.join(tmp, sid3 + ".json"), "w") as f:
+        json.dump({"sid": sid3, "pid": 5252, "started_at": time.time() - 30,
+                   "features": "firefox-test,kdb", "running": True,
+                   "pcap_path": pcap_path}, f)
 
     sw = load_module(tmp)
 
@@ -348,6 +596,11 @@ def main():
     print("── core-profile gate visibility ──")
     _core_profile_gate_checks(sw, tmp)
 
+    # ── screenshot streams: base64 PNG decode (VGA framebuffer + FF render) ──
+    print("── screenshot decode (VGA framebuffer + Firefox render) ──")
+    _screenshot_checks(sw, tmp)
+    _real_fixture_checks(sw)
+
     # ── HTTP layer end-to-end on an ephemeral port ──
     print("── HTTP endpoints ──")
     from http.server import ThreadingHTTPServer
@@ -376,6 +629,63 @@ def main():
         check("GET /api/blkmap 200", st == 200 and b'"buckets"' in body)
         st, body = get("/")
         check("GET / dashboard 200", st == 200 and b"AstryxOS" in body)
+        # the dashboard HTML wires up the wire/network panel + endpoints
+        check("dashboard HTML references wire panel",
+              b"id=wire" in body and b"/api/pcap?" in body
+              and b"/api/wire?" in body)
+
+        # ── /api/pcap (raw libpcap download) ──────────────────────────────
+        reqc = urllib.request.urlopen(base + f"/api/pcap?sid={sid3}", timeout=5)
+        bodyc = reqc.read()
+        check("GET /api/pcap 200 + libpcap content-type",
+              reqc.status == 200
+              and reqc.headers.get("Content-Type") == "application/vnd.tcpdump.pcap")
+        check("GET /api/pcap Content-Disposition attachment",
+              "attachment" in (reqc.headers.get("Content-Disposition") or ""))
+        check("GET /api/pcap returns the exact capture bytes",
+              bodyc == pcap_fixture)
+        # absent capture (session not run with --pcap) -> JSON 404, never 500
+        try:
+            urllib.request.urlopen(base + f"/api/pcap?sid={sid}", timeout=5)
+            pcap404 = False
+        except urllib.error.HTTPError as e:
+            pcap404 = (e.code == 404
+                       and e.headers.get("Content-Type") == "application/json")
+        check("GET /api/pcap absent -> JSON 404 (no 500)", pcap404)
+
+        # ── /api/wire (decoded DNS/TCP/TLS/HTTP summary) ──────────────────
+        st, body = get(f"/api/wire?sid={sid3}")
+        wire = json.loads(body)
+        check("GET /api/wire 200 envelope", st == 200 and "decode_available" in wire)
+        if wire.get("decode_available"):
+            # decoder present: the fixture's DNS question + TLS SNI must surface
+            check("GET /api/wire decoded ok", wire.get("ok") is True)
+            check("GET /api/wire carries pcap_url",
+                  wire.get("pcap_url") == f"/api/pcap?sid={sid3}")
+            check("GET /api/wire surfaces DNS example.com",
+                  any((d.get("name") == "example.com") for d in wire.get("dns", [])))
+            check("GET /api/wire surfaces TLS SNI example.com",
+                  any((t.get("sni") == "example.com") for t in wire.get("tls", [])))
+            check("GET /api/wire packet count >= 3", (wire.get("packets") or 0) >= 3)
+        else:
+            # checkout without pcap_decode.py: must still return raw-download hint
+            check("GET /api/wire degrades to decode_available=false",
+                  wire.get("ok") is False and wire.get("pcap_url"))
+        # absent capture -> JSON 404 with decode_available flag, never 500
+        try:
+            urllib.request.urlopen(base + f"/api/wire?sid={sid}", timeout=5)
+            wire404 = False
+        except urllib.error.HTTPError as e:
+            wire404 = e.code == 404
+        check("GET /api/wire absent -> JSON 404 (no 500)", wire404)
+        # bad sid -> 400, never 500
+        try:
+            urllib.request.urlopen(base + "/api/wire?sid=../../etc/passwd", timeout=5)
+            wirebad = False
+        except urllib.error.HTTPError as e:
+            wirebad = e.code in (400, 404)
+        check("GET /api/wire bad sid rejected", wirebad)
+
         # path-traversal / bad sid rejected
         try:
             get("/api/metrics?sid=../../etc/passwd")

--- a/scripts/serial-web.py
+++ b/scripts/serial-web.py
@@ -13,6 +13,26 @@ serial logs (read-only; safe alongside live boots).
                               proxy/IO bytes+IOPS/net, plus per-pid breakdown
   GET /api/blkmap?sid=&grid=N JSON: data.img block-map histogram built from
                               feature-gated [BLK] op/lba/len trace lines
+  GET /api/screenshots?sid=   JSON: metadata for BOTH base64 PNG streams a
+                              firefox-test/test-mode boot emits —
+                              {vga:{present,complete,chunks,total,w,h,…}, ff:{…}}
+  GET /api/screenshot?sid=&kind=vga|ff
+                              image/png: the decoded screenshot. kind=vga is the
+                              VGA framebuffer ([SCREENSHOT-B64:…], Test 198);
+                              kind=ff is Firefox's render (/tmp/out.png,
+                              [FF-OUT-PNG-B64:…]). Partial/in-progress streams
+                              serve best-effort (200 + X-Screenshot-Complete:
+                              false); absent/invalid streams return a JSON 404.
+  GET /api/pcap?sid=<sid>     application/vnd.tcpdump.pcap (attachment): the raw
+                              libpcap file QEMU's host-side filter-dump captured
+                              for a `start --pcap` session — opens directly in
+                              Wireshark.  404 JSON if the session wasn't run
+                              with --pcap or no file exists yet.
+  GET /api/wire?sid=<sid>     JSON: a decoded wire summary of the same .pcap
+                              (DNS / TCP flows / TLS-SNI / HTTP) via
+                              scripts/pcap_decode.py.  decode_available=False
+                              when that module isn't on this checkout — the raw
+                              /api/pcap download still works regardless.
 
   python3 scripts/serial-web.py [--port 8088] [--host 0.0.0.0]
 
@@ -33,6 +53,17 @@ try:
     import gate_marks as _gate_marks  # noqa: E402
 except Exception:
     _gate_marks = None
+
+# Wire-summary decoder (component B — scripts/pcap_decode.py).  Optional, same
+# degrade-gracefully contract as _gate_marks: if the module isn't on this
+# checkout the /api/wire route reports decode_available=False and the raw
+# .pcap download (/api/pcap) still works regardless.  Contract: the module
+# exposes `decode_pcap(path, max_packets=...) -> dict` returning a
+# JSON-serialisable wire summary (DNS / TCP flows / TLS-SNI / HTTP).
+try:
+    import pcap_decode as _pcap_decode  # noqa: E402
+except Exception:
+    _pcap_decode = None
 
 HARNESS_DIR = os.path.expanduser("~/.astryx-harness")
 SID_RE = re.compile(r"^[A-Za-z0-9_-]{4,64}$")
@@ -435,6 +466,212 @@ def scan_blkmap(path, size, grid):
     }
 
 
+# ── screenshot streams: decode the base64 PNG the boot emits over serial ──────
+#
+# A firefox-test / test-mode boot emits TWO DISTINCT chunked base64 PNG streams.
+# Both share the same wire shape (0-based index N, total M, base64 payload) but
+# carry DIFFERENT images — the UI must label them unambiguously:
+#
+#   VGA framebuffer (Test 198) — the guest's console/GUI screen (the QEMU VGA
+#   framebuffer), 800x450 RGBA in practice:
+#       [SCREENSHOT-B64:N/M] <base64 chunk>
+#       ...
+#       [SCREENSHOT-B64-END]
+#
+#   Firefox render (/tmp/out.png) — Firefox's actual off-screen rendered page,
+#   emitted after FF exits (the DEMO GOAL output), DISTINCT from the framebuffer.
+#   Preceded by a header line carrying the guest-side byte size:
+#       [FF-OUT-PNG:path=/tmp/out.png size=<N> sig_ok=<bool>]
+#       [FF-OUT-PNG-B64:N/M] <base64 chunk>
+#       ...
+#       [FF-OUT-PNG-END]
+#
+# Decode (identical to qemu-harness.py read-png / read-ff-png): collect the
+# chunks in index order, concatenate the base64, decode (RFC 4648 §4), and the
+# result is a PNG (8-byte magic 89 50 4E 47 0D 0A 1A 0A, W3C PNG §5.2 / ISO
+# 15948). PARTIAL / in-progress streams are decoded best-effort: we keep the
+# leading contiguous run of chunks (0,1,2,… until the first gap), pad the
+# concatenated base64 to a multiple of 4, and decode what is present — so a
+# truncated stream still yields a (partial) PNG the browser can render the top
+# of, rather than a 500.
+#
+# Two image "kinds" the endpoints accept: kind=vga (the framebuffer) and
+# kind=ff (the Firefox render). Read-only, like every other endpoint.
+
+PNG_SIGNATURE = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+_SHOT_KINDS = {
+    "vga": {
+        "label":  "VGA framebuffer (Test 198)",
+        "source": "QEMU VGA framebuffer — the guest console/GUI screen",
+        # header is optional for the VGA stream (no size line); chunk + end only
+        "header_re": None,
+        "chunk_re": re.compile(r"\[SCREENSHOT-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"),
+        "end_re":   re.compile(r"\[SCREENSHOT-B64-END\]"),
+    },
+    "ff": {
+        "label":  "Firefox render (/tmp/out.png)",
+        "source": "Firefox's off-screen rendered page, emitted after FF exits",
+        "header_re": re.compile(
+            r"\[FF-OUT-PNG:path=(\S+)\s+size=(\d+)\s+sig_ok=(true|false)"),
+        "chunk_re": re.compile(r"\[FF-OUT-PNG-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"),
+        "end_re":   re.compile(r"\[FF-OUT-PNG-END\]"),
+    },
+}
+
+# Cap a single screenshot decode: 25275 chunks x ~64 base64 chars ~= 1.6 MB of
+# base64 -> ~1.2 MB PNG. Bound the scan so a pathological log can't OOM us.
+SHOT_SCAN_MAX_LINES = 4_000_000
+
+
+def _png_dimensions(png_bytes):
+    """(width, height) from the IHDR chunk, or (None, None). The IHDR is the
+    first chunk after the 8-byte signature: bytes [16:20]=width, [20:24]=height,
+    big-endian uint32 (W3C PNG §11.2.2). Tolerates a partial PNG as long as the
+    first 24 bytes (signature + length + 'IHDR' + W + H) are present."""
+    if len(png_bytes) < 24 or png_bytes[:8] != PNG_SIGNATURE:
+        return None, None
+    if png_bytes[12:16] != b"IHDR":
+        return None, None
+    w = int.from_bytes(png_bytes[16:20], "big")
+    h = int.from_bytes(png_bytes[20:24], "big")
+    return w, h
+
+
+def _collect_shot_chunks(path, spec):
+    """Single forward scan of the serial log for one screenshot stream's chunks.
+    Returns (chunks, total, end_seen, header). `chunks` is {idx: b64}; `total`
+    is the announced M (None if no chunk line seen); `end_seen` is True once the
+    stream's END marker appears; `header` is {path,size,sig_ok} for the ff
+    stream (None otherwise). Best-effort and read-only — never raises."""
+    import base64  # noqa: F401  (kept local, mirrors harness convention)
+    chunks = {}
+    total = None
+    end_seen = False
+    header = None
+    header_re = spec["header_re"]
+    chunk_re = spec["chunk_re"]
+    end_re = spec["end_re"]
+    n = 0
+    try:
+        with open(path, "r", errors="replace") as f:
+            for line in f:
+                n += 1
+                if n > SHOT_SCAN_MAX_LINES:
+                    break
+                if header_re is not None and header is None:
+                    hm = header_re.search(line)
+                    if hm:
+                        header = {"path": hm.group(1),
+                                  "size": int(hm.group(2)),
+                                  "sig_ok": hm.group(3) == "true"}
+                m = chunk_re.search(line)
+                if m:
+                    idx = int(m.group(1))
+                    tot = int(m.group(2))
+                    if total is None:
+                        total = tot
+                    # Tolerate a single stream only (ignore stray lines that
+                    # announce a different M than the first chunk's).
+                    if tot == total and idx >= 0:
+                        chunks[idx] = m.group(3)
+                    continue
+                if end_re.search(line):
+                    end_seen = True
+    except OSError:
+        pass
+    return chunks, total, end_seen, header
+
+
+def _contiguous_b64(chunks, total):
+    """Concatenate the leading CONTIGUOUS run of chunks (0,1,2,… until the first
+    missing index). Returns (b64_concat, contig_count, first_gap). For a
+    complete stream contig_count == total and first_gap is None."""
+    parts = []
+    i = 0
+    limit = total if total is not None else (max(chunks) + 1 if chunks else 0)
+    while i < limit and i in chunks:
+        parts.append(chunks[i])
+        i += 1
+    first_gap = None if (total is not None and i >= total) else i
+    return "".join(parts), i, first_gap
+
+
+def _decode_shot(path, kind):
+    """Decode one screenshot stream from `path` to PNG bytes, best-effort.
+
+    Returns a dict (never raises on a malformed/partial stream):
+        present     bool   any chunk line for this kind was seen
+        complete    bool   END marker seen AND all 0..M-1 chunks present
+        chunks      int    contiguous chunks decoded (leading run)
+        total       int|None  announced M
+        png         bytes|None decoded PNG (signature-verified prefix)
+        bytes       int    decoded byte length
+        w,h         int|None  PNG dimensions from IHDR
+        sig_ok      bool   decoded bytes start with the PNG magic
+        partial_pct int|None  100*chunks/total when total known and <100
+        guest_size  int|None  ff stream's header-reported byte size
+        error       str|None  set only when present but undecodable
+    """
+    import base64
+    spec = _SHOT_KINDS[kind]
+    chunks, total, end_seen, header = _collect_shot_chunks(path, spec)
+    if not chunks:
+        return {"kind": kind, "label": spec["label"], "source": spec["source"],
+                "present": False, "complete": False, "chunks": 0,
+                "received": 0, "total": total, "first_gap": 0,
+                "end_seen": end_seen, "bytes": 0, "w": None, "h": None,
+                "sig_ok": False, "partial_pct": None, "png": None,
+                "guest_size": header["size"] if header else None,
+                "error": None}
+    b64, contig, first_gap = _contiguous_b64(chunks, total)
+    # Normalise the concatenated base64 to a decodable length. A base64 group is
+    # 4 chars -> 3 bytes; a partial/truncated tail can leave 1-3 leftover chars.
+    # A remainder of 1 is invalid (encodes 0 bytes) — drop it; a remainder of 2
+    # or 3 is a valid final group once padded with '='. So: trim to a multiple
+    # of 4, then re-pad the LAST whole-or-partial group. Concretely, drop the
+    # trailing (len % 4) chars (the torn group) so what remains is a clean
+    # multiple of 4 we can decode without raising. This loses at most the final
+    # 2 bytes of a partial PNG — the browser still renders the leading scanlines.
+    rem = len(b64) % 4
+    b64_clean = b64[:-rem] if rem else b64
+    png = b""
+    error = None
+    try:
+        png = base64.b64decode(b64_clean, validate=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        error = f"base64_decode_failed: {exc}"
+        png = b""
+    sig_ok = len(png) >= 8 and png[:8] == PNG_SIGNATURE
+    if png and not sig_ok and error is None:
+        error = "png_signature_mismatch"
+    w, h = _png_dimensions(png)
+    have_all = (total is not None and contig >= total)
+    complete = bool(end_seen and have_all and sig_ok)
+    pct = (int(100 * contig / total) if (total and total > 0 and not complete)
+           else (100 if complete else None))
+    return {"kind": kind, "label": spec["label"], "source": spec["source"],
+            "present": True, "complete": complete, "chunks": contig,
+            "received": len(chunks), "total": total, "first_gap": first_gap,
+            "end_seen": end_seen, "bytes": len(png), "w": w, "h": h,
+            "sig_ok": sig_ok, "partial_pct": pct, "png": png,
+            "guest_size": header["size"] if header else None,
+            "error": error}
+
+
+def scan_screenshots(path):
+    """Metadata for BOTH screenshot streams in one log, WITHOUT shipping the PNG
+    bytes — what the UI needs to decide which thumbnails to show. Returns
+    {vga:{present,complete,chunks,total,w,h,partial_pct,…}, ff:{…}}. The decoded
+    PNG itself is fetched separately from /api/screenshot."""
+    out = {}
+    for kind in ("vga", "ff"):
+        d = _decode_shot(path, kind)
+        d.pop("png", None)   # metadata only — keep the JSON small
+        out[kind] = d
+    return out
+
+
 # ── launch-time / session listing ─────────────────────────────────────────────
 def _launch_info(sid, log_path, log_stat):
     """Absolute + relative launch time, anchored to the host clock. Reads
@@ -475,12 +712,19 @@ def list_sessions():
         feats, running, pid = "", None, None
         started_at, started_src = _launch_info(sid, log, st)
         meta = os.path.join(HARNESS_DIR, sid + ".json")
+        # Additive livelock-autoreap surfacing: the watcher stamps these onto
+        # the session JSON so the dashboard can badge a spinning boot before it
+        # is reaped (livelock_suspected) and show the verdict after (terminal).
+        livelock_suspected = False
+        terminal_cause = None
         if os.path.exists(meta):
             try:
                 m = json.load(open(meta))
                 feats = m.get("features", "") or ""
                 running = m.get("running")
                 pid = m.get("pid")
+                livelock_suspected = bool(m.get("livelock_suspected", False))
+                terminal_cause = m.get("terminal_cause")
             except Exception:
                 pass
         elapsed = (now - started_at) if started_at else None
@@ -488,6 +732,8 @@ def list_sessions():
              "age": age, "active": age < 20, "running": running, "pid": pid,
              "started_at": started_at, "started_src": started_src,
              "elapsed": int(elapsed) if elapsed is not None else None,
+             "livelock_suspected": livelock_suspected,
+             "terminal_cause": terminal_cause,
              "mtime": st.st_mtime}
         if age < GATE_SCAN_MAX_AGE:
             p = scan_progress(log)   # SAME source as the milestone rail
@@ -574,6 +820,50 @@ PAGE = """<!doctype html><html><head><meta charset="utf-8">
  #blk .hd b{color:#56b6c2} #blkcanvas{display:block;width:100%;height:34px;image-rendering:pixelated;border:1px solid var(--edge);border-radius:3px}
  #blk .hint{color:var(--dim);font-size:11px} #blk .lg{font-size:10px;color:var(--dim);margin-top:3px}
  #blk .lg i{display:inline-block;width:9px;height:9px;border-radius:2px;vertical-align:middle;margin:0 3px 0 9px}
+ /* screenshots panel — decoded base64 PNG streams (VGA framebuffer + FF render) */
+ #shots{display:none;border-bottom:1px solid var(--edge);background:#0d111a;padding:8px 12px}
+ #shots.show{display:block} #shots .hd{font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px;margin-bottom:6px}
+ #shots .grid{display:flex;gap:14px;flex-wrap:wrap}
+ #shots .hint{color:var(--dim);font-size:11px}
+ .shot{border:1px solid var(--edge);border-radius:6px;background:#11151f;padding:8px;width:236px}
+ .shot.ff{border-color:#3a2a52} .shot.vga{border-color:#214a52}
+ .shot .knd{font-size:11px;font-weight:600;display:flex;align-items:center;gap:6px;margin-bottom:5px}
+ .shot.vga .knd{color:#56b6c2} .shot.ff .knd{color:#d2a8ff}
+ .shot .knd .tag{font-size:9px;font-weight:600;padding:1px 5px;border-radius:8px;text-transform:uppercase;letter-spacing:.5px}
+ .shot.vga .knd .tag{background:#0e1c22;color:#56b6c2;border:1px solid #214a52}
+ .shot.ff .knd .tag{background:#160e22;color:#d2a8ff;border:1px solid #3a2a52}
+ .shot .thumb{width:100%;height:124px;background:#0b0e14 repeating-conic-gradient(#161b27 0 25%,#0b0e14 0 50%) 0 0/16px 16px;
+   border:1px solid var(--edge);border-radius:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;cursor:pointer}
+ .shot .thumb img{max-width:100%;max-height:100%;display:block;image-rendering:auto}
+ .shot .thumb.empty{color:var(--dim);font-size:11px;cursor:default;text-align:center;padding:6px}
+ .shot .src{color:var(--dim);font-size:10px;margin:5px 0 3px;line-height:1.3}
+ .shot .stat{font-size:10px;color:var(--dim);display:flex;flex-wrap:wrap;gap:4px 8px}
+ .shot .stat .ok{color:#7ee787} .shot .stat .part{color:#f0c674} .shot .stat .dim{color:#56b6c2}
+ .shot .pbar{height:4px;background:#1b2230;border-radius:2px;margin-top:5px;overflow:hidden}
+ .shot.vga .pbar>i{display:block;height:100%;background:#56b6c2} .shot.ff .pbar>i{display:block;height:100%;background:#d2a8ff}
+ /* network / wire panel — host-side filter-dump capture (needs start --pcap) */
+ #wire{display:none;border-bottom:1px solid var(--edge);background:#0d111a;padding:8px 12px}
+ #wire.show{display:block}
+ #wire .hd{font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:.5px;margin-bottom:6px;display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+ #wire .hd b{color:#56b6c2} #wire .hint{color:var(--dim);font-size:11px}
+ #wire a.dl{font-size:11px;font-weight:600;color:#0b0e14;background:#39d353;border-radius:5px;padding:3px 10px;text-decoration:none}
+ #wire a.dl:hover{box-shadow:0 0 6px var(--accent)}
+ #wire .stats{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px}
+ #wire .pill{font-size:11px;border:1px solid var(--edge);border-radius:10px;padding:2px 9px;color:var(--dim);background:#11151f}
+ #wire .pill b{color:#7ee787}
+ #wire .grid{display:flex;gap:14px;flex-wrap:wrap;align-items:flex-start}
+ #wire .col{flex:1;min-width:240px;border:1px solid var(--edge);border-radius:6px;background:#11151f;padding:8px}
+ #wire .col h4{margin:0 0 6px;font-size:11px;text-transform:uppercase;letter-spacing:.5px;color:#56b6c2;font-weight:600}
+ #wire .col.dns h4{color:#7ee787} #wire .col.tls h4{color:#d2a8ff} #wire .col.http h4{color:#f0c674}
+ #wire table{width:100%;border-collapse:collapse;font-size:11px}
+ #wire td{padding:2px 6px 2px 0;color:var(--fg);vertical-align:top;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px}
+ #wire td.dim{color:var(--dim)} #wire tr:nth-child(even){background:#0d111a}
+ #wire .empty{color:var(--dim);font-size:11px;padding:4px 0}
+ /* full-size lightbox */
+ #lightbox{display:none;position:fixed;inset:0;background:rgba(2,4,8,.92);z-index:50;align-items:center;justify-content:center;flex-direction:column;cursor:zoom-out}
+ #lightbox.show{display:flex} #lightbox img{max-width:94vw;max-height:86vh;border:1px solid var(--edge);box-shadow:0 0 30px rgba(0,0,0,.7);image-rendering:auto}
+ #lightbox .cap{margin-top:10px;font-size:12px;color:var(--fg);background:var(--panel);border:1px solid var(--edge);padding:6px 12px;border-radius:6px}
+ #lightbox .cap b{color:#7ee787} #lightbox .cap .part{color:#f0c674}
  .toggles{display:flex;gap:6px} .toggles button.on{border-color:var(--accent);color:#7ee787}
 </style></head><body><div id=app>
  <div id=side>
@@ -591,6 +881,8 @@ PAGE = """<!doctype html><html><head><meta charset="utf-8">
      <span class=toggles>
        <button id=tMetrics class=on title="guest metrics + sparklines">metrics</button>
        <button id=tBlk title="data.img block map (needs blk-trace)">blkmap</button>
+       <button id=tShots class=on title="decoded screenshot streams (VGA framebuffer + Firefox render)">shots</button>
+       <button id=tWire title="captured network wire (needs start --pcap): DNS / TCP / TLS-SNI / HTTP + .pcap download">wire</button>
        <button id=tRail class=on title="gate progression rail">rail</button>
      </span>
      <input id=flt placeholder="filter lines…"><label><input type=checkbox id=follow checked> follow</label>
@@ -601,12 +893,15 @@ PAGE = """<!doctype html><html><head><meta charset="utf-8">
    <div id=metrics class=show></div>
    <div id=pids></div>
    <div id=blk></div>
+   <div id=shots></div>
+   <div id=wire></div>
    <div id=miles></div>
    <div id=logwrap>
      <div id=log><div id=empty>Pick a session on the left to stream its serial output.</div></div>
      <div id=rail class=open></div>
    </div>
  </div></div>
+ <div id=lightbox><img id=lbimg alt=""><div class=cap id=lbcap></div></div>
 <script>
 let cur=null,es=null,sessions=[],rate={n:0,t:Date.now()};
 let miles=[],frozen=false,metaCur=null;
@@ -665,8 +960,10 @@ function openS(sid){
   if(es)es.close(); rate={n:0,t:Date.now(),last:null}; mPrev=null;
   for(const k in buf)buf[k]=[];
   $('jumpLive').style.display='none';
+  shotsSig=''; shotsMetaCache=null; $('shots').innerHTML='';
+  wireSig=''; $('wire').innerHTML='';
   startStream(sid);
-  render(); loadMiles(sid); pollMetrics(); pollBlk();
+  render(); loadMiles(sid); pollMetrics(); pollBlk(); pollShots(); pollWire();
 }
 function startStream(sid){
   if(es)es.close();
@@ -813,13 +1110,151 @@ function drawBlk(bk){
   x.putImageData(img,0,0);
 }
 
+// ── screenshots: decoded base64 PNG streams (VGA framebuffer + FF render) ──
+// Two DISTINCT streams a firefox-test/test-mode boot emits, labeled
+// unambiguously so a VGA framebuffer is never mistaken for a Firefox render.
+// Metadata comes from /api/screenshots (no PNG bytes); each present stream's
+// <img src> points at /api/screenshot?kind=… which decodes + serves the PNG.
+let shotsSig='';                     // cache-bust + change-detect signature
+let wireSig='';                      // wire panel change-detect signature
+function pctOf(s){return s.complete?100:(s.partial_pct!=null?s.partial_pct:0);}
+function shotCard(sid,kind,s){
+  const cls='shot '+kind;
+  const tag=kind==='vga'?'VGA':'FF';
+  // image src: cache-bust on (chunks,complete) so a growing partial refreshes,
+  // but a frozen complete log isn't re-decoded every poll.
+  const v=encodeURIComponent(sid)+'.'+kind+'.'+s.chunks+'.'+(s.complete?1:0);
+  const src='/api/screenshot?sid='+encodeURIComponent(sid)+'&kind='+kind+'&v='+v;
+  const dims=s.w!=null?(s.w+'×'+s.h):'—';
+  const comp=s.complete
+    ?'<span class=ok>✓ complete</span>'
+    :'<span class=part>◔ partial '+pctOf(s)+'%</span>';
+  const chunks=s.total!=null?(s.chunks+'/'+s.total+' chunks'):(s.chunks+' chunks');
+  const thumb=s.sig_ok
+    ?('<div class=thumb data-kind="'+kind+'" data-src="'+src+'"><img src="'+src+'" alt="'+s.label+'"></div>')
+    :('<div class="thumb empty">stream present but no valid PNG yet<br><small>'+(s.error||'awaiting chunks')+'</small></div>');
+  return '<div class="'+cls+'">'
+    +'<div class=knd><span class=tag>'+tag+'</span>'+s.label+'</div>'
+    +thumb
+    +'<div class=src>'+s.source+'<br>session <b>'+sid+'</b></div>'
+    +'<div class=stat>'+comp+' <span class=dim>'+dims+'</span> '+chunks
+      +(s.bytes?' · '+bytes(s.bytes):'')+'</div>'
+    +'<div class=pbar><i style=width:'+pctOf(s)+'%></i></div>'
+    +'</div>';
+}
+let shotsMetaCache=null;             // last metadata (for the lightbox caption)
+async function pollShots(){
+  if(!cur||!$('tShots').classList.contains('on'))return;
+  let m;try{m=await(await fetch('/api/screenshots?sid='+encodeURIComponent(cur))).json()}catch(e){return}
+  if(cur==null)return;
+  shotsMetaCache=m;
+  const present=['vga','ff'].filter(k=>m[k]&&m[k].present);
+  // signature: only re-render when something actually changed (avoids the <img>
+  // flicker that re-setting innerHTML every poll would cause).
+  const sig=present.map(k=>k+':'+m[k].chunks+':'+(m[k].complete?1:0)+':'+(m[k].sig_ok?1:0)).join('|');
+  $('shots').className='show';
+  if(!present.length){
+    if(shotsSig!=='__none__'){
+      $('shots').innerHTML='<div class=hd>screenshots</div><div class=hint>'
+        +'No <b>[SCREENSHOT-B64]</b> (VGA framebuffer, Test 198) or '
+        +'<b>[FF-OUT-PNG-B64]</b> (Firefox render, /tmp/out.png) stream in this log. '
+        +'A <b>firefox-test</b> / <b>test-mode</b> boot emits these after the screenshot is taken.</div>';
+      shotsSig='__none__';
+    }
+    return;
+  }
+  if(sig===shotsSig)return; shotsSig=sig;
+  $('shots').innerHTML='<div class=hd>screenshots · decoded base64 PNG streams</div>'
+    +'<div class=grid>'+present.map(k=>shotCard(cur,k,m[k])).join('')+'</div>';
+  $('shots').querySelectorAll('.thumb[data-src]').forEach(e=>{
+    e.onclick=()=>openLightbox(e.dataset.src,e.dataset.kind);});
+}
+function openLightbox(src,kind){
+  const m=shotsMetaCache&&shotsMetaCache[kind];
+  $('lbimg').src=src;
+  if(m){
+    const comp=m.complete?'<b>complete</b>':'<span class=part>partial '+pctOf(m)+'%</span>';
+    $('lbcap').innerHTML=m.label+' · session '+cur+' · '
+      +(m.w!=null?m.w+'×'+m.h+' · ':'')+comp
+      +(m.total!=null?' · '+m.chunks+'/'+m.total+' chunks':'');
+  } else $('lbcap').textContent=kind;
+  $('lightbox').classList.add('show');
+}
+$('lightbox').onclick=()=>$('lightbox').classList.remove('show');
+document.addEventListener('keydown',e=>{if(e.key==='Escape')$('lightbox').classList.remove('show');});
+
+// network / wire panel — decoded host-side filter-dump capture (start --pcap)
+function esc(s){return (s==null?'':String(s)).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
+function wireRows(arr,cols){
+  if(!arr||!arr.length)return '<div class=empty>none</div>';
+  return '<table>'+arr.slice(0,200).map(r=>'<tr>'+cols.map(c=>{
+    const v=r[c.k]; return '<td'+(c.dim?' class=dim':'')+' title="'+esc(v)+'">'+esc(v==null?'':v)+'</td>';
+  }).join('')+'</tr>').join('')+'</table>';
+}
+async function pollWire(){
+  if(!cur||!$('tWire').classList.contains('on'))return;
+  let w;try{w=await(await fetch('/api/wire?sid='+encodeURIComponent(cur))).json()}catch(e){return}
+  if(cur==null)return;
+  $('wire').className='show';
+  const dl='/api/pcap?sid='+encodeURIComponent(cur);
+  // No capture for this session: explain how to enable it. Raw download link
+  // is still offered (it will 404 cleanly until a --pcap session exists).
+  if(w.error==='no_pcap'){
+    if(wireSig!=='__none__'){
+      $('wire').innerHTML='<div class=hd>network / wire</div><div class=hint>'
+        +'No <b>.pcap</b> capture for this session. Start it with '
+        +'<b>qemu-harness.py start --pcap …</b> — a host-side QEMU '
+        +'<b>filter-dump</b> taps the e1000/SLIRP netdev (zero guest VM-exits) '
+        +'and records DNS / TCP / TLS / HTTP to a libpcap file for Wireshark.</div>';
+      wireSig='__none__';
+    }
+    return;
+  }
+  if(w.decode_available===false){
+    // Raw .pcap exists but the decode module isn't on this checkout.
+    if(wireSig!=='__nodecode__'){
+      $('wire').innerHTML='<div class=hd>network / wire '
+        +'<a class=dl href="'+dl+'">⤓ download .pcap</a></div>'
+        +'<div class=hint>Capture present, but the wire-decode module '
+        +'(<b>scripts/pcap_decode.py</b>) is not on this checkout. '
+        +'Download the raw <b>.pcap</b> and open it in Wireshark.</div>';
+      wireSig='__nodecode__';
+    }
+    return;
+  }
+  const dns=w.dns||[], tls=w.tls||[], http=w.http||[], flows=w.flows||[];
+  const sig=JSON.stringify([w.packets,w.bytes,dns.length,tls.length,http.length,flows.length]);
+  if(sig===wireSig)return; wireSig=sig;
+  // Stat pills: tolerate whatever top-level counters the decoder provides.
+  const pill=(k,v)=> v==null?'':'<span class=pill>'+k+' <b>'+esc(v)+'</b></span>';
+  const stats='<div class=stats>'
+    +pill('packets',w.packets)+pill('bytes',w.bytes!=null?bytes(w.bytes):null)
+    +pill('flows',flows.length||null)+pill('DNS',dns.length||null)
+    +pill('TLS',tls.length||null)+pill('HTTP',http.length||null)+'</div>';
+  $('wire').innerHTML='<div class=hd>network / wire · host-side filter-dump capture '
+      +'<a class=dl href="'+dl+'">⤓ download .pcap</a></div>'
+    +stats
+    +'<div class=grid>'
+    +'<div class="col dns"><h4>DNS queries</h4>'
+      +wireRows(dns,[{k:'name'},{k:'type',dim:1},{k:'answer',dim:1}])+'</div>'
+    +'<div class="col tls"><h4>TLS · SNI</h4>'
+      +wireRows(tls,[{k:'sni'},{k:'version',dim:1},{k:'dst',dim:1}])+'</div>'
+    +'<div class="col http"><h4>HTTP</h4>'
+      +wireRows(http,[{k:'method'},{k:'host'},{k:'path',dim:1}])+'</div>'
+    +'<div class="col"><h4>TCP flows</h4>'
+      +wireRows(flows,[{k:'dst'},{k:'bytes',dim:1},{k:'pkts',dim:1}])+'</div>'
+    +'</div>';
+}
+
 // toggles
 function tog(btn,after){btn.onclick=()=>{btn.classList.toggle('on');
   if(btn===$('tRail'))$('rail').classList.toggle('open',btn.classList.contains('on'));
   if(btn===$('tMetrics')&&!btn.classList.contains('on')){$('metrics').classList.remove('show');$('pids').classList.remove('show');}
   if(btn===$('tBlk')&&!btn.classList.contains('on'))$('blk').classList.remove('show');
+  if(btn===$('tShots')&&!btn.classList.contains('on'))$('shots').classList.remove('show');
+  if(btn===$('tWire')&&!btn.classList.contains('on'))$('wire').classList.remove('show');
   if(after&&btn.classList.contains('on'))after();};}
-tog($('tMetrics'),pollMetrics);tog($('tBlk'),pollBlk);tog($('tRail'),null);
+tog($('tMetrics'),pollMetrics);tog($('tBlk'),pollBlk);tog($('tShots'),pollShots);tog($('tWire'),pollWire);tog($('tRail'),null);
 $('tRail').onclick=()=>{$('tRail').classList.toggle('on');$('rail').classList.toggle('open',$('tRail').classList.contains('on'));};
 
 setInterval(()=>{const now=Date.now(),dt=(now-rate.t)/1000;if(dt>=2){const r=rate.n/dt;rate.last=r;$('rate').textContent=cur?r.toFixed(0)+' ln/s':'';rate={n:0,t:now,last:r};}},1000);
@@ -827,6 +1262,8 @@ refresh(); setInterval(refresh,3000);
 setInterval(()=>{if(cur)loadMiles(cur);},5000);
 setInterval(pollMetrics,2000);
 setInterval(pollBlk,3000);
+setInterval(pollShots,4000);
+setInterval(pollWire,5000);
 </script></body></html>"""
 
 
@@ -847,6 +1284,32 @@ class H(BaseHTTPRequestHandler):
         if not SID_RE.match(sid):
             return None
         path = os.path.join(HARNESS_DIR, sid + ".serial.log")
+        if not os.path.realpath(path).startswith(os.path.realpath(HARNESS_DIR)):
+            return None
+        return path if os.path.exists(path) else None
+
+    def _pcap_path(self, sid):
+        """Validate sid and resolve its capture pcap inside HARNESS_DIR, or None.
+
+        Prefers the session-json's `pcap_path` (authoritative, set by
+        `start --pcap`), but falls back to the conventional
+        HARNESS_DIR/<sid>.pcap location.  Returns None when the sid is
+        malformed, the resolved path escapes HARNESS_DIR, or no file exists
+        (e.g. the session was not run with --pcap)."""
+        if not SID_RE.match(sid):
+            return None
+        path = None
+        meta = os.path.join(HARNESS_DIR, sid + ".json")
+        try:
+            with open(meta) as f:
+                pp = json.load(f).get("pcap_path") or ""
+            if pp:
+                path = pp
+        except (OSError, ValueError):
+            pass
+        if not path:
+            path = os.path.join(HARNESS_DIR, sid + ".pcap")
+        # Containment: the resolved real path must stay inside HARNESS_DIR.
         if not os.path.realpath(path).startswith(os.path.realpath(HARNESS_DIR)):
             return None
         return path if os.path.exists(path) else None
@@ -897,10 +1360,184 @@ class H(BaseHTTPRequestHandler):
             except (OSError, ValueError):
                 size, grid = 0, 256
             self._json(scan_blkmap(p, size, grid))
+        elif u.path == "/api/screenshots":
+            # metadata for BOTH streams (no PNG bytes) — the UI uses this to
+            # decide which thumbnails to show without decoding twice.
+            p = self._log_path(q.get("sid", [""])[0])
+            if not p:
+                self._hdr(404, "text/plain"); self.wfile.write(b"no log"); return
+            self._json(scan_screenshots(p))
+        elif u.path == "/api/screenshot":
+            self._screenshot(q.get("sid", [""])[0], q.get("kind", ["vga"])[0])
+        elif u.path == "/api/pcap":
+            self._pcap(q.get("sid", [""])[0])
+        elif u.path == "/api/wire":
+            self._wire(q.get("sid", [""])[0],
+                       q.get("max", [""])[0])
         elif u.path == "/api/stream":
             self._stream(q.get("sid", [""])[0])
         else:
             self._hdr(404, "text/plain"); self.wfile.write(b"404")
+
+    def _screenshot(self, sid, kind):
+        """Decode a session's screenshot stream and serve it as image/png.
+
+        kind=vga -> the VGA framebuffer ([SCREENSHOT-B64:…], Test 198);
+        kind=ff  -> Firefox's render (/tmp/out.png, [FF-OUT-PNG-B64:…]).
+
+        Partial / in-progress streams are served best-effort (HTTP 200, with an
+        X-Screenshot-Complete: false header so the caller can tell). Only a
+        genuinely absent or signature-invalid stream returns a JSON 404 — we
+        never 500 on a truncated log."""
+        if kind not in _SHOT_KINDS:
+            self._hdr(400, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "bad_kind",
+                 "valid": sorted(_SHOT_KINDS)}).encode())
+            return
+        p = self._log_path(sid)
+        if not p:
+            self._hdr(404, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "no_log", "sid": sid}).encode())
+            return
+        d = _decode_shot(p, kind)
+        png = d.get("png") or b""
+        # No valid PNG to serve: report clearly as JSON (never 500). Either the
+        # stream is absent, or its leading bytes aren't a PNG (torn/garbage).
+        if not d["present"] or not d["sig_ok"] or len(png) < 8:
+            self._hdr(404, "application/json")
+            self.wfile.write(json.dumps({
+                "ok": False,
+                "error": ("no_stream" if not d["present"]
+                          else (d.get("error") or "no_valid_png")),
+                "sid": sid, "kind": kind, "label": d["label"],
+                "present": d["present"], "chunks": d["chunks"],
+                "total": d["total"], "bytes": d["bytes"],
+            }).encode())
+            return
+        # Serve the PNG (complete or partial). Custom X- headers carry the
+        # provenance so callers/curl can see kind + completeness without the
+        # metadata endpoint. Content-Disposition names it for a save.
+        extra = {
+            "X-Screenshot-Kind":     kind,
+            "X-Screenshot-Label":    d["label"],
+            "X-Screenshot-Complete": "true" if d["complete"] else "false",
+            "X-Screenshot-Chunks":   f"{d['chunks']}/{d['total']}"
+                                     if d["total"] is not None else str(d["chunks"]),
+            "X-Screenshot-Bytes":    str(len(png)),
+            "Cache-Control":         "no-cache",
+            "Content-Disposition":   f'inline; filename="{sid}.{kind}.png"',
+        }
+        if d["w"] is not None:
+            extra["X-Screenshot-Dimensions"] = f"{d['w']}x{d['h']}"
+        if d["partial_pct"] is not None:
+            extra["X-Screenshot-Partial-Pct"] = str(d["partial_pct"])
+        try:
+            self._hdr(ctype="image/png", extra=extra)
+            self.wfile.write(png)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
+
+    def _pcap(self, sid):
+        """Serve the raw libpcap file for download into Wireshark.
+
+        Content-Type application/vnd.tcpdump.pcap + Content-Disposition
+        attachment so a browser GET saves <sid>.pcap.  A JSON 404 (never 500)
+        when the session wasn't run with --pcap or no file exists yet — the
+        capture only appears once QEMU's filter-dump has flushed its global
+        header.  Streamed in 64 KiB chunks so a multi-MB page-load capture
+        doesn't buffer entirely in memory."""
+        if not SID_RE.match(sid):
+            self._hdr(400, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "bad_sid", "sid": sid}).encode())
+            return
+        path = self._pcap_path(sid)
+        if not path:
+            self._hdr(404, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "no_pcap", "sid": sid,
+                 "hint": "session not started with --pcap, or no frames "
+                         "captured yet"}).encode())
+            return
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            size = 0
+        try:
+            self._hdr(ctype="application/vnd.tcpdump.pcap", extra={
+                "Content-Disposition": f'attachment; filename="{sid}.pcap"',
+                "Content-Length": str(size),
+                "Cache-Control": "no-cache",
+            })
+            with open(path, "rb") as f:
+                while True:
+                    chunk = f.read(65536)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
+
+    def _wire(self, sid, max_str):
+        """Serve the decoded wire summary (DNS / TCP flows / TLS-SNI / HTTP).
+
+        Delegates the actual parse to scripts/pcap_decode.py (component B).
+        Always returns JSON.  When that module isn't present the response is
+        {ok:False, decode_available:False, ...} so the UI can still offer the
+        raw /api/pcap download.  A malformed sid or absent capture is reported
+        as a structured 404/400, never a 500."""
+        if not SID_RE.match(sid):
+            self._hdr(400, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "bad_sid", "sid": sid}).encode())
+            return
+        path = self._pcap_path(sid)
+        if not path:
+            self._hdr(404, "application/json")
+            self.wfile.write(json.dumps(
+                {"ok": False, "error": "no_pcap", "sid": sid,
+                 "decode_available": _pcap_decode is not None,
+                 "hint": "session not started with --pcap, or no frames "
+                         "captured yet"}).encode())
+            return
+        if _pcap_decode is None:
+            # Decoder not on this checkout — the raw download still works.
+            self._hdr(200, "application/json")
+            self.wfile.write(json.dumps({
+                "ok": False, "decode_available": False, "sid": sid,
+                "pcap_url": f"/api/pcap?sid={sid}",
+                "error": "pcap_decode module not present on this checkout",
+            }).encode())
+            return
+        try:
+            max_packets = int(max_str) if max_str else 0
+        except ValueError:
+            max_packets = 0
+        try:
+            if max_packets > 0:
+                summary = _pcap_decode.decode_pcap(path, max_packets=max_packets)
+            else:
+                summary = _pcap_decode.decode_pcap(path)
+        except Exception as e:  # never 500 on a torn/partial capture
+            self._hdr(200, "application/json")
+            self.wfile.write(json.dumps({
+                "ok": False, "decode_available": True, "sid": sid,
+                "pcap_url": f"/api/pcap?sid={sid}",
+                "error": "decode_failed", "detail": str(e),
+            }).encode())
+            return
+        # Pass the decoder's dict through verbatim (additive keys tolerated),
+        # annotating with our own provenance so the UI has a stable envelope.
+        out = {"ok": True, "decode_available": True, "sid": sid,
+               "pcap_url": f"/api/pcap?sid={sid}"}
+        if isinstance(summary, dict):
+            out.update(summary)
+        else:
+            out["summary"] = summary
+        self._hdr(200, "application/json")
+        self.wfile.write(json.dumps(out).encode())
 
     def _stream(self, sid):
         path = self._log_path(sid)


### PR DESCRIPTION
Restores the host-side network **pcap capture + serial-monitor wire panel** onto `ff/real-website`, which branched before this tooling landed elsewhere. Future https/real-website render boots on this branch now auto-capture their VM↔internet traffic for the `:8088` wire panel.

## What lands (clean additive superset)
- **`--pcap`** — injects a host-side `-object filter-dump,id=netdump,netdev=net0,file=~/.astryx-harness/<sid>.pcap`. filter-dump taps the e1000/SLIRP netdev frontend *inside the host QEMU process*, so the guest takes **ZERO extra VM-exits**; the only cost is a host fwrite per frame. References the netdev by id (`net0`), so the in-place kdb/http/ssh hostfwd patch leaves the binding intact. Classic libpcap, LINKTYPE_ETHERNET.
- **Default-ON for Firefox-render boots, `--no-pcap` opt-out** — a pure helper `_resolve_pcap_decision(feats, pcap_flag, no_pcap_flag)` centralises the precedence `--no-pcap > --pcap > FF-feature-set > off`. FF profiles (`firefox-test` / `firefox-test-core` / `firefox-test-trace`) capture by default; non-FF boots stay OFF.
- **serial-web wire panel** (`serial-web.py` + new `pcap_decode.py`, both verbatim from the canonical tooling) — `/api/pcap` (raw .pcap download) + `/api/wire` (decoded DNS/TCP-anomalies/TLS-SNI/HTTP via a pure-stdlib decoder, graceful `decode_available:false` when the module is absent).
- **`epoll-watch` (PR #536) preserved byte-for-byte**; livelock-reap intentionally NOT pulled (it's not on this branch and would change `start` behaviour).

## Additive-only — no breaking changes
- `qemu-harness.py` diff has **zero deleted lines** — every hunk is an insertion. `start`/`wait`/`grep`/`kdb`/`stop`/`status`/`list` parse and dispatch identically.
- New JSON fields (`pcap_path`, `pcap_enabled`, `pcap_reason`) and start/status output fields are additive; pre-feature sessions read back `pcap_enabled` via `bool(pcap_path)` and `pcap_reason` as null.
- **No field renames.** `--pcap`/`--no-pcap` are new optional flags on `start`.

## Verification (host-only — KVM left for the live render probe)
- `qemu-harness-smoke.py` host-only suite (incl. new `run_pcap_argv_check`): default-on/opt-out matrix, filter-dump ordered after `-netdev`, survives the kdb-hostfwd patch, serial-web `/api/pcap` byte-identity + `/api/wire` envelope — **all pass**.
- `serial-web-smoke.py`: `/api/pcap` + `/api/wire` end-to-end incl. DNS/TLS-SNI decode + path-traversal rejection — **all pass**.
- `pcap_decode.py --selftest`: green; added as a `tooling-smoke` CI step so the decoder cannot silently regress.
- Composed `start --features firefox-test` confirmed to inject the filter-dump on `netdev=net0` after `-netdev`; `--no-pcap` removes it; a file://-loading FF boot still captures (benign near-empty pcap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)