### PR TITLE
fix(mm/pfh): gen-abort over-release SIGSEGV'd live VMAs on concurrent SMP

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1425,22 +1425,60 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 // Re-check generation right before install — Acquire pairs
                 // with the Release fetch_add in `bump_generation_for_cr3`
                 // and `VmSpace::*` mutators (Intel SDM Vol. 3A §8.2.3).
+                //
+                // `generation` is address-space-WIDE, so a bump here can come
+                // from an unrelated VA's mutation.  This arm's install is an
+                // atomic compare-and-swap: `map_page_in_cow_if_unchanged` (below)
+                // writes the leaf PTE only if it STILL maps `old_phys` under
+                // `VMM_LOCK`, and the loser frees `new_phys` cleanly and returns
+                // true.  That CAS is the true protection against a concurrent
+                // unmap/CoW of THIS VA — if a sibling cleared or replaced the
+                // PTE, the CAS fails and we back out without aliasing.  A
+                // `return false` on a bare generation bump would instead deliver
+                // SIGSEGV to a thread doing a legitimate CoW write of a present,
+                // valid page (this kernel has no silent re-fault), so we no
+                // longer abort on a bump alone.  We only abandon the fault if the
+                // faulting VA's own VMA is gone or no longer writable — the case
+                // where the user genuinely lost write access (POSIX SIGSEGV).
                 let gen_now = vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
                 if gen_now != gen_at_start {
+                    let still_writable_here = vm_space
+                        .find_vma(faulting_addr)
+                        .map(|v| v.prot & crate::mm::vma::PROT_WRITE != 0)
+                        .unwrap_or(false);
+                    if !still_writable_here {
+                        #[cfg(feature = "firefox-test-core")]
+                        {
+                            static CNT: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 5 || n % 500 == 0 {
+                                crate::serial_println!(
+                                    "[PF/gen-abort] COW-COPY #{} addr={:#x} \
+                                     gen_at_start={} gen_now={} — faulting VMA \
+                                     gone/RO, dropping new frame",
+                                    n, page_addr, gen_at_start, gen_now);
+                            }
+                        }
+                        crate::mm::pmm::free_page(new_phys);
+                        return false;
+                    }
+                    // Unrelated mutation — the faulting VA is still a writable
+                    // mapping.  Fall through to the atomic CAS install, which
+                    // re-validates `old_phys` under the page-table lock.
                     #[cfg(feature = "firefox-test-core")]
                     {
-                        static CNT: core::sync::atomic::AtomicU64 =
+                        static REVAL: core::sync::atomic::AtomicU64 =
                             core::sync::atomic::AtomicU64::new(0);
-                        let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                        if n < 5 || n % 500 == 0 {
+                        let n = REVAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                        if n < 5 || n % 5000 == 0 {
                             crate::serial_println!(
-                                "[PF/gen-abort] COW-COPY #{} addr={:#x} \
-                                 gen_at_start={} gen_now={} — dropping new frame",
+                                "[PF/gen-reval] COW-COPY #{} addr={:#x} \
+                                 gen_at_start={} gen_now={} — VMA still writable, \
+                                 proceeding with CAS install",
                                 n, page_addr, gen_at_start, gen_now);
                         }
                     }
-                    crate::mm::pmm::free_page(new_phys);
-                    return false;
                 }
                 // W215 measurement (Phase-1 witness, behaviourally inert):
                 // re-read the leaf PTE immediately before the install.  If a
@@ -1754,16 +1792,43 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     return false;
                 }
 
-                // Closure: per-arm generation re-check.  Returns true if the
-                // caller should abort (and the caller must release `cached_phys`
-                // appropriately before returning false).  The CoW-copy sub-arm
-                // additionally frees its freshly-allocated `private_phys` via
-                // its own check immediately before installing.
-                let gen_unchanged = || -> bool {
+                // Closure: per-arm "safe to install" re-check.  Returns true if
+                // the caller may proceed with the install, false if it must
+                // abandon the fault.
+                //
+                // `generation` is an address-space-WIDE counter: a bump can be
+                // caused by a mutation on a virtual address unrelated to the one
+                // we are faulting on.  Aborting (→ `return false` → SIGSEGV, with
+                // no silent re-fault in this kernel) on a bare bump killed
+                // processes whose faulting page was a live, unchanged cache-hit
+                // mapping — a fatal use-after-fault that any concurrent sibling
+                // mmap could trigger.  The cache-hit install below is atomic
+                // (`map_page_in_if_absent`, mm_sem + VMM_LOCK, present-recheck),
+                // so the install/unmap race on THIS VA is already closed.  We
+                // therefore treat a bump as "safe to proceed" UNLESS the faulting
+                // VA's own VMA has been removed or re-backed away from this
+                // (mount,inode) — the only case where the cached frame would be
+                // stale for the VA (a brief PROCESS_TABLE re-acquire; that lock
+                // is top of the order here, MOUNTS/cache/PMM are not held).
+                let gen_safe_to_install = || -> bool {
                     match ch_vm_generation.as_ref() {
                         Some(g) => {
                             let now = g.load(core::sync::atomic::Ordering::Acquire);
-                            now == ch_gen_at_revalidate
+                            if now == ch_gen_at_revalidate {
+                                return true;
+                            }
+                            // Generation moved — re-validate the SPECIFIC
+                            // faulting VA against the same file backing.
+                            let procs = crate::proc::PROCESS_TABLE.lock();
+                            procs.iter()
+                                .find(|p| p.pid == target_pid)
+                                .and_then(|p| p.vm_space.as_ref())
+                                .and_then(|vs| vs.find_vma(faulting_addr))
+                                .map(|v| matches!(&v.backing,
+                                    crate::mm::vma::VmBacking::File {
+                                        mount_idx: m, inode: ino, ..
+                                    } if *m == mount_idx && *ino == inode))
+                                .unwrap_or(false)
                         }
                         None => true,
                     }
@@ -1799,9 +1864,12 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                 crate::mm::pmm::PAGE_SIZE,
                             );
                         }
-                        // W216 H_5j-B (unified concurrency): re-check generation
-                        // immediately before install — see arm-level closure.
-                        if !gen_unchanged() {
+                        // W216 H_5j-B (unified concurrency): re-validate the
+                        // faulting VA before install — see arm-level closure.
+                        // Only abandon if the faulting VA's own VMA was
+                        // removed/re-backed (an unrelated address-space mutation
+                        // is no longer treated as a reason to SIGSEGV).
+                        if !gen_safe_to_install() {
                             #[cfg(feature = "firefox-test-core")]
                             {
                                 static CNT: core::sync::atomic::AtomicU64 =
@@ -1810,7 +1878,8 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                 if n < 5 || n % 500 == 0 {
                                     crate::serial_println!(
                                         "[PF/gen-abort] CACHE-PRIVATE #{} addr={:#x} \
-                                         gen_at_rev={} — releasing private+cache refs",
+                                         gen_at_rev={} — faulting VMA replaced, \
+                                         releasing private+cache refs",
                                         n, page_addr, ch_gen_at_revalidate);
                                 }
                             }
@@ -1908,11 +1977,12 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // Steady state after install: cache holds one ref,
                     // this PTE holds one ref (the promoted guard ref) = rc ≥ 2.
                     //
-                    // W216 H_5j-B (unified concurrency): re-check generation
-                    // immediately before install.  On abort we release the
-                    // guard ref so the cache's own reference remains the sole
-                    // holder of `cached_phys`.
-                    if !gen_unchanged() {
+                    // W216 H_5j-B (unified concurrency): re-validate the faulting
+                    // VA before install — see arm-level closure.  Only abandon if
+                    // the faulting VA's own VMA was removed/re-backed; on abort
+                    // we release the guard ref so the cache's own reference
+                    // remains the sole holder of `cached_phys`.
+                    if !gen_safe_to_install() {
                         #[cfg(feature = "firefox-test-core")]
                         {
                             static CNT: core::sync::atomic::AtomicU64 =
@@ -1921,7 +1991,8 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             if n < 5 || n % 500 == 0 {
                                 crate::serial_println!(
                                     "[PF/gen-abort] CACHE-ALIAS #{} addr={:#x} \
-                                     gen_at_rev={} — releasing guard ref",
+                                     gen_at_rev={} — faulting VMA replaced, \
+                                     releasing guard ref",
                                     n, page_addr, ch_gen_at_revalidate);
                             }
                         }
@@ -2365,32 +2436,106 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 // Phase 2b, MADV_DONTNEED, mprotect, sysv_shm push/remove,
                 // brk grow/shrink, clone_for_fork CoW write-protect) since
                 // the post-revalidate sample bumps `vm_space.generation`.
-                // A mismatch means the snapshot we computed before this
-                // iteration is no longer authoritative — abort the install
-                // loop, free remaining frames, return false so the user
-                // re-faults against the new VMA.  Per Intel SDM Vol. 3A
-                // §8.2.3, this Acquire load pairs with the Release fetch_add
-                // in `bump_generation_for_cr3` and `VmSpace::*` mutators.
+                //
+                // `generation` is an address-space-WIDE counter, so a bump can
+                // be caused by a mutation on a virtual address that has nothing
+                // to do with the one we are faulting on.  The original abort
+                // here did `free_page` on every remaining frame and `return
+                // false`; but `false` from `handle_page_fault` delivers SIGSEGV
+                // to the faulting thread immediately (exception_handler →
+                // `deliver_sigsegv_from_isr`) — this kernel has no silent
+                // re-fault, so the "user re-faults against the new VMA" rationale
+                // was incorrect.  When the abort fired on iteration 0 — the
+                // FAULTING page (pages_to_map[0]) — it freed that page WITHOUT
+                // installing any PTE for it and then SIGSEGV'd the live
+                // mapping: a fatal use-after-fault that an unrelated concurrent
+                // mmap on a sibling CPU could trigger at will.
+                //
+                // The only real hazard — installing a PTE over a frame a
+                // concurrent `unmap_and_free_range_in` is freeing — is closed by
+                // the per-page atomic installs below (`map_page_in_if_absent`,
+                // which holds `mm_sem` + `VMM_LOCK` and only writes an absent
+                // leaf PTE; Intel SDM Vol. 3A §4.10.4.3).  So on a bump we
+                // re-validate the SPECIFIC faulting VA's VMA: if it still names
+                // the same file backing and span, the mutation was elsewhere and
+                // we continue the install loop (resyncing the generation
+                // baseline).  Only if the faulting VA's own VMA was replaced do
+                // we drop the not-yet-installed frames; even then we only
+                // SIGSEGV when the faulting page (index 0) itself was never
+                // installed — if an earlier iteration already mapped it, the
+                // fault is resolved and we break to `return true`.
                 if let Some(g) = vm_generation.as_ref() {
                     let gen_now = g.load(core::sync::atomic::Ordering::Acquire);
                     if gen_now != gen_at_revalidate {
-                        #[cfg(feature = "firefox-test-core")]
-                        crate::serial_println!(
-                            "[PF/gen-abort] READAHEAD addr={:#x} mount={} inode={} \
-                             foff={:#x} gen_at_rev={} gen_now={} — releasing {} \
-                             unmapped frames",
-                            faulting_addr, mount_idx, inode, file_base_offset,
-                            gen_at_revalidate, gen_now, n_pages.saturating_sub(i));
-                        // Release every frame we have not yet installed.
-                        // Frames already installed in earlier iterations (i'
-                        // < i) are reachable via PTE refs and the cache, so
-                        // they remain valid; the user keeps observing them
-                        // through the existing PTEs.
-                        for j in i..n_pages {
-                            let (_v, p, _f) = pages_to_map[j];
-                            crate::mm::pmm::free_page(p);
+                        // Re-validate the faulting VA's VMA (brief PROCESS_TABLE
+                        // re-acquire; PROCESS_TABLE is top of the lock order here
+                        // — MOUNTS / cache / PMM are NOT held).  Mirrors the
+                        // post-I/O revalidate above.
+                        let faulting_vma_ok = {
+                            let procs = crate::proc::PROCESS_TABLE.lock();
+                            procs.iter()
+                                .find(|p| p.pid == target_pid)
+                                .and_then(|p| p.vm_space.as_ref())
+                                .and_then(|vs| vs.find_vma(faulting_addr))
+                                .map(|v| {
+                                    matches!(&v.backing,
+                                        crate::mm::vma::VmBacking::File {
+                                            mount_idx: m, inode: ino, offset: o, ..
+                                        } if *m == mount_idx && *ino == inode
+                                            && *o == file_base_offset)
+                                    && v.base == vma_base
+                                    && v.base + v.length == vma_end
+                                })
+                                .unwrap_or(false)
+                        };
+                        if faulting_vma_ok {
+                            // Unrelated mutation — the faulting VMA is intact.
+                            // Resync the baseline and keep installing.  The
+                            // per-page atomic install protects against any
+                            // residual install/unmap race on each individual VA.
+                            gen_at_revalidate = gen_now;
+                            #[cfg(feature = "firefox-test-core")]
+                            {
+                                static REVAL: core::sync::atomic::AtomicU64 =
+                                    core::sync::atomic::AtomicU64::new(0);
+                                let n = REVAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                                if n < 5 || n % 5000 == 0 {
+                                    crate::serial_println!(
+                                        "[PF/gen-reval] READAHEAD addr={:#x} mount={} \
+                                         inode={} foff={:#x} gen_now={} — faulting VMA \
+                                         intact, continuing install (i={}/{})",
+                                        faulting_addr, mount_idx, inode,
+                                        file_base_offset, gen_now, i, n_pages);
+                                }
+                            }
+                        } else {
+                            // The faulting VA's own VMA was replaced/removed.
+                            // Drop every frame we have not yet installed; frames
+                            // installed in earlier iterations (i' < i) stay valid
+                            // via their PTE + cache refs.
+                            #[cfg(feature = "firefox-test-core")]
+                            crate::serial_println!(
+                                "[PF/gen-abort] READAHEAD addr={:#x} mount={} inode={} \
+                                 foff={:#x} gen_at_rev={} gen_now={} — faulting VMA \
+                                 replaced, releasing {} unmapped frames (i={})",
+                                faulting_addr, mount_idx, inode, file_base_offset,
+                                gen_at_revalidate, gen_now,
+                                n_pages.saturating_sub(i), i);
+                            for j in i..n_pages {
+                                let (_v, p, _f) = pages_to_map[j];
+                                crate::mm::pmm::free_page(p);
+                            }
+                            // The faulting page is pages_to_map[0].  If we already
+                            // passed iteration 0 it is installed and the fault is
+                            // resolved → break to the `mapped_faulting` return.
+                            // If we are still at iteration 0 the faulting page was
+                            // never mapped against a VMA that no longer describes
+                            // it → SIGSEGV (POSIX: access to an unmapped VA).
+                            if i == 0 {
+                                return false;
+                            }
+                            break;
                         }
-                        return false;
                     }
                 }
 
@@ -2794,17 +2939,58 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     }
                 }
                 // W216 H_5j-B: re-check generation immediately before install.
+                //
+                // `generation` is address-space-WIDE, so a bump can come from a
+                // mutation on an unrelated VA.  A `return false` here delivers
+                // SIGSEGV to the faulting thread immediately (this kernel has no
+                // silent re-fault), so the original abort killed a process whose
+                // faulting page was still a live, unchanged file mapping.  The
+                // recycle hazard is already closed by the `map_page_in_if_absent`
+                // install below (mm_sem + VMM_LOCK, present-recheck).  On a bump
+                // we therefore re-validate the SPECIFIC faulting VA; if its VMA
+                // still names the same backing we proceed, and only abandon the
+                // fault (legitimate SIGSEGV) if the faulting VA's own VMA was
+                // replaced/removed.  Per Intel SDM Vol. 3A §4.10.4.3.
                 if let Some(g) = sp_vm_generation.as_ref() {
                     let gen_now = g.load(core::sync::atomic::Ordering::Acquire);
                     if gen_now != sp_gen_at_revalidate {
+                        let faulting_vma_ok = {
+                            let procs = crate::proc::PROCESS_TABLE.lock();
+                            procs.iter()
+                                .find(|p| p.pid == target_pid)
+                                .and_then(|p| p.vm_space.as_ref())
+                                .and_then(|vs| vs.find_vma(faulting_addr))
+                                .map(|v| matches!(&v.backing,
+                                    crate::mm::vma::VmBacking::File {
+                                        mount_idx: m, inode: ino, ..
+                                    } if *m == mount_idx && *ino == inode))
+                                .unwrap_or(false)
+                        };
+                        if !faulting_vma_ok {
+                            #[cfg(feature = "firefox-test-core")]
+                            crate::serial_println!(
+                                "[PF/gen-abort] SINGLE-PAGE addr={:#x} mount={} inode={} \
+                                 foff={:#x} gen_at_rev={} gen_now={} — faulting VMA \
+                                 replaced, dropping frame",
+                                faulting_addr, mount_idx, inode, file_page_offset,
+                                sp_gen_at_revalidate, gen_now);
+                            crate::mm::pmm::free_page(phys);
+                            return false;
+                        }
                         #[cfg(feature = "firefox-test-core")]
-                        crate::serial_println!(
-                            "[PF/gen-abort] SINGLE-PAGE addr={:#x} mount={} inode={} \
-                             foff={:#x} gen_at_rev={} gen_now={} — dropping frame",
-                            faulting_addr, mount_idx, inode, file_page_offset,
-                            sp_gen_at_revalidate, gen_now);
-                        crate::mm::pmm::free_page(phys);
-                        return false;
+                        {
+                            static REVAL: core::sync::atomic::AtomicU64 =
+                                core::sync::atomic::AtomicU64::new(0);
+                            let n = REVAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 5 || n % 5000 == 0 {
+                                crate::serial_println!(
+                                    "[PF/gen-reval] SINGLE-PAGE addr={:#x} mount={} \
+                                     inode={} foff={:#x} gen_now={} — faulting VMA \
+                                     intact, proceeding with atomic install",
+                                    faulting_addr, mount_idx, inode,
+                                    file_page_offset, gen_now);
+                            }
+                        }
                     }
                 }
                 // Bug-B fix (single-page fallback): hold a guard reference
@@ -3052,23 +3238,81 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         core::ptr::write_bytes((PHYS_OFF + phys) as *mut u8, 0, crate::mm::pmm::PAGE_SIZE);
                     }
                     // Re-check generation immediately before install.
+                    //
+                    // A generation bump means SOME VMA-list mutation happened on
+                    // a sibling CPU since `gen_at_start` (sys_mmap/munmap,
+                    // MAP_FIXED Phase 2b, MADV_DONTNEED, brk grow/shrink, a CoW
+                    // write-protect pass) — but `generation` is an
+                    // address-space-WIDE counter: it is bumped for mutations on
+                    // UNRELATED virtual addresses, not just the faulting one.
+                    // The original abort here did `free_page(phys); return
+                    // false`, and a `false` return from `handle_page_fault`
+                    // delivers SIGSEGV to the faulting thread IMMEDIATELY
+                    // (exception_handler → `deliver_sigsegv_from_isr`) — this
+                    // kernel has NO silent re-fault/retry of the instruction, so
+                    // `false` is a hard kill, not a "re-fault against the new
+                    // VMA".  A bump caused by an unrelated mmap on another VA
+                    // therefore SIGSEGV'd a process whose faulting page was
+                    // perfectly valid.  Under a genuinely-concurrent SMP
+                    // scheduler (per-CPU runqueues) sibling mutations land
+                    // constantly during process startup, making this a fatal
+                    // use-after-fault on a LIVE anonymous VMA.
+                    //
+                    // The real hazard the gen-check was meant to guard —
+                    // installing a PTE over a frame a concurrent
+                    // `unmap_and_free_range_in` is freeing — is already closed by
+                    // the atomic `map_page_in_if_absent` install below: it holds
+                    // `mm_sem` + `VMM_LOCK` and writes the leaf PTE only if it is
+                    // still absent, so the loser of any install/unmap race on
+                    // THIS VA backs out and frees its own fresh frame (`phys`),
+                    // never aliasing or resurrecting a recycled one (Intel SDM
+                    // Vol. 3A §4.10.4.3).
+                    //
+                    // Correct response to a bump: re-validate the SPECIFIC
+                    // faulting VA.  If its VMA is still anonymous and still
+                    // covers `page_addr`, the mutation was elsewhere — proceed
+                    // with the atomic install.  Only if the faulting VA's own
+                    // VMA was removed or re-backed do we abandon the fault — a
+                    // legitimate SIGSEGV: the user really lost this mapping
+                    // (POSIX: access to an unmapped address raises SIGSEGV).
                     let gen_now =
                         vm_space.generation.load(core::sync::atomic::Ordering::Acquire);
                     if gen_now != gen_at_start {
+                        let still_anon_here = matches!(
+                            vm_space.find_vma(faulting_addr).map(|v| &v.backing),
+                            Some(crate::mm::vma::VmBacking::Anonymous));
+                        if !still_anon_here {
+                            #[cfg(feature = "firefox-test-core")]
+                            {
+                                static CNT: core::sync::atomic::AtomicU64 =
+                                    core::sync::atomic::AtomicU64::new(0);
+                                let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                                if n < 5 || n % 500 == 0 {
+                                    crate::serial_println!(
+                                        "[PF/gen-abort] ANON #{} addr={:#x} \
+                                         gen_at_start={} gen_now={} — faulting VMA \
+                                         removed/re-backed, releasing frame",
+                                        n, page_addr, gen_at_start, gen_now);
+                                }
+                            }
+                            crate::mm::pmm::free_page(phys);
+                            return false;
+                        }
+                        // Unrelated mutation — the faulting VA is still a live
+                        // anonymous mapping.  Fall through to the atomic install.
                         #[cfg(feature = "firefox-test-core")]
                         {
-                            static CNT: core::sync::atomic::AtomicU64 =
+                            static REVAL: core::sync::atomic::AtomicU64 =
                                 core::sync::atomic::AtomicU64::new(0);
-                            let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                            if n < 5 || n % 500 == 0 {
+                            let n = REVAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                            if n < 5 || n % 5000 == 0 {
                                 crate::serial_println!(
-                                    "[PF/gen-abort] ANON #{} addr={:#x} \
-                                     gen_at_start={} gen_now={} — releasing frame",
+                                    "[PF/gen-reval] ANON #{} addr={:#x} \
+                                     gen_at_start={} gen_now={} — VMA still live, \
+                                     proceeding with atomic install",
                                     n, page_addr, gen_at_start, gen_now);
                             }
                         }
-                        crate::mm::pmm::free_page(phys);
-                        return false;
                     }
                     // Anti-aliasing re-check (POSIX mmap(2) demand paging;
                     // Intel SDM Vol. 3A §4.10.4.3 "Optional Invalidation").

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1227,6 +1227,90 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
     );
 }
 
+/// The pure FILE-arm re-validation predicate, factored out so that the install
+/// arms AND Test 98j drive the SAME definition (a regression in the full-tuple
+/// check propagates to the test).  Takes the faulting VA's current VMA (or
+/// `None` if it was removed) and returns `Some((page_flags, is_shared))` —
+/// both RE-DERIVED from the LIVE VMA, not the pre-fault snapshot — iff the full
+/// `(mount, inode, offset)` backing AND span `base..base+length` tuple matches;
+/// `None` otherwise (legitimate SIGSEGV per POSIX mmap(2): access to an
+/// unmapped / re-mapped address).
+///
+/// The FULL tuple — not just `(mount, inode)` — is mandatory.  A
+/// same-inode-different-offset `MAP_FIXED` remap (the ld.so reserve-then-
+/// overwrite pattern) or a `remove_range` hole-punch landing in the
+/// generation-bump window passes a `(mount, inode)`-only test yet describes a
+/// DIFFERENT file page at the VA; installing the OLD-offset frame at the
+/// NEW-offset VA is silent `.text`/GOT corruption (the wrong-offset class).
+///
+/// Re-deriving `page_flags`/`is_shared` from the live VMA (rather than reusing
+/// the pre-fault snapshot) closes the stale-permission window: a racing
+/// `mprotect(PROT_READ)` in the generation-bump window would otherwise install
+/// from stale `PROT_WRITE` flags, letting a store that should `SIGSEGV` succeed
+/// (POSIX mprotect(2): the new protection takes effect for subsequent accesses).
+#[inline]
+pub(crate) fn pfh_file_vma_match(
+    vma: Option<&crate::mm::vma::VmArea>,
+    mount_idx: usize,
+    inode: u64,
+    file_base_offset: u64,
+    vma_base: u64,
+    vma_end: u64,
+) -> Option<(u64, bool)> {
+    let v = vma?;
+    let backing_ok = matches!(&v.backing,
+        crate::mm::vma::VmBacking::File {
+            mount_idx: m, inode: ino, offset: o, ..
+        } if *m == mount_idx && *ino == inode && *o == file_base_offset);
+    if backing_ok && v.base == vma_base && v.base + v.length == vma_end {
+        // Re-derive flags from the LIVE VMA so a racing mprotect narrowing
+        // (e.g. PROT_READ) is reflected in the installed PTE.
+        Some((
+            v.to_page_flags(),
+            v.flags & crate::mm::vma::MAP_SHARED != 0,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Full-tuple re-validation of a file-backed faulting VA against a held
+/// `PROCESS_TABLE` guard, shared by all three FILE demand-paging install arms
+/// (cache-hit, readahead, single-page).  Delegates the predicate to
+/// `pfh_file_vma_match` after the per-process `find_vma`.
+///
+/// `procs` must be an already-locked `PROCESS_TABLE` guard; the caller is
+/// expected to hold that lock across BOTH this re-validation AND the subsequent
+/// leaf-PTE install, mirroring the ANON/COW arms which never drop PROCESS_TABLE
+/// across their install.  Holding it across the install closes the
+/// install-into-a-just-munmapped-range window: `sys_munmap` removes the VMA
+/// under PROCESS_TABLE (Phase 2a) before clearing PTEs lock-free (Phase 2b), so
+/// a concurrent munmap of the faulting range serialises behind this guard — it
+/// either removes the VMA before us (→ `None`, abandon) or after us (→ its
+/// Phase 2b clears the PTE we just installed).  Lock order: PROCESS_TABLE (top)
+/// → cache / PMM / mm_sem.read() / VMM_LOCK (the same nesting the COW arm's
+/// `map_page_in_cow_if_unchanged` and the ANON arm's `map_page_in_if_absent`
+/// already use under a held PROCESS_TABLE).  No VFS/MOUNTS call occurs between
+/// re-validation and install on any FILE arm, so MOUNTS is never nested here.
+#[inline]
+fn pfh_file_vma_revalidate(
+    procs: &[crate::proc::Process],
+    target_pid: crate::proc::Pid,
+    faulting_addr: u64,
+    mount_idx: usize,
+    inode: u64,
+    file_base_offset: u64,
+    vma_base: u64,
+    vma_end: u64,
+) -> Option<(u64, bool)> {
+    let vma = procs
+        .iter()
+        .find(|p| p.pid == target_pid)
+        .and_then(|p| p.vm_space.as_ref())
+        .and_then(|vs| vs.find_vma(faulting_addr));
+    pfh_file_vma_match(vma, mount_idx, inode, file_base_offset, vma_base, vma_end)
+}
+
 /// Attempt to handle a page fault.
 ///
 /// Returns `true` if the fault was successfully resolved (demand-paging, CoW),
@@ -1746,91 +1830,50 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 // holder (freeing the frame only if the cache has also evicted it).
                 // The user will re-fault against the new VMA and receive correct data.
                 //
-                // Lock ordering preserved: PROCESS_TABLE (top) → nothing else.
-                // MOUNTS is NOT held here; cache/PMM locks are NOT held here.
-                // W216 H_5j-B (unified concurrency): capture the VmSpace
-                // generation Arc + post-revalidate sample under the same
-                // PROCESS_TABLE critical section as the revalidate.  Re-checked
-                // immediately before each `map_page_in` in the install sub-arms
-                // below to catch sibling-CPU VMA mutations that fire between
-                // this revalidate and the install.
-                let mut ch_vm_generation:
-                    Option<alloc::sync::Arc<core::sync::atomic::AtomicU64>> = None;
-                let mut ch_gen_at_revalidate: u64 = 0;
-                let still_valid = {
-                    let procs = crate::proc::PROCESS_TABLE.lock();
-                    let vs_opt = procs.iter()
-                        .find(|p| p.pid == target_pid)
-                        .and_then(|p| p.vm_space.as_ref());
-                    if let Some(vs) = vs_opt {
-                        ch_vm_generation = Some(vs.generation.clone());
-                        ch_gen_at_revalidate =
-                            vs.generation.load(core::sync::atomic::Ordering::Acquire);
-                    }
-                    vs_opt
-                        .and_then(|vs| vs.find_vma(faulting_addr))
-                        .map(|v| {
-                            matches!(&v.backing,
-                                crate::mm::vma::VmBacking::File {
-                                    mount_idx: m, inode: ino, offset: o, ..
-                                } if *m == mount_idx && *ino == inode && *o == file_base_offset)
-                            && v.base == vma_base
-                            && v.base + v.length == vma_end
-                        })
-                        .unwrap_or(false)
-                };
-                if !still_valid {
-                    // Release the guard ref — cache's own ref keeps the frame
-                    // alive, or frees it if the cache evicted the entry between
-                    // our lookup and now.
-                    let _ = crate::mm::refcount::page_ref_dec(cached_phys);
-                    #[cfg(feature = "firefox-test-core")]
-                    crate::serial_println!(
-                        "[PF/revalidate] CACHE-HIT VMA stale addr={:#x} \
-                         mount={} inode={} foff={:#x} — abandoning",
-                        faulting_addr, mount_idx, inode, file_page_offset);
-                    return false;
-                }
-
-                // Closure: per-arm "safe to install" re-check.  Returns true if
-                // the caller may proceed with the install, false if it must
-                // abandon the fault.
+                // Lock ordering: PROCESS_TABLE (top) → cache / PMM / mm_sem.read()
+                // / VMM_LOCK.  MOUNTS is NOT held here and no VFS call occurs
+                // between this re-validation and the install below, so holding
+                // PROCESS_TABLE across both is safe and matches the ANON/COW arms
+                // (which install under a continuously-held PROCESS_TABLE via
+                // `map_page_in_if_absent` / `map_page_in_cow_if_unchanged`).
                 //
-                // `generation` is an address-space-WIDE counter: a bump can be
-                // caused by a mutation on a virtual address unrelated to the one
-                // we are faulting on.  Aborting (→ `return false` → SIGSEGV, with
-                // no silent re-fault in this kernel) on a bare bump killed
-                // processes whose faulting page was a live, unchanged cache-hit
-                // mapping — a fatal use-after-fault that any concurrent sibling
-                // mmap could trigger.  The cache-hit install below is atomic
-                // (`map_page_in_if_absent`, mm_sem + VMM_LOCK, present-recheck),
-                // so the install/unmap race on THIS VA is already closed.  We
-                // therefore treat a bump as "safe to proceed" UNLESS the faulting
-                // VA's own VMA has been removed or re-backed away from this
-                // (mount,inode) — the only case where the cached frame would be
-                // stale for the VA (a brief PROCESS_TABLE re-acquire; that lock
-                // is top of the order here, MOUNTS/cache/PMM are not held).
-                let gen_safe_to_install = || -> bool {
-                    match ch_vm_generation.as_ref() {
-                        Some(g) => {
-                            let now = g.load(core::sync::atomic::Ordering::Acquire);
-                            if now == ch_gen_at_revalidate {
-                                return true;
-                            }
-                            // Generation moved — re-validate the SPECIFIC
-                            // faulting VA against the same file backing.
-                            let procs = crate::proc::PROCESS_TABLE.lock();
-                            procs.iter()
-                                .find(|p| p.pid == target_pid)
-                                .and_then(|p| p.vm_space.as_ref())
-                                .and_then(|vs| vs.find_vma(faulting_addr))
-                                .map(|v| matches!(&v.backing,
-                                    crate::mm::vma::VmBacking::File {
-                                        mount_idx: m, inode: ino, ..
-                                    } if *m == mount_idx && *ino == inode))
-                                .unwrap_or(false)
-                        }
-                        None => true,
+                // PFH-REVAL-1 (hold-across-install): acquire PROCESS_TABLE ONCE
+                // and keep it held across BOTH the full-tuple re-validation AND
+                // the leaf-PTE install.  `sys_munmap` removes the VMA under
+                // PROCESS_TABLE (Phase 2a) before clearing PTEs lock-free
+                // (Phase 2b), so a concurrent munmap of the faulting range either
+                // removes the VMA before us (→ abandon) or after us (→ its
+                // Phase 2b clears the PTE we install); the previous
+                // re-acquire-then-drop admitted an install into a just-munmapped,
+                // VMA-less range (a stranded-PTE leak + future-alias).  Holding it
+                // also subsumes the address-space-wide generation re-check: no
+                // VMA-list mutation can land between this re-validation and the
+                // install while we hold PROCESS_TABLE, so the per-install
+                // generation closure is no longer needed.
+                //
+                // PFH-REVAL-2 (full tuple) + PFH-REVAL-3 (fresh flags): the
+                // shared `pfh_file_vma_revalidate` helper re-validates the FULL
+                // `(mount, inode, offset, base, end)` tuple and re-derives
+                // `page_flags`/`is_shared` from the LIVE VMA — see its doc.
+                let _ch_pt_guard = crate::proc::PROCESS_TABLE.lock();
+                let (page_flags, is_shared) = match pfh_file_vma_revalidate(
+                    &_ch_pt_guard, target_pid, faulting_addr,
+                    mount_idx, inode, file_base_offset, vma_base, vma_end,
+                ) {
+                    Some(fresh) => fresh,
+                    None => {
+                        // Faulting VA's VMA removed or re-backed (incl. a
+                        // same-inode-different-offset MAP_FIXED remap).  Release
+                        // the guard ref — cache's own ref keeps the frame alive,
+                        // or frees it if the cache evicted the entry.
+                        drop(_ch_pt_guard);
+                        let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                        #[cfg(feature = "firefox-test-core")]
+                        crate::serial_println!(
+                            "[PF/revalidate] CACHE-HIT VMA stale addr={:#x} \
+                             mount={} inode={} foff={:#x} — abandoning",
+                            faulting_addr, mount_idx, inode, file_page_offset);
+                        return false;
                     }
                 };
 
@@ -1864,29 +1907,11 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                 crate::mm::pmm::PAGE_SIZE,
                             );
                         }
-                        // W216 H_5j-B (unified concurrency): re-validate the
-                        // faulting VA before install — see arm-level closure.
-                        // Only abandon if the faulting VA's own VMA was
-                        // removed/re-backed (an unrelated address-space mutation
-                        // is no longer treated as a reason to SIGSEGV).
-                        if !gen_safe_to_install() {
-                            #[cfg(feature = "firefox-test-core")]
-                            {
-                                static CNT: core::sync::atomic::AtomicU64 =
-                                    core::sync::atomic::AtomicU64::new(0);
-                                let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                                if n < 5 || n % 500 == 0 {
-                                    crate::serial_println!(
-                                        "[PF/gen-abort] CACHE-PRIVATE #{} addr={:#x} \
-                                         gen_at_rev={} — faulting VMA replaced, \
-                                         releasing private+cache refs",
-                                        n, page_addr, ch_gen_at_revalidate);
-                                }
-                            }
-                            crate::mm::pmm::free_page(private_phys);
-                            let _ = crate::mm::refcount::page_ref_dec(cached_phys);
-                            return false;
-                        }
+                        // PFH-REVAL-1/2/3: the faulting VA was re-validated
+                        // (full tuple) under the PROCESS_TABLE guard still held
+                        // here, and no VMA-list mutation can land while we hold
+                        // it (munmap's Phase 2a serialises behind this guard), so
+                        // no per-install generation re-check is needed.
                         // Anti-aliasing install (POSIX mmap(2) MAP_PRIVATE;
                         // Intel SDM Vol. 3A §4.10.4.3 "Optional Invalidation").
                         // On a shared address space (CLONE_VM / vfork — several
@@ -1977,28 +2002,10 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     // Steady state after install: cache holds one ref,
                     // this PTE holds one ref (the promoted guard ref) = rc ≥ 2.
                     //
-                    // W216 H_5j-B (unified concurrency): re-validate the faulting
-                    // VA before install — see arm-level closure.  Only abandon if
-                    // the faulting VA's own VMA was removed/re-backed; on abort
-                    // we release the guard ref so the cache's own reference
-                    // remains the sole holder of `cached_phys`.
-                    if !gen_safe_to_install() {
-                        #[cfg(feature = "firefox-test-core")]
-                        {
-                            static CNT: core::sync::atomic::AtomicU64 =
-                                core::sync::atomic::AtomicU64::new(0);
-                            let n = CNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                            if n < 5 || n % 500 == 0 {
-                                crate::serial_println!(
-                                    "[PF/gen-abort] CACHE-ALIAS #{} addr={:#x} \
-                                     gen_at_rev={} — faulting VMA replaced, \
-                                     releasing guard ref",
-                                    n, page_addr, ch_gen_at_revalidate);
-                            }
-                        }
-                        let _ = crate::mm::refcount::page_ref_dec(cached_phys);
-                        return false;
-                    }
+                    // PFH-REVAL-1/2/3: the faulting VA was re-validated (full
+                    // tuple) under the PROCESS_TABLE guard still held here, and no
+                    // VMA-list mutation can land while we hold it, so no
+                    // per-install generation re-check is needed.
                     // W215 H3a diagnostic: check whether cached_phys is held
                     // under a different key in the cache — which would mean a
                     // MAP_SHARED+PROT_WRITE PTE is about to alias a page the cache
@@ -2340,58 +2347,52 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
             // recycled physical frames (the residual 5th-class aliasing that
             // remained after PRs #222 / #225 / #226 / #230).
             //
-            // Lock ordering preserved: PROCESS_TABLE (top) → nothing else here.
-            // MOUNTS is NOT held at this point; cache/PMM locks are NOT held yet.
-            // W216 H_5j-B: also capture the VmSpace generation Arc + a
-            // post-revalidate sample so we can detect any further VMA-list
-            // mutation that happens BETWEEN this revalidate and each
-            // cache::insert + map_page_in iteration in the install loop
-            // below.  PR #226's revalidate alone catches mutations that
-            // happened during the I/O phase; the install loop itself can
-            // span microseconds during which a sibling CPU running
-            // sys_munmap / MAP_FIXED Phase 2b / MADV_DONTNEED can drain
-            // frames out from under us.  See `VmSpace::generation`.
-            let mut vm_generation: Option<alloc::sync::Arc<core::sync::atomic::AtomicU64>> = None;
-            let mut gen_at_revalidate: u64 = 0;
-            if n_pages > 0 {
-                let still_valid = {
-                    let procs = crate::proc::PROCESS_TABLE.lock();
-                    let vs_opt = procs.iter()
-                        .find(|p| p.pid == target_pid)
-                        .and_then(|p| p.vm_space.as_ref());
-                    if let Some(vs) = vs_opt {
-                        vm_generation = Some(vs.generation.clone());
-                        gen_at_revalidate =
-                            vs.generation.load(core::sync::atomic::Ordering::Acquire);
+            // PFH-REVAL-1 (hold-across-install): acquire PROCESS_TABLE ONCE after
+            // the I/O completes and HOLD it across the full-tuple re-validation
+            // AND the entire install loop below.  The I/O (`fs.read`) is already
+            // done, so no MOUNTS/VFS call occurs in this span; lock order is
+            // PROCESS_TABLE (top) → cache / PMM / mm_sem.read() / VMM_LOCK — the
+            // same nesting the ANON/COW arms already use under a held
+            // PROCESS_TABLE.  Holding it across the install closes the
+            // install-into-a-just-munmapped-range window (`sys_munmap` removes
+            // the VMA under PROCESS_TABLE in Phase 2a, then clears PTEs lock-free
+            // in Phase 2b; a concurrent munmap of the faulting range serialises
+            // behind this guard) AND subsumes the address-space-wide generation
+            // re-check — no VMA-list mutation can land while we hold PROCESS_TABLE,
+            // so the previous per-iteration `vm_space.generation` closure is gone.
+            //
+            // PFH-REVAL-2 (full tuple) + PFH-REVAL-3 (fresh flags): the shared
+            // `pfh_file_vma_revalidate` helper re-validates the full
+            // `(mount, inode, offset, base, end)` tuple and re-derives
+            // `page_flags`/`is_shared` from the LIVE VMA.
+            let _ra_pt_guard = crate::proc::PROCESS_TABLE.lock();
+            let (page_flags, is_shared) = if n_pages > 0 {
+                match pfh_file_vma_revalidate(
+                    &_ra_pt_guard, target_pid, faulting_addr,
+                    mount_idx, inode, file_base_offset, vma_base, vma_end,
+                ) {
+                    Some(fresh) => fresh,
+                    None => {
+                        // VMA replaced/removed during I/O (incl. a same-inode-
+                        // different-offset MAP_FIXED remap).  Free every frame we
+                        // allocated, then abandon the fault.
+                        drop(_ra_pt_guard);
+                        #[cfg(feature = "firefox-test-core")]
+                        crate::serial_println!(
+                            "[PF/revalidate] READAHEAD VMA stale after I/O addr={:#x} \
+                             mount={} inode={} foff={:#x} — dropping {} pages",
+                            faulting_addr, mount_idx, inode, file_base_offset, n_pages);
+                        for i in 0..n_pages {
+                            let (_vaddr, phys, _foff) = pages_to_map[i];
+                            crate::mm::pmm::free_page(phys);
+                        }
+                        return false;
                     }
-                    vs_opt
-                        .and_then(|vs| vs.find_vma(faulting_addr))
-                        .map(|v| {
-                            matches!(&v.backing,
-                                crate::mm::vma::VmBacking::File {
-                                    mount_idx: m, inode: ino, offset: o, ..
-                                } if *m == mount_idx && *ino == inode && *o == file_base_offset)
-                            && v.base == vma_base
-                            && v.base + v.length == vma_end
-                        })
-                        .unwrap_or(false)
-                };
-                if !still_valid {
-                    // VMA replaced or removed during I/O.  Free all frames we
-                    // allocated, then abandon the fault.  The user will re-fault
-                    // against the new VMA and receive correct data.
-                    #[cfg(feature = "firefox-test-core")]
-                    crate::serial_println!(
-                        "[PF/revalidate] READAHEAD VMA stale after I/O addr={:#x} \
-                         mount={} inode={} foff={:#x} — dropping {} pages",
-                        faulting_addr, mount_idx, inode, file_base_offset, n_pages);
-                    for i in 0..n_pages {
-                        let (_vaddr, phys, _foff) = pages_to_map[i];
-                        crate::mm::pmm::free_page(phys);
-                    }
-                    return false;
                 }
-            }
+            } else {
+                // No pages to install; the snapshot flags are unused below.
+                (page_flags, is_shared)
+            };
 
             // Map all readahead pages and insert into cache.  Three regimes
             // need to be distinguished and the per-arm logic below must match
@@ -2431,113 +2432,19 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     crate::mm::w215_diag::pack_cache_key(inode, foff),
                 );
 
-                // W216 H_5j-B: per-iteration generation re-check.  Any sibling
-                // CPU that mutated the address space (sys_munmap, MAP_FIXED
-                // Phase 2b, MADV_DONTNEED, mprotect, sysv_shm push/remove,
-                // brk grow/shrink, clone_for_fork CoW write-protect) since
-                // the post-revalidate sample bumps `vm_space.generation`.
-                //
-                // `generation` is an address-space-WIDE counter, so a bump can
-                // be caused by a mutation on a virtual address that has nothing
-                // to do with the one we are faulting on.  The original abort
-                // here did `free_page` on every remaining frame and `return
-                // false`; but `false` from `handle_page_fault` delivers SIGSEGV
-                // to the faulting thread immediately (exception_handler →
-                // `deliver_sigsegv_from_isr`) — this kernel has no silent
-                // re-fault, so the "user re-faults against the new VMA" rationale
-                // was incorrect.  When the abort fired on iteration 0 — the
-                // FAULTING page (pages_to_map[0]) — it freed that page WITHOUT
-                // installing any PTE for it and then SIGSEGV'd the live
-                // mapping: a fatal use-after-fault that an unrelated concurrent
-                // mmap on a sibling CPU could trigger at will.
-                //
-                // The only real hazard — installing a PTE over a frame a
-                // concurrent `unmap_and_free_range_in` is freeing — is closed by
-                // the per-page atomic installs below (`map_page_in_if_absent`,
-                // which holds `mm_sem` + `VMM_LOCK` and only writes an absent
-                // leaf PTE; Intel SDM Vol. 3A §4.10.4.3).  So on a bump we
-                // re-validate the SPECIFIC faulting VA's VMA: if it still names
-                // the same file backing and span, the mutation was elsewhere and
-                // we continue the install loop (resyncing the generation
-                // baseline).  Only if the faulting VA's own VMA was replaced do
-                // we drop the not-yet-installed frames; even then we only
-                // SIGSEGV when the faulting page (index 0) itself was never
-                // installed — if an earlier iteration already mapped it, the
-                // fault is resolved and we break to `return true`.
-                if let Some(g) = vm_generation.as_ref() {
-                    let gen_now = g.load(core::sync::atomic::Ordering::Acquire);
-                    if gen_now != gen_at_revalidate {
-                        // Re-validate the faulting VA's VMA (brief PROCESS_TABLE
-                        // re-acquire; PROCESS_TABLE is top of the lock order here
-                        // — MOUNTS / cache / PMM are NOT held).  Mirrors the
-                        // post-I/O revalidate above.
-                        let faulting_vma_ok = {
-                            let procs = crate::proc::PROCESS_TABLE.lock();
-                            procs.iter()
-                                .find(|p| p.pid == target_pid)
-                                .and_then(|p| p.vm_space.as_ref())
-                                .and_then(|vs| vs.find_vma(faulting_addr))
-                                .map(|v| {
-                                    matches!(&v.backing,
-                                        crate::mm::vma::VmBacking::File {
-                                            mount_idx: m, inode: ino, offset: o, ..
-                                        } if *m == mount_idx && *ino == inode
-                                            && *o == file_base_offset)
-                                    && v.base == vma_base
-                                    && v.base + v.length == vma_end
-                                })
-                                .unwrap_or(false)
-                        };
-                        if faulting_vma_ok {
-                            // Unrelated mutation — the faulting VMA is intact.
-                            // Resync the baseline and keep installing.  The
-                            // per-page atomic install protects against any
-                            // residual install/unmap race on each individual VA.
-                            gen_at_revalidate = gen_now;
-                            #[cfg(feature = "firefox-test-core")]
-                            {
-                                static REVAL: core::sync::atomic::AtomicU64 =
-                                    core::sync::atomic::AtomicU64::new(0);
-                                let n = REVAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                                if n < 5 || n % 5000 == 0 {
-                                    crate::serial_println!(
-                                        "[PF/gen-reval] READAHEAD addr={:#x} mount={} \
-                                         inode={} foff={:#x} gen_now={} — faulting VMA \
-                                         intact, continuing install (i={}/{})",
-                                        faulting_addr, mount_idx, inode,
-                                        file_base_offset, gen_now, i, n_pages);
-                                }
-                            }
-                        } else {
-                            // The faulting VA's own VMA was replaced/removed.
-                            // Drop every frame we have not yet installed; frames
-                            // installed in earlier iterations (i' < i) stay valid
-                            // via their PTE + cache refs.
-                            #[cfg(feature = "firefox-test-core")]
-                            crate::serial_println!(
-                                "[PF/gen-abort] READAHEAD addr={:#x} mount={} inode={} \
-                                 foff={:#x} gen_at_rev={} gen_now={} — faulting VMA \
-                                 replaced, releasing {} unmapped frames (i={})",
-                                faulting_addr, mount_idx, inode, file_base_offset,
-                                gen_at_revalidate, gen_now,
-                                n_pages.saturating_sub(i), i);
-                            for j in i..n_pages {
-                                let (_v, p, _f) = pages_to_map[j];
-                                crate::mm::pmm::free_page(p);
-                            }
-                            // The faulting page is pages_to_map[0].  If we already
-                            // passed iteration 0 it is installed and the fault is
-                            // resolved → break to the `mapped_faulting` return.
-                            // If we are still at iteration 0 the faulting page was
-                            // never mapped against a VMA that no longer describes
-                            // it → SIGSEGV (POSIX: access to an unmapped VA).
-                            if i == 0 {
-                                return false;
-                            }
-                            break;
-                        }
-                    }
-                }
+                // PFH-REVAL-1: the per-iteration `vm_space.generation` re-check
+                // is gone — PROCESS_TABLE is held continuously across this whole
+                // install loop (`_ra_pt_guard`), so no sibling-CPU VMA-list
+                // mutation (sys_munmap Phase 2a, MAP_FIXED replace, MADV_DONTNEED,
+                // mprotect, brk, clone_for_fork CoW write-protect) can land
+                // between the full-tuple re-validation above and any install
+                // below.  A concurrent munmap of the faulting range either
+                // removes the VMA before us (→ helper returned None above,
+                // abandon) or after us (its lock-free Phase 2b clears the PTEs we
+                // install).  The per-page atomic `map_page_in_if_absent`
+                // (mm_sem.read() + VMM_LOCK, present-recheck) still guards each
+                // individual VA against any residual install/install race on a
+                // shared CR3 (Intel SDM Vol. 3A §4.10.4.3).
 
                 // ---- Bug-B fix: guard reference ----------------------------
                 // Acquire a guard reference on `phys` BEFORE inserting it into
@@ -2790,6 +2697,17 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                 return true;  // Readahead handled the faulting page + extras.
             }
 
+            // PFH-REVAL-1: release the readahead PROCESS_TABLE guard BEFORE the
+            // single-page fallback.  The fallback re-enters the VFS read path
+            // (snapshots the FS handle, drops MOUNTS, dispatches `fs.read`), so
+            // it must NOT run under PROCESS_TABLE (PROCESS_TABLE → MOUNTS would
+            // invert the lock order).  When `mapped_faulting` is true the guard
+            // is dropped on the `return true` above; when false (`n_pages == 0`)
+            // no install ran under it, so dropping it here is safe.  The
+            // single-page fallback re-validates the faulting VA under its OWN
+            // re-acquired guard (`_sp_pt_guard`) after its I/O completes.
+            drop(_ra_pt_guard);
+
             // Fallback: readahead failed entirely — allocate single page.
             if let Some(phys) = crate::mm::pmm::alloc_page() {
                 unsafe {
@@ -2888,47 +2806,34 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     crate::mm::pmm::free_page(phys);
                     return false;
                 }
-                // === W216 Hypothesis-V fix: post-I/O VMA re-validation (single-page path) ===
+                // === Post-I/O VMA re-validation (single-page path) ===
                 //
-                // Same race as the readahead path above.  Between the PROCESS_TABLE
-                // drop (before I/O) and here, a sibling CPU running sys_mmap
-                // MAP_FIXED Phase 2b may have freed the frames backing this VA and
-                // replaced the VMA with a new one.  Re-validate before installing.
-                // W216 H_5j-B: capture the VmSpace generation post-revalidate
-                // and re-check it just before the cache::insert + map_page_in
-                // below.  Single-page path has one install, but a sibling CPU
-                // can still mutate the address space between the revalidate
-                // critical section and the install — same race class as the
-                // readahead arm above.  See `VmSpace::generation` doc comment.
-                let mut sp_vm_generation:
-                    Option<alloc::sync::Arc<core::sync::atomic::AtomicU64>> = None;
-                let mut sp_gen_at_revalidate: u64 = 0;
-                {
-                    let still_valid = {
-                        let procs = crate::proc::PROCESS_TABLE.lock();
-                        let vs_opt = procs.iter()
-                            .find(|p| p.pid == target_pid)
-                            .and_then(|p| p.vm_space.as_ref());
-                        if let Some(vs) = vs_opt {
-                            sp_vm_generation = Some(vs.generation.clone());
-                            sp_gen_at_revalidate =
-                                vs.generation.load(core::sync::atomic::Ordering::Acquire);
-                        }
-                        vs_opt
-                            .and_then(|vs| vs.find_vma(faulting_addr))
-                            .map(|v| {
-                                matches!(&v.backing,
-                                    crate::mm::vma::VmBacking::File {
-                                        mount_idx: m, inode: ino, offset: o, ..
-                                    } if *m == mount_idx && *ino == inode && *o == file_base_offset)
-                                && v.base == vma_base
-                                && v.base + v.length == vma_end
-                            })
-                            .unwrap_or(false)
-                    };
-                    if !still_valid {
-                        // VMA replaced during I/O.  Release the frame and let
-                        // the user re-fault against the replacement VMA.
+                // PFH-REVAL-1 (hold-across-install): the single-page I/O
+                // (`fs.read`) is complete by here, so acquire PROCESS_TABLE ONCE
+                // and HOLD it across the full-tuple re-validation AND the install
+                // below.  No MOUNTS/VFS call occurs in this span; lock order is
+                // PROCESS_TABLE (top) → cache / PMM / mm_sem.read() / VMM_LOCK,
+                // matching the ANON/COW arms.  Holding it closes the
+                // install-into-a-just-munmapped-range window (`sys_munmap` Phase
+                // 2a removes the VMA under PROCESS_TABLE before its lock-free
+                // Phase 2b PTE clear) AND subsumes the generation re-check — no
+                // VMA-list mutation can land between re-validation and install.
+                //
+                // PFH-REVAL-2 (full tuple) + PFH-REVAL-3 (fresh flags): the shared
+                // `pfh_file_vma_revalidate` helper re-validates the full
+                // `(mount, inode, offset, base, end)` tuple and re-derives
+                // `page_flags`/`is_shared` from the LIVE VMA.
+                let _sp_pt_guard = crate::proc::PROCESS_TABLE.lock();
+                let (page_flags, is_shared) = match pfh_file_vma_revalidate(
+                    &_sp_pt_guard, target_pid, faulting_addr,
+                    mount_idx, inode, file_base_offset, vma_base, vma_end,
+                ) {
+                    Some(fresh) => fresh,
+                    None => {
+                        // VMA replaced/removed during I/O (incl. a same-inode-
+                        // different-offset MAP_FIXED remap).  Release the frame
+                        // and let the user re-fault against the replacement VMA.
+                        drop(_sp_pt_guard);
                         #[cfg(feature = "firefox-test-core")]
                         crate::serial_println!(
                             "[PF/revalidate] SINGLE-PAGE VMA stale after I/O addr={:#x} \
@@ -2937,62 +2842,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                         crate::mm::pmm::free_page(phys);
                         return false;
                     }
-                }
-                // W216 H_5j-B: re-check generation immediately before install.
-                //
-                // `generation` is address-space-WIDE, so a bump can come from a
-                // mutation on an unrelated VA.  A `return false` here delivers
-                // SIGSEGV to the faulting thread immediately (this kernel has no
-                // silent re-fault), so the original abort killed a process whose
-                // faulting page was still a live, unchanged file mapping.  The
-                // recycle hazard is already closed by the `map_page_in_if_absent`
-                // install below (mm_sem + VMM_LOCK, present-recheck).  On a bump
-                // we therefore re-validate the SPECIFIC faulting VA; if its VMA
-                // still names the same backing we proceed, and only abandon the
-                // fault (legitimate SIGSEGV) if the faulting VA's own VMA was
-                // replaced/removed.  Per Intel SDM Vol. 3A §4.10.4.3.
-                if let Some(g) = sp_vm_generation.as_ref() {
-                    let gen_now = g.load(core::sync::atomic::Ordering::Acquire);
-                    if gen_now != sp_gen_at_revalidate {
-                        let faulting_vma_ok = {
-                            let procs = crate::proc::PROCESS_TABLE.lock();
-                            procs.iter()
-                                .find(|p| p.pid == target_pid)
-                                .and_then(|p| p.vm_space.as_ref())
-                                .and_then(|vs| vs.find_vma(faulting_addr))
-                                .map(|v| matches!(&v.backing,
-                                    crate::mm::vma::VmBacking::File {
-                                        mount_idx: m, inode: ino, ..
-                                    } if *m == mount_idx && *ino == inode))
-                                .unwrap_or(false)
-                        };
-                        if !faulting_vma_ok {
-                            #[cfg(feature = "firefox-test-core")]
-                            crate::serial_println!(
-                                "[PF/gen-abort] SINGLE-PAGE addr={:#x} mount={} inode={} \
-                                 foff={:#x} gen_at_rev={} gen_now={} — faulting VMA \
-                                 replaced, dropping frame",
-                                faulting_addr, mount_idx, inode, file_page_offset,
-                                sp_gen_at_revalidate, gen_now);
-                            crate::mm::pmm::free_page(phys);
-                            return false;
-                        }
-                        #[cfg(feature = "firefox-test-core")]
-                        {
-                            static REVAL: core::sync::atomic::AtomicU64 =
-                                core::sync::atomic::AtomicU64::new(0);
-                            let n = REVAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                            if n < 5 || n % 5000 == 0 {
-                                crate::serial_println!(
-                                    "[PF/gen-reval] SINGLE-PAGE addr={:#x} mount={} \
-                                     inode={} foff={:#x} gen_now={} — faulting VMA \
-                                     intact, proceeding with atomic install",
-                                    faulting_addr, mount_idx, inode,
-                                    file_page_offset, gen_now);
-                            }
-                        }
-                    }
-                }
+                };
                 // Bug-B fix (single-page fallback): hold a guard reference
                 // before inserting into the cache, mirroring the readahead-
                 // path fix above.  Without the guard, a concurrent cache::insert

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -31358,15 +31358,27 @@ fn test_pfh_gen_abort_revalidate_faulting_va() -> bool {
     use crate::mm::vma::{VmArea, VmBacking, VmSpace,
                          PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS};
     use core::sync::atomic::Ordering;
+    // Drive the SAME full-tuple FILE predicate the CACHE/READAHEAD/SINGLE-PAGE
+    // install arms call (`pfh_file_vma_match`), so any regression in the install
+    // arms' re-validation — in particular weakening the (mount, inode, offset,
+    // base, end) tuple back to a (mount, inode)-only check — fails this test.
+    use crate::arch::x86_64::idt::pfh_file_vma_match;
 
     let mut vm = match VmSpace::new_user() {
         Some(vs) => vs,
         None => { test_fail!("gen-reval", "VmSpace::new_user() OOM"); return false; }
     };
 
-    // Faulting anonymous VA + an UNRELATED file-backed VA elsewhere.
+    // Faulting anonymous VA, a faulting FILE-backed VA, and an UNRELATED VA.
     let anon_va: u64 = 0x5556_0001_0000;
     let anon_base = crate::mm::vma::page_align_down(anon_va);
+    let file_va: u64 = 0x5556_0020_0000;
+    let file_base = crate::mm::vma::page_align_down(file_va);
+    let file_len: u64 = 0x4000;
+    let file_end = file_base + file_len;
+    const F_MOUNT: usize = 0;
+    const F_INODE: u64 = 42;
+    const F_OFFSET: u64 = 0x8000;       // page-aligned file offset of this VMA
     let unrelated_base: u64 = 0x5556_0100_0000;
 
     macro_rules! bail { ($($arg:tt)*) => {{
@@ -31380,17 +31392,25 @@ fn test_pfh_gen_abort_revalidate_faulting_va() -> bool {
         prot: PROT_READ | PROT_WRITE, flags: MAP_PRIVATE | MAP_ANONYMOUS,
         backing: VmBacking::Anonymous, name: "[anon]",
     }).is_err() { bail!("insert anon VMA failed"); }
+    if vm.insert_vma(VmArea {
+        base: file_base, length: file_len,
+        prot: PROT_READ | PROT_WRITE, flags: MAP_PRIVATE,
+        backing: VmBacking::File {
+            mount_idx: F_MOUNT, inode: F_INODE, offset: F_OFFSET, elf_load_delta: 0 },
+        name: "[mmap-file]",
+    }).is_err() { bail!("insert file VMA failed"); }
 
     // Snapshot the generation BEFORE an unrelated mutation.
     let gen_before = vm.generation.load(Ordering::Acquire);
 
-    // (1) Unrelated mutation: insert a file VMA elsewhere.  insert_vma bumps
-    //     the address-space-wide generation (the trigger that used to SIGSEGV).
+    // (1) Unrelated mutation: insert an UNRELATED file VMA elsewhere.
+    //     insert_vma bumps the address-space-wide generation (the trigger that
+    //     used to SIGSEGV).
     if vm.insert_vma(VmArea {
         base: unrelated_base, length: 0x2000,
         prot: PROT_READ, flags: MAP_PRIVATE,
         backing: VmBacking::File { mount_idx: 0, inode: 7, offset: 0, elf_load_delta: 0 },
-        name: "[mmap-file]",
+        name: "[mmap-file2]",
     }).is_err() { bail!("insert unrelated file VMA failed"); }
 
     let gen_after = vm.generation.load(Ordering::Acquire);
@@ -31412,10 +31432,61 @@ fn test_pfh_gen_abort_revalidate_faulting_va() -> bool {
     if !still_writable {
         bail!("writable re-validation FALSE after unrelated bump — would spuriously SIGSEGV");
     }
-    test_println!("  (1) unrelated bump (gen {}→{}); faulting anon VMA intact → install proceeds ✓",
+    // The fixed FILE arms' shared predicate: faulting file VA, full tuple
+    // unchanged → Some (proceed), and the install would use the LIVE flags.
+    match pfh_file_vma_match(
+        vm.find_vma(file_va), F_MOUNT, F_INODE, F_OFFSET, file_base, file_end) {
+        Some((flags, is_shared)) => {
+            if flags & crate::mm::vmm::PAGE_WRITABLE == 0 {
+                bail!("file predicate returned RO flags for a PROT_WRITE VMA");
+            }
+            if is_shared {
+                bail!("file predicate reported MAP_SHARED for a MAP_PRIVATE VMA");
+            }
+        }
+        None => bail!("file re-validation FALSE after unrelated bump — would spuriously SIGSEGV"),
+    }
+    test_println!("  (1) unrelated bump (gen {}→{}); faulting anon+file VMAs intact → install proceeds ✓",
         gen_before, gen_after);
 
-    // (2) Genuine removal of the faulting VA's own VMA → predicate FALSE →
+    // (2) NON-TAUTOLOGY GUARD: same inode, DIFFERENT offset at the SAME VA.
+    //     Re-back the faulting file VA with a VMA that keeps (mount, inode) but
+    //     names a different file offset — the ld.so reserve-then-overwrite /
+    //     hole-punch class.  A (mount, inode)-only check (the pre-fix predicate)
+    //     would wrongly return Some and install OLD-offset bytes at this VA;
+    //     the full-tuple predicate MUST return None.  This is the assertion that
+    //     fails if the install arms regress to (mount, inode)-only.
+    if vm.remove_range(file_base, file_len).is_err() {
+        bail!("remove_range(file) failed");
+    }
+    if vm.insert_vma(VmArea {
+        base: file_base, length: file_len,
+        prot: PROT_READ | PROT_WRITE, flags: MAP_PRIVATE,
+        backing: VmBacking::File {
+            mount_idx: F_MOUNT, inode: F_INODE,
+            offset: F_OFFSET + file_len,   // SAME inode, DIFFERENT offset
+            elf_load_delta: 0 },
+        name: "[mmap-file-remap]",
+    }).is_err() { bail!("re-insert different-offset file VMA failed"); }
+    // Sanity: a (mount, inode)-only check WOULD match here (proves the case is
+    // real and the test is not vacuously passing on a missing VMA).
+    let mount_inode_only_would_match = matches!(
+        vm.find_vma(file_va).map(|v| &v.backing),
+        Some(VmBacking::File { mount_idx: m, inode: ino, .. })
+            if *m == F_MOUNT && *ino == F_INODE);
+    if !mount_inode_only_would_match {
+        bail!("remap VMA not found / wrong inode — test setup broken");
+    }
+    // The full-tuple predicate (asked for the ORIGINAL offset) must reject it.
+    if pfh_file_vma_match(
+        vm.find_vma(file_va), F_MOUNT, F_INODE, F_OFFSET, file_base, file_end).is_some() {
+        bail!("FULL-TUPLE FILE predicate returned Some for a same-inode-DIFFERENT-offset \
+               remap — wrong-offset .text/GOT corruption (predicate weakened to (mount,inode))");
+    }
+    test_println!("  (2) same-inode-different-offset remap → full-tuple predicate FALSE \
+                   (would install OLD-offset bytes under a (mount,inode)-only check) ✓");
+
+    // (3) Genuine removal of the faulting anon VA's own VMA → predicate FALSE →
     //     legitimate SIGSEGV (the user really lost this mapping).
     if vm.remove_range(anon_base, 0x4000).is_err() {
         bail!("remove_range(anon) failed");
@@ -31424,7 +31495,22 @@ fn test_pfh_gen_abort_revalidate_faulting_va() -> bool {
     if !gone {
         bail!("faulting VMA still present after remove_range — predicate would not SIGSEGV");
     }
-    test_println!("  (2) faulting VMA removed → re-validation FALSE → legitimate SIGSEGV ✓");
+    // The FILE predicate on a fully-removed VA must also be None.
+    if pfh_file_vma_match(
+        vm.find_vma(file_va), F_MOUNT, F_INODE, F_OFFSET + file_len, file_base, file_end).is_some() {
+        // (file VA still mapped by the remap; remove it too, then re-check)
+        let _ = vm.remove_range(file_base, file_len);
+        if pfh_file_vma_match(
+            vm.find_vma(file_va), F_MOUNT, F_INODE, F_OFFSET + file_len, file_base, file_end).is_some() {
+            bail!("FILE predicate returned Some after the VMA was removed");
+        }
+    }
+    test_println!("  (3) faulting VMA removed → re-validation FALSE → legitimate SIGSEGV ✓");
+
+    // NOTE (future work): this models the predicates the install arms call; a
+    // full two-CPU concurrency test (sibling munmap/MAP_FIXED racing the FILE
+    // install while PROCESS_TABLE is held across both re-validation and install)
+    // is not exercised here and is left for a dedicated SMP harness test.
 
     crate::proc::free_vm_space(vm);
     test_pass!("PFH gen-abort re-validates faulting VA");

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1174,6 +1174,10 @@ pub fn run() -> ! {
     total += 1;
     if test_pfh_cow_arm_anti_alias_refcount() { passed += 1; }
 
+    // ── Test 98j: gen-abort re-validates the faulting VA (no spurious SIGSEGV)
+    total += 1;
+    if test_pfh_gen_abort_revalidate_faulting_va() { passed += 1; }
+
     // ── Test 99: procfs self/maps — per-process VMA listing ──────────────
 
     total += 1;
@@ -31326,6 +31330,104 @@ fn test_pfh_install_arm_anti_alias_backout() -> bool {
     crate::proc::free_vm_space(vm);
 
     test_pass!("PFH install-arm anti-aliasing back-out");
+    true
+}
+
+/// Regression test for the PFH generation-abort over-release use-after-fault.
+///
+/// The page-fault handler's install arms sample an address-space-wide
+/// `generation` counter and re-check it immediately before installing a PTE.
+/// The original arms returned `false` on ANY generation change; a `false`
+/// return from `handle_page_fault` delivers SIGSEGV to the faulting thread
+/// immediately (this kernel has no silent re-fault), so an unrelated
+/// concurrent mmap/munmap/brk on a SIBLING virtual address killed processes
+/// whose faulting page was a live, unchanged mapping — a fatal
+/// use-after-fault exposed once SMP became genuinely concurrent.
+///
+/// The fix narrows the abort: on a generation change the handler re-validates
+/// the SPECIFIC faulting VA and only abandons the fault (SIGSEGV) if that VA's
+/// OWN VMA was removed or re-backed; an unrelated mutation lets the install
+/// proceed.  This test models the exact re-validation predicates the fixed
+/// arms use (anonymous VMA still covers the addr; file VMA still names the
+/// same (mount,inode); writable VMA still grants PROT_WRITE) and confirms:
+///   (1) an unrelated generation bump leaves every predicate TRUE → proceed;
+///   (2) removing/re-backing the faulting VMA flips its predicate FALSE →
+///       legitimate SIGSEGV.
+fn test_pfh_gen_abort_revalidate_faulting_va() -> bool {
+    test_header!("PFH gen-abort re-validates faulting VA (no spurious SIGSEGV)");
+    use crate::mm::vma::{VmArea, VmBacking, VmSpace,
+                         PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS};
+    use core::sync::atomic::Ordering;
+
+    let mut vm = match VmSpace::new_user() {
+        Some(vs) => vs,
+        None => { test_fail!("gen-reval", "VmSpace::new_user() OOM"); return false; }
+    };
+
+    // Faulting anonymous VA + an UNRELATED file-backed VA elsewhere.
+    let anon_va: u64 = 0x5556_0001_0000;
+    let anon_base = crate::mm::vma::page_align_down(anon_va);
+    let unrelated_base: u64 = 0x5556_0100_0000;
+
+    macro_rules! bail { ($($arg:tt)*) => {{
+        crate::proc::free_vm_space(vm);
+        test_fail!("gen-reval", $($arg)*);
+        return false;
+    }}; }
+
+    if vm.insert_vma(VmArea {
+        base: anon_base, length: 0x4000,
+        prot: PROT_READ | PROT_WRITE, flags: MAP_PRIVATE | MAP_ANONYMOUS,
+        backing: VmBacking::Anonymous, name: "[anon]",
+    }).is_err() { bail!("insert anon VMA failed"); }
+
+    // Snapshot the generation BEFORE an unrelated mutation.
+    let gen_before = vm.generation.load(Ordering::Acquire);
+
+    // (1) Unrelated mutation: insert a file VMA elsewhere.  insert_vma bumps
+    //     the address-space-wide generation (the trigger that used to SIGSEGV).
+    if vm.insert_vma(VmArea {
+        base: unrelated_base, length: 0x2000,
+        prot: PROT_READ, flags: MAP_PRIVATE,
+        backing: VmBacking::File { mount_idx: 0, inode: 7, offset: 0, elf_load_delta: 0 },
+        name: "[mmap-file]",
+    }).is_err() { bail!("insert unrelated file VMA failed"); }
+
+    let gen_after = vm.generation.load(Ordering::Acquire);
+    if gen_after == gen_before {
+        bail!("unrelated insert did not bump generation (before={} after={})",
+            gen_before, gen_after);
+    }
+
+    // The fixed ANON arm's predicate: faulting VA is still anonymous → proceed.
+    let still_anon = matches!(
+        vm.find_vma(anon_va).map(|v| &v.backing),
+        Some(VmBacking::Anonymous));
+    if !still_anon {
+        bail!("anon re-validation FALSE after unrelated bump — would spuriously SIGSEGV");
+    }
+    // The fixed COW-COPY arm's predicate: faulting VA still writable → proceed.
+    let still_writable = vm.find_vma(anon_va)
+        .map(|v| v.prot & PROT_WRITE != 0).unwrap_or(false);
+    if !still_writable {
+        bail!("writable re-validation FALSE after unrelated bump — would spuriously SIGSEGV");
+    }
+    test_println!("  (1) unrelated bump (gen {}→{}); faulting anon VMA intact → install proceeds ✓",
+        gen_before, gen_after);
+
+    // (2) Genuine removal of the faulting VA's own VMA → predicate FALSE →
+    //     legitimate SIGSEGV (the user really lost this mapping).
+    if vm.remove_range(anon_base, 0x4000).is_err() {
+        bail!("remove_range(anon) failed");
+    }
+    let gone = vm.find_vma(anon_va).is_none();
+    if !gone {
+        bail!("faulting VMA still present after remove_range — predicate would not SIGSEGV");
+    }
+    test_println!("  (2) faulting VMA removed → re-validation FALSE → legitimate SIGSEGV ✓");
+
+    crate::proc::free_vm_space(vm);
+    test_pass!("PFH gen-abort re-validates faulting VA");
     true
 }
 


### PR DESCRIPTION
## Summary

The page-fault handler's six demand-paging install arms (COW-COPY, CACHE-PRIVATE, CACHE-ALIAS, READAHEAD, SINGLE-PAGE, ANON in `arch/x86_64/idt.rs`) sample the address-space-wide `VmSpace::generation` counter and re-check it immediately before installing a leaf PTE. Each arm returned `false` on **any** change to that counter. This is the hard blocker for the Firefox real-website demo: 2/2 boots SIGSEGV'd the main Firefox process (PID 1) during startup, before any page navigation.

## Answer to the key open question — why does the retry SIGSEGV?

It is **not** a retry. A `false` return from `handle_page_fault` delivers SIGSEGV to the faulting thread **immediately** — there is no silent re-fault in this kernel:

- `idt.rs:622` — `if handle_page_fault(cr2, error_code, frame) { … return; }`; on `false` the handler falls through.
- `idt.rs:738` — `deliver_sigsegv_from_isr(...)` is called directly on the `false` path.

So the gen-abort's documented rationale ("abort … so the user re-faults against the new VMA") was factually wrong: the `free_page(...); return false` in the abort arms **is** the SIGSEGV. This is option **(d)** from the dispatch: the abort path explicitly signals failure → SIGSEGV delivery. In the READAHEAD/ANON arms the aborted page is the **faulting page itself** (readahead window starts at `page_addr`, `pages_to_map[0]`), freed without ever installing a PTE, then SIGSEGV'd on the live VMA — a deterministic use-after-fault, not a recoverable re-fault.

## Root cause

`VmSpace::generation` is an **address-space-wide** counter bumped for *every* VMA-list mutation anywhere in the address space — `insert_vma` (mmap), `remove_range` (munmap / MAP_FIXED replace / MADV_DONTNEED), `adjust_brk`, and the `clone_for_fork` CoW write-protect pass — including mutations on virtual addresses **unrelated** to the faulting one. A sibling CPU running any mmap/brk during the faulting thread's install window aborted (→ SIGSEGV) a fault whose page was a perfectly valid, unchanged mapping.

The bug was dormant while one CPU was effectively single-threaded through each install loop. Once both CPUs became genuinely concurrent (`[SCHED/STARVE] force-select` firing on both CPUs in the failing boots) it fired deterministically during Firefox startup — `[PROC] PID 1 exit_group(11) caller_tid=2` at sc~150-205k.

## Serial evidence (reproduced before the fix, unmodified base kernel)

```
[PF/gen-abort] ANON #0 addr=0x7ef53f03a000 gen_at_start=9465 gen_now=9466 — releasing frame
!!! Page Fault (error_code=0x6)  CR2: 0x00007ef53f03a000  RIP: 0x00007f6565f1640c  not-present WRITE USER
[SIGNAL] SIGSEGV ISR delivery: PID=1 CR2=0x7ef53f03a000 ...
[SIGNAL/VMA] pid=1 name=[mmap] base=0x7ef53f02b000 end=0x7ef53f12c000 prot=rw- anon=1   ← faulting VMA STILL LIVE
[D13/CR2-PROV] pid=1 tid=2 cr2=0x7ef53f03a000 data_phys=UNMAPPED
```
RIP bytes `f3 48 a5` = musl `rep movsq` into the still-mapped anon VMA. The gen-abort and the SIGSEGV are the **same** fault, tid=2, same address — exactly one gen-abort → exactly one SIGSEGV → PID 1 dies.

## The fix

The actual hazard the gen-check was meant to guard — installing a PTE over a frame a concurrent `unmap_and_free_range_in` is freeing — is already closed by the atomic install primitives each arm uses: `map_page_in_if_absent` and `map_page_in_cow_if_unchanged` hold `mm_sem` + `VMM_LOCK` and write the leaf PTE only if it is still absent / still maps the expected old frame (Intel SDM Vol. 3A §4.10.4.3). The loser of any install/unmap race on **this** VA backs out and frees only its own fresh frame — the established CAS-install loser-backout contract.

So on a generation change we re-validate the **specific faulting VA** instead of aborting unconditionally:
- **Faulting VMA still covers the address with the same backing** (anonymous / same file `(mount,inode)` / still `PROT_WRITE` for CoW) → unrelated mutation → proceed with the atomic install (READAHEAD resyncs its generation baseline and continues).
- **Faulting VA's own VMA removed or re-backed** → abandon the fault — a legitimate SIGSEGV per POSIX (access to an unmapped address). In READAHEAD, a replaced VMA after iteration 0 means the faulting page is already installed → break to `return true` rather than SIGSEGV.

No lock added; `PROCESS_TABLE` re-acquired briefly for re-validation only where it was already dropped (top of the lock order; MOUNTS/cache/PMM not held). The CAS loser-backout contract is preserved on every arm. The generation property (don't install over a concurrently-mutated faulting VA) is retained — narrowed from "any mutation" to "this VA's mutation".

## Verification — 3/3 firefox-test boots at smp=2 KVM

| sid | gen-abort | PID-1 SIGSEGV | exit_group(11) | content-procs | bbc.com TLS ClientHello | teardown bugcheck |
|---|---|---|---|---|---|---|
| `a1d0cb5922d9` | 0 | 0 | 0 | ✓ | 6 (incl. BBC 212.58.235.129 + Fastly) | 0 |
| `724f51e147f5` | 0 | 0 | 0 | ✓ | 4 (Fastly 151.101.x) | 0 |
| `bb16ebbf19b7` | 0 | 0 | 0 | ✓ | 6 (incl. BBC 212.58.236.129 + Fastly) | 0 |

All 3 boots ran past the sc150-205k window where the unmodified kernel deterministically crashed (now at sc 152k-180k, still running), reached the `[GATE] content-procs` gate, and issued real bbc.com HTTPS TLS ClientHellos — navigation begins (the gold marker; the unfixed kernel issued ZERO TLS ClientHello). Zero teardown bugchecks confirms no #552 regression. The kernel builds clean under `test-mode`; adds `test_pfh_gen_abort_revalidate_faulting_va` (Test 98j) modelling the re-validation predicates.

> The in-kernel `test-mode` suite currently hangs on a pre-existing `pipe blocking write` sub-test (`test_pipe_blocking_write_semantics`, registered far earlier than the mm tests; introduced by the recent pipe-blocking lineage `a33910a`) under genuinely-concurrent SMP — orthogonal to this change, which touches only PFH install arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)