### PR TITLE
vfs: path-resolution cache with negative-dentry support — first-TLS-handshake cert-verify storm fix

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -458,6 +458,14 @@ pub fn run() -> ! {
     total += 1;
     if test_ext2_inode_cache_coherence() { passed += 1; }
 
+    // ── Test 16f: VFS path cache (positive + negative dentries) ─────────
+    total += 1;
+    if test_vfs_path_cache_negative_create() { passed += 1; }
+    total += 1;
+    if test_vfs_path_cache_rename_unlink() { passed += 1; }
+    total += 1;
+    if test_vfs_path_cache_storm() { passed += 1; }
+
     // ── Test 18: Signal Delivery Trampoline ─────────────────────────────
 
     total += 1;
@@ -8284,6 +8292,394 @@ fn test_ext2_inode_cache_coherence() -> bool {
 
     test_println!("  write/truncate/chmod refresh + unlink invalidation all coherent");
     test_pass!("EXT2-INODE-CACHE-COHERENCE");
+    true
+}
+
+// ============================================================================
+// Test 16f: VFS path cache — positive + NEGATIVE dentry correctness + perf
+// ============================================================================
+//
+// `vfs::path_cache` memoizes per-component lookup outcomes in front of
+// `resolve_path_opts`, including negative (ENOENT) outcomes — the pattern
+// sqlite uses for hot-journal detection (`<db>-journal` / `<db>-wal` probed
+// before every transaction).  A stale negative entry would make a newly
+// created file invisible to stat(2)/open(2) — a direct POSIX pathname-
+// resolution violation — so these tests drive every invalidation edge
+// through the public VFS API on the root ramfs (the cache is FS-agnostic;
+// ext2 exercises the identical VFS-layer code path).
+
+/// The sqlite-journal pattern: repeat-stat a missing name (negative entry
+/// populated + hit), then CREATE the name — the very next stat MUST see it.
+/// Covers create_file, mkdir, symlink, link materialization edges.
+fn test_vfs_path_cache_negative_create() -> bool {
+    test_header!("VFS-PATHCACHE-NEG-CREATE: cached ENOENT invalidated by create/mkdir/symlink/link");
+    use crate::vfs::{self, path_cache, VfsError};
+
+    let _ = vfs::mkdir("/tmp/pc_neg");
+
+    // 1. Probe a missing name twice: first populates the negative entry,
+    //    second must be served from it (neg-hit counter advances).
+    match vfs::stat("/tmp/pc_neg/cert9.db-journal") {
+        Err(VfsError::NotFound) => {}
+        other => {
+            test_fail!("VFS-PATHCACHE-NEG-CREATE", "cold probe: want ENOENT, got {:?}", other.map(|s| s.inode));
+            return false;
+        }
+    }
+    let (_, neg_before, _, _, _, _) = path_cache::stats();
+    match vfs::stat("/tmp/pc_neg/cert9.db-journal") {
+        Err(VfsError::NotFound) => {}
+        other => {
+            test_fail!("VFS-PATHCACHE-NEG-CREATE", "warm probe: want ENOENT, got {:?}", other.map(|s| s.inode));
+            return false;
+        }
+    }
+    let (_, neg_after, _, _, _, _) = path_cache::stats();
+    if neg_after <= neg_before {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE",
+            "warm ENOENT probe did not hit the negative cache (neg_hits {} -> {})",
+            neg_before, neg_after);
+        return false;
+    }
+
+    // 2. THE killer assertion: create the file; stat must now see it.
+    if let Err(e) = vfs::create_file("/tmp/pc_neg/cert9.db-journal") {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "create_file failed: {:?}", e);
+        return false;
+    }
+    match vfs::stat("/tmp/pc_neg/cert9.db-journal") {
+        Ok(_) => {}
+        Err(e) => {
+            test_fail!("VFS-PATHCACHE-NEG-CREATE",
+                "STALE NEGATIVE ENTRY: file created but stat still fails: {:?}", e);
+            return false;
+        }
+    }
+
+    // 3. mkdir materialization: probe missing dir, create, probe again.
+    let _ = vfs::stat("/tmp/pc_neg/subdir");     // populate negative
+    let _ = vfs::stat("/tmp/pc_neg/subdir");     // hit negative
+    if let Err(e) = vfs::mkdir("/tmp/pc_neg/subdir") {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "mkdir failed: {:?}", e);
+        return false;
+    }
+    if vfs::stat("/tmp/pc_neg/subdir").is_err() {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "STALE NEGATIVE ENTRY after mkdir");
+        return false;
+    }
+    // ...and resolution THROUGH the new directory must work too.
+    if let Err(e) = vfs::create_file("/tmp/pc_neg/subdir/inner") {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "create through new dir failed: {:?}", e);
+        return false;
+    }
+    if vfs::stat("/tmp/pc_neg/subdir/inner").is_err() {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "resolve through fresh dir failed");
+        return false;
+    }
+
+    // 4. symlink materialization: probe missing, symlink, lstat must see it.
+    let _ = vfs::stat("/tmp/pc_neg/ln");         // populate negative
+    if let Err(e) = vfs::symlink("/tmp/pc_neg/ln", "/tmp/pc_neg/cert9.db-journal") {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "symlink failed: {:?}", e);
+        return false;
+    }
+    match vfs::lstat("/tmp/pc_neg/ln") {
+        Ok(st) if st.file_type == crate::vfs::FileType::SymLink => {}
+        Ok(st) => {
+            test_fail!("VFS-PATHCACHE-NEG-CREATE", "lstat of new symlink wrong type {:?}", st.file_type);
+            return false;
+        }
+        Err(e) => {
+            test_fail!("VFS-PATHCACHE-NEG-CREATE", "STALE NEGATIVE ENTRY after symlink: {:?}", e);
+            return false;
+        }
+    }
+    // Follow it: stat() through the symlink must reach the target.
+    if vfs::stat("/tmp/pc_neg/ln").is_err() {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "stat through new symlink failed");
+        return false;
+    }
+
+    // 5. link(2) materialization: probe missing, hard-link, stat must see it.
+    let _ = vfs::stat("/tmp/pc_neg/hardlink");   // populate negative
+    if let Err(e) = vfs::link("/tmp/pc_neg/cert9.db-journal", "/tmp/pc_neg/hardlink") {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "link failed: {:?}", e);
+        return false;
+    }
+    if vfs::stat("/tmp/pc_neg/hardlink").is_err() {
+        test_fail!("VFS-PATHCACHE-NEG-CREATE", "STALE NEGATIVE ENTRY after link(2)");
+        return false;
+    }
+
+    test_println!("  create/mkdir/symlink/link all invalidate cached ENOENT correctly");
+    test_pass!("VFS-PATHCACHE-NEG-CREATE");
+    true
+}
+
+/// Positive-entry invalidation: unlink and rename (BOTH names) must drop
+/// stale positive entries, and rename must drop the destination's negative.
+fn test_vfs_path_cache_rename_unlink() -> bool {
+    test_header!("VFS-PATHCACHE-RENAME-UNLINK: positive/negative flip on rename + unlink");
+    use crate::vfs::{self, VfsError};
+
+    let _ = vfs::mkdir("/tmp/pc_mv");
+    if vfs::create_file("/tmp/pc_mv/a").is_err() {
+        test_fail!("VFS-PATHCACHE-RENAME-UNLINK", "setup create failed");
+        return false;
+    }
+
+    // Warm the cache on both names: "a" positive, "b" negative.
+    let _ = vfs::stat("/tmp/pc_mv/a");
+    let _ = vfs::stat("/tmp/pc_mv/a");
+    match vfs::stat("/tmp/pc_mv/b") {
+        Err(VfsError::NotFound) => {}
+        other => {
+            test_fail!("VFS-PATHCACHE-RENAME-UNLINK", "b should not exist yet: {:?}", other.map(|s| s.inode));
+            return false;
+        }
+    }
+
+    // rename a -> b: cached positive "a" must die, cached negative "b" must die.
+    if let Err(e) = vfs::rename("/tmp/pc_mv/a", "/tmp/pc_mv/b") {
+        test_fail!("VFS-PATHCACHE-RENAME-UNLINK", "rename failed: {:?}", e);
+        return false;
+    }
+    match vfs::stat("/tmp/pc_mv/a") {
+        Err(VfsError::NotFound) => {}
+        other => {
+            test_fail!("VFS-PATHCACHE-RENAME-UNLINK",
+                "STALE POSITIVE: old name 'a' still resolves after rename: {:?}",
+                other.map(|s| s.inode));
+            return false;
+        }
+    }
+    match vfs::stat("/tmp/pc_mv/b") {
+        Ok(_) => {}
+        Err(e) => {
+            test_fail!("VFS-PATHCACHE-RENAME-UNLINK",
+                "STALE NEGATIVE: new name 'b' invisible after rename: {:?}", e);
+            return false;
+        }
+    }
+
+    // Recreate "a" (covers negative re-populated by the post-rename stat).
+    if vfs::create_file("/tmp/pc_mv/a").is_err()
+        || vfs::stat("/tmp/pc_mv/a").is_err()
+    {
+        test_fail!("VFS-PATHCACHE-RENAME-UNLINK", "recreate of old name 'a' invisible");
+        return false;
+    }
+
+    // unlink b: cached positive "b" must die.
+    let _ = vfs::stat("/tmp/pc_mv/b"); // ensure positive entry present
+    if let Err(e) = vfs::remove("/tmp/pc_mv/b") {
+        test_fail!("VFS-PATHCACHE-RENAME-UNLINK", "remove failed: {:?}", e);
+        return false;
+    }
+    match vfs::stat("/tmp/pc_mv/b") {
+        Err(VfsError::NotFound) => {}
+        other => {
+            test_fail!("VFS-PATHCACHE-RENAME-UNLINK",
+                "STALE POSITIVE: 'b' still resolves after unlink: {:?}",
+                other.map(|s| s.inode));
+            return false;
+        }
+    }
+
+    // ...and the create-after-unlink round-trip (journal lifecycle).
+    if vfs::create_file("/tmp/pc_mv/b").is_err() || vfs::stat("/tmp/pc_mv/b").is_err() {
+        test_fail!("VFS-PATHCACHE-RENAME-UNLINK", "recreate after unlink invisible");
+        return false;
+    }
+
+    test_println!("  rename (both names) + unlink + recreate all coherent");
+    test_pass!("VFS-PATHCACHE-RENAME-UNLINK");
+    true
+}
+
+/// The resolve-storm microbench (the necko-deadline shape): N repeat ENOENT
+/// probes of one path.  Post-warm probes must be served entirely from the
+/// negative cache — zero FS dispatches — and the measured TSC cost must
+/// collapse relative to the flushed-cold walk.
+fn test_vfs_path_cache_storm() -> bool {
+    test_header!("VFS-PATHCACHE-STORM: repeat ENOENT probes collapse to cache hits");
+    use crate::vfs::{self, path_cache, VfsError};
+
+    #[inline]
+    fn rdtsc() -> u64 {
+        let lo: u32;
+        let hi: u32;
+        unsafe {
+            core::arch::asm!("rdtsc", out("eax") lo, out("edx") hi,
+                             options(nomem, nostack, preserves_flags));
+        }
+        ((hi as u64) << 32) | lo as u64
+    }
+
+    // A directory with enough entries that a cold final-component miss does
+    // non-trivial scan work (the shape of a profile dir holding cert9.db).
+    let _ = vfs::mkdir("/tmp/pc_storm");
+    for i in 0..100u32 {
+        let name = alloc::format!("/tmp/pc_storm/filler_{:03}", i);
+        if vfs::create_file(&name).is_err() {
+            test_fail!("VFS-PATHCACHE-STORM", "setup create #{} failed", i);
+            return false;
+        }
+    }
+
+    const N: usize = 200;
+    let probe = "/tmp/pc_storm/cert9.db-wal";
+
+    // Cold loop: flush before every probe so each walk pays the full
+    // per-component dispatch cost.
+    let mut cold_tsc: u64 = 0;
+    for _ in 0..N {
+        path_cache::_test_flush();
+        let t0 = rdtsc();
+        match vfs::stat(probe) {
+            Err(VfsError::NotFound) => {}
+            other => {
+                test_fail!("VFS-PATHCACHE-STORM", "cold probe: want ENOENT, got {:?}", other.map(|s| s.inode));
+                return false;
+            }
+        }
+        cold_tsc += rdtsc().wrapping_sub(t0);
+    }
+
+    // Warm loop: one priming probe, then N probes that must all be served
+    // from the negative cache.
+    path_cache::_test_flush();
+    let _ = vfs::stat(probe); // prime
+    let (_, neg_before, miss_before, ins_before, _, _) = path_cache::stats();
+    let mut warm_tsc: u64 = 0;
+    for _ in 0..N {
+        let t0 = rdtsc();
+        match vfs::stat(probe) {
+            Err(VfsError::NotFound) => {}
+            other => {
+                test_fail!("VFS-PATHCACHE-STORM", "warm probe: want ENOENT, got {:?}", other.map(|s| s.inode));
+                return false;
+            }
+        }
+        warm_tsc += rdtsc().wrapping_sub(t0);
+    }
+    let (_, neg_after, miss_after, ins_after, _, _) = path_cache::stats();
+
+    // Counter proof of zero FS dispatch: every warm probe must end in a
+    // negative hit, and the warm loop must neither miss on the final
+    // component nor insert anything new.  (Each probe walks 2 cached
+    // intermediate components + the negative final component.)
+    let neg_hits = neg_after - neg_before;
+    if neg_hits < N {
+        test_fail!("VFS-PATHCACHE-STORM",
+            "warm probes not served from negative cache: neg_hits {} < {}", neg_hits, N);
+        return false;
+    }
+    if ins_after != ins_before {
+        test_fail!("VFS-PATHCACHE-STORM",
+            "warm probes re-inserted entries ({} -> {}) — final component missed",
+            ins_before, ins_after);
+        return false;
+    }
+    let _ = miss_before;
+    let _ = miss_after;
+
+    // TSC sanity on ramfs: the warm walk skips every per-component FS
+    // dispatch, but a ramfs cold walk is itself all-in-memory, so the
+    // ramfs delta only shows the dispatch overhead (~2× observed), not the
+    // disk-I/O collapse this cache exists for.  Assert strict improvement
+    // here; the orders-of-magnitude assertion runs on ext2 below.
+    let cold_avg = cold_tsc / N as u64;
+    let warm_avg = warm_tsc / N as u64;
+    test_println!("  ramfs: cold avg {} TSC/probe, warm avg {} TSC/probe ({} probes, ratio {}%)",
+        cold_avg, warm_avg, N,
+        if cold_tsc > 0 { warm_tsc.saturating_mul(100) / cold_tsc } else { 0 });
+    if warm_avg >= cold_avg {
+        test_fail!("VFS-PATHCACHE-STORM",
+            "ramfs post-warm cost did not improve: warm {} vs cold {} TSC/probe",
+            warm_avg, cold_avg);
+        return false;
+    }
+
+    // ── ext2 leg: the disk-backed collapse (the necko-deadline shape) ────
+    // A cold final-component miss on ext2 scans the directory's data
+    // blocks on virtio-blk every probe; a warm probe is a single in-memory
+    // negative-cache hit.  This is exactly the cert9.db-journal/-wal storm
+    // and the delta must be a different order of magnitude.
+    if crate::vfs::stat("/disk").is_ok() {
+        let _ = vfs::mkdir("/disk/pc_storm");
+        let mut setup_ok = true;
+        for i in 0..40u32 {
+            let name = alloc::format!("/disk/pc_storm/filler_{:03}", i);
+            if vfs::create_file(&name).is_err() {
+                setup_ok = false;
+                break;
+            }
+        }
+        if !setup_ok {
+            test_fail!("VFS-PATHCACHE-STORM", "ext2 setup create failed");
+            return false;
+        }
+
+        const M: usize = 100;
+        let dprobe = "/disk/pc_storm/cert9.db-wal";
+
+        let mut dcold_tsc: u64 = 0;
+        for _ in 0..M {
+            path_cache::_test_flush();
+            let t0 = rdtsc();
+            match vfs::stat(dprobe) {
+                Err(VfsError::NotFound) => {}
+                other => {
+                    test_fail!("VFS-PATHCACHE-STORM",
+                        "ext2 cold probe: want ENOENT, got {:?}", other.map(|s| s.inode));
+                    return false;
+                }
+            }
+            dcold_tsc += rdtsc().wrapping_sub(t0);
+        }
+
+        path_cache::_test_flush();
+        let _ = vfs::stat(dprobe); // prime
+        let (_, dneg_before, _, dins_before, _, _) = path_cache::stats();
+        let mut dwarm_tsc: u64 = 0;
+        for _ in 0..M {
+            let t0 = rdtsc();
+            match vfs::stat(dprobe) {
+                Err(VfsError::NotFound) => {}
+                other => {
+                    test_fail!("VFS-PATHCACHE-STORM",
+                        "ext2 warm probe: want ENOENT, got {:?}", other.map(|s| s.inode));
+                    return false;
+                }
+            }
+            dwarm_tsc += rdtsc().wrapping_sub(t0);
+        }
+        let (_, dneg_after, _, dins_after, _, _) = path_cache::stats();
+        if dneg_after - dneg_before < M || dins_after != dins_before {
+            test_fail!("VFS-PATHCACHE-STORM",
+                "ext2 warm probes not pure cache hits (neg {} -> {}, ins {} -> {})",
+                dneg_before, dneg_after, dins_before, dins_after);
+            return false;
+        }
+
+        let dcold_avg = dcold_tsc / M as u64;
+        let dwarm_avg = dwarm_tsc / M as u64;
+        test_println!("  ext2:  cold avg {} TSC/probe, warm avg {} TSC/probe ({} probes, ratio {}%)",
+            dcold_avg, dwarm_avg, M,
+            if dcold_tsc > 0 { dwarm_tsc.saturating_mul(100) / dcold_tsc } else { 0 });
+        // Conservative collapse bound: warm must be < 10% of cold.
+        if dwarm_avg.saturating_mul(10) > dcold_avg {
+            test_fail!("VFS-PATHCACHE-STORM",
+                "ext2 post-warm cost did not collapse: warm {} vs cold {} TSC/probe (want <10%)",
+                dwarm_avg, dcold_avg);
+            return false;
+        }
+    } else {
+        test_println!("  ext2 leg skipped: /disk not mounted in this configuration");
+    }
+
+    test_pass!("VFS-PATHCACHE-STORM");
     true
 }
 

--- a/kernel/src/vfs/ext2.rs
+++ b/kernel/src/vfs/ext2.rs
@@ -2537,6 +2537,14 @@ impl FileSystemOps for Ext2Fs {
         "ext2"
     }
 
+    /// ext2 opts in to the VFS path cache (positive + negative dentries):
+    /// names are case-sensitive byte strings, every directory mutation flows
+    /// through the VFS helpers (which invalidate), and the namespace is not
+    /// externally synthesized.  See `FileSystemOps::lookup_cacheable`.
+    fn lookup_cacheable(&self) -> bool {
+        true
+    }
+
     fn stat(&self, inode: u64) -> VfsResult<FileStat> {
         let ino = self.read_inode(inode).ok_or(VfsError::NotFound)?;
         let file_type = match ino.mode & S_IFMT {

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -17,6 +17,7 @@
 pub mod ext2;
 pub mod fat32;
 pub mod ntfs;
+pub mod path_cache;
 pub mod ramfs;
 pub mod tmpfs;
 pub mod procfs;
@@ -316,6 +317,27 @@ pub trait FileSystemOps: Send + Sync {
     /// update `i_uid` / `i_gid` and write the inode back).
     fn chown(&self, _inode: u64, _uid: u32, _gid: u32) -> VfsResult<()> {
         Err(VfsError::Unsupported)
+    }
+
+    /// May the VFS-level path cache ([`path_cache`]) memoize `lookup`
+    /// outcomes (positive **and negative** dentries) for this filesystem?
+    ///
+    /// Opt-in, default `false`.  `true` is only safe when ALL hold:
+    ///
+    /// 1. Every directory mutation (create / unlink / rmdir / rename /
+    ///    symlink / link) flows through the VFS helpers in this module,
+    ///    which invalidate the affected cache keys.  A filesystem whose
+    ///    namespace changes through any other channel must stay `false`.
+    /// 2. Name lookup is case-sensitive byte-string comparison.  On a
+    ///    case-insensitive filesystem (FAT32, NTFS) differently-cased
+    ///    queries alias one directory entry, and exact-string invalidation
+    ///    cannot cover the aliases — stale entries would survive.
+    /// 3. The namespace is not synthesized from live kernel state.
+    ///    Pseudo-filesystems (procfs, sysfs) materialize and retire entries
+    ///    (e.g. `/proc/<pid>`) with no VFS-visible mutation event, so any
+    ///    cached entry — especially a negative one — goes stale silently.
+    fn lookup_cacheable(&self) -> bool {
+        false
     }
 }
 
@@ -762,6 +784,9 @@ pub fn mount(path: &str, fs: Box<dyn FileSystemOps>, root_inode: u64) {
         fs: Arc::from(fs),
         root_inode,
     });
+    // Mount-table change: the new mount may shadow cached lookups under its
+    // path — flush the path cache (see path_cache invalidation contract).
+    path_cache::flush();
 }
 
 /// Initialize disks: mount in-memory test image at /mnt, then probe for
@@ -1494,27 +1519,88 @@ fn resolve_path_opts(
             return Err(VfsError::TimedOut);
         }
 
-        // Snapshot the current FS handle before each dispatch.  Holding
-        // `MOUNTS` across `lookup` / `stat` / `readlink` would deadlock if
-        // the FS implementation faults on a user-supplied or file-backed
-        // buffer — the page-fault handler also needs `MOUNTS` to demand-page
-        // the missing frame, but this thread already holds it (#82).
-        let fs = fs_at(cur_mount).ok_or(VfsError::NotFound)?.0;
+        // ── Path-cache fast path ────────────────────────────────────────
+        // `path_cache` memoizes per-component lookup outcomes — positive
+        // (child inode + file type, so the symlink-check `stat` dispatch is
+        // skipped too) and negative (memoized ENOENT, the sqlite
+        // journal-probe pattern).  A hit replaces ONLY the `lookup`+`stat`
+        // dispatches below; the deadline, trace, symlink-follow and
+        // mount-crossing logic are identical on both paths.  `".."` is
+        // never cached: rename(2) of a directory rewires its parent linkage
+        // without touching any key invalidation could name.  Entries are
+        // only ever inserted for filesystems that opt in via
+        // `lookup_cacheable` (see the trait doc), so a hit implies the FS
+        // already consented — the hit path needs no FS handle at all.
+        let cache_this = *component != "..";
+        let cached = if cache_this {
+            path_cache::lookup(cur_mount, cur_inode, component)
+        } else {
+            None
+        };
 
-        // Lookup this component in the current directory.
-        let child_inode = fs.lookup(cur_inode, component)?;
+        let (child_inode, child_file_type) = match cached {
+            Some(path_cache::Cached::Negative) => return Err(VfsError::NotFound),
+            Some(path_cache::Cached::Positive { child, ftype }) => (child, ftype),
+            None => {
+                // Generation snapshot BEFORE the FS dispatch: if any
+                // directory mutation invalidates concurrently, the insert
+                // below is dropped instead of caching a stale outcome
+                // (see path_cache module docs, "the insert/mutate race").
+                let gen = path_cache::generation();
 
-        // Check if the child is a symlink.
-        let child_stat = fs.stat(child_inode)?;
+                // Snapshot the current FS handle before each dispatch.  Holding
+                // `MOUNTS` across `lookup` / `stat` / `readlink` would deadlock if
+                // the FS implementation faults on a user-supplied or file-backed
+                // buffer — the page-fault handler also needs `MOUNTS` to demand-page
+                // the missing frame, but this thread already holds it (#82).
+                let fs = fs_at(cur_mount).ok_or(VfsError::NotFound)?.0;
+                let cacheable = cache_this && fs.lookup_cacheable();
 
-        if child_stat.file_type == FileType::SymLink {
+                // Lookup this component in the current directory.
+                let child_inode = match fs.lookup(cur_inode, component) {
+                    Ok(c) => c,
+                    Err(VfsError::NotFound) => {
+                        // Memoize the ENOENT so repeat probes of the same
+                        // missing name (sqlite -journal/-wal hot-journal
+                        // checks) skip the directory scan entirely.
+                        if cacheable {
+                            path_cache::insert(
+                                gen, cur_mount, cur_inode, component,
+                                path_cache::Cached::Negative,
+                            );
+                        }
+                        return Err(VfsError::NotFound);
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                // Check if the child is a symlink.
+                let child_stat = fs.stat(child_inode)?;
+                if cacheable {
+                    path_cache::insert(
+                        gen, cur_mount, cur_inode, component,
+                        path_cache::Cached::Positive {
+                            child: child_inode,
+                            ftype: child_stat.file_type,
+                        },
+                    );
+                }
+                (child_inode, child_stat.file_type)
+            }
+        };
+
+        if child_file_type == FileType::SymLink {
             // If this is the final component and we were asked not to follow,
             // return the symlink inode directly.
             if is_final && !follow_final {
                 return Ok((cur_mount, child_inode));
             }
 
-            // Read the symlink target.
+            // Read the symlink target.  Re-fetch the FS handle here: on the
+            // path-cache hit path no handle was fetched (the hit replaces
+            // the lookup/stat dispatches), and `readlink` must observe the
+            // live target — symlink targets are intentionally NOT cached.
+            let fs = fs_at(cur_mount).ok_or(VfsError::NotFound)?.0;
             let target = fs.readlink(child_inode)?;
 
             // Build the new path: target + remaining components after this one.
@@ -1610,6 +1696,9 @@ pub fn create_file(path: &str) -> VfsResult<()> {
     let (mount_idx, parent_inode, name) = resolve_parent(path)?;
     let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
     fs.create_file(parent_inode, &name)?;
+    // The name now exists: drop any cached (negative) lookup outcome so the
+    // next resolve observes the new file (path_cache invalidation contract).
+    path_cache::invalidate(mount_idx, parent_inode, &name);
     // Fire IN_CREATE on the parent directory.
     let (parent_dir, filename) = split_parent_name(path);
     crate::ipc::inotify::notify_event(parent_dir, filename, crate::ipc::inotify::IN_CREATE, 0);
@@ -1623,6 +1712,8 @@ pub fn mkdir(path: &str) -> VfsResult<()> {
         let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
         fs.create_dir(parent_inode, &name)?;
     }
+    // The name now exists: drop any cached (negative) lookup outcome.
+    path_cache::invalidate(mount_idx, parent_inode, &name);
     // Fire IN_CREATE|IN_ISDIR on the parent directory.
     let (parent_dir, filename) = split_parent_name(path);
     crate::ipc::inotify::notify_event(
@@ -1661,6 +1752,10 @@ pub fn remove(path: &str) -> VfsResult<()> {
     } else {
         fs.remove(parent_inode, &name)?;
     }
+    // The name is gone (immediately in both branches — deferred deletion
+    // only keeps the *inode* alive, the directory entry is already
+    // unlinked): drop any cached positive lookup outcome.
+    path_cache::invalidate(mount_idx, parent_inode, &name);
     // Fire IN_DELETE on the parent directory.
     let (parent_dir, filename) = split_parent_name(path);
     crate::ipc::inotify::notify_event(parent_dir, filename, crate::ipc::inotify::IN_DELETE, 0);
@@ -1810,6 +1905,11 @@ pub fn rename(old_path: &str, new_path: &str) -> VfsResult<()> {
         let fs = fs_at(old_mount).ok_or(VfsError::NotFound)?.0;
         fs.rename(old_parent, &old_name, new_parent, &new_name)?;
     }
+    // Per rename(2) BOTH names changed binding: the old name no longer
+    // exists (drop its positive entry) and the new name now exists,
+    // possibly replacing an earlier ENOENT probe (drop its negative entry).
+    path_cache::invalidate(old_mount, old_parent, &old_name);
+    path_cache::invalidate(new_mount, new_parent, &new_name);
     // Fire IN_MOVED_FROM / IN_MOVED_TO with a shared non-zero cookie.
     // Use a simple increment from the tick counter as the cookie.
     let cookie = (crate::arch::x86_64::irq::TICK_COUNT
@@ -1826,6 +1926,8 @@ pub fn symlink(link_path: &str, target: &str) -> VfsResult<()> {
     let (mount_idx, parent_inode, name) = resolve_parent(link_path)?;
     let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
     fs.symlink(parent_inode, &name, target)?;
+    // The link name now exists: drop any cached (negative) lookup outcome.
+    path_cache::invalidate(mount_idx, parent_inode, &name);
     Ok(())
 }
 
@@ -1846,6 +1948,8 @@ pub fn link(old_path: &str, new_path: &str) -> VfsResult<()> {
         let fs = fs_at(new_mount).ok_or(VfsError::NotFound)?.0;
         fs.link(target_inode, new_parent, &new_name)?;
     }
+    // The new name now exists: drop any cached (negative) lookup outcome.
+    path_cache::invalidate(new_mount, new_parent, &new_name);
     // A new name appeared in the target directory — fire IN_CREATE so inotify
     // watchers (and any dentry-cache invalidation riding on it) observe it.
     let (new_dir, new_fn) = split_parent_name(new_path);
@@ -2145,6 +2249,11 @@ pub fn open(pid: crate::proc::Pid, path: &str, open_flags: u32) -> VfsResult<usi
             let (m, parent, name) = resolve_parent(lookup_path)?;
             let fs = fs_at(m).ok_or(VfsError::NotFound)?.0;
             let ino = fs.create_file(parent, &name)?;
+            // The failed resolve above may have cached a negative entry for
+            // this name; the create materialized it — invalidate so the
+            // next resolve (including the sqlite journal-probe pattern:
+            // stat ENOENT → open(O_CREAT) → stat) sees the file.
+            path_cache::invalidate(m, parent, &name);
             (m, ino, true)
         }
         Err(e) => return Err(e),
@@ -3070,6 +3179,9 @@ pub fn sys_mount(
                     root_inode: ri,
                 });
             }
+            // Mount-table change: flush the path cache (the new mount
+            // shadows cached lookups under its path).
+            path_cache::flush();
             crate::serial_println!("[VFS] mount: {} mounted at '{}' (rdonly={})", fstype, target, rdonly);
             0
         }
@@ -3083,6 +3195,8 @@ pub fn sys_mount(
                 fs: Arc::new(proc_fs),
                 root_inode: proc_root,
             });
+            // Mount-table change: flush the path cache.
+            path_cache::flush();
             crate::serial_println!("[VFS] mount: procfs mounted at '{}'", target);
             0
         }
@@ -3161,6 +3275,10 @@ pub fn sys_umount(target: &str, _flags: u64) -> i64 {
         }
         mounts.remove(mount_idx);
     }
+    // Mount-table change: `Vec::remove` SHIFTED every mount index above
+    // `mount_idx`, and the path cache keys entries by mount index — a flush
+    // is mandatory, not just hygienic (stale keys would alias other mounts).
+    path_cache::flush();
 
     // Any remaining open-fd mount_idx values that were above `mount_idx` are
     // now off-by-one.  Fix them up so existing fds stay valid.

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -3274,11 +3274,16 @@ pub fn sys_umount(target: &str, _flags: u64) -> i64 {
             return -2; // ENOENT — raced with another umount
         }
         mounts.remove(mount_idx);
+        // Mount-table change: `Vec::remove` SHIFTED every mount index above
+        // `mount_idx`, and the path cache keys entries by mount index — a
+        // flush is mandatory, not just hygienic (stale keys would alias
+        // other mounts).  The flush must complete before the MOUNTS lock is
+        // released: a resolver that can observe the shifted table must never
+        // be able to read a pre-shift cache entry, or a cross-mount
+        // inode-number collision could serve a child from the wrong
+        // filesystem.
+        path_cache::flush();
     }
-    // Mount-table change: `Vec::remove` SHIFTED every mount index above
-    // `mount_idx`, and the path cache keys entries by mount index — a flush
-    // is mandatory, not just hygienic (stale keys would alias other mounts).
-    path_cache::flush();
 
     // Any remaining open-fd mount_idx values that were above `mount_idx` are
     // now off-by-one.  Fix them up so existing fds stay valid.

--- a/kernel/src/vfs/path_cache.rs
+++ b/kernel/src/vfs/path_cache.rs
@@ -1,0 +1,284 @@
+//! VFS-level path-component lookup cache (positive **and negative** dentries).
+//!
+//! # What this caches
+//!
+//! `resolve_path_opts` walks a pathname component by component (IEEE Std
+//! 1003.1-2017 §4.13 *Pathname Resolution*), dispatching one `lookup` plus
+//! one `stat` into the concrete filesystem per component.  On a disk-backed
+//! filesystem each dispatch can cost block-device round-trips, and under
+//! load every round-trip is amplified by scheduler deschedule gaps.  Repeat
+//! resolutions of the same components — including repeat *failed* lookups of
+//! names that do not exist (e.g. sqlite probing `<db>-journal` / `<db>-wal`
+//! before every transaction, per the documented hot-journal detection in
+//! sqlite's locking protocol) — pay that full cost every time.
+//!
+//! This module memoizes the per-component outcome:
+//!
+//! * **positive entry** — `(mount, dir_inode, name) → (child_inode,
+//!   file_type)`: a subsequent walk skips both the `lookup` and the
+//!   symlink-check `stat` dispatch.
+//! * **negative entry** — `(mount, dir_inode, name) → ENOENT`: a subsequent
+//!   walk fails immediately with `NotFound`, with **zero** FS dispatches.
+//!
+//! The cache is strictly a fast path in front of `resolve_path_opts`; on a
+//! miss the resolver behaves byte-identically to the uncached walk (same
+//! dispatch order, same error propagation, same mount-crossing and symlink
+//! semantics, same no-progress deadline).
+//!
+//! # Correctness: invalidation rules
+//!
+//! A stale **negative** entry makes a newly created file invisible
+//! (`stat(2)` keeps returning ENOENT after a successful `creat(2)` — a
+//! direct POSIX violation and an instant sqlite breaker); a stale
+//! **positive** entry resurrects an unlinked name.  Every VFS operation
+//! that can change a `(directory, name) → object` binding therefore
+//! invalidates the affected key(s) **after** the concrete-FS mutation
+//! completes:
+//!
+//! | Operation (vfs/mod.rs helper)     | Invalidated key(s)                  |
+//! |-----------------------------------|-------------------------------------|
+//! | `create_file` / `open(O_CREAT)`   | (mount, parent, name)               |
+//! | `mkdir`                           | (mount, parent, name)               |
+//! | `remove` (unlink / rmdir, both    | (mount, parent, name)               |
+//! |   immediate and deferred-unlink)  |                                     |
+//! | `rename`                          | BOTH (mount, old_parent, old_name)  |
+//! |                                   | AND  (mount, new_parent, new_name)  |
+//! | `symlink`                         | (mount, parent, name)               |
+//! | `link`                            | (mount, parent, name)               |
+//! | mount-table change (mount/umount) | full flush (mount indices shift on  |
+//! |                                   | umount; new mounts shadow paths)    |
+//!
+//! Invalidation runs *after* the FS mutation so a racing reader can never
+//! observe the old cached binding once the mutating call has returned to
+//! its caller (linearizability at the syscall boundary).
+//!
+//! # Correctness: the insert/mutate race (SMP)
+//!
+//! Lookup-miss inserts are *not* atomic with the FS dispatch they memoize:
+//!
+//! ```text
+//!   CPU A: cache miss → fs.lookup("x") = ENOENT      (dispatch, no lock)
+//!   CPU B: create("x") completes → invalidate("x")   (removes nothing)
+//!   CPU A: insert negative "x"                       (STALE — never expires!)
+//! ```
+//!
+//! Mature kernels close this by holding the parent directory lock across
+//! both the FS operation and the cache update; this VFS dispatches lock-free
+//! (never holds a lock across FS calls — see the #82/#476 deadlock class),
+//! so instead every insert carries a **generation guard**: the resolver
+//! snapshots the cache generation *before* the FS dispatch, and the insert
+//! is dropped if *any* invalidation bumped the generation in between.  The
+//! guard is deliberately global (coarse): invalidations are rare compared
+//! to lookups, so the cost of a rejected insert is one extra future miss.
+//! Either ordering of A's insert vs B's invalidate is now safe:
+//! insert-then-invalidate → the entry is removed; invalidate-then-insert →
+//! the generation mismatch drops the insert.
+//!
+//! # What is deliberately NOT cached
+//!
+//! * `".."` components — `rename(2)` of a directory rewires its parent
+//!   linkage without touching the keys this cache could invalidate by name.
+//!   (`"."` never reaches the cache; the resolver filters it.)
+//! * Filesystems that do not opt in via `FileSystemOps::lookup_cacheable`.
+//!   Pseudo-filesystems (procfs, sysfs) synthesize entries from live kernel
+//!   state with no VFS-visible mutation events, and case-insensitive
+//!   filesystems (FAT32, NTFS) would alias differently-cased keys that
+//!   exact-string invalidation cannot cover.  Opt-in is the safe default
+//!   for any future filesystem.
+//!
+//! # Bounds and eviction
+//!
+//! FIFO eviction over a fixed capacity ([`PATH_CACHE_CAP`] entries).  FIFO
+//! keeps the hit path a single map probe under a leaf spinlock (no LRU
+//! stamp maintenance) and is O(1) per eviction; the workloads this cache
+//! targets (repeat probes of a small hot set during library load / database
+//! open) have far fewer distinct hot keys than the capacity, so recency
+//! tracking buys nothing measurable.  Memory is bounded by `2 ×
+//! PATH_CACHE_CAP` keys (lazy FIFO deletion, see `compact`).
+//!
+//! # Lock discipline
+//!
+//! One global spinlock, strictly a **leaf** lock: every critical section is
+//! a point operation on the in-memory maps (no FS dispatch, no `MOUNTS`, no
+//! `PROCESS_TABLE`, no allocation-heavy work beyond the inserted key, never
+//! held across `schedule()` or blocking I/O).
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, VecDeque};
+use alloc::string::String;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use super::FileType;
+
+/// Maximum number of cached entries (positive + negative combined).
+///
+/// Sizing: a Firefox-class userspace touches ~10⁵ files during startup, but
+/// the *hot* resolution set (repeatedly probed names: shared-library search
+/// paths, sqlite journal probes, config re-stats) is a few hundred keys.
+/// 4096 entries ≈ a few hundred KiB worst-case heap (key strings dominate)
+/// — bounded regardless of file churn.
+const PATH_CACHE_CAP: usize = 4096;
+
+/// A memoized per-component lookup outcome.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Cached {
+    /// The name does not exist in the directory (`fs.lookup` → `NotFound`).
+    Negative,
+    /// The name resolved to `child` with file type `ftype` (the type is
+    /// cached so the resolver can skip the symlink-check `stat` dispatch;
+    /// an inode's type can only change if the name is unlinked and
+    /// recreated, which invalidates the entry).
+    Positive { child: u64, ftype: FileType },
+}
+
+struct Inner {
+    /// (mount_idx, dir_inode) → name → outcome.  Nested so the hit path can
+    /// probe with `&str` (no per-lookup `String` allocation).
+    map: BTreeMap<(usize, u64), BTreeMap<String, Cached>>,
+    /// Total entries across all inner maps.
+    count: usize,
+    /// Insertion order for FIFO eviction.  Lazily pruned: invalidated
+    /// entries may leave stale keys here, popped harmlessly at eviction
+    /// time and bounded by `compact`.
+    fifo: VecDeque<(usize, u64, String)>,
+    /// Invalidation generation.  Bumped (under this same lock) by every
+    /// invalidate/flush; inserts snapshotted before the FS dispatch are
+    /// dropped if it moved (see module docs, "the insert/mutate race").
+    gen: u64,
+}
+
+impl Inner {
+    const fn new() -> Self {
+        Self {
+            map: BTreeMap::new(),
+            count: 0,
+            fifo: VecDeque::new(),
+            gen: 0,
+        }
+    }
+
+    fn remove_key(&mut self, mount: usize, dir: u64, name: &str) -> bool {
+        if let Some(inner) = self.map.get_mut(&(mount, dir)) {
+            if inner.remove(name).is_some() {
+                self.count -= 1;
+                if inner.is_empty() {
+                    self.map.remove(&(mount, dir));
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Evict FIFO-oldest entries until `count <= PATH_CACHE_CAP`, and bound
+    /// the FIFO itself (stale keys from invalidations) at `2 × CAP`.
+    fn compact(&mut self) {
+        while self.count > PATH_CACHE_CAP || self.fifo.len() > 2 * PATH_CACHE_CAP {
+            match self.fifo.pop_front() {
+                Some((m, d, n)) => {
+                    // May be a stale key (already invalidated) — remove_key
+                    // is a no-op then, and the pop alone shrinks the FIFO.
+                    self.remove_key(m, d, &n);
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+static CACHE: spin::Mutex<Inner> = spin::Mutex::new(Inner::new());
+
+// ── Statistics (test + diagnostic surface; no correctness role) ────────────
+static POS_HITS: AtomicUsize = AtomicUsize::new(0);
+static NEG_HITS: AtomicUsize = AtomicUsize::new(0);
+static MISSES: AtomicUsize = AtomicUsize::new(0);
+static INSERTS: AtomicUsize = AtomicUsize::new(0);
+static REJECTED_INSERTS: AtomicUsize = AtomicUsize::new(0);
+static INVALIDATIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// Probe the cache for one path component.  `None` = miss (caller must
+/// dispatch into the FS).  Hit-path cost: one leaf-spinlock acquire and two
+/// `BTreeMap` probes; no allocation.
+pub fn lookup(mount: usize, dir: u64, name: &str) -> Option<Cached> {
+    let cache = CACHE.lock();
+    let hit = cache
+        .map
+        .get(&(mount, dir))
+        .and_then(|inner| inner.get(name).copied());
+    drop(cache);
+    match hit {
+        Some(Cached::Positive { .. }) => { POS_HITS.fetch_add(1, Ordering::Relaxed); }
+        Some(Cached::Negative) => { NEG_HITS.fetch_add(1, Ordering::Relaxed); }
+        None => { MISSES.fetch_add(1, Ordering::Relaxed); }
+    }
+    hit
+}
+
+/// Snapshot the invalidation generation.  Call **before** the FS `lookup`
+/// dispatch whose outcome will be inserted; pass the snapshot to [`insert`].
+pub fn generation() -> u64 {
+    CACHE.lock().gen
+}
+
+/// Insert a memoized outcome, unless any invalidation ran since
+/// `gen_snapshot` was taken (in which case the outcome may be stale and is
+/// dropped — the next walk simply misses and re-dispatches).
+pub fn insert(gen_snapshot: u64, mount: usize, dir: u64, name: &str, value: Cached) {
+    let mut cache = CACHE.lock();
+    if cache.gen != gen_snapshot {
+        drop(cache);
+        REJECTED_INSERTS.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    let inner = cache.map.entry((mount, dir)).or_insert_with(BTreeMap::new);
+    if inner.insert(String::from(name), value).is_none() {
+        cache.count += 1;
+        cache.fifo.push_back((mount, dir, String::from(name)));
+        cache.compact();
+    }
+    drop(cache);
+    INSERTS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Drop the entry for `(mount, dir, name)` and bump the generation.  Must be
+/// called **after** the concrete-FS mutation that changes the binding has
+/// completed (create / unlink / rmdir / rename(×2) / symlink / link).
+pub fn invalidate(mount: usize, dir: u64, name: &str) {
+    let mut cache = CACHE.lock();
+    cache.gen += 1;
+    cache.remove_key(mount, dir, name);
+    drop(cache);
+    INVALIDATIONS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Drop everything and bump the generation.  Required on any mount-table
+/// change: `umount` shifts the mount indices that key this cache, and a new
+/// mount may shadow paths under it.
+pub fn flush() {
+    let mut cache = CACHE.lock();
+    cache.gen += 1;
+    cache.map.clear();
+    cache.fifo.clear();
+    cache.count = 0;
+    drop(cache);
+    INVALIDATIONS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// (pos_hits, neg_hits, misses, inserts, rejected_inserts, invalidations).
+pub fn stats() -> (usize, usize, usize, usize, usize, usize) {
+    (
+        POS_HITS.load(Ordering::Relaxed),
+        NEG_HITS.load(Ordering::Relaxed),
+        MISSES.load(Ordering::Relaxed),
+        INSERTS.load(Ordering::Relaxed),
+        REJECTED_INSERTS.load(Ordering::Relaxed),
+        INVALIDATIONS.load(Ordering::Relaxed),
+    )
+}
+
+/// Test-only: empty the cache so a benchmark can measure the cold path.
+#[doc(hidden)]
+pub fn _test_flush() {
+    flush();
+}

--- a/kernel/src/vfs/ramfs.rs
+++ b/kernel/src/vfs/ramfs.rs
@@ -117,6 +117,14 @@ impl FileSystemOps for RamFs {
         "ramfs"
     }
 
+    /// ramfs opts in to the VFS path cache (positive + negative dentries):
+    /// names are case-sensitive byte strings, every directory mutation flows
+    /// through the VFS helpers (which invalidate), and the namespace is not
+    /// externally synthesized.  See `FileSystemOps::lookup_cacheable`.
+    fn lookup_cacheable(&self) -> bool {
+        true
+    }
+
     fn create_file(&self, parent_inode: u64, name: &str) -> VfsResult<u64> {
         let mut inodes = self.inodes.lock();
 

--- a/kernel/src/vfs/tmpfs.rs
+++ b/kernel/src/vfs/tmpfs.rs
@@ -60,6 +60,13 @@ impl FileSystemOps for TmpFs {
         "tmpfs"
     }
 
+    /// tmpfs opts in to the VFS path cache (positive + negative dentries) on
+    /// the same grounds as the embedded ramfs it delegates to: case-sensitive
+    /// names, all mutations via the VFS helpers, no external synthesis.
+    fn lookup_cacheable(&self) -> bool {
+        true
+    }
+
     fn create_file(&self, parent_inode: u64, name: &str) -> VfsResult<u64> {
         self.check_writable()?;
         self.inner.create_file(parent_inode, name)


### PR DESCRIPTION
## What

Adds `vfs::path_cache` — a bounded, SMP-safe VFS-layer path-component lookup cache with **negative-entry (cached-ENOENT) support** — as a pure fast path in front of `resolve_path_opts`, plus the per-FS opt-in (`FileSystemOps::lookup_cacheable`: ext2/ramfs/tmpfs opt in; procfs/sysfs/FAT32/NTFS stay uncached).

## Why (GATE #2 of the BBC real-website chain)

With the TCP recv truncation fixed (#546), the first-attempt TLS handshake still took **+40–50 s** (client reply after server flight), blowing necko's 30 s handshake deadline → channel abort → no page. The latency was NSS cert verification doing wall-to-wall uncached path resolution: **191× `cert9.db-journal` + 189× `cert9.db-wal` ENOENT probes** (sqlite's documented hot-journal detection), each a full multi-component cache-less walk with directory scans on virtio-blk. The ext2 inode half of the walk cost is already served by the merged inode cache (#522); the missing piece was memoizing the lookups themselves — especially the *failed* ones.

## Design

| Aspect | Choice |
|---|---|
| Keying | `(mount_idx, dir_inode, name)` → positive `(child_inode, file_type)` / negative |
| Capacity / eviction | 4096 entries, FIFO (O(1), no hit-path stamp maintenance; hot sets ≪ capacity), lazy FIFO pruning bounded at 2× cap |
| Hit path | one leaf-spinlock acquire + two BTreeMap probes, zero allocation, zero FS dispatch (positive hits also skip the symlink-check `stat`) |
| Invalidation | after-mutation in every VFS helper: create_file / open(O_CREAT) / mkdir / remove (immediate + deferred unlink) / rename (**both names**, per rename(2)) / symlink / link; full flush on mount-table change (umount shifts mount indices) |
| SMP insert/mutate race | generation guard — resolver snapshots the cache generation before the FS dispatch; any concurrent invalidation drops the insert. No lock is ever held across an FS dispatch (#82/#476 class) |
| Deliberately uncached | `..` components (rename(2) of a directory rewires parent linkage invisibly to name-keyed invalidation); non-opt-in filesystems |
| Resolver semantics | byte-identical on miss: same dispatch order, error propagation, symlink depth, mount-crossing, no-progress deadline (IEEE Std 1003.1-2017 §4.13) |

## Verification

**T1 (new in-kernel tests, all PASS):**
- `VFS-PATHCACHE-NEG-CREATE` — cached ENOENT then create/mkdir/symlink/link: next stat sees the name (the sqlite-journal pattern)
- `VFS-PATHCACHE-RENAME-UNLINK` — rename flips both names; unlink kills the positive; recreate visible
- `VFS-PATHCACHE-STORM` — counter-proof that post-warm ENOENT probes are pure cache hits (zero FS dispatch / zero inserts); TSC collapse on the ext2 leg: **cold 243,851 → warm 4,608 TSC/probe (1.9%, 53×)**; ramfs leg strict improvement (50%)

**T2 (full test-mode suite):** 379/388 — FAIL set identical to the known baseline envelope (missing-fixture + monotonic-rate + epollet(#538) classes; cross-checked against 5 historical runs). No new FAILs.

## 🎉 V (live BBC run: this branch + #546 + #545 + local-only `https://bbc.com/news` cmdline)

**Upstream unmodified headless Firefox rendered a real-website screenshot PNG on AstryxOS for the first time.**

- First-attempt TLS handshake CREPLY delta (server-flight-done → client-reply, measured on the wire): boot 1 **2.7 s**, boot 2 **30.6 s** for the very first connection then **2.7–7.6 s** for every subsequent fresh handshake and **4 ms** resumed (was 40–50 s on every attempt → channel aborts). Necko's 30 s deadline no longer kills the chain.
- Boot 2 rode the full ladder: TLS → ~564 KB HTTPS payload over ~51 connections (Fastly + bbc.co.uk origin + Akamai static) → `[GATE] screenshot-actors` → full-page snapshot → **`/tmp/out.png` = 1366×7136 RGBA PNG, 1,082,265 bytes** (BBC News front page: masthead, NEWS banner, headline grid, article cards, footer) → **pid 1 `exit_group(0)` clean**. Extracted via `kdb-read-png`, byte-count match, archived.
- Zero `[VFS/resolve] DEADLINE EXCEEDED`, zero panics across both boots (~75 + ~85 min).
- Note for reviewers: the page takes ~10+ min of post-fetch layout/JS on 2 emulated vCPUs before the snapshot fires — waits keyed on serial text like "drawSnapshot" are misleading (no such marker exists in this build); the PNG file write + clean exit are the real signals.
- Residual (follow-up, not this PR): the *first-ever* handshake of a boot is still ~30 s — remaining cold cost is cert/key DB *content* reads (ext2 file reads), not repeat-ENOENT walks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)