### PR TITLE
net/tcp: keep surplus bytes queued on stream recv (bounded drain)

### DIFF
--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -452,7 +452,18 @@ pub enum RecvOutcome {
 /// `recv(2)` on a non-blocking socket with no data pending must return
 /// `EAGAIN` per IEEE 1003.1; returning 0 there is an EOF lie that drives a
 /// polled reactor into a tight re-read loop.
-pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
+///
+/// `max` is the caller's buffer capacity.  For a STREAM (TCP) socket the
+/// dequeue is bounded by it: per IEEE Std 1003.1-2017 §recv / recv(2), data
+/// in excess of the supplied buffer SHALL remain in the receive queue for
+/// subsequent receives.  An unbounded drain here silently destroyed the
+/// surplus, which breaks any exact-length record reader (e.g. a TLS client
+/// reading the 5-byte record header first: the header read consumed the
+/// entire buffered server flight, and the handshake then waited forever for
+/// bytes the kernel had discarded).  For a DATAGRAM (UDP) socket the whole
+/// datagram is returned and the syscall layer truncates (excess datagram
+/// bytes are discarded per §recvfrom — that is SOCK_DGRAM-only semantics).
+pub fn socket_recv_status(id: u64, max: usize) -> Result<RecvOutcome, &'static str> {
     let sockets = SOCKETS.lock();
     let sock = sockets.iter().find(|s| s.id == id)
         .ok_or("socket not found")?;
@@ -484,9 +495,10 @@ pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
                 return Err("not bound");
             }
             let data = if sock.connected && sock.remote_port != 0 {
-                super::tcp::read_from(sock.local_port, sock.remote_ip, sock.remote_port)
+                super::tcp::read_from_n(sock.local_port, sock.remote_ip,
+                                        sock.remote_port, max)
             } else {
-                super::tcp::read(sock.local_port)
+                super::tcp::read_n(sock.local_port, max)
             };
             if !data.is_empty() {
                 crate::proc::proc_metrics::bump_net_read(
@@ -541,7 +553,11 @@ pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
 /// On a non-`Data` outcome the returned address is the connected peer (or a
 /// zero 4-tuple for an unconnected datagram socket), which `recvmsg(2)`
 /// leaves unused because `msg_namelen` is only written on a real message.
-pub fn socket_recv_status_from(id: u64)
+///
+/// `max` bounds the stream dequeue exactly as in [`socket_recv_status`]
+/// (IEEE Std 1003.1-2017 §recv: excess STREAM bytes remain queued; datagram
+/// truncation stays at the syscall layer).
+pub fn socket_recv_status_from(id: u64, max: usize)
     -> Result<(RecvOutcome, Ipv4Address, u16), &'static str>
 {
     let sockets = SOCKETS.lock();
@@ -581,9 +597,10 @@ pub fn socket_recv_status_from(id: u64)
             let peer_ip   = sock.remote_ip;
             let peer_port = sock.remote_port;
             let data = if sock.connected && sock.remote_port != 0 {
-                super::tcp::read_from(sock.local_port, sock.remote_ip, sock.remote_port)
+                super::tcp::read_from_n(sock.local_port, sock.remote_ip,
+                                        sock.remote_port, max)
             } else {
-                super::tcp::read(sock.local_port)
+                super::tcp::read_n(sock.local_port, max)
             };
             if !data.is_empty() {
                 crate::proc::proc_metrics::bump_net_read(
@@ -619,7 +636,10 @@ pub fn socket_recv_status_from(id: u64)
 }
 
 /// Receive data from a socket (non-blocking).
-pub fn socket_recv(id: u64) -> Result<Vec<u8>, &'static str> {
+///
+/// `max` bounds the stream dequeue — see [`socket_recv_status`]
+/// (IEEE Std 1003.1-2017 §recv: excess STREAM bytes remain queued).
+pub fn socket_recv(id: u64, max: usize) -> Result<Vec<u8>, &'static str> {
     let sockets = SOCKETS.lock();
     let sock = sockets.iter().find(|s| s.id == id)
         .ok_or("socket not found")?;
@@ -650,11 +670,11 @@ pub fn socket_recv(id: u64) -> Result<Vec<u8>, &'static str> {
             // RFC 793 §3.8 demultiplexing.  Falls back to the
             // port-only drain only for the legacy single-peer case.
             if sock.connected && sock.remote_port != 0 {
-                Ok(super::tcp::read_from(sock.local_port,
-                                         sock.remote_ip,
-                                         sock.remote_port))
+                Ok(super::tcp::read_from_n(sock.local_port,
+                                           sock.remote_ip,
+                                           sock.remote_port, max))
             } else {
-                Ok(super::tcp::read(sock.local_port))
+                Ok(super::tcp::read_n(sock.local_port, max))
             }
         }
     };

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -1203,6 +1203,21 @@ pub fn has_data_for(local_port: u16,
 }
 
 pub fn read(port: u16) -> Vec<u8> {
+    read_n(port, usize::MAX)
+}
+
+/// Bounded drain: dequeue at most `max` bytes, leaving any surplus in the
+/// receive queue for subsequent reads.
+///
+/// Per IEEE Std 1003.1-2017 §recv and recv(2): on a STREAM socket, data in
+/// excess of the caller's buffer "shall remain in the socket receive queue"
+/// — discarding it corrupts the byte stream.  (Datagram truncation discard
+/// is a property of SOCK_DGRAM only, handled at the syscall layer.)  An
+/// exact-length record reader (read N-byte header, then the body it
+/// announces) is destroyed by an unbounded drain: its first short read
+/// silently consumes the whole queue and every subsequent read blocks for
+/// bytes the peer already sent.
+pub fn read_n(port: u16, max: usize) -> Vec<u8> {
     let mut conns = TCP_CONNECTIONS.lock();
     if let Some(conn) = conns.iter_mut()
         // `Established | CloseWait`: drain any buffered tail that arrived
@@ -1215,11 +1230,19 @@ pub fn read(port: u16) -> Vec<u8> {
                   && matches!(c.state,
                       TcpState::Established | TcpState::CloseWait))
     {
-        let d = conn.recv_buffer.clone();
-        conn.recv_buffer.clear();
-        d
+        drain_up_to(&mut conn.recv_buffer, max)
     } else {
         Vec::new()
+    }
+}
+
+/// Dequeue at most `max` bytes from the front of `buf`, keeping the rest.
+fn drain_up_to(buf: &mut Vec<u8>, max: usize) -> Vec<u8> {
+    if max >= buf.len() {
+        core::mem::take(buf)
+    } else {
+        let rest = buf.split_off(max);
+        core::mem::replace(buf, rest)
     }
 }
 
@@ -1366,6 +1389,13 @@ pub fn test_recv_next(local_port: u16, remote_ip: Ipv4Address,
 ///
 /// Mirrors the shape of [`send_data_to`] / [`close_connection`].
 pub fn read_from(local_port: u16, remote_ip: Ipv4Address, remote_port: u16) -> Vec<u8> {
+    read_from_n(local_port, remote_ip, remote_port, usize::MAX)
+}
+
+/// Bounded 4-tuple drain — see [`read_n`] for the stream-surplus contract
+/// (IEEE Std 1003.1-2017 §recv: excess stream bytes remain queued).
+pub fn read_from_n(local_port: u16, remote_ip: Ipv4Address, remote_port: u16,
+                   max: usize) -> Vec<u8> {
     let mut conns = TCP_CONNECTIONS.lock();
     if let Some(conn) = conns.iter_mut().find(|c| {
         c.local_port  == local_port
@@ -1376,9 +1406,7 @@ pub fn read_from(local_port: u16, remote_ip: Ipv4Address, remote_port: u16) -> V
             && matches!(c.state,
                 TcpState::Established | TcpState::CloseWait)
     }) {
-        let d = conn.recv_buffer.clone();
-        conn.recv_buffer.clear();
-        d
+        drain_up_to(&mut conn.recv_buffer, max)
     } else {
         Vec::new()
     }

--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -425,7 +425,9 @@ pub fn dispatch(
             // same way the Linux personality does — an empty receive on a
             // live socket must not read as a 0-byte EOF, or a polled reader
             // busy-loops.  See recv(2) / IEEE 1003.1 §recv.
-            match crate::net::socket::socket_recv_status(socket_id) {
+            // Bounded by the caller's buffer: excess stream bytes remain
+            // queued for the next receive (IEEE 1003.1 §recv).
+            match crate::net::socket::socket_recv_status(socket_id, buf_len) {
                 Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                     let copy_len = data.len().min(buf_len);
                     if copy_len > 0 {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2116,7 +2116,11 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // (POLLIN|POLLHUP) is left faithful; only the recv return
                 // is corrected so a level-triggered reactor observes EOF,
                 // closes the fd, and stops re-polling it forever.
-                match crate::net::socket::socket_recv_status_from(socket_id) {
+                // Stream-bounded dequeue: pass the caller's buffer length so
+                // excess STREAM bytes stay queued (IEEE 1003.1 §recv); the
+                // datagram arm still returns the whole datagram and the
+                // `.min(len)` below performs the SOCK_DGRAM truncation.
+                match crate::net::socket::socket_recv_status_from(socket_id, len) {
                     Ok((crate::net::socket::RecvOutcome::Data(data), src_ip, src_port)) => {
                         let n = data.len().min(len);
                         if n > 0 {
@@ -2833,7 +2837,9 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     // re-issued recvmsg in a tight loop, never yielding.  Use the
                     // status-aware recv so the two cases get their correct
                     // returns (WouldBlock → -EAGAIN, Eof → 0).
-                    bytes_read = match crate::net::socket::socket_recv_status(socket_id) {
+                    // Bounded by the iovec capacity: excess stream bytes
+                    // remain queued for the next recvmsg (IEEE 1003.1 §recv).
+                    bytes_read = match crate::net::socket::socket_recv_status(socket_id, cap) {
                         Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                             let n = data.len().min(cap);
                             unsafe {
@@ -6460,7 +6466,9 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
         // reader does not mistake an empty queue for EOF and re-read in a
         // busy loop (mirrors the pipe path above, which already separates
         // EOF from would-block).
-        return match crate::net::socket::socket_recv_status(socket_id) {
+        // Bounded by the read(2) buffer: excess stream bytes remain queued
+        // for the next read (IEEE 1003.1 §recv).
+        return match crate::net::socket::socket_recv_status(socket_id, count) {
             Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                 let n = data.len().min(count);
                 unsafe {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1628,6 +1628,23 @@ pub fn run() -> ! {
         if test_tcp_peer_fin_read_closed_edge() { passed += 1; }
     }
 
+    // ── Test 519: TCP stream surplus retention on bounded recv ──────────
+    //
+    // IEEE Std 1003.1-2017 §recv / recv(2): on a STREAM socket, data in
+    // excess of the caller's buffer SHALL remain in the receive queue for
+    // subsequent receives.  Guards the recv(2)/recvfrom(2)/recvmsg(2)/read(2)
+    // arms against the unbounded-drain regression where a short read
+    // silently destroyed every byte beyond the user buffer — which broke
+    // any exact-length record reader (a TLS client reads the 5-byte record
+    // header first; the surplus server flight was discarded and the
+    // handshake waited forever).
+
+    #[cfg(feature = "kdb")]
+    {
+        total += 1;
+        if test_519_tcp_stream_surplus_retention() { passed += 1; }
+    }
+
     // ── Test 282: TCP out-of-order receive reassembly (RFC 9293 §3.10.7.4) ──
     //
     // A segment that arrives ahead of recv_next (a reorder, or after an
@@ -31245,7 +31262,7 @@ fn test_tcp_peer_fin_read_closed_edge() -> bool {
     }
 
     // Drain the tail — read_from must accept CloseWait, not Established only.
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::Data(d)) => {
             if d != TAIL {
                 test_fail!("tcp_peer_fin", "drained {} bytes, expected {} (tail truncated)",
@@ -31272,7 +31289,7 @@ fn test_tcp_peer_fin_read_closed_edge() -> bool {
         test_fail!("tcp_peer_fin", "post-drain: POLLHUP not raised (reader never observes EOF)");
         socket::socket_close(sid); return false;
     }
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::Eof) => {}
         other => {
             test_fail!("tcp_peer_fin", "post-drain: expected EOF, got {:?}", other.is_ok());
@@ -31282,6 +31299,100 @@ fn test_tcp_peer_fin_read_closed_edge() -> bool {
 
     socket::socket_close(sid);
     test_pass!("AF_INET peer-FIN read-closed edge + CloseWait drain");
+    true
+}
+
+// ── Test 519: TCP stream surplus retention on bounded recv ──────────────────
+//
+// IEEE Std 1003.1-2017 §recv / recv(2): for SOCK_STREAM, bytes in excess of
+// the caller's buffer remain in the receive queue; only SOCK_DGRAM discards
+// the excess of a truncated datagram.  Exercises the bounded dequeue end to
+// end on an injected Established TCB:
+//
+//   1. recv with max=5 returns EXACTLY the first 5 bytes,
+//   2. the socket stays readable (POLLIN level holds on the surplus),
+//   3. the next recv returns the remaining bytes in order, byte-exact,
+//   4. the drained-empty socket is WouldBlock (not EOF).
+#[cfg(feature = "kdb")]
+fn test_519_tcp_stream_surplus_retention() -> bool {
+    test_header!("TCP stream surplus retention on bounded recv (Test 519)");
+
+    use crate::net::{tcp, socket};
+    use crate::net::socket::RecvOutcome;
+
+    const LOCAL_PORT: u16 = 47121;
+    // SLIRP gateway as synthetic peer (MAC already ARP-cached, see the
+    // peer-FIN test above) so socket_close's FIN egresses without a poll loop.
+    let peer_ip:   [u8; 4] = [10, 0, 2, 2];
+    let peer_port: u16     = 52346;
+    // Shaped like a TLS server flight: a 5-byte record header followed by a
+    // body — the reader takes the header first, then expects the body to
+    // still be there.
+    const FLIGHT: &[u8] = b"\x16\x03\x03\x00\x1cServerHelloBodyBytes12345678";
+
+    if let Err(e) = tcp::listen(LOCAL_PORT) {
+        test_fail!("tcp_surplus", "listen({}) failed: {}", LOCAL_PORT, e);
+        return false;
+    }
+    if let Err(e) = tcp::test_inject_established(LOCAL_PORT, peer_ip, peer_port, FLIGHT) {
+        test_fail!("tcp_surplus", "inject failed: {}", e);
+        return false;
+    }
+    let sid = socket::socket_create_accepted(LOCAL_PORT, peer_ip, peer_port);
+
+    // (1) Bounded read of the 5-byte record header.
+    match socket::socket_recv_status(sid, 5) {
+        Ok(RecvOutcome::Data(d)) => {
+            if d != &FLIGHT[..5] {
+                test_fail!("tcp_surplus", "header read returned {} bytes {:x?}, expected first 5",
+                    d.len(), &d[..d.len().min(8)]);
+                socket::socket_close(sid); return false;
+            }
+            test_println!("  recv(max=5) → first 5 bytes exactly ✓");
+        }
+        other => {
+            test_fail!("tcp_surplus", "header read not Data (ok={})", other.is_ok());
+            socket::socket_close(sid); return false;
+        }
+    }
+
+    // (2) Surplus must still be queued and readable (POLLIN level).
+    if !socket::socket_has_data(sid) {
+        test_fail!("tcp_surplus",
+            "surplus discarded: socket not readable after bounded read (stream bytes lost)");
+        socket::socket_close(sid); return false;
+    }
+    test_println!("  surplus still queued, socket readable ✓");
+
+    // (3) The rest arrives in order, byte-exact.
+    match socket::socket_recv_status(sid, usize::MAX) {
+        Ok(RecvOutcome::Data(d)) => {
+            if d != &FLIGHT[5..] {
+                test_fail!("tcp_surplus", "body read returned {} bytes, expected {} (stream corrupted)",
+                    d.len(), FLIGHT.len() - 5);
+                socket::socket_close(sid); return false;
+            }
+            test_println!("  second recv → remaining {} bytes in order ✓", d.len());
+        }
+        other => {
+            test_fail!("tcp_surplus", "body read not Data (ok={})", other.is_ok());
+            socket::socket_close(sid); return false;
+        }
+    }
+
+    // (4) Fully drained, peer live → WouldBlock (not EOF).
+    match socket::socket_recv_status(sid, usize::MAX) {
+        Ok(RecvOutcome::WouldBlock) => {
+            test_println!("  drained live socket → WouldBlock ✓");
+        }
+        other => {
+            test_fail!("tcp_surplus", "drained socket not WouldBlock (ok={})", other.is_ok());
+            socket::socket_close(sid); return false;
+        }
+    }
+
+    socket::socket_close(sid);
+    test_pass!("TCP stream surplus retention on bounded recv (Test 519)");
     true
 }
 
@@ -31612,7 +31723,7 @@ fn test_af_inet_accept_end_to_end() -> bool {
     }
 
     // Drain A — must see exactly RX_A.
-    let got_a = match socket::socket_recv(sid_a) {
+    let got_a = match socket::socket_recv(sid_a, usize::MAX) {
         Ok(d) => d,
         Err(e) => {
             test_fail!("test270", "socket_recv A failed: {}", e);
@@ -31629,7 +31740,7 @@ fn test_af_inet_accept_end_to_end() -> bool {
         test_fail!("test270", "B's recv buffer drained when only A was read");
         return false;
     }
-    let got_b = match socket::socket_recv(sid_b) {
+    let got_b = match socket::socket_recv(sid_b, usize::MAX) {
         Ok(d) => d,
         Err(e) => {
             test_fail!("test270", "socket_recv B failed: {}", e);
@@ -32722,7 +32833,7 @@ fn test_recv_status_from_udp_returns_sender_4tuple() -> bool {
     udp::send([127, 0, 0, 1], CLIENT_PORT, SERVER_PORT, PAYLOAD);
     crate::net::poll();
 
-    let (outcome, src_ip, src_port) = match socket::socket_recv_status_from(id) {
+    let (outcome, src_ip, src_port) = match socket::socket_recv_status_from(id, usize::MAX) {
         Ok(t) => t,
         Err(e) => {
             socket::socket_close(id);
@@ -32775,7 +32886,7 @@ fn test_recv_status_from_udp_wouldblock_when_empty() -> bool {
         return false;
     }
 
-    let r = socket::socket_recv_status_from(id);
+    let r = socket::socket_recv_status_from(id, usize::MAX);
     socket::socket_close(id);
 
     match r {
@@ -33038,7 +33149,7 @@ fn test_shutdown_tcp_rd_returns_eof() -> bool {
     };
     let _ = socket::socket_shutdown(id, socket::SHUT_RD);
     // Even though the TCB has QUEUED bytes pending, recv must return EOF.
-    let recv_result = socket::socket_recv(id);
+    let recv_result = socket::socket_recv(id, usize::MAX);
     let _ = tcp::abort(PORT);
     match recv_result {
         Ok(d) if d.is_empty() => {
@@ -33097,7 +33208,7 @@ fn test_shutdown_tcp_rdwr_breaks_both() -> bool {
         Some(i) => i, None => return false,
     };
     let _ = socket::socket_shutdown(id, socket::SHUT_RDWR);
-    let recv_ok    = matches!(socket::socket_recv(id), Ok(ref d) if d.is_empty());
+    let recv_ok    = matches!(socket::socket_recv(id, usize::MAX), Ok(ref d) if d.is_empty());
     let send_epipe = matches!(socket::socket_send(id, b"x"), Err("EPIPE"));
     let state = tcp::snapshot_connections().iter()
         .find(|c| c.local_port == PORT && c.remote_ip == peer).map(|c| c.state);
@@ -48401,7 +48512,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
     }
 
     // (1) Empty queue, socket live → MUST be WouldBlock (the storm-fix case).
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::WouldBlock) => {
             test_println!("  empty bound UDP socket → WouldBlock ✓");
         }
@@ -48436,7 +48547,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
         pkt.extend_from_slice(PAYLOAD);
         crate::net::udp::handle_udp([10, 0, 2, 2], [10, 0, 2, 15], &pkt);
     }
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::Data(d)) if d == PAYLOAD => {
             test_println!("  injected datagram → Data({} bytes) ✓", d.len());
         }
@@ -48454,7 +48565,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
     // (3) After draining, the queue is empty again → WouldBlock, NOT Eof.
     //     This is the regression's heart: an empty-but-live socket must never
     //     read as EOF.
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::WouldBlock) => {
             test_println!("  drained socket → WouldBlock (not EOF) ✓");
         }
@@ -48470,7 +48581,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
         test_fail!("recv_eagain", "socket_shutdown(SHUT_RD) failed");
         return false;
     }
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::Eof) => {
             test_println!("  after SHUT_RD → Eof ✓");
         }


### PR DESCRIPTION
Every AF_INET stream receive arm (recvfrom nr=45, recvmsg nr=47 TCP arm, read(2) on socket fds, native SYS_RECVFROM) drained the connection's entire receive queue, copied `min(queued, buflen)` to the caller, and discarded the surplus.

Per recv(2) / IEEE Std 1003.1-2017: for SOCK_STREAM, bytes in excess of the caller's buffer shall remain in the receive queue; discard-on-truncation is datagram-only semantics.

Impact: any consumer doing exact-size framed reads on TCP stalls — e.g. a TLS record layer reading a 5-byte record header destroyed the rest of the buffered server flight, then polled forever for bytes that no longer existed. Verified on the wire: pre-fix, every TLS connection stalled after ClientHello with the complete server flight ACKed but unread; post-fix, TLS 1.2 and 1.3 handshakes complete and a full HTTPS request/response runs on the same connection.

Fix: bounded drain at the source — `tcp::read_n`/`read_from_n(max)`; socket-layer recv entry points take the caller's capacity; syscall arms pass the user buffer length. UDP datagram semantics untouched. POLLIN level follows from buffer non-emptiness.

Test 519: recv(max=5) returns exactly 5, surplus stays queued and readable, second recv returns the remainder byte-exact, drained-live socket is WouldBlock. Neighboring TCP/recv tests pass. (Note: feature-branch PRs receive no CI — verification was live wire-capture + test-mode boot; review gate to follow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)