### PR TITLE
shell: clear ctx_rsp_valid before marking a Running tid Dead in kill

### DIFF
--- a/kernel/src/shell/mod.rs
+++ b/kernel/src/shell/mod.rs
@@ -1371,9 +1371,30 @@ fn cmd_kill(parts: &[&str]) {
                 orbit_println!("kill: cannot kill idle thread");
             } else {
                 // Mark the target thread as Dead.
+                //
+                // INVARIANT: if the target is currently Running on another
+                // logical processor, its saved kernel RSP has not been
+                // committed — ctx_rsp_valid is stale-true from the thread's
+                // last switch-OUT.  The kstack reaper
+                // (sched::reap_dead_threads_sched) admits a Dead thread for
+                // stack-free only when ctx_rsp_valid==true (i.e. the RSP has
+                // been saved and the CPU has left that stack).  Observing
+                // Dead+ctx_rsp_valid==true on a thread that is still
+                // executing on that stack is a UAF.  Release-store false
+                // BEFORE writing Dead so that switch_context_asm on the peer
+                // CPU re-sets true only AFTER saving the RSP, at which point
+                // the stack is safe to reap.  Non-Running threads already had
+                // their RSP saved at their last switch-out and their
+                // ctx_rsp_valid is correctly true — leave it unchanged.
                 let found = {
                     let mut threads = crate::proc::THREAD_TABLE.lock();
                     if let Some(t) = threads.iter_mut().find(|t| t.tid == tid) {
+                        if t.state == crate::proc::ThreadState::Running {
+                            t.ctx_rsp_valid.store(
+                                false,
+                                core::sync::atomic::Ordering::Release,
+                            );
+                        }
                         t.state = crate::proc::ThreadState::Dead;
                         t.exit_code = 137; // SIGKILL
                         true


### PR DESCRIPTION
## Summary

The operator shell `kill <tid>` command was writing `ThreadState::Dead` unconditionally, without clearing `ctx_rsp_valid` first when the target thread was `Running` on a peer logical processor.

**Invariant violated:** The kstack reaper (`sched::reap_dead_threads_sched`) admits a `Dead` thread for stack-free when `ctx_rsp_valid.load(Acquire) == true`. When a thread switches out, `switch_context_asm` saves the kernel RSP and *then* sets `ctx_rsp_valid=true`. If a foreign CPU marks that thread `Dead` while it is still executing (state=`Running`, `ctx_rsp_valid` stale-true from its last switch-out), the reaper can immediately free a live kernel stack — UAF.

**Fix:** Mirror the pattern at the futex/waitpid/vfork park sites (`ke/wait.rs`, `proc/mod.rs`): if the target's current state is `Running`, `Release`-store `ctx_rsp_valid=false` BEFORE writing `Dead`. `switch_context_asm` on the peer CPU will re-set `true` only after committing the RSP, at which point the stack is genuinely safe to reap. Non-`Running` threads (Blocked, Ready, Sleeping) already had their RSP committed at their last switch-out; `ctx_rsp_valid` is correctly `true` for them — leave it unchanged.

**Scope:** One file, one call site (`shell::cmd_kill`). No impact on any non-shell path.

**Verification:**
- Build clean via `qemu-harness.py build` (23.85 s, zero errors).
- Boot under smp=2 KVM: clean boot, all phases complete, no BUGCHECK / FAULT / PANIC in serial log.
- The operator shell inputs to the framebuffer, not serial, so interactive `kill` exercise via harness send/grep is not practical; correctness rests on the code path analysis and the invariant matching the established park-site pattern.

## Test plan

- [ ] Review that `ctx_rsp_valid.store(false, Release)` precedes `state = Dead` when `state == Running` — matches the invariant at `sched::reap_dead_threads_sched:535`.
- [ ] Confirm diff touches only `kernel/src/shell/mod.rs` (1 file, 21 lines added, 0 deleted).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)