### PR TITLE
test(pipe): keep scheduler enabled across blocking-write sub-tests 5→6 (fix smp=2 wedge)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -36137,17 +36137,30 @@ fn test_pipe_blocking_write_semantics() -> bool {
     let leaked5 = crate::ipc::pipe::debug_writer_waiter_count(pipe_id5);
     crate::syscall::dispatch_linux_kernel(3, rfd5, 0, 0, 0, 0, 0);
     crate::syscall::dispatch_linux_kernel(3, wfd5, 0, 0, 0, 0, 0);
-    if !was_active { crate::sched::disable(); }
+    // NOTE: do NOT disable the scheduler here on the success path — sub-test 6
+    // follows in the same function and spawns a kernel-context watchdog process
+    // (`pipe_kdrain_watchdog`) that must be picked by the scheduler to drain the
+    // pipe and wake the parked writer.  Disabling the scheduler between the two
+    // sub-tests strands that watchdog forever (`SCHEDULER_ACTIVE == false` keeps
+    // every AP in its pre-scheduler `hlt` idle loop and makes the BSP's
+    // `schedule()` a no-op), so the sub-test-6 blocking write parks and
+    // livelocks with no drainer — a wedge that only manifests under true SMP
+    // (`smp=2`), where the watchdog needs a peer CPU to run it.  The scheduler
+    // stays enabled across sub-tests 3-6 and is disabled once, at the end of
+    // sub-test 6.  Each `return false` below restores the scheduler state it
+    // promised the caller (off iff it was off on entry).
 
     // Both writers must have deposited their full 2500-byte record.
     if a_ret != REC as i64 || b_ret != REC as i64 {
         test_fail!("pipe_blocking_write",
             "concurrent writers returned a={} b={} (expected {} each — a short return means a partial atomic record)", a_ret, b_ret, REC);
+        if !was_active { crate::sched::disable(); }
         return false;
     }
     if stream.len() != 2 * REC {
         test_fail!("pipe_blocking_write",
             "drained {} bytes from concurrent writers (expected {})", stream.len(), 2 * REC);
+        if !was_active { crate::sched::disable(); }
         return false;
     }
     // Atomicity check: scan the stream for contiguous same-byte runs.  Each
@@ -36166,11 +36179,13 @@ fn test_pipe_blocking_write_semantics() -> bool {
         test_fail!("pipe_blocking_write",
             "concurrent atomicity VIOLATED: expected 2 contiguous runs of {} (0xA1, 0xB2); got {} runs {:?} (a split/interleaved <=PIPE_BUF record — BLOCKER #3)",
             REC, runs.len(), runs);
+        if !was_active { crate::sched::disable(); }
         return false;
     }
     if leaked5 != 0 {
         test_fail!("pipe_blocking_write",
             "{} stale writer(s) on PIPE_WRITE_WAITERS after concurrent completion", leaked5);
+        if !was_active { crate::sched::disable(); }
         return false;
     }
     test_println!("  concurrent two-writer atomicity: 2 contiguous {}B records, no interleave ✓", REC);
@@ -36294,6 +36309,10 @@ fn test_pipe_blocking_write_semantics() -> bool {
     }
     test_println!("  kernel-context supervisor drain (pipe_read_wake) woke parked writer ✓");
 
+    // All sub-tests passed — restore the scheduler state we found on entry
+    // (the single `sched::enable()` before sub-test 3 stays in effect across
+    // sub-tests 3-6; disable once here on the success path).
+    if !was_active { crate::sched::disable(); }
     test_pass!("pipe blocking write — atomic / blocks-until-drained / atomic-park / concurrent-atomicity / kernel-drain-wake / EAGAIN / EPIPE");
     true
 }


### PR DESCRIPTION
## Summary

The in-kernel `test_pipe_blocking_write_semantics` (`kernel/src/test_runner.rs`) **wedged under true dual-core (`smp=2`)**: the two-writer sub-test's `pipe_writer_a`/`pipe_writer_b` kernel processes froze at `sc=1` and the suite never advanced past the pipe test. Confirmed pre-existing (reproduces independent of the #552 gen-barrier/park-protocol work).

Root-caused via **GDB autopsy** to a **scheduler-bracketing bug in the test harness**, NOT the kernel pipe/wake path. The kernel pipe wake machinery (#551 needs-aware `wait_writable` park, the `read(2)`-arm `wake_writers_all`, and `pipe_read_wake` for kernel-context drains — 58151bc) is faithful.

## Root cause

`test_pipe_blocking_write_semantics` enables the scheduler **once** (before sub-test 3) and must keep it enabled through sub-test 6, which spawns a kernel-context watchdog process (`pipe_kdrain_watchdog`) via `create_kernel_process`. The scheduler must pick that watchdog so it can drain the pipe and wake the parked writer.

Sub-test 5's **success path** unconditionally ran `if !was_active { sched::disable(); }` mid-flow, clearing `SCHEDULER_ACTIVE` before sub-test 6. With the scheduler disabled:

- every AP stays in its pre-scheduler idle `hlt` loop in `ap_rust_entry` (it only breaks out when `SCHEDULER_ACTIVE != 0`), and
- the BSP's `schedule()` short-circuits as a no-op.

So the watchdog never runs. Sub-test 6's blocking 512-byte write into a full pipe parks correctly (per POSIX.1-2017 `write(2)` / `pipe(7)` `PIPE_BUF` atomicity) and then **livelocks** with no drainer to wake it. The sub-test-5 writer threads finished their writes but couldn't be reaped (reaping needs the picker), so they linger at `sc=1` — the visible symptom. Only manifests under `smp=2` because the watchdog needs a peer CPU to run it.

## Evidence (GDB autopsy)

- `dual-regs` at the wedge: CPU0 (BSP) churning heap-alloc / BTreeMap enqueue+cleanup on the writer wait list; CPU1 (AP) pinned in `ap_rust_entry+0x511` (pre-scheduler idle loop).
- Guest-memory read: **`SCHEDULER_ACTIVE == 0x00`**.
- `PIPE_TABLE` read for the sub-test-6 pipe: `count=4096 writers=1 readers=1` — i.e. the `wait_writable` predicate (`space >= need || readers == 0`) would correctly return `Enqueued` (park). This rules out a wake/predicate defect and pins the spin on the disabled-scheduler no-op.

## Fix

- Remove the premature mid-flow `sched::disable()` on sub-test 5's success path.
- Guard sub-test 5's remaining failure `return false`s with `if !was_active { disable() }` (they previously relied on that disable having already run).
- Disable once on sub-test 6's success path.

The scheduler now spans sub-tests 3–6 and is restored to its entry state on every exit path. **Test-mode only** (`#[cfg(feature = "test-mode")]`) — no kernel runtime / Firefox path is compiled with or affected by this change.

## Verification

- `smp=2` test-mode boot: sub-test 4 (atomic-park), sub-test 5 (concurrent two-writer atomicity), and **sub-test 6 (kernel-context supervisor drain) all pass**; `[PASS] pipe blocking write — … kernel-drain-wake …`. The suite proceeds (200+ tests pass).
- No #551 regression: EAGAIN / EPIPE / atomic-park / blocks-until-drained sub-tests unchanged.
- No #552 regression: change is test-mode-only and structurally unreachable from Firefox boots.

Diff: +20 / −1, one file (`kernel/src/test_runner.rs`).

Refs: POSIX.1-2017 `write(2)`, `pipe(7)` (PIPE_BUF atomicity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)