### PR TITLE
eventfd: per-OFD refcount across fork/dup/SCM + wakeup-driven EPOLLET re-fire (render gate)

### DIFF
--- a/kernel/src/ipc/eventfd.rs
+++ b/kernel/src/ipc/eventfd.rs
@@ -56,11 +56,28 @@ struct EventFdEntry {
     counter: u64,
     flags:   u32,
     in_use:  bool,
+    /// Open-file-description reference count.  One reference per
+    /// `FileDescriptor` (in any process's fd table) that names this slot,
+    /// plus one per in-flight SCM_RIGHTS copy.  Per POSIX.1-2017 §2.14,
+    /// `fork(2)`, and `dup(2)`: duplicated descriptors refer to the SAME
+    /// open file description, and per `close(2)` the underlying object is
+    /// released only when the LAST descriptor referring to it is closed.
+    /// `create()` starts this at 1; `inc_ref()` bumps it on fork/dup/
+    /// SCM-enqueue; `close()` decrements and frees the slot only at zero.
+    refs:    u32,
+    /// Wakeup-edge marker for EPOLLET watchers.  Per `eventfd(2)`, every
+    /// successful `write(2)` adds to the counter AND constitutes a new
+    /// readiness notification; per `epoll(7)` an edge-triggered watcher
+    /// must receive one event per such notification even if the counter
+    /// was already nonzero (the consumer may deliberately never drain a
+    /// wakeup eventfd).  Set on every successful `write()`, consumed by
+    /// the epoll delivery path (`take_write_edge`).
+    write_edge: bool,
 }
 
 impl EventFdEntry {
     const fn empty() -> Self {
-        Self { counter: 0, flags: 0, in_use: false }
+        Self { counter: 0, flags: 0, in_use: false, refs: 0, write_edge: false }
     }
 }
 
@@ -92,10 +109,30 @@ pub fn create(initval: u64, flags: u32) -> u64 {
             slot.in_use  = true;
             slot.counter = initval;
             slot.flags   = flags;
+            slot.refs    = 1; // the creating fd's open-file-description ref
+            slot.write_edge = false;
             return i as u64;
         }
     }
     u64::MAX // No free slot
+}
+
+/// Add one open-file-description reference to a live slot.
+///
+/// Call sites mirror the unix-socket / pipe refcount discipline:
+/// `fork(2)`/`clone(2)`-without-CLONE_FILES fd-table duplication,
+/// `dup(2)`/`dup2(2)`/`fcntl(F_DUPFD)`, and SCM_RIGHTS enqueue.  Per
+/// POSIX.1-2017 §2.14 the duplicate descriptor refers to the same open
+/// file description; without this bump the FIRST `close(2)` from either
+/// holder would free the shared counter slot, leaving the survivor with
+/// a dangling id that fails EBADF — or worse, lands on a recycled slot.
+pub fn inc_ref(id: u64) {
+    let mut table = TABLE.lock();
+    if let Some(slot) = table.get_mut(id as usize) {
+        if slot.in_use {
+            slot.refs = slot.refs.saturating_add(1);
+        }
+    }
 }
 
 /// Non-blocking read from eventfd.  Returns the current counter as a u64
@@ -164,20 +201,75 @@ pub fn write(id: u64, val: u64) -> Result<(), i64> {
         return Err(-27); // EFBIG
     }
     slot.counter += val;
+    // Every successful write is a fresh readiness notification for
+    // edge-triggered pollers, independent of prior counter history —
+    // see the `write_edge` field doc (eventfd(2) + epoll(7)).
+    slot.write_edge = true;
     Ok(())
 }
 
-/// Free an eventfd slot.  Wakes every reader parked on the slot so they
+/// Consume the pending write-edge marker: returns `true` exactly once per
+/// `write()` (or per coalesced burst of writes) since the last call.  Used
+/// by the `epoll_wait(2)` delivery path so an EPOLLET watcher receives one
+/// event per wakeup notification even when the counter stays nonzero
+/// (never-drained wakeup-eventfd reactor pattern; epoll(7)).  When several
+/// edge-triggered watchers share one eventfd, the edge is delivered to the
+/// first poller that reaches delivery — consistent with epoll(7)'s
+/// guidance that ET consumers must tolerate wakeup races.
+pub fn take_write_edge(id: u64) -> bool {
+    let mut table = TABLE.lock();
+    match table.get_mut(id as usize) {
+        Some(slot) if slot.in_use && slot.write_edge => {
+            slot.write_edge = false;
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Non-consuming probe of the pending write-edge marker.  Used by the
+/// epoll park predicate (prepare-to-wait recheck), which must never
+/// consume an edge — only the call path that actually returns events to
+/// userspace does (see `take_write_edge`).
+pub fn peek_write_edge(id: u64) -> bool {
+    let table = TABLE.lock();
+    table.get(id as usize)
+        .map(|s| s.in_use && s.write_edge)
+        .unwrap_or(false)
+}
+
+/// Drop one open-file-description reference; free the slot only when the
+/// LAST reference is released.  Per POSIX `close(2)`: "If fildes is the
+/// last file descriptor referring to the open file description, the
+/// resources associated with the open file description shall be
+/// released."  An eventfd inherited across `fork(2)` (or duplicated via
+/// `dup(2)`/SCM_RIGHTS) is one shared object with multiple references —
+/// a child's close (e.g. a pre-`execve(2)` close-on-exec scrub) must NOT
+/// destroy the counter the parent is still writing to.
+///
+/// On the final free, wakes every reader parked on the slot so they
 /// observe EBADF on the next try_read call rather than blocking
 /// indefinitely against a counter that nobody can ever post to.
 pub fn close(id: u64) {
-    {
+    let freed = {
         let mut table = TABLE.lock();
-        if let Some(slot) = table.get_mut(id as usize) {
-            *slot = EventFdEntry::empty();
+        match table.get_mut(id as usize) {
+            Some(slot) if slot.in_use => {
+                if slot.refs > 1 {
+                    slot.refs -= 1;
+                    false
+                } else {
+                    *slot = EventFdEntry::empty();
+                    true
+                }
+            }
+            // Not in use: double-close or stale id — nothing to drop.
+            _ => false,
         }
+    };
+    if freed {
+        wake_readers_all(id);
     }
-    wake_readers_all(id);
 }
 
 /// Check if counter > 0 (used by `poll` / `select`).
@@ -266,4 +358,13 @@ pub fn waiter_cleanup(efd_id: u64, tid: u64) {
 pub fn debug_reader_waiter_count(efd_id: u64) -> usize {
     let waiters = EVENTFD_READ_WAITERS.lock();
     waiters.get(&efd_id).map(|l| l.len()).unwrap_or(0)
+}
+
+/// Test-only diagnostic: returns the open-file-description reference
+/// count for `efd_id` (0 when the slot is free).
+pub fn debug_ref_count(efd_id: u64) -> u32 {
+    let table = TABLE.lock();
+    table.get(efd_id as usize)
+        .map(|s| if s.in_use { s.refs } else { 0 })
+        .unwrap_or(0)
 }

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2032,9 +2032,14 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // promptly.  Iterate a snapshot to avoid holding PROCESS_TABLE while calling
     // into PIPE_TABLE / unix socket TABLE (lock ordering: resource table before
     // PROCESS_TABLE).
-    let (pipe_ends, socket_ids): (alloc::vec::Vec<(u64, bool)>, alloc::vec::Vec<u64>) = {
+    let (pipe_ends, socket_ids, eventfd_ids): (
+        alloc::vec::Vec<(u64, bool)>,
+        alloc::vec::Vec<u64>,
+        alloc::vec::Vec<u64>,
+    ) = {
         let procs = PROCESS_TABLE.lock();
-        let (mut pipes, mut sockets) = (alloc::vec::Vec::new(), alloc::vec::Vec::new());
+        let (mut pipes, mut sockets, mut eventfds) =
+            (alloc::vec::Vec::new(), alloc::vec::Vec::new(), alloc::vec::Vec::new());
         if let Some(p) = procs.iter().find(|p| p.pid == pid) {
             for f in p.file_descriptors.iter().filter_map(|f| f.as_ref()) {
                 if f.file_type == crate::vfs::FileType::Pipe
@@ -2046,10 +2051,12 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
                     && f.flags & crate::syscall::UNIX_SOCKET_FLAG != 0
                 {
                     sockets.push(f.inode);
+                } else if f.file_type == crate::vfs::FileType::EventFd {
+                    eventfds.push(f.inode);
                 }
             }
         }
-        (pipes, sockets)
+        (pipes, sockets, eventfds)
     };
     for (pipe_id, is_write) in pipe_ends {
         if is_write {
@@ -2062,6 +2069,13 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // close tears the slot down and notifies the peer.
     for socket_id in socket_ids {
         crate::net::unix::close(socket_id);
+    }
+    // Drop the exiting process's eventfd open-file-description refs; the
+    // slot is freed only when the last reference (parent's fd, in the
+    // inherited case) goes away — per POSIX close(2) last-reference
+    // semantics, mirroring the socket/pipe handling above.
+    for efd_id in eventfd_ids {
+        crate::ipc::eventfd::close(efd_id);
     }
 
     // Release POSIX file locks held by this process (C1).
@@ -2732,6 +2746,24 @@ fn inc_pipe_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
     }
 }
 
+/// Bump the eventfd open-file-description refcount for every eventfd fd
+/// the child inherits via fork/vfork/clone-without-`CLONE_FILES`.  Same
+/// rationale as `inc_socket_refs_for_fork` / `inc_pipe_refs_for_fork`:
+/// per POSIX.1-2017 §2.14 and `fork(2)`, the duplicated descriptors refer
+/// to the same open file description, so each inherited eventfd fd must
+/// count as one more reference.  Without this bump, the child's
+/// close-on-exec scrub (a plain `close(2)` loop before `execve(2)`) frees
+/// the parent's live counter slot — the parent's next `write(2)` to its
+/// own fd then fails EBADF, and a later `eventfd2(2)` recycles the slot
+/// out from under the stale id (CWE-416 class via slot reuse).
+fn inc_eventfd_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
+    for fd in fds.iter().filter_map(|f| f.as_ref()) {
+        if fd.file_type == crate::vfs::FileType::EventFd {
+            crate::ipc::eventfd::inc_ref(fd.inode);
+        }
+    }
+}
+
 /// Drop the pipe-end refcount associated with a single `FileDescriptor`
 /// that is about to be cleared (e.g. by `close(2)`, by `execve(2)`'s
 /// `FD_CLOEXEC` purge, or by `dup2(2)` overwriting an existing slot).
@@ -2818,6 +2850,9 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
     // purges its CLOEXEC fd, so parent's `read` would see premature EOF
     // (or worse, refcount underflow on the second close).
     inc_pipe_refs_for_fork(&fds);
+    // And eventfd slots — the child's pre-exec close-on-exec scrub must
+    // not free a counter the parent still posts to (AudioIPC waker case).
+    inc_eventfd_refs_for_fork(&fds);
 
     // Enforce RLIMIT_NPROC: count non-zombie processes.
     {
@@ -3084,6 +3119,8 @@ pub fn fork_process_share_vm(
     // (and any other inherited pipe end) survives until BOTH the parent's
     // copy AND the child's copy are closed.  See `inc_pipe_refs_for_fork`.
     inc_pipe_refs_for_fork(&fds);
+    // And eventfd open-file-description refs (see `inc_eventfd_refs_for_fork`).
+    inc_eventfd_refs_for_fork(&fds);
 
     // RLIMIT_NPROC.
     {
@@ -3790,6 +3827,8 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
     inc_socket_refs_for_fork(&fds);
     // And pipe fd refcounts.
     inc_pipe_refs_for_fork(&fds);
+    // And eventfd open-file-description refs (see `inc_eventfd_refs_for_fork`).
+    inc_eventfd_refs_for_fork(&fds);
 
     // Get parent's TLS base from thread struct.
     let parent_tls = {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1280,7 +1280,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
                 crate::net::socket::socket_close(socket_id);
             }
-            // If it's an eventfd, free the counter slot.
+            // If it's an eventfd, drop one open-file-description reference.
+            // The counter slot is freed only when the LAST reference goes
+            // away (POSIX close(2)) — an eventfd inherited across fork(2)
+            // or duplicated via dup(2)/SCM_RIGHTS is one shared object, so
+            // a child's pre-execve close-on-exec scrub must not destroy
+            // the counter the parent still writes to.
             if crate::syscall::is_eventfd_fd(pid, fd) {
                 let efd_id = crate::syscall::get_eventfd_id(pid, fd);
                 crate::ipc::eventfd::close(efd_id);
@@ -2375,6 +2380,17 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                                 // on drain (scm_drop_fds path).
                                                 crate::vfs::pin_inode(
                                                     fdesc.mount_idx, fdesc.inode);
+                                            } else if fdesc.file_type
+                                                == crate::vfs::FileType::EventFd
+                                            {
+                                                // The in-flight copy is one more
+                                                // reference to the same open file
+                                                // description (unix(7) SCM_RIGHTS);
+                                                // balanced by the receiver's later
+                                                // close(2), or by scm_drop_fds if
+                                                // the batch is never received.
+                                                crate::ipc::eventfd::inc_ref(
+                                                    fdesc.inode);
                                             }
                                         }
                                         cloned
@@ -11010,7 +11026,7 @@ fn sys_epoll_ctl(epfd: usize, op: u64, fd: usize, event_ptr: u64) -> i64 {
 
 /// epoll_wait — collect ready events into caller's buffer.
 fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i32) -> i64 {
-    use crate::ipc::epoll::{EpollEvent, EPOLLERR, EPOLLHUP, EPOLLET};
+    use crate::ipc::epoll::{EpollEvent, EPOLLERR, EPOLLHUP, EPOLLET, EPOLLIN};
     if maxevents == 0 { return -22; } // EINVAL
     let pid = crate::proc::current_pid_lockless();
 
@@ -11027,7 +11043,13 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // is retained so the (possibly updated) edge baselines can be written
     // back into the live `EpollInstance` after the poll completes.
     let epoll_id: u64;
-    let watches_snap: alloc::vec::Vec<(usize, u32, u64, u32)> = {
+    let watches_snap: alloc::vec::Vec<(usize, u32, u64, u32)>;
+    // Per-watch eventfd slot id (index-aligned with `watches_snap`);
+    // `u64::MAX` for non-eventfd watches.  Resolved once under the same
+    // lock hold so the EPOLLET write-edge re-fire below (see `efd_edge`)
+    // does not need a PROCESS_TABLE lookup per poll iteration.
+    let efd_for: alloc::vec::Vec<u64>;
+    {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = match procs.iter().find(|p| p.pid == pid) {
             Some(p) => p,
@@ -11041,8 +11063,16 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
             Some(i) => i,
             None    => return -9,
         };
-        inst.watches.iter().map(|w| (w.fd, w.events, w.data, w.et_seen)).collect()
-    }; // lock released here
+        watches_snap = inst.watches.iter()
+            .map(|w| (w.fd, w.events, w.data, w.et_seen)).collect();
+        efd_for = inst.watches.iter().map(|w| {
+            proc.file_descriptors.get(w.fd)
+                .and_then(|f| f.as_ref())
+                .filter(|f| f.file_type == crate::vfs::FileType::EventFd)
+                .map(|f| f.inode)
+                .unwrap_or(u64::MAX)
+        }).collect();
+    } // lock released here
 
     // Live edge-trigger baselines, one per snapshot entry (index-aligned).
     // Seeded from the stored `et_seen` and mutated by `do_poll` / `probe_ready`
@@ -11116,12 +11146,45 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
         report
     };
 
+    // Wakeup-driven EPOLLET re-fire for eventfds.  The `et_seen` baseline
+    // above models edge-triggering as a LEVEL DELTA ("became ready after
+    // not being ready"), but per eventfd(2) every successful write(2) is a
+    // fresh readiness notification, and per epoll(7) an edge-triggered
+    // watcher gets one event per notification — even when the counter was
+    // already nonzero.  A reactor that deliberately never drains its wakeup
+    // eventfd (the common waker pattern) would otherwise see exactly one
+    // event ever: write #2 against the still-nonzero counter computes
+    // `interest & !seen == 0` and the parked epoll_wait never returns.
+    //
+    // This helper reports EPOLLIN for an EPOLLET eventfd watch whose slot
+    // carries a pending write edge.  `consume == true` (delivery path)
+    // claims the edge via `take_write_edge`; the park predicate passes
+    // `consume == false` and only peeks.  When the level-delta machinery in
+    // `deliver_for` already reports EPOLLIN (`already & EPOLLIN != 0`), the
+    // pending edge is folded into that delivery — claimed but not
+    // re-reported — so one write never yields two events.  Scoped strictly
+    // to eventfd watches; all other fd types keep the level-delta model.
+    let efd_edge = |idx: usize, subscribed: u32, ready_ev: u32,
+                    already: u32, consume: bool| -> u32 {
+        if efd_for[idx] == u64::MAX        { return 0; } // not an eventfd
+        if subscribed & EPOLLET == 0       { return 0; } // level-triggered
+        if subscribed & EPOLLIN == 0       { return 0; } // not read-interested
+        if ready_ev   & EPOLLIN == 0       { return 0; } // counter is zero
+        let pending = if consume {
+            crate::ipc::eventfd::take_write_edge(efd_for[idx])
+        } else {
+            crate::ipc::eventfd::peek_write_edge(efd_for[idx])
+        };
+        if pending && already & EPOLLIN == 0 { EPOLLIN } else { 0 }
+    };
+
     // ── Step 2: poll without holding the lock ────────────────────────────────
     let do_poll = |fired: &mut alloc::vec::Vec<EpollEvent>| {
         for (idx, &(fd, subscribed, data, _)) in watches_snap.iter().enumerate() {
             if fired.len() >= maxevents { break; }
             let ready_ev = epoll_poll_events(pid, fd);
-            let report = deliver_for(idx, subscribed, ready_ev);
+            let mut report = deliver_for(idx, subscribed, ready_ev);
+            report |= efd_edge(idx, subscribed, ready_ev, report, true);
             if report != 0 {
                 fired.push(EpollEvent { events: report, data });
             }
@@ -11139,7 +11202,15 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     let probe_ready = || -> bool {
         for (idx, &(fd, subscribed, _data, _)) in watches_snap.iter().enumerate() {
             let ready_ev = epoll_poll_events(pid, fd);
-            if peek_for(idx, subscribed, ready_ev) != 0 { return true; }
+            let peeked = peek_for(idx, subscribed, ready_ev);
+            if peeked != 0 { return true; }
+            // A pending eventfd write edge is deliverable even when the
+            // level-delta peek reports nothing (counter stayed nonzero
+            // across the write) — without this the parked waiter wakes on
+            // the poll bell, computes 0, and re-parks forever.
+            if efd_edge(idx, subscribed, ready_ev, peeked, false) != 0 {
+                return true;
+            }
         }
         false
     };

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -710,7 +710,9 @@ pub fn scm_drain_receiver(receiver_id: u64) -> Vec<crate::vfs::FileDescriptor> {
 ///     (`vfs::pin_inode`); when that was the last reference to a deferred-
 ///     deleted (unlinked) memfd, the inode is freed by `unpin_inode`.  Without
 ///     this the pin (and thus the inode) would leak forever.
-///   * eventfd / other sentinel fds → no per-object refcount to balance.
+///   * eventfd → drop one open-file-description reference
+///     (`ipc::eventfd::close`); the counter slot is freed on the last drop.
+///   * other sentinel fds → no per-object refcount to balance.
 ///
 /// MUST be called with no unix `TABLE` / `PENDING_SCM` lock held — it re-enters
 /// `net::unix::close`, which takes the unix TABLE lock.
@@ -733,8 +735,11 @@ pub fn scm_drop_fds(fds: Vec<crate::vfs::FileDescriptor>) {
             && fd.mount_idx != usize::MAX
         {
             crate::vfs::unpin_inode(fd.mount_idx, fd.inode);
+        } else if fd.file_type == crate::vfs::FileType::EventFd {
+            // Balance the inc_ref taken at SCM enqueue time.
+            crate::ipc::eventfd::close(fd.inode);
         }
-        // eventfds / other sentinel fds: no per-object refcount to drop.
+        // Other sentinel fds: no per-object refcount to drop.
     }
 }
 
@@ -1765,6 +1770,14 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
                             && f.flags & crate::syscall::UNIX_SOCKET_FLAG != 0
                         {
                             crate::net::unix::close(f.inode);
+                        }
+                        // Drop the eventfd open-file-description ref too —
+                        // the slot is freed only on the LAST reference
+                        // (POSIX close(2)), so a CLOEXEC-marked eventfd
+                        // inherited from the parent does not destroy the
+                        // counter the parent still posts to.
+                        if f.file_type == crate::vfs::FileType::EventFd {
+                            crate::ipc::eventfd::close(f.inode);
                         }
                     }
                 }
@@ -4285,6 +4298,12 @@ pub(crate) fn sys_dup(old_fd: usize) -> i64 {
             crate::ipc::pipe::pipe_add_reader(fd_clone.inode);
         }
     }
+    // And eventfd slots — the duplicate is one more reference to the same
+    // open file description (POSIX.1-2017 §2.14 / dup(2)); close(2) frees
+    // the counter slot only when the last reference drops.
+    if fd_clone.file_type == crate::vfs::FileType::EventFd {
+        crate::ipc::eventfd::inc_ref(fd_clone.inode);
+    }
 
     // Find lowest free fd
     for i in 0..proc.file_descriptors.len() {
@@ -4346,6 +4365,10 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
             crate::ipc::pipe::pipe_add_reader(fd_clone.inode);
         }
     }
+    // And eventfd slots (same open-file-description rule as sys_dup).
+    if fd_clone.file_type == crate::vfs::FileType::EventFd {
+        crate::ipc::eventfd::inc_ref(fd_clone.inode);
+    }
 
     // Grow the table if needed
     while proc.file_descriptors.len() <= new_fd {
@@ -4363,6 +4386,10 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
             && prev.flags & UNIX_SOCKET_FLAG != 0
         {
             crate::net::unix::close(prev.inode);
+        }
+        // A displaced eventfd loses one open-file-description ref too.
+        if prev.file_type == crate::vfs::FileType::EventFd {
+            crate::ipc::eventfd::close(prev.inode);
         }
     }
     proc.file_descriptors[new_fd] = Some(fd_clone);

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2811,6 +2811,26 @@ pub fn run() -> ! {
     total += 1;
     if test_296_proc_fd_reopen_unlinked_memfd() { passed += 1; }
 
+    // ── Test 297: eventfd open-file-description refcount across fork/dup ───
+    // Per POSIX.1-2017 §2.14, fork(2), and dup(2): duplicate descriptors
+    // refer to the SAME open file description, and per close(2) the object
+    // is released only when the LAST reference is closed.  An eventfd
+    // inherited across fork is one shared counter with two references; the
+    // child's pre-execve close-on-exec scrub must NOT free the slot the
+    // parent still writes to.  Refs: close(2), fork(2), dup(2), eventfd(2).
+    total += 1;
+    if test_297_eventfd_ofd_refcount() { passed += 1; }
+
+    // ── Test 298: EPOLLET eventfd re-fires on EVERY write (wakeup-driven) ──
+    // Per eventfd(2) every successful write(2) is a readiness notification;
+    // per epoll(7) an edge-triggered watcher receives one event per
+    // notification — including a write that bumps an ALREADY-nonzero
+    // counter.  The reactor waker pattern (write-to-wake, never drain)
+    // depends on this; a pure level-delta model parks the waiter forever
+    // after the first delivery.  Refs: eventfd(2), epoll(7).
+    total += 1;
+    if test_298_epollet_eventfd_write_refire() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -49406,6 +49426,274 @@ fn test_294_epoll_edge_triggered_eventfd() -> bool {
 
     if ok {
         test_pass!("epoll EPOLLET edge-trigger on a level-ready eventfd (Test 294)");
+    }
+    ok
+}
+
+// ── Test 297: eventfd open-file-description refcount across fork/dup ─────────
+//
+// Per POSIX.1-2017 §2.14, fork(2), and dup(2): duplicated file descriptors
+// refer to the SAME open file description; per close(2), "If fildes is the
+// last file descriptor referring to the open file description, the resources
+// associated with the open file description shall be released" — i.e. only
+// the LAST close frees the object.  An eventfd inherited across fork(2) is
+// one shared counter with two references: the child's pre-execve(2)
+// close-on-exec scrub (a plain close(2) loop) must NOT free the slot the
+// parent still writes to.  Without the refcount, the child's scrub freed the
+// parent's waker slot, the parent's next write(2) returned EBADF, and a later
+// eventfd2(2) recycled the slot under the stale id.
+// Refs: close(2), fork(2), dup(2), eventfd(2).
+fn test_297_eventfd_ofd_refcount() -> bool {
+    test_header!("eventfd OFD refcount across fork/dup (Test 297)");
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+    let mut ok = true;
+
+    // Linux ABI for this process (eventfd/dup are Linux-personality calls).
+    let pid = crate::proc::current_pid();
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = true;
+            p.subsystem = crate::win32::SubsystemType::Linux;
+        }
+    }
+
+    // ── Part 1: module level — simulated fork inheritance ───────────────────
+    // create() takes the creating fd's reference; inc_ref() is exactly what
+    // `inc_eventfd_refs_for_fork` does for each inherited eventfd fd; the
+    // first close() models the child's CLOEXEC scrub.
+    {
+        use crate::ipc::eventfd;
+        let id = eventfd::create(0, 0);
+        if id == u64::MAX {
+            test_fail!("efd-refs", "create() returned no slot");
+            return false;
+        }
+        if eventfd::debug_ref_count(id) != 1 {
+            test_fail!("efd-refs", "refs after create = {} (want 1)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        eventfd::inc_ref(id); // fork: child inherits the fd
+        if eventfd::debug_ref_count(id) != 2 {
+            test_fail!("efd-refs", "refs after fork-inherit = {} (want 2)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        eventfd::close(id);   // child's CLOEXEC scrub close(2)
+        // THE regression: parent's write must still succeed (was Err(-9)
+        // EBADF — the child's close freed the shared slot).
+        match eventfd::write(id, 1) {
+            Ok(()) => test_println!("  parent write after child close → Ok ✓"),
+            Err(e) => {
+                test_fail!("efd-refs",
+                    "parent write after child close = {} (want Ok) — \
+                     child close freed the shared slot", e);
+                ok = false;
+            }
+        }
+        if !eventfd::is_readable(id) {
+            test_fail!("efd-refs", "slot not readable after parent write");
+            ok = false;
+        }
+        eventfd::close(id);   // parent's close — the LAST reference
+        if eventfd::write(id, 1) != Err(-9) {
+            test_fail!("efd-refs", "write after last close should be EBADF");
+            ok = false;
+        }
+        if eventfd::debug_ref_count(id) != 0 {
+            test_fail!("efd-refs", "refs after last close = {} (want 0)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        if ok {
+            test_println!("  simulated fork: 1→2→1→0 refs, free on last close ✓");
+        }
+    }
+
+    // ── Part 2: syscall level — dup(2) bumps, close(2) arm drops ────────────
+    {
+        const SYS_EVENTFD2: u64 = 290;
+        const SYS_DUP:      u64 = 32;
+        const SYS_CLOSE:    u64 = 3;
+        const SYS_WRITE:    u64 = 1;
+        const SYS_READ:     u64 = 0;
+
+        let efd = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+        if efd < 0 {
+            test_fail!("efd-refs", "eventfd2 = {}", efd);
+            return false;
+        }
+        let id = crate::syscall::get_eventfd_id(pid, efd as usize);
+        let dupfd = dispatch(SYS_DUP, efd as u64, 0, 0, 0, 0, 0);
+        if dupfd < 0 {
+            test_fail!("efd-refs", "dup(eventfd) = {}", dupfd);
+            ok = false;
+        }
+        if crate::ipc::eventfd::debug_ref_count(id) != 2 {
+            test_fail!("efd-refs", "refs after dup = {} (want 2)",
+                crate::ipc::eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        // Close the ORIGINAL fd through the real close(2) dispatch arm —
+        // the duplicate must keep the slot alive.
+        let r = dispatch(SYS_CLOSE, efd as u64, 0, 0, 0, 0, 0);
+        if r != 0 {
+            test_fail!("efd-refs", "close(efd) = {}", r);
+            ok = false;
+        }
+        let v: u64 = 7;
+        let w = dispatch(SYS_WRITE, dupfd as u64, (&v as *const u64) as u64, 8, 0, 0, 0);
+        if w == 8 {
+            test_println!("  write via dup'd fd after close(original) → 8 ✓");
+        } else {
+            test_fail!("efd-refs",
+                "write via dup'd fd after close(original) = {} (want 8)", w);
+            ok = false;
+        }
+        let mut rbuf = [0u8; 8];
+        let n = dispatch(SYS_READ, dupfd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+        if n != 8 || u64::from_le_bytes(rbuf) != 7 {
+            test_fail!("efd-refs", "read via dup'd fd = {} val={} (want 8/7)",
+                n, u64::from_le_bytes(rbuf));
+            ok = false;
+        }
+        let _ = dispatch(SYS_CLOSE, dupfd as u64, 0, 0, 0, 0, 0);
+        if crate::ipc::eventfd::debug_ref_count(id) != 0 {
+            test_fail!("efd-refs", "refs after closing both fds = {} (want 0)",
+                crate::ipc::eventfd::debug_ref_count(id));
+            ok = false;
+        }
+    }
+
+    if ok {
+        test_pass!("eventfd OFD refcount across fork/dup (Test 297)");
+    }
+    ok
+}
+
+// ── Test 298: EPOLLET eventfd re-fires on EVERY write (wakeup-driven) ────────
+//
+// Per eventfd(2): "A write(2) call adds the 8-byte integer value supplied in
+// its buffer to the counter" — and each successful write constitutes a
+// readiness notification.  Per epoll(7), an edge-triggered watcher receives
+// an event for each such notification, including a write that bumps an
+// ALREADY-nonzero counter.  The canonical reactor waker pattern — one thread
+// write(2)s an eventfd to wake a sibling parked in epoll_wait(2), and the
+// reactor deliberately never read(2)s the counter — depends on this: under a
+// pure level-delta model the second write computes "still ready, no new
+// edge" and the parked waiter never returns (the AudioIPC-server reactor
+// park behind the Firefox render gate).  Refs: eventfd(2), epoll(7).
+fn test_298_epollet_eventfd_write_refire() -> bool {
+    test_header!("EPOLLET eventfd re-fires on every write (Test 298)");
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+
+    let pid = crate::proc::current_pid();
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = true;
+            p.subsystem = crate::win32::SubsystemType::Linux;
+        }
+    }
+
+    fn make_ev(events: u32, data: u64) -> [u8; 12] {
+        let mut b = [0u8; 12];
+        b[0..4].copy_from_slice(&events.to_le_bytes());
+        b[4..12].copy_from_slice(&data.to_le_bytes());
+        b
+    }
+    fn ev_events(b: &[u8; 12]) -> u32 {
+        u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+    }
+
+    const EPOLLIN: u32 = 0x0001;
+    const EPOLLET: u32 = 1 << 31;
+    const CTL_ADD: u64 = 1;
+    const SYS_EPOLL_CTL:    u64 = 233;
+    const SYS_EPOLL_WAIT:   u64 = 232;
+    const SYS_EPOLL_CREATE: u64 = 291; // epoll_create1
+    const SYS_EVENTFD2:     u64 = 290;
+    const SYS_CLOSE:        u64 = 3;
+    const SYS_WRITE:        u64 = 1;
+
+    let mut ok = true;
+
+    let efd = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+    let epfd = dispatch(SYS_EPOLL_CREATE, 0, 0, 0, 0, 0, 0);
+    if efd < 0 || epfd < 0 {
+        test_fail!("et-refire", "setup failed efd={} epfd={}", efd, epfd);
+        return false;
+    }
+    {
+        let ev = make_ev(EPOLLIN | EPOLLET, 0xE8);
+        let r = dispatch(SYS_EPOLL_CTL, epfd as u64, CTL_ADD, efd as u64,
+                         ev.as_ptr() as u64, 0, 0);
+        if r != 0 {
+            test_fail!("et-refire", "epoll_ctl(ADD, ET) = {}", r);
+            ok = false;
+        }
+    }
+    let write1 = |efd: i64| -> i64 {
+        let v: u64 = 1;
+        dispatch(SYS_WRITE, efd as u64, (&v as *const u64) as u64, 8, 0, 0, 0)
+    };
+    let wait0 = |epfd: i64| -> (i64, u32) {
+        let mut buf = [[0u8; 12]; 4];
+        let r = dispatch(SYS_EPOLL_WAIT, epfd as u64,
+                         buf[0].as_mut_ptr() as u64, 4, 0, 0, 0);
+        (r, ev_events(&buf[0]))
+    };
+
+    // write #1: counter 0→1 (a genuine rising edge) → one event.
+    if write1(efd) != 8 { test_fail!("et-refire", "write#1 failed"); ok = false; }
+    let (r, ev) = wait0(epfd);
+    if r == 1 && ev & EPOLLIN != 0 {
+        test_println!("  write#1 → wait → 1 event EPOLLIN ✓");
+    } else {
+        test_fail!("et-refire", "wait after write#1: r={} ev={:#x}", r, ev);
+        ok = false;
+    }
+
+    // No intervening write → no event (guards against a spurious refire:
+    // the pending edge must be consumed by the delivery above).
+    let (r, ev) = wait0(epfd);
+    if r == 0 {
+        test_println!("  no new write → wait → 0 events ✓");
+    } else {
+        test_fail!("et-refire",
+            "wait with no new write: r={} ev={:#x} (want 0 — edge not consumed?)",
+            r, ev);
+        ok = false;
+    }
+
+    // write #2 against the NEVER-DRAINED counter (1→2): per eventfd(2) +
+    // epoll(7) this is a fresh notification and MUST re-fire the ET watch.
+    // A level-delta kernel returns 0 here forever — the reactor park bug.
+    if write1(efd) != 8 { test_fail!("et-refire", "write#2 failed"); ok = false; }
+    let (r, ev) = wait0(epfd);
+    if r == 1 && ev & EPOLLIN != 0 {
+        test_println!("  write#2 (counter 1→2, never drained) → wait → 1 event EPOLLIN ✓");
+    } else {
+        test_fail!("et-refire",
+            "wait after write#2 on non-drained counter: r={} ev={:#x} \
+             (want 1/EPOLLIN — wakeup-driven ET re-fire missing)", r, ev);
+        ok = false;
+    }
+
+    // And the edge is again consumed exactly once.
+    let (r, ev) = wait0(epfd);
+    if r != 0 {
+        test_fail!("et-refire",
+            "wait after delivery: r={} ev={:#x} (want 0)", r, ev);
+        ok = false;
+    }
+
+    let _ = dispatch(SYS_CLOSE, epfd as u64, 0, 0, 0, 0, 0);
+    let _ = dispatch(SYS_CLOSE, efd as u64, 0, 0, 0, 0, 0);
+
+    if ok {
+        test_pass!("EPOLLET eventfd re-fires on every write (Test 298)");
     }
     ok
 }


### PR DESCRIPTION
# eventfd: per-OFD refcount across fork/dup/SCM + wakeup-driven EPOLLET re-fire

Implements the two named divergences behind the Firefox render gate (the
AudioIPC `new_client` parent-main park that starves the hello.html renderer of
its LoadURI → no `drawSnapshot` → no PNG).

## Fix A — eventfd open-file-description refcount (PRIMARY)

The eventfd table freed a slot unconditionally on the FIRST `close(2)`, while
`fork(2)` / `dup(2)` / SCM_RIGHTS all duplicate descriptors referring to the
SAME open file description (POSIX.1-2017 §2.14). Captured cascade (lossless
ring, boot#3): parent creates the AudioIPC waker eventfd → forks the renderer →
the child's pre-`execve(2)` close-on-exec scrub `close(49)` **freed the
parent's live slot** → parent's next `write(2)` = EBADF
(`[ERROR audioipc2_server] bind_server failed: Bad file descriptor`) → a later
`eventfd2(2)` recycled the slot, so subsequent writes landed on an unrelated
eventfd and woke nobody → parent main parked forever in cubeb `new_client` →
renderer idle at sc≈3.9k.

Changes (mirroring the existing unix-socket / pipe refcount discipline):

* `ipc/eventfd.rs` — `EventFdEntry.refs`; `create()`=1; `close()` decrements
  and frees (+ wakes parked readers) only at zero; `inc_ref()`.
* `proc/mod.rs` — `inc_eventfd_refs_for_fork` called at all three fd-table
  duplication sites (fork / clone / vfork-style spawn); process-exit fd
  teardown now drops eventfd refs alongside pipes/sockets.
* `syscall/mod.rs` — `sys_dup` / `sys_dup2` bump (covers `fcntl(F_DUPFD)`,
  `F_DUPFD_CLOEXEC`, `dup3(2)`, which route through the same helpers);
  `dup2(2)` displaced-slot drop; `execve(2)` FD_CLOEXEC purge drop;
  `scm_drop_fds` drop for undelivered in-flight batches.
* `subsys/linux/syscall.rs` — SCM_RIGHTS enqueue bump; `close(2)` arm is now a
  reference drop instead of an unconditional free.

## Fix B — EPOLLET on eventfd re-fires on every write (CO-REQUISITE)

The per-watch `et_seen` baseline models edge-triggering as a level delta, so a
`write(2)` against an already-nonzero counter produced no new event: the woken
waiter computed `interest & !seen == 0` and re-parked forever. The AudioIPC
reactor never drains its waker (golden trace: waker eventfd written 7×, never
read, reactor woken every time), so even with Fix A the second write would
strand the parked `epoll_pwait`. Per `eventfd(2)` every successful write is a
readiness notification; per `epoll(7)` an edge-triggered watcher gets one event
per notification.

Each successful eventfd `write()` now records a pending write edge
(`write_edge`); the `epoll_wait(2)` delivery path reports EPOLLIN for an
EPOLLET eventfd watch carrying a pending edge (consuming it exactly once —
folded into a level-delta delivery when both fire), and the park predicate
treats a pending edge as deliverable without consuming it. **Scoped strictly to
eventfd watches** — every other fd type keeps the existing level-delta model.

Lock-order note: the epoll probe path acquires POLL_BELL → eventfd `TABLE`;
the writer side touches them strictly sequentially (TABLE released before the
poll bell rings), so no new lock-order pair is introduced.

Known limitation (documented at `take_write_edge`): with several EPOLLET
watchers on one eventfd, the pending edge is claimed by the first poller to
reach delivery; ET consumers must tolerate wakeup races per `epoll(7)`.

## Out of scope (flagged for follow-up)

`timerfd` / `signalfd` / `inotify` share Fix A's unconditional-free defect
(`subsys/linux/syscall.rs` close(2) arm frees their slots on ANY close, and
none are covered by the fork refcount helpers). Same recipe applies.

## Tests (in-kernel, Test 297 / 298)

* **297 eventfd OFD refcount** — module-level simulated fork (create → inc_ref
  → child close → parent `write` MUST succeed → last close frees, EBADF after)
  + syscall-level dup/close(2)-arm path (close original, write via duplicate,
  refs 2→1→0). Failed `-EBADF` before Fix A.
* **298 EPOLLET re-fire** — write → wait=1 → wait=0 (no spurious) → write on
  NEVER-drained counter → wait MUST =1 → wait=0. Returned 0 before Fix B.
* Test 294's drained/re-armed expectations are preserved (wait#1 consumes the
  pending edge, so the still-level-ready wait#2 correctly reports 0).

T1 suite: 297 + 298 PASS; remaining FAILs are pre-existing environment gaps
(missing `/disk/bin/{hello,tcc,busybox}` fixtures + glibc interp after a
data.img regeneration — the `ci/allow-fail.json` env-gap class — plus the
timing-sensitive `monotonic-rate` under triple-QEMU host load and allow-failed
`firefox_oracle` in the 1 GiB test-mode guest).

## Live verification (V1/V2)

Three fresh KVM boots with a LOCAL-ONLY file:///tmp/hello.html cmdline-swap
testing commit that is NOT part of this PR.
### Results — 3/3 boots rendered the PNG 🎉

Three fresh KVM boots (`--features firefox-test,kdb`, smp=2, 2 GiB), branch =
this PR + the local file:// testing commit:

| Boot | sid | V1 (`bind_server failed` / EBADF in FF stderr) | Outcome |
|---|---|---|---|
| 1 | `53307fbf0413` | **0 hits** | hello.html loaded → screenshot-actors → `/tmp/out.png` written → `exit_group(0)` all procs → **PNG extracted** |
| 2 | `4115b157ce08` | **0 hits** | same chain → **PNG extracted** |
| 3 | `d006022f9749` | **0 hits** | same chain → **PNG extracted** |

All three PNGs: **1366×768, 8-bit RGBA, 30,186 bytes, byte-identical**
(md5 `8c84148acdfd18294e078d975fc37b31`) — a correctly typeset render of
hello.html ("AstryxOS / Firefox 115 ESR — headless screenshot demo").
Extracted via `qemu-harness.py kdb-read-png` (guest-size + PNG-signature
verified); copies archived at `/tmp/render-win-boot{1,2,3}.png`.

The historical park-vs-success flaky split did not reproduce: 3/3 success.
The boot#2-era exit-path wedge also did not reproduce on this lineage — the
`[FUTEX_WAKE_EXIT]` drain grinds (slow, serial-bound) but terminates;
all processes reach zombie, machine stays healthy, kdb responsive.

### Distinct finding (NOT this PR's mechanism — reported separately)

On all 3 boots the firefox-test **supervisor loop on the BSP parks in `hlt`
and never wakes** (GDB: RIP frozen at `_start`+0x1991, byte at RIP-1 =
`0xF4`/HLT, EFLAGS.IF=1; zero `[FFTEST] tick=` status lines the whole run;
`[HB]` heartbeats come from cpu=1 only). The BSP LAPIC timer stops firing
while the sibling CPU keeps TICK_COUNT advancing, which defeats
`idle_tick()`'s starvation detection (`kernel/src/main.rs:1565`), so
`firefox_exited` / the `[FF-OUT-PNG-B64]` auto-emit never run. Firefox
itself is unaffected (runs to completion on CPU1); the PNG was pulled via
kdb instead. Harness/driver-level gap, pre-existing on this lineage.


Refs: POSIX.1-2017 §2.14, close(2), fork(2), dup(2), eventfd(2), epoll(7),
unix(7) SCM_RIGHTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
