### PR TITLE
linux: implement link(2)/linkat(2) — unblocks FF content renderer fontconfig cache

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3621,6 +3621,22 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 Err(e) => crate::subsys::linux::errno::vfs_err(e),
             }
         }
+        // 86: link(oldpath, newpath) — create a hard link.  Both are C-string
+        // paths.  Implements POSIX `link(2)`; the dominant real-world caller on
+        // this path is fontconfig's atomic cache-lock idiom `link(TMP, LCK)`
+        // (FcDirCacheLock).  Without it fontconfig cannot lock the cache dir,
+        // never persists a font cache, and rescans fonts forever — stalling the
+        // content-process font-init thread.
+        86 => {
+            let old_raw = read_cstring_from_user(arg1);
+            let new_raw = read_cstring_from_user(arg2);
+            let old_str = core::str::from_utf8(&old_raw).unwrap_or("");
+            let new_str = core::str::from_utf8(&new_raw).unwrap_or("");
+            match crate::vfs::link(old_str, new_str) {
+                Ok(()) => 0,
+                Err(e) => crate::subsys::linux::errno::vfs_err(e),
+            }
+        }
         // 89: readlink(path, buf, bufsiz) — C string path
         // Special-cased for /proc/self/exe → returns current process executable path.
         89 => {
@@ -5726,6 +5742,8 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         263 => sys_unlinkat(arg1, arg2, arg3),
         // 264: renameat(olddirfd, oldpath, newdirfd, newpath)
         264 => sys_renameat(arg1, arg2, arg3, arg4),
+        // 265: linkat(olddirfd, oldpath, newdirfd, newpath, flags) — hard link.
+        265 => sys_linkat(arg1, arg2, arg3, arg4, arg5),
 
         // ─── T1 batch 2 additions ─────────────────────────────────────────
 
@@ -11744,6 +11762,35 @@ fn sys_renameat(olddirfd: u64, oldpath: u64, newdirfd: u64, newpath: u64) -> i64
         Err(e) => return e,
     };
     match crate::vfs::rename(&old, &new) {
+        Ok(()) => 0,
+        Err(e) => crate::subsys::linux::errno::vfs_err(e),
+    }
+}
+
+/// linkat(olddirfd, oldpath, newdirfd, newpath, flags) — create a hard link
+/// relative to directory fds.  Implements POSIX/Linux `linkat(2)`.
+///
+/// `flags` may carry `AT_SYMLINK_FOLLOW` (0x400) — follow a trailing symlink
+/// in `oldpath` — and `AT_EMPTY_PATH` (0x1000).  AstryxOS' `vfs::link` does
+/// not follow a trailing symlink (it links the named object itself); since
+/// the dominant caller (fontconfig's `link(TMP, LCK)`) links a regular file,
+/// not a symlink, both behaviours coincide and the flags are accepted but
+/// have no observable effect here.  Unknown flag bits are rejected (EINVAL).
+fn sys_linkat(olddirfd: u64, oldpath: u64, newdirfd: u64, newpath: u64, flags: u64) -> i64 {
+    const AT_SYMLINK_FOLLOW: u64 = 0x400;
+    const AT_EMPTY_PATH: u64 = 0x1000;
+    if flags & !(AT_SYMLINK_FOLLOW | AT_EMPTY_PATH) != 0 {
+        return -22; // EINVAL
+    }
+    let old = match resolve_at_path(olddirfd, oldpath) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let new = match resolve_at_path(newdirfd, newpath) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    match crate::vfs::link(&old, &new) {
         Ok(()) => 0,
         Err(e) => crate::subsys::linux::errno::vfs_err(e),
     }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -564,6 +564,11 @@ pub fn run() -> ! {
     total += 1;
     if test_vfs_rename() { passed += 1; }
 
+    // ── Test 517: VFS hard links (link/linkat + nlink lifetime) ─────────
+
+    total += 1;
+    if test_vfs_hardlink() { passed += 1; }
+
     // ── Test 35: VFS Symlinks ───────────────────────────────────────────
 
     total += 1;
@@ -12349,6 +12354,72 @@ fn test_vfs_rename() -> bool {
     // Clean up
     let _ = crate::vfs::remove("/tmp/rename_dir_dst/file_inside");
     let _ = crate::vfs::remove("/tmp/rename_dir_dst");
+
+    if ok { test_println!("  PASS"); } else { test_println!("  FAIL"); }
+    ok
+}
+
+fn test_vfs_hardlink() -> bool {
+    test_header!("VFS Hard Links (link/linkat + nlink lifetime)");
+    let mut ok = true;
+
+    // Create the original file with known content.
+    let _ = crate::vfs::remove("/tmp/hl_orig");
+    let _ = crate::vfs::remove("/tmp/hl_link");
+    if crate::vfs::create_file("/tmp/hl_orig").is_err() {
+        test_println!("  FAIL: could not create /tmp/hl_orig");
+        return false;
+    }
+    if crate::vfs::write_file("/tmp/hl_orig", b"hardlink payload").is_err() {
+        test_println!("  FAIL: could not write /tmp/hl_orig");
+        ok = false;
+    }
+
+    // link(orig, new) — both names must now resolve to the same content.
+    match crate::vfs::link("/tmp/hl_orig", "/tmp/hl_link") {
+        Ok(()) => {
+            match crate::vfs::read_file("/tmp/hl_link") {
+                Ok(d) if d == b"hardlink payload" => {}
+                Ok(_) => { test_println!("  FAIL: linked name has wrong content"); ok = false; }
+                Err(e) => { test_println!("  FAIL: cannot read linked name: {:?}", e); ok = false; }
+            }
+        }
+        Err(e) => { test_println!("  FAIL: link() failed: {:?}", e); ok = false; }
+    }
+
+    // EEXIST: linking onto an existing name must fail.
+    if crate::vfs::link("/tmp/hl_orig", "/tmp/hl_link").is_ok() {
+        test_println!("  FAIL: link onto existing name should fail (EEXIST)");
+        ok = false;
+    }
+
+    // ENOENT: linking a nonexistent source must fail.
+    if crate::vfs::link("/tmp/hl_nope", "/tmp/hl_link2").is_ok() {
+        test_println!("  FAIL: link of nonexistent source should fail (ENOENT)");
+        ok = false;
+    }
+
+    // The fontconfig lock invariant: remove the ORIGINAL name; the inode must
+    // survive because the second link still references it (POSIX link count).
+    if crate::vfs::remove("/tmp/hl_orig").is_err() {
+        test_println!("  FAIL: could not unlink original name");
+        ok = false;
+    }
+    match crate::vfs::read_file("/tmp/hl_link") {
+        Ok(d) if d == b"hardlink payload" => {}
+        Ok(_) => { test_println!("  FAIL: surviving link has wrong content after orig unlink"); ok = false; }
+        Err(e) => {
+            test_println!("  FAIL: inode died after one unlink (nlink not honoured): {:?}", e);
+            ok = false;
+        }
+    }
+
+    // Remove the last name; the file must now be gone.
+    let _ = crate::vfs::remove("/tmp/hl_link");
+    if crate::vfs::stat("/tmp/hl_link").is_ok() {
+        test_println!("  FAIL: file still present after last unlink");
+        ok = false;
+    }
 
     if ok { test_println!("  PASS"); } else { test_println!("  FAIL"); }
     ok

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -1829,6 +1829,30 @@ pub fn symlink(link_path: &str, target: &str) -> VfsResult<()> {
     Ok(())
 }
 
+/// Create a hard link `new_path` referencing the same inode as `old_path`.
+///
+/// Per POSIX `link(2)`: the final component of `old_path` names the file to
+/// be linked (a trailing symlink is NOT followed — this is `link()`, not the
+/// `AT_SYMLINK_FOLLOW` form); `new_path` must not already exist (EEXIST);
+/// both paths must reside on the same filesystem (cross-mount hard links are
+/// not representable — POSIX EXDEV, reported here as `Unsupported`).
+pub fn link(old_path: &str, new_path: &str) -> VfsResult<()> {
+    let (old_mount, target_inode) = resolve_path_no_follow(old_path)?;
+    let (new_mount, new_parent, new_name) = resolve_parent(new_path)?;
+    if old_mount != new_mount {
+        return Err(VfsError::Unsupported); // EXDEV-equivalent
+    }
+    {
+        let fs = fs_at(new_mount).ok_or(VfsError::NotFound)?.0;
+        fs.link(target_inode, new_parent, &new_name)?;
+    }
+    // A new name appeared in the target directory — fire IN_CREATE so inotify
+    // watchers (and any dentry-cache invalidation riding on it) observe it.
+    let (new_dir, new_fn) = split_parent_name(new_path);
+    crate::ipc::inotify::notify_event(new_dir, new_fn, crate::ipc::inotify::IN_CREATE, 0);
+    Ok(())
+}
+
 /// Read the target of a symbolic link (does not follow the final symlink).
 pub fn readlink(path: &str) -> VfsResult<String> {
     let (mount_idx, inode) = resolve_path_no_follow(path)?;

--- a/kernel/src/vfs/ramfs.rs
+++ b/kernel/src/vfs/ramfs.rs
@@ -33,6 +33,13 @@ enum RamInode {
         created: u64,
         modified: u64,
         accessed: u64,
+        /// Hard-link count (POSIX `st_nlink`).  Created with 1; incremented
+        /// by `link(2)` (a second directory entry naming this inode) and
+        /// decremented by `unlink(2)`.  The inode's storage is freed only
+        /// when this count reaches 0, so a file kept alive solely by a
+        /// second link (e.g. fontconfig's `link(TMP, LCK)` lockfile pattern,
+        /// per `link(2)`) survives removal of its original name.
+        nlink: u32,
     },
     Dir {
         inode: u64,
@@ -137,6 +144,7 @@ impl FileSystemOps for RamFs {
             created: now,
             modified: now,
             accessed: now,
+            nlink: 1,
         };
         inodes.push(new_file);
 
@@ -217,8 +225,22 @@ impl FileSystemOps for RamFs {
             entries.retain(|e| e.name != name);
         }
 
-        // Remove the inode.
-        inodes.retain(|n| n.inode_number() != target_inode);
+        // Per POSIX `unlink(2)`: "When the file's link count reaches 0 and no
+        // process has the file open, the space occupied by the file shall be
+        // freed."  A regular file may have multiple hard links (see `link`);
+        // decrement its link count and only free the inode storage once the
+        // last name is gone.  Directories and symlinks have exactly one link
+        // in ramfs, so they are freed unconditionally.
+        let drop_inode = match &mut inodes[target_idx] {
+            RamInode::File { nlink, .. } => {
+                *nlink = nlink.saturating_sub(1);
+                *nlink == 0
+            }
+            _ => true,
+        };
+        if drop_inode {
+            inodes.retain(|n| n.inode_number() != target_inode);
+        }
 
         Ok(())
     }
@@ -298,7 +320,7 @@ impl FileSystemOps for RamFs {
         let idx = Self::find_inode_idx(&inodes, inode).ok_or(VfsError::NotFound)?;
 
         match &inodes[idx] {
-            RamInode::File { inode, data, permissions, created, modified, accessed } => Ok(FileStat {
+            RamInode::File { inode, data, permissions, created, modified, accessed, .. } => Ok(FileStat {
                 inode: *inode,
                 file_type: FileType::RegularFile,
                 size: data.len() as u64,
@@ -537,6 +559,50 @@ impl FileSystemOps for RamFs {
         Ok(())
     }
 
+    /// Create a hard link: insert `name` in `parent_inode` referencing the
+    /// existing `target_inode`, bumping its link count.
+    ///
+    /// Per POSIX `link(2)`:
+    ///   * "If the path named by `path2` exists, `link()` shall fail" — EEXIST.
+    ///   * Hard-linking a directory is not permitted — EPERM.
+    /// Symlinks are likewise not hard-linkable here (ramfs tracks a link
+    /// count only on regular files).  This implements exactly the lockfile
+    /// idiom `link(TMP, LCK)` that fontconfig (`FcDirCacheLock`) and many
+    /// other tools use for atomic, NFS-safe locking.
+    fn link(&self, target_inode: u64, parent_inode: u64, name: &str) -> VfsResult<()> {
+        let mut inodes = self.inodes.lock();
+
+        let parent_idx = Self::find_inode_idx(&inodes, parent_inode).ok_or(VfsError::NotFound)?;
+        match &inodes[parent_idx] {
+            RamInode::Dir { entries, .. } => {
+                if entries.iter().any(|e| e.name == name) {
+                    return Err(VfsError::FileExists);
+                }
+            }
+            _ => return Err(VfsError::NotADirectory),
+        }
+
+        // The target must exist and be a regular file (no dir/symlink links).
+        let target_idx = Self::find_inode_idx(&inodes, target_inode).ok_or(VfsError::NotFound)?;
+        match &mut inodes[target_idx] {
+            RamInode::File { nlink, .. } => {
+                *nlink = nlink.saturating_add(1);
+            }
+            RamInode::Dir { .. } => return Err(VfsError::PermissionDenied), // EPERM
+            RamInode::SymLink { .. } => return Err(VfsError::Unsupported),
+        }
+
+        if let RamInode::Dir { entries, modified, .. } = &mut inodes[parent_idx] {
+            entries.push(DirEntry {
+                name: String::from(name),
+                inode: target_inode,
+            });
+            *modified = now_secs();
+        }
+
+        Ok(())
+    }
+
     fn symlink(&self, parent_inode: u64, name: &str, target: &str) -> VfsResult<u64> {
         let mut inodes = self.inodes.lock();
 
@@ -599,6 +665,16 @@ impl FileSystemOps for RamFs {
         let mut inodes = self.inodes.lock();
         let parent_idx = Self::find_inode_idx(&inodes, parent_inode)
             .ok_or(VfsError::NotFound)?;
+        // Resolve the target inode of the name being removed so we can drop its
+        // link count.  `unlink_entry` removes only the directory entry (the
+        // deferred-delete path keeps the inode storage alive until the last fd
+        // closes), but the *link* count must still fall — otherwise a file with
+        // a second hard link would over-count and never be freed.
+        let target_inode = match &inodes[parent_idx] {
+            RamInode::Dir { entries, .. } =>
+                entries.iter().find(|e| e.name == name).map(|e| e.inode),
+            _ => return Err(VfsError::NotADirectory),
+        };
         match &mut inodes[parent_idx] {
             RamInode::Dir { entries, modified, .. } => {
                 let before = entries.len();
@@ -607,14 +683,33 @@ impl FileSystemOps for RamFs {
                     return Err(VfsError::NotFound);
                 }
                 *modified = now_secs();
-                Ok(())
             }
-            _ => Err(VfsError::NotADirectory),
+            _ => return Err(VfsError::NotADirectory),
         }
+        if let Some(ti) = target_inode {
+            if let Some(tidx) = Self::find_inode_idx(&inodes, ti) {
+                if let RamInode::File { nlink, .. } = &mut inodes[tidx] {
+                    *nlink = nlink.saturating_sub(1);
+                }
+            }
+        }
+        Ok(())
     }
 
     fn remove_inode(&self, inode: u64) -> VfsResult<()> {
         let mut inodes = self.inodes.lock();
+        // Honour the hard-link count: the deferred-delete machinery calls this
+        // on last-close of an unlinked file, but if another hard link still
+        // names the inode (nlink > 0) its storage must survive (POSIX
+        // `unlink(2)` link-count semantics).  Only regular files carry a link
+        // count; directories/symlinks are single-linked here.
+        if let Some(idx) = Self::find_inode_idx(&inodes, inode) {
+            if let RamInode::File { nlink, .. } = &inodes[idx] {
+                if *nlink > 0 {
+                    return Ok(()); // still referenced by another name — keep it
+                }
+            }
+        }
         inodes.retain(|n| n.inode_number() != inode);
         Ok(())
     }


### PR DESCRIPTION
## Root cause

The Firefox headless-screenshot content **renderer** (childID-2) wedged in
startup: its worker pool parked in `pthread_cond_timedwait` waiting for a
gecko work predicate the main thread never set, because the main thread was
stuck in an **infinite fontconfig cache-rebuild loop**.

`PROC-METRICS` for the renderer showed the `file` syscall class growing
unbounded while `vm`/`net` stayed frozen. The loop was fontconfig repeatedly
opening `/var/cache/fontconfig//<hash>-le64.cache-9` and getting `ENOENT`
every time — the cache never persisted, so fontconfig rescanned the font
tree forever and never finished font-init, never dispatched JS-engine init,
and never produced the predicate its worker pool waits on. No JIT, no paint,
no PNG.

The cache never persisted because fontconfig acquires its directory lock with
the atomic `link(2)` idiom — `link("<cache>.TMP-XXXXXX", "<cache>.LCK")`
(`FcDirCacheLock`) — and **`link(2)` (nr 86) and `linkat(2)` (nr 265) were
unhandled**, falling through the Linux syscall dispatcher's catch-all to
`-ENOSYS` (logged as `Unknown Linux syscall: 86`, 11×/boot). The working
reference run makes 356 fontconfig `link()` calls; ours made zero successful
ones.

## Fix

* `vfs::link(old, new)` — same-filesystem hard link; no trailing-symlink
  follow; `EEXIST` on an existing target; cross-mount returns the
  EXDEV-equivalent; fires `IN_CREATE`. Mirrors `vfs::rename`/`vfs::symlink`.
* `sys_link` (nr 86) and `sys_linkat` (nr 265) in the Linux personality.
  `linkat` accepts `AT_SYMLINK_FOLLOW` / `AT_EMPTY_PATH` and rejects unknown
  flag bits (`EINVAL`).
* `ramfs` gains a per-file link count (POSIX `st_nlink`). `create_file`
  starts it at 1; `link()` inserts a second directory entry and increments
  it; both unlink paths — immediate `remove` and deferred
  unlink-on-last-close (`unlink_entry` + `remove_inode`) — decrement it and
  free the inode storage only at 0. This is `unlink(2)` link-count semantics:
  the `.LCK` link keeps the inode alive after the temp name is unlinked.

Per POSIX `link(2)` / `linkat(2)` and `unlink(2)`.

## Test

Test 517 (`test_vfs_hardlink`): link round-trip, `EEXIST`, `ENOENT`, the
unlink-original-keeps-inode-alive invariant, and free-on-last-name. Passes;
existing VFS Rename / Symlink tests unaffected.

## Verification (live FF boot)

* `Unknown Linux syscall: 86` → **0** (was 11).
* `/var/cache/fontconfig//…cache-9` opens now return a valid fd — the cache
  **persists** and is re-read, matching the reference run.
* The renderer escapes the font loop into NSS / SQLite / JS / XPCOM init
  (`libfreeblpriv3.so`, `libsqlite3.so.0`, `/dev/urandom`,
  `/proc/self/{statm,smaps}`); its `net`/IPC class grows; content-process
  syscall count advanced from the prior ~36k stall to 85k+ and climbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)