### PR TITLE
mm/mmap: re-pick base on lost placement race (GATE-A startup SIGSEGV)

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -3424,6 +3424,53 @@ pub(crate) fn sys_dsp_ioctl(request: u64, arg_ptr: *mut u8) -> i64 {
 ///
 /// Supports both anonymous (MAP_ANONYMOUS) and file-backed mappings.
 /// Actual physical pages are allocated on demand via the page-fault handler.
+/// Test-mode state for the mmap placement-race re-pick test (see
+/// `mmap_test_inject_placement_squatter` and `test_runner.rs`).
+#[cfg(feature = "test-mode")]
+pub mod mmap_race_test {
+    use core::sync::atomic::AtomicU64;
+    /// Pid armed to deterministically lose the Phase-1→Phase-3 placement
+    /// race on its next kernel-placed mmap (0 = disarmed).
+    pub static ARMED_PID: AtomicU64 = AtomicU64::new(0);
+    /// Base address where the squatter VMA was injected (for the test to
+    /// read back and clean up; 0 = hook has not fired).
+    pub static SQUATTER_BASE: AtomicU64 = AtomicU64::new(0);
+}
+
+/// When armed for `pid`, insert a 1-page anonymous VMA at `base` — the
+/// address Phase 1 just chose — mimicking a sibling thread's concurrent
+/// kernel-placed mmap winning the Phase-1→Phase-3 window.  One-shot.
+#[cfg(feature = "test-mode")]
+fn mmap_test_inject_placement_squatter(pid: u64, base: u64, is_fixed: bool) {
+    use core::sync::atomic::Ordering;
+    use crate::mm::vma::*;
+    if is_fixed {
+        return;
+    }
+    if mmap_race_test::ARMED_PID
+        .compare_exchange(pid, 0, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    let mut procs = crate::proc::PROCESS_TABLE.lock();
+    if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+        if let Some(space) = p.vm_space.as_mut() {
+            let squatter = VmArea {
+                base,
+                length: 0x1000,
+                prot: PROT_READ | PROT_WRITE,
+                flags: MAP_PRIVATE | MAP_ANONYMOUS,
+                backing: VmBacking::Anonymous,
+                name: "[test-squatter]",
+            };
+            if space.insert_vma(squatter).is_ok() {
+                mmap_race_test::SQUATTER_BASE.store(base, Ordering::Release);
+            }
+        }
+    }
+}
+
 pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u64, offset: u64) -> i64 {
     use crate::mm::vma::*;
 
@@ -3631,6 +3678,15 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
     #[cfg(not(any(feature = "firefox-test-core", feature = "test-mode-trace")))]
     let (cr3, backing, name, base) = mmap_setup;
 
+    // ── Test-mode hook: deterministically lose the Phase-1→Phase-3 placement
+    // race.  When armed for this pid, a 1-page squatter VMA is inserted at the
+    // just-chosen base — exactly what a sibling thread's concurrent mmap
+    // Phase 3 would do in the window between our two PROCESS_TABLE
+    // acquisitions — so the Phase-3 re-pick path is exercised without relying
+    // on real cross-CPU timing.  Compiled out of production kernels.
+    #[cfg(feature = "test-mode")]
+    mmap_test_inject_placement_squatter(pid, base, is_fixed);
+
     // W215 H3a diagnostic: count MAP_SHARED+PROT_WRITE file-backed mappings.
     //
     // The check is after argument decode and backing resolution (above), but
@@ -3787,6 +3843,51 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
         None => return -3,
     };
 
+    // Re-validate the Phase-1 placement under the lock we now hold.  The
+    // address pick (find_free_range / find_free_stack_range, Phase 1) and
+    // this insert run under SEPARATE PROCESS_TABLE acquisitions, so a sibling
+    // thread's mmap / brk / stack allocation can claim an overlapping range in
+    // the window between them.  For kernel-placed (non-MAP_FIXED) requests
+    // POSIX mmap(2) leaves the placement entirely to the implementation, so
+    // the correct response to losing that race is to RE-PICK here — atomically
+    // with the insert — never to fail the call.  Returning ENOMEM for the
+    // transient collision was a real-workload killer: the loser of two
+    // concurrent kernel-placed mmaps on SMP got a spurious ENOMEM, which a
+    // release-assert in the caller then escalated to a fatal abort.
+    //
+    // MAP_FIXED keeps its address contract and is NOT re-picked: its Phase 2a
+    // remove_range cleared the requested range, and a squatter VMA appearing
+    // in the 2a→3 window still fails the insert below (residual divergence —
+    // mmap(2) MAP_FIXED would atomically replace; tracked as a follow-up
+    // because handling it requires re-running the 2a/2b teardown loop).
+    let mut vma = vma;
+    let mut base = base;
+    if !is_fixed && space.areas.iter().any(|v| v.overlaps(base, length)) {
+        let repick = if is_stack_alloc {
+            space.find_free_stack_range(length)
+        } else {
+            space.find_free_range(length)
+        };
+        match repick {
+            Some(b) => {
+                #[cfg(feature = "firefox-test-core")]
+                crate::serial_println!(
+                    "[MMAP-REPICK] pid={} lost placement race: base={:#x} len={:#x} re-placed at {:#x}",
+                    pid, base, length, b
+                );
+                base = b;
+                vma.base = b;
+            }
+            None => {
+                crate::serial_println!(
+                    "[MMAP-ERR] pid={} address space exhausted on re-pick: len={:#x} flags={:#x} fd={}",
+                    pid, length, flags, fd as i64
+                );
+                return -12; // ENOMEM — genuinely out of address space
+            }
+        }
+    }
+
     match space.insert_vma(vma) {
         Ok(()) => {
             // Lower `mmap_hint` only when this allocation participates in the
@@ -3813,7 +3914,14 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
                 "[MMAP-ERR] pid={} insert_vma failed: base={:#x} len={:#x} flags={:#x} fd={}",
                 pid, base, length, flags, fd as i64
             );
-            -12 // ENOMEM
+            if is_noreplace {
+                // A mapping appeared in the requested range between the
+                // Phase-1 conflict check and this insert.  Per mmap(2),
+                // MAP_FIXED_NOREPLACE reports a collision as EEXIST.
+                -17 // EEXIST
+            } else {
+                -12 // ENOMEM
+            }
         }
     }
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2927,6 +2927,13 @@ pub fn run() -> ! {
     total += 1;
     if test_298_epollet_eventfd_write_refire() { passed += 1; }
 
+    // ── Test 299: mmap re-picks the base when it loses the placement race ──
+    // Per POSIX mmap(2), a NULL-addr non-FIXED request leaves placement to
+    // the implementation; losing the internal Phase-1→Phase-3 window to a
+    // sibling thread's allocation must re-pick, never return ENOMEM.
+    total += 1;
+    if test_299_mmap_placement_race_repick() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -52063,6 +52070,90 @@ fn test_298_epollet_eventfd_write_refire() -> bool {
 
     if ok {
         test_pass!("EPOLLET eventfd re-fires on every write (Test 298)");
+    }
+    ok
+}
+
+// ── Test 299: mmap re-picks the base when it loses the placement race ─────────
+//
+// sys_mmap chooses the base address (Phase 1) and inserts the VMA (Phase 3)
+// under SEPARATE PROCESS_TABLE acquisitions; a sibling thread's mmap can
+// claim an overlapping range in the window.  Per POSIX mmap(2), when addr is
+// NULL and MAP_FIXED is unset the placement is entirely the implementation's
+// choice — losing the internal race must therefore re-pick a fresh base, not
+// fail.  The regression (spurious ENOMEM for the loser) aborted real
+// multi-threaded workloads whose shared-memory paths release-assert on mmap
+// success.  The test arms a deterministic hook that injects a 1-page squatter
+// VMA at the Phase-1-chosen base (exactly what the winning sibling would
+// install), then asserts the call still succeeds at a non-overlapping
+// address.  Refs: POSIX.1-2017 mmap(2).
+fn test_299_mmap_placement_race_repick() -> bool {
+    use core::sync::atomic::Ordering;
+    test_header!("mmap re-pick on lost placement race (Test 299)");
+    let mut ok = true;
+
+    let pid = crate::proc::current_pid();
+
+    const LEN: u64 = 0x3000;
+    const PROT_RW: u32 = 3; // PROT_READ | PROT_WRITE
+    const MAP_PRIVATE_ANON: u32 = 0x22; // MAP_PRIVATE | MAP_ANONYMOUS
+
+    // Arm the one-shot squatter injection for our pid, then mmap.
+    crate::syscall::mmap_race_test::SQUATTER_BASE.store(0, Ordering::Release);
+    crate::syscall::mmap_race_test::ARMED_PID.store(pid, Ordering::Release);
+    let ret = crate::syscall::sys_mmap(0, LEN, PROT_RW, MAP_PRIVATE_ANON, u64::MAX, 0);
+    // Defensive disarm in case the hook did not consume the arm.
+    crate::syscall::mmap_race_test::ARMED_PID.store(0, Ordering::Release);
+    let squatter = crate::syscall::mmap_race_test::SQUATTER_BASE.swap(0, Ordering::AcqRel);
+
+    if squatter == 0 {
+        test_fail!("mmap-repick", "squatter hook did not fire (no race simulated)");
+        return false;
+    }
+    test_println!("  squatter injected at {:#x}", squatter);
+
+    if ret < 0 {
+        test_fail!("mmap-repick",
+            "lost placement race returned error {} (want success at a fresh base)", ret);
+        // Clean up the squatter before bailing.
+        let _ = crate::syscall::sys_munmap(squatter, 0x1000);
+        return false;
+    }
+    let got = ret as u64;
+    test_println!("  mmap returned {:#x}", got);
+
+    // The returned range must not overlap the squatter page.
+    if got < squatter + 0x1000 && squatter < got + LEN {
+        test_fail!("mmap-repick",
+            "returned range [{:#x}..{:#x}) overlaps squatter [{:#x}..{:#x})",
+            got, got + LEN, squatter, squatter + 0x1000);
+        ok = false;
+    }
+
+    // The VMA list must hold both areas with no pairwise overlap (list is
+    // sorted by base; adjacent-pair check is sufficient).
+    {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter().find(|p| p.pid == pid) {
+            if let Some(space) = p.vm_space.as_ref() {
+                for w in space.areas.windows(2) {
+                    if w[0].base + w[0].length > w[1].base {
+                        test_fail!("mmap-repick",
+                            "overlapping VMAs after re-pick: [{:#x}..{:#x}) and [{:#x}..{:#x})",
+                            w[0].base, w[0].base + w[0].length, w[1].base, w[1].base + w[1].length);
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    let _ = crate::syscall::sys_munmap(got, LEN);
+    let _ = crate::syscall::sys_munmap(squatter, 0x1000);
+
+    if ok {
+        test_pass!("mmap re-picks a fresh base on lost placement race (Test 299)");
     }
     ok
 }


### PR DESCRIPTION
## Root cause — GATE-A flaky Firefox startup NULL-deref

`sys_mmap` picks the base address (Phase 1: `find_free_range` / `find_free_stack_range` under PROCESS_TABLE) and inserts the VMA (Phase 3: `insert_vma` under a **separate** PROCESS_TABLE acquisition). A sibling thread's mmap/brk/stack allocation can claim an overlapping range in the window; `insert_vma`'s only failure mode is Overlap, and the call returned **ENOMEM**.

Per POSIX mmap(2), a NULL-addr non-FIXED request leaves placement entirely to the implementation — losing an internal placement race is not an observable error. Firefox's shared-memory paths `MOZ_RELEASE_ASSERT` on mapping success; the loser of two concurrent kernel-placed mmaps aborted via the deliberate `mov [0], <line>` crash store (the observed CR2=0x0, rbp=0 SIGSEGV).

### Evidence chain (boots on 4c9234e, smp=2 KVM, `--trace`)
- 3/3 boots died at GATE-A; **every** death preceded 1:1 by `[MMAP-ERR] pid=N insert_vma failed ... flags=0x1` for the dying pid (observed pids 1/3/5, 5 instances across 3 boots).
- Syscall ring shows the exact losing call, e.g. `mmap(0, 0x87c, RW, MAP_SHARED, fd=32) = -12` — a sub-page shared mapping "out of memory" at startup.
- FF stderr names it: `WARNING: Call to mmap failed: Out of memory: ... shared_memory_posix.cc:515`.
- All three death RIPs decode to deliberate Gecko aborts (`MOZ_RELEASE_ASSERT(result.isOk())` ×2 sites, `MOZ_CRASH(IPC FatalError in the parent process!)`).
- `--trace` widens the window (serial emit sits between the phases): 3/3 vs ~50% plain — consistent with a pure timing race.
- Dual-core exposure: pre-#552 the machine was de-facto single-core; the window needs true concurrency.

### Fix
Phase 3 re-validates the chosen base under the lock it already holds; if the range was claimed, it re-picks via the same allocator arm (stack window or general walk) atomically with the insert. ENOMEM remains only for genuine address-space exhaustion. MAP_FIXED keeps its address contract (never re-picked). MAP_FIXED_NOREPLACE collisions in the window now report EEXIST per mmap(2).

### Test
Test 299 arms a deterministic test-mode hook that injects a 1-page squatter VMA at the Phase-1-chosen base (exactly what the winning sibling would install) and asserts success at a non-overlapping address + an overlap-free VMA list. Passes; full suite run shows no new failures (remaining: known env-gap fixtures + pre-existing test518b / monotonic-rate flakes in untouched subsystems).

### Verification (live)
- Base (4c9234e): 3/3 boots → GATE-A death (PID=1 SIGSEGV CR2=0x0).
- Fixed: see verification results in PR comments (4 boots, expect 0 deaths + `[MMAP-REPICK]` lines proving the race fired and was healed).

### Residual divergences noted (not in scope)
- MAP_FIXED squatter in the Phase-2a→3 window still fails the insert (mmap(2) would atomically replace) — needs the 2a/2b teardown re-run loop; never observed live.
- `[FFTEST/mmap-so]` trace line prints the pre-re-pick base if a `.so` map loses the race (symbolication off for that one lib until the `[MMAP-REPICK]` line is consumed by the harness symboliser).
- `[TLB/TIMEOUT]` warnings are a separate liveness symptom (quarantine path engages by design, `mm/tlb.rs:585`) — present in 2 of 3 dying boots but absent in the third; ruled out as GATE-A's cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)