### PR TITLE
net/unix: sever peer linkage at teardown — stop slot-recycle cross-channel bleed

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -49,6 +49,14 @@ firefox-test-core = ["heap-canary"]
 # `dump_futex_wait_stack` rbp-chain walker) — trace is a strict superset of the
 # functional core, never a standalone.
 firefox-test-trace = ["firefox-test-core"]
+# `ff-stderr-mirror` — JUST the [FF/stderr] / [FF/write] stdout/stderr mirror,
+# without the rest of the `firefox-test-trace` firehose ([POLL_RET],
+# [VFS/resolve], futex traces).  Lets a perf-profile boot capture a child
+# process's crash/abort text (e.g. an assertion-failure reason printed to
+# fd 2 immediately before exit) while keeping near-perf timing — the full
+# trace profile perturbs scheduling enough to mask timing-dependent failures.
+# Pure diagnostic — no correctness role.
+ff-stderr-mirror = ["firefox-test-core"]
 # Backward-compatible super-feature: `--features firefox-test` enables both the
 # functional core and the full diagnostic trace, so existing debugging
 # invocations are byte-identical to before this split.  Perf/render/CI boots

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -2042,6 +2042,8 @@ fn op_unix_diag(req: &str, out: &mut String) {
                 let _ = write!(out, r#""recv_popped":{},"#, d.recv_popped);
                 let _ = write!(out, r#""read_shutdown":{},"#, d.read_shutdown);
                 let _ = write!(out, r#""write_shutdown":{},"#, d.write_shutdown);
+                let _ = write!(out, r#""rx_eof":{},"#, d.rx_eof);
+                let _ = write!(out, r#""peer_closed":{},"#, d.peer_closed);
                 let _ = write!(out, r#""has_data":{},"#, d.recv_avail > 0);
                 let _ = write!(out, r#""scm_deliverable":{},"#, has_scm_deliv);
                 out.push_str(r#""scm_batches":["#);

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -99,6 +99,21 @@ struct UnixSocket {
     /// the in-memory pipe.
     shut_rd:     bool,
     shut_wr:     bool,
+    /// "No more bytes will ever arrive" — set on this socket when its peer
+    /// performs `shutdown(SHUT_WR)` or fully closes.  Distinct from the local
+    /// `shut_rd` (SHUT_RD discards queued data and EOFs immediately per
+    /// IEEE 1003.1 §shutdown): with `rx_eof` the reader first DRAINS any
+    /// bytes already queued in `recv_buf` and only then observes the orderly
+    /// EOF — the recv(2) contract for a peer that performed an orderly
+    /// shutdown ("return 0 once all queued data is consumed").  Feeds the
+    /// `POLLIN`/`POLLRDHUP` readiness edges via [`read_shutdown`].
+    rx_eof:      bool,
+    /// The peer endpoint has FULLY closed (last open file description gone).
+    /// Set together with severing our `peer_id` back-pointer in [`close`], so
+    /// no code path can ever dereference the freed — and possibly RECYCLED —
+    /// peer slot through us.  Drives `POLLHUP` ([`fully_hung_up`]), the
+    /// always-writable EPIPE fast-path ([`writable`]), and write(2) → -EPIPE.
+    peer_closed: bool,
     /// Count of open file-description references to this socket slot.
     ///
     /// `socket(2)` / `socketpair(2)` initialise this to 1.  Every call that
@@ -148,6 +163,8 @@ impl UnixSocket {
             backlog_len: 0,
             shut_rd:     false,
             shut_wr:     false,
+            rx_eof:      false,
+            peer_closed: false,
             ref_count:   0,
             creator_pid: 0,
             creator_uid: 0,
@@ -169,6 +186,8 @@ impl UnixSocket {
         self.backlog_len = 0;
         self.shut_rd     = false;
         self.shut_wr     = false;
+        self.rx_eof      = false;
+        self.peer_closed = false;
         self.ref_count   = 0;
         self.creator_pid = 0;
         self.creator_uid = 0;
@@ -445,9 +464,28 @@ pub fn write(id: u64, data: &[u8]) -> i64 {
         if s.state != UnixState::Connected { return -32; }
         // SHUT_WR locally → -EPIPE per IEEE 1003.1 §shutdown.
         if s.shut_wr { return -32; }
+        // Peer fully closed → -EPIPE per POSIX write(2)/send(2) on a
+        // stream socket whose peer is gone.  (`peer_id` is severed to
+        // u64::MAX at peer teardown, so the bounds check below also
+        // catches this; the explicit flag keeps the intent readable.)
+        if s.peer_closed { return -32; }
         (s.peer_id, s.kind)
     };
     if peer_id as usize >= MAX_UNIX_SOCKETS { return -32; }
+    // Mutual-pairing gate: only deliver if the resolved peer slot still
+    // points back at US.  The socket table recycles slot indices the moment
+    // a slot's last reference is closed; a stale `peer_id` held across that
+    // recycling would otherwise inject this stream's bytes into an UNRELATED
+    // connection's receive ring (cross-channel corruption).  A connected
+    // pair is mutual by construction (socketpair(2)/connect(2)), so a
+    // mismatch can only mean "freed and possibly recycled" → the write must
+    // observe -EPIPE, exactly as if the peer had closed (POSIX send(2)).
+    {
+        let peer = &t.0[peer_id as usize];
+        if peer.state != UnixState::Connected || peer.peer_id != id {
+            return -32;
+        }
+    }
 
     if kind == SockKind::SeqPacket {
         // SEQPACKET: an entire message must fit in the receiver's ring AND
@@ -535,7 +573,14 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
     if s.kind == SockKind::SeqPacket {
         // SEQPACKET: dequeue exactly one message, truncating any tail that
         // does not fit per `man 7 unix` §SOCK_SEQPACKET.
-        if s.seq_head == s.seq_tail { return Err(-11); } // EAGAIN — no message
+        if s.seq_head == s.seq_tail {
+            // No queued message.  If the peer's write side is gone
+            // (orderly shutdown or full close), report EOF — but only
+            // AFTER the queue is empty: recv(2) requires queued data to
+            // be returned before the 0-byte orderly-shutdown indication.
+            if s.rx_eof { return Ok((0, 0)); }
+            return Err(-11); // EAGAIN — no message
+        }
         let msg_len = s.seq_lens[s.seq_head] as usize;
         s.seq_head = (s.seq_head + 1) % SEQ_QUEUE_CAP;
 
@@ -555,7 +600,13 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
         result  = Ok((copied, discard));
     } else {
         // STREAM: byte-stream — copy as many bytes as fit, no boundaries.
-        if s.recv_available() == 0 { return Err(-11); }
+        if s.recv_available() == 0 {
+            // Drain-then-EOF (recv(2)): once the ring is empty AND the peer
+            // can never push more bytes (peer SHUT_WR or peer fully closed),
+            // the read observes the orderly EOF.  Queued bytes always win.
+            if s.rx_eof { return Ok((0, 0)); }
+            return Err(-11);
+        }
         let copied = s.pop(buf);
         drained = copied;
         result  = Ok((copied, 0));
@@ -594,7 +645,16 @@ pub fn shutdown(id: u64, shut_rd_flag: bool, shut_wr_flag: bool) -> i64 {
     if shut_rd_flag { s.shut_rd = true; }
     if shut_wr_flag { s.shut_wr = true; }
     if shut_wr_flag && (peer_id as usize) < MAX_UNIX_SOCKETS {
-        t.0[peer_id as usize].shut_rd = true;
+        let p = &mut t.0[peer_id as usize];
+        // Mutual-pairing gate (see `write`): never flip half-close state on
+        // a slot that no longer points back at us — after slot recycling it
+        // belongs to an UNRELATED connection, and a stale SHUT_WR here would
+        // EOF-kill that innocent stream.  Also: the peer's read direction is
+        // marked `rx_eof` (drain-then-EOF per recv(2)), NOT `shut_rd` —
+        // bytes we pushed before half-closing must remain readable.
+        if p.state == UnixState::Connected && p.peer_id == id {
+            p.rx_eof = true;
+        }
     }
     // Drop the table lock before ringing — per `man 2 shutdown` and
     // `man 7 unix`, a half-close surfaces on the peer as an orderly
@@ -668,8 +728,24 @@ pub fn close(id: u64) {
     let mut ring = false;
     if (peer_id as usize) < MAX_UNIX_SOCKETS {
         let peer = &mut t.0[peer_id as usize];
-        if peer.state == UnixState::Connected {
-            peer.shut_rd = true;
+        // Mutual-pairing gate: only notify the peer if it still points back
+        // at the slot we just freed.  Slot indices are recycled the moment a
+        // slot's last reference drops; without this check, closing a STALE
+        // survivor (one whose own peer died earlier) would flip half-close
+        // state on whatever UNRELATED connection re-allocated the index.
+        if peer.state == UnixState::Connected && peer.peer_id == id {
+            // The peer survives us:
+            //  * `rx_eof` — its reads drain any queued bytes, then observe
+            //    the orderly EOF (recv(2): data first, then 0).
+            //  * `peer_closed` — its writes fail -EPIPE, poll reports
+            //    POLLHUP (full hang-up; POSIX poll(2)).
+            //  * SEVER its back-pointer: our slot index is about to become
+            //    recyclable, and any later dereference of it through the
+            //    survivor (write/shutdown/close/SCM enqueue) would reach an
+            //    unrelated connection.  u64::MAX fails every bounds check.
+            peer.rx_eof      = true;
+            peer.peer_closed = true;
+            peer.peer_id     = u64::MAX;
             ring = true;
         }
     }
@@ -721,7 +797,11 @@ pub fn read_shutdown(id: u64) -> bool {
     let t = TABLE.lock();
     let s = &t.0[id as usize];
     if s.state == UnixState::Free { return true; }
-    s.shut_rd
+    // `rx_eof` (peer SHUT_WR or peer close) raises the same POLLIN/POLLRDHUP
+    // readiness edges as a local SHUT_RD: the read side can no longer block
+    // (queued bytes are returned, then 0).  Edge TIMING is identical to the
+    // pre-`rx_eof` behaviour, which flipped `shut_rd` directly.
+    s.shut_rd || s.rx_eof
 }
 
 /// Returns true on a *full* hang-up — the SHUTDOWN_MASK / TCP_CLOSE
@@ -746,6 +826,10 @@ pub fn fully_hung_up(id: u64) -> bool {
     let s = &t.0[id as usize];
     if s.state == UnixState::Free { return true; }
     if s.shut_rd && s.shut_wr { return true; }
+    // Peer fully closed — recorded as a flag at teardown time (the peer's
+    // slot index is severed/recyclable, so probing `t.0[peer].state` would
+    // race with re-allocation and is no longer meaningful).
+    if s.peer_closed { return true; }
     let peer = s.peer_id;
     if peer == u64::MAX { return false; }
     if (peer as usize) >= MAX_UNIX_SOCKETS { return false; }
@@ -780,6 +864,7 @@ pub fn writable(id: u64) -> bool {
     if s.state == UnixState::Free { return true; }     // closed: write → EPIPE, no block
     if s.state != UnixState::Connected { return true; } // not connected: never blocks
     if s.shut_wr { return true; }                       // SHUT_WR: write → EPIPE, no block
+    if s.peer_closed { return true; }                   // peer gone: write → EPIPE, no block
     let peer = s.peer_id;
     if peer == u64::MAX || (peer as usize) >= MAX_UNIX_SOCKETS { return true; }
     let peer = &t.0[peer as usize];
@@ -930,6 +1015,8 @@ pub fn diag_for(id: u64) -> Option<UnixDiag> {
         recv_popped: s.recv_popped,
         read_shutdown: s.shut_rd,
         write_shutdown: s.shut_wr,
+        rx_eof: s.rx_eof,
+        peer_closed: s.peer_closed,
     })
 }
 
@@ -944,6 +1031,10 @@ pub struct UnixDiag {
     pub recv_popped: u64,
     pub read_shutdown: bool,
     pub write_shutdown: bool,
+    /// Peer write side gone (SHUT_WR or full close) — reads drain then EOF.
+    pub rx_eof: bool,
+    /// Peer endpoint fully closed; `peer_id` has been severed to u64::MAX.
+    pub peer_closed: bool,
 }
 
 pub fn state(id: u64) -> UnixState {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -6813,8 +6813,11 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     // ~45 MB log) and has no correctness role — it transcribes every tracked
     // write(2) to COM1, one PIO VM-exit per byte under KVM.  Gated on the
     // *-trace features so the functional `firefox-test-core` / plain `test-mode`
-    // builds run identically without the spew.
-    #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace"))]
+    // builds run identically without the spew.  `ff-stderr-mirror` enables
+    // JUST this mirror (no other firehose) for near-perf-timing capture of a
+    // child's abort/assertion text — see kernel/Cargo.toml.
+    #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace",
+              feature = "ff-stderr-mirror"))]
     {
         let pid = crate::proc::current_pid_lockless();
         if pid == 1 || crate::syscall::ring::is_tracked(pid) {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -732,6 +732,10 @@ pub fn run() -> ! {
     total += 1;
     if test_unix_pollout_writable_gate() { passed += 1; }
 
+    // ── AF_UNIX peer-close: sever pairing, drain-then-EOF, no recycle bleed ─
+    total += 1;
+    if test_unix_peer_close_sever_and_recycle() { passed += 1; }
+
     // ── Test 54: AF_UNIX bind/listen/connect/accept ───────────────────────
 
     total += 1;
@@ -15265,6 +15269,137 @@ fn test_unix_socketpair() -> bool {
     crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
 
     test_pass!("AF_UNIX socketpair round-trip");
+    true
+}
+
+// ── AF_UNIX peer-close: sever pairing, drain-then-EOF, no recycle bleed ─────────
+//
+// Proves the slot-recycling safety contract of the global AF_UNIX socket table
+// against POSIX (recv(2), send(2), poll(2)) and `man 7 unix`:
+//   (1) Drain-then-EOF — bytes queued by the peer before it fully closed are
+//       still returned by read(); only THEN does read() report the orderly
+//       EOF (recv(2): queued data first, then 0).
+//   (2) write() on the survivor returns -EPIPE (peer gone), never "success
+//       into nowhere".
+//   (3) The survivor reports POLLHUP (fully_hung_up) + read_shutdown + writable
+//       (write can no longer block).
+//   (4) NO RECYCLE BLEED: after the dead peer's slot index is re-allocated to a
+//       brand-new pair, neither write() nor shutdown() nor close() on the stale
+//       survivor may touch the new pair — no injected bytes, no spurious EOF.
+//       (This was the live Gate-1 failure shape: a stale survivor's writes /
+//       half-close state landing on a freshly-spawned process's IPC channel.)
+fn test_unix_peer_close_sever_and_recycle() -> bool {
+    use crate::net::unix;
+    test_header!("AF_UNIX peer-close severing + slot-recycle isolation");
+    let creds = unix::PeerCreds { pid: 0, uid: 0, gid: 0 };
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream, creds);
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("unix_sever", "socketpair returned MAX");
+        return false;
+    }
+
+    // Queue 5 bytes b→a, then fully close b.  a's reads must drain the bytes
+    // FIRST and only then observe EOF.
+    let n = unix::write(b, b"HELLO");
+    if n != 5 {
+        test_fail!("unix_sever", "seed write returned {} (expected 5)", n);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    unix::close(b);
+
+    // (3) readiness edges on the survivor.
+    if !unix::read_shutdown(a) || !unix::fully_hung_up(a) || !unix::writable(a) {
+        test_fail!("unix_sever",
+            "survivor edges wrong: rdshut={} hup={} writable={}",
+            unix::read_shutdown(a), unix::fully_hung_up(a), unix::writable(a));
+        unix::close(a);
+        return false;
+    }
+    test_println!("  survivor: POLLIN/RDHUP+POLLHUP+writable edges ✓");
+
+    // (1) drain-then-EOF.
+    let mut buf = [0u8; 16];
+    let r1 = unix::read(a, &mut buf);
+    if r1 != 5 || &buf[..5] != b"HELLO" {
+        test_fail!("unix_sever",
+            "drain read returned {} (expected 5 queued bytes before EOF)", r1);
+        unix::close(a);
+        return false;
+    }
+    let r2 = unix::read(a, &mut buf);
+    if r2 != 0 {
+        test_fail!("unix_sever", "post-drain read returned {} (expected 0 EOF)", r2);
+        unix::close(a);
+        return false;
+    }
+    test_println!("  drain-then-EOF: 5 bytes then 0 ✓");
+
+    // (2) write → EPIPE.
+    let w = unix::write(a, b"X");
+    if w != -32 {
+        test_fail!("unix_sever", "write to dead peer returned {} (expected -EPIPE)", w);
+        unix::close(a);
+        return false;
+    }
+    test_println!("  write after peer close → -EPIPE ✓");
+
+    // (4) Recycle b's slot index into a fresh pair.  The allocator scans for
+    // the lowest Free slot, so one of (c, d) re-uses b's index.
+    let (c, d) = unix::socketpair(unix::SockKind::Stream, creds);
+    if c == u64::MAX || d == u64::MAX {
+        test_fail!("unix_sever", "recycle socketpair returned MAX");
+        unix::close(a);
+        return false;
+    }
+    if c != b && d != b {
+        // Environmental: another slot was free below b.  The severing already
+        // proved (get_peer == MAX); isolation cannot be exercised — pass with
+        // a note rather than fail spuriously.
+        test_println!("  note: fresh pair ({}, {}) did not re-use slot {} — \
+                       isolation leg skipped", c, d, b);
+    }
+    // Stale survivor must be fully severed: no path back to the recycled slot.
+    if unix::get_peer(a) != u64::MAX {
+        test_fail!("unix_sever", "survivor peer_id not severed: {}", unix::get_peer(a));
+        unix::close(a); unix::close(c); unix::close(d);
+        return false;
+    }
+    // Stale write must NOT inject into the new pair.
+    let _ = unix::write(a, b"INJECT");
+    if unix::bytes_available(c) != 0 || unix::bytes_available(d) != 0 {
+        test_fail!("unix_sever",
+            "stale write bled into recycled pair (avail c={} d={})",
+            unix::bytes_available(c), unix::bytes_available(d));
+        unix::close(a); unix::close(c); unix::close(d);
+        return false;
+    }
+    // Stale shutdown(SHUT_WR) and close must NOT flip EOF state on the new pair.
+    let _ = unix::shutdown(a, false, true);
+    unix::close(a);
+    if unix::read_shutdown(c) || unix::read_shutdown(d)
+        || unix::fully_hung_up(c) || unix::fully_hung_up(d)
+    {
+        test_fail!("unix_sever",
+            "stale shutdown/close bled into recycled pair (rdshut c={} d={})",
+            unix::read_shutdown(c), unix::read_shutdown(d));
+        unix::close(c); unix::close(d);
+        return false;
+    }
+    // New pair still fully functional.
+    let wn = unix::write(c, b"OK");
+    let mut nb = [0u8; 4];
+    let rn = unix::read(d, &mut nb);
+    unix::close(c); unix::close(d);
+    if wn != 2 || rn != 2 || &nb[..2] != b"OK" {
+        test_fail!("unix_sever",
+            "recycled pair round-trip broken (w={} r={})", wn, rn);
+        return false;
+    }
+    test_println!("  recycled pair isolated from stale survivor ✓");
+
+    test_pass!("AF_UNIX peer-close severing + slot-recycle isolation");
     true
 }
 


### PR DESCRIPTION
## Problem

The AF_UNIX socket table recycles slot indices the moment a slot's last open file description closes, but teardown left the **surviving** endpoint's `peer_id` pointing at the freed index. Once the index was re-allocated to an unrelated connection:

- `write(2)` on the stale survivor **injected bytes into the new connection's receive ring** (cross-channel stream corruption) — and even before re-allocation, reported success instead of `-EPIPE` (silent data loss; POSIX send(2)/write(2)).
- `shutdown(SHUT_WR)` / `close(2)` on the stale survivor **flipped read-EOF state on the unrelated connection**, delivering a spurious orderly EOF to a live stream.
- Peer-close also set the survivor's `shut_rd`, so bytes already queued at teardown were **discarded** — recv(2) requires queued data to be returned before the 0-byte orderly-shutdown indication (drain-then-EOF).

### Live evidence (boot at d675cc8, kdb)

`fd-map`/`unix-diag` captured an **asymmetric pairing**: pid 1 fd 53 → socket 3 with `peer_id=4`, while slot 4 had been recycled and re-paired with slot 9 (`socket 4: peer_id=9`). Any write/close on fd 53 acts on the recycled, unrelated pair.

Under the multi-process Firefox launch this is a self-sustaining failure: every child holds AF_UNIX IPC channel ends across a window where short-lived connections (glxtest, X11 clients — the in-kernel X11 server writes through this same API with a lazy dead-client sweep) close and recycle slots; one stale write/half-close kills a fresh child's IPC handshake; the parent respawns; the dead child's slots recycle again. Child syscall rings end in channel teardown (`epoll_ctl DEL fd=3`, `close(3)`, IO-thread exit) + `exit_group(1)`.

## Fix (all under the existing TABLE lock)

- `close()`: validate **mutual pairing** (`peer.peer_id == id`) before touching the peer; mark the survivor `rx_eof` + `peer_closed`; **sever** its `peer_id` to `u64::MAX` so no later path can dereference the recyclable index.
- `shutdown(SHUT_WR)`: same mutual-pairing gate; sets the peer's `rx_eof` (drain-then-EOF) instead of `shut_rd`.
- `write()`: mutual-pairing gate → `-EPIPE` on a stale/foreign peer; `peer_closed` → `-EPIPE`.
- `read_msg()`: empty ring + `rx_eof` → orderly EOF; queued bytes always delivered first. Local `SHUT_RD` keeps immediate-EOF semantics (IEEE 1003.1).
- Readiness helpers: `read_shutdown()` = `shut_rd || rx_eof`; `fully_hung_up()`/`writable()` key on `peer_closed` — **edge timing identical** to the pre-fix peer-Free probes (POLLIN/POLLRDHUP/POLLHUP/POLLOUT unchanged).
- kdb `unix-diag`: additive `rx_eof`/`peer_closed` fields.

## Verification

- New kernel test (AF_UNIX peer-close severing + slot-recycle isolation): drain-then-EOF, `-EPIPE`, hang-up edges, and recycle isolation (stale write/shutdown/close must not perturb a fresh pair on the recycled index) — **passes**.
- Full `test-mode` suite: 383/391; all 8 fails pre-existing/environmental (missing `/disk/bin` binaries + glibc interp on the FF-musl data image, the known-flaky `monotonic-rate` and `smp_blocking_state_ordering` SMP-timing tests). All AF_UNIX/SCM/epoll/pipe tests green.
- FF boot (firefox-test-core): content children now survive their IPC handshakes and run (hundreds of KB of channel traffic, multi-minute soak) instead of the respawn churn. Note: a *separate* residual remains — the socket process still aborts in its own init (MOZ_CRASH-shaped, under investigation); this PR removes the channel-corruption mechanism and is correct independently.

Cite: POSIX.1-2017 (write(2), send(2), recv(2), shutdown(2), poll(2)); man 7 unix; man 7 epoll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)