### PR TITLE
fix(vfs): /dev/urandom must never repeat blocks across same-tick reads (BBC loadURI gate root cause)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1307,6 +1307,11 @@ pub fn run() -> ! {
     total += 1;
     if test_dev_dsp_ioctl_set_format() { passed += 1; }
 
+    // ── Test 520: /dev/urandom — consecutive same-tick blocks differ ───────
+
+    total += 1;
+    if test_dev_urandom_consecutive_blocks_differ() { passed += 1; }
+
     // ── Test 116: mount tmpfs + write/read + umount ────────────────────────
 
     total += 1;
@@ -26289,6 +26294,70 @@ fn test_dev_dsp_open_with_ac97_absent() -> bool {
         test_fail!("dev_dsp_absent", "expected -19 (ENODEV), got {}", fd);
         false
     }
+}
+
+// ── Test 520: /dev/urandom — consecutive same-tick blocks differ ─────────────
+//
+// Regression test for the navigation-killing RNG defect: the /dev/urandom
+// read arm in `vfs::fd_read` derived every byte purely from the 10 ms
+// scheduler tick, so two 32-byte reads inside one tick were byte-identical.
+// PKCS#11 soft-token modules run the FIPS 140-2 §4.9.2 continuous RNG
+// self-test at C_Initialize — consecutive fixed-size blocks from the system
+// RNG must differ, else the module fails with CKR_DEVICE_ERROR and every
+// TLS consumer in the process loses its crypto provider.  This test mirrors
+// that exact access pattern: open → read(32) → close, twice back-to-back
+// (guaranteed to land in the same tick at boot-test speed), plus an
+// advancing-stream check on a single open fd.
+fn test_dev_urandom_consecutive_blocks_differ() -> bool {
+    test_header!("/dev/urandom — consecutive same-tick 32-byte blocks differ");
+
+    let mut blocks = [[0u8; 32]; 2];
+    for block in blocks.iter_mut() {
+        let fd = crate::syscall::sys_open_test("/dev/urandom", 0 /* O_RDONLY */);
+        if fd < 0 {
+            test_fail!("urandom_blocks", "open(/dev/urandom) = {}", fd);
+            return false;
+        }
+        let n = crate::syscall::sys_read_test(fd as usize, block.as_mut_ptr(), 32);
+        let _ = crate::syscall::sys_close_test(fd as usize);
+        if n != 32 {
+            test_fail!("urandom_blocks", "read 32 returned {}", n);
+            return false;
+        }
+    }
+    if blocks[0] == blocks[1] {
+        test_fail!("urandom_blocks",
+            "two consecutive 32-byte reads returned identical blocks");
+        return false;
+    }
+    if blocks[0] == [0u8; 32] || blocks[1] == [0u8; 32] {
+        test_fail!("urandom_blocks", "urandom returned an all-zero block");
+        return false;
+    }
+
+    // Stream must also advance WITHIN one open file description.
+    let fd = crate::syscall::sys_open_test("/dev/urandom", 0);
+    if fd < 0 {
+        test_fail!("urandom_blocks", "re-open(/dev/urandom) = {}", fd);
+        return false;
+    }
+    let mut c = [0u8; 32];
+    let mut d = [0u8; 32];
+    let n1 = crate::syscall::sys_read_test(fd as usize, c.as_mut_ptr(), 32);
+    let n2 = crate::syscall::sys_read_test(fd as usize, d.as_mut_ptr(), 32);
+    let _ = crate::syscall::sys_close_test(fd as usize);
+    if n1 != 32 || n2 != 32 {
+        test_fail!("urandom_blocks", "same-fd reads returned {} / {}", n1, n2);
+        return false;
+    }
+    if c == d {
+        test_fail!("urandom_blocks",
+            "two 32-byte reads on one fd returned identical blocks");
+        return false;
+    }
+
+    test_pass!("/dev/urandom consecutive 32-byte blocks differ (cross-open and same-fd)");
+    true
 }
 
 // ── Test 111: /dev/dsp — open + write when AC97 present ──────────────────────

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2572,13 +2572,33 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                 }
                 return Ok(count);
             }
-            // bit 24 = /dev/urandom | /dev/random  → fill with pseudo-random bytes
+            // bit 24 = /dev/urandom | /dev/random  → fill with CSPRNG bytes.
+            //
+            // The stream MUST advance between consecutive reads.  PKCS#11
+            // soft-token modules (the TLS stack Firefox ships is one) run the
+            // FIPS 140-2 §4.9.2 continuous random-number-generator self-test:
+            // each fixed-size block read from the system RNG is compared with
+            // the previous one, and the module fails C_Initialize with
+            // CKR_DEVICE_ERROR when two consecutive blocks are identical
+            // (PKCS#11 v2.40 §5.1.6 error semantics).  The previous generator
+            // here was a pure function of the 10 ms scheduler tick plus the
+            // byte index, so two 32-byte reads landing in the same tick
+            // returned byte-identical blocks → every TLS-capable process lost
+            // its crypto provider at init.  Route through
+            // `security::rand::rand_u64` instead: RDRAND-backed with a
+            // TSC-seeded fallback, and the same chokepoint that ASLR,
+            // AT_RANDOM and getrandom(2) use — so `astryx.rng_seed=`
+            // record-replay determinism covers this path too.  Per random(4),
+            // /dev/random and /dev/urandom may serve the same CSPRNG.
             if flags & 0x0100_0000 != 0 {
-                let t = crate::arch::x86_64::irq::get_ticks();
                 unsafe {
                     let _g = crate::arch::x86_64::smap::UserGuard::new();
-                    for i in 0..count {
-                        *buf.add(i) = (t.wrapping_add(i as u64).wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407) & 0xFF) as u8;
+                    let mut i: usize = 0;
+                    while i < count {
+                        let bytes = crate::security::rand::rand_u64().to_le_bytes();
+                        let n = (count - i).min(8);
+                        core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf.add(i), n);
+                        i += n;
                     }
                 }
                 return Ok(count);


### PR DESCRIPTION
## The gate

QA retest at `8bffee9` (3 boots, smp=2 KVM, `--ff-url https://bbc.com/news`): FF reaches `[GATE] screenshot-actors` with a full e10s tree, but **never navigates** — pcap shows zero TLS ClientHello, zero `:443` SYNs (DNS resolves, plain `:80` HTTP works), pid 3 (the socket process) dead as an unreaped zombie at `exit_group(1)`, pid 1 livelocked. 5/5 deterministic across two feature builds at head.

## Root cause (one bug, every symptom)

`vfs::fd_read`'s `/dev/urandom` arm computed every byte as a **pure function of the 10 ms scheduler tick + byte index**. Two back-to-back 32-byte reads inside one tick are byte-identical.

PKCS#11 soft tokens run the FIPS 140-2 §4.9.2 **continuous RNG self-test** at `C_Initialize`: consecutive fixed-size system-RNG blocks must differ, else the module fails with `CKR_DEVICE_ERROR`. Captured live with the parent's stderr mirrored (`MOZ_LOG=pipnss:5`):

```
failed to initialize NSS with codes -8023 -8023      (= SEC_ERROR_PKCS11_DEVICE_ERROR)
attempting no-module db init
last-resort NSS_NoDB_Init
failed to initialize NSS
nsNSSComponent::InitializeNSS() failed               (loops forever)
```

Consequences:
- **Parent**: all four NSS init fallbacks fail → no TLS socket provider → every `https://` channel dies before `connect(2)` → zero ClientHello / zero `:443`, while `http://` traffic (openh264, detectportal) flows normally. Navigation to `https://bbc.com/news` can never start.
- **Socket process (pid 3)**: child init hits the same failing step, returns false → orderly `exit(1)` in its init window — the long-standing "pid-3 silent early death" (Gate-1) signature. Syscall ring shows the canonical fingerprint: softokn3/sqlite3/freeblpriv3 dlopen → `open/read(32)` `/dev/urandom` twice **at the same tick t** → no further syscalls → teardown. The golden Linux strace of the same binary shows 5×32 B + 1×1024 B urandom reads at this point and proceeds.

**Why it looked like a regression**: survival is a pure timing-phase artifact — do the two 32-byte reads straddle a tick boundary? Slow/trace builds pass the window, fast profiles die, and *any* kernel change shifts the phase. That retroactively explains the ~10-25 %/boot win rate on 2026-06-10, the trace-build "positive control", and the deterministic 0/3 after #552-556. No PR in the merge chain is at fault; a bisect would have falsely named #552.

## Fix

Route the `/dev/urandom` / `/dev/random` arm through `security::rand::rand_u64` — RDRAND-backed with a TSC-seeded fallback, and the same chokepoint ASLR / AT_RANDOM / `getrandom(2)` already use (so `astryx.rng_seed=` record-replay determinism still covers the path). Per random(4), both nodes may serve the same CSPRNG. 24 lines + comment.

**Test 520** mirrors the consumer access pattern (open → read(32) → close, twice back-to-back = same tick at boot-test speed; plus two reads on one fd) and asserts blocks differ and are non-zero. Passes on the fixed kernel.

## Verification (fixed kernel, smp=2 KVM, https://bbc.com/news)

First fixed boot (sid c26a4bedb58f):
- pid 3 socket process **survives** (zero `exit_group`, first time in 6 observed boots)
- TLS ClientHello to 151.101.0.81:443 (bbc.com Fastly edge), full handshake + data flow
- `[GATE] png-write path=/tmp/out.png bytes=972247` — **1366×7420 RGBA PNG of bbc.com/news**, extracted and band-analyzed: 13 sparse text bands / 3 blank — same shape as the 2026-06-10 calibration win (remaining blanks = the separate, pre-existing image-CDN Gate-2)
- Closed crash classes: gen-abort 0, MMAP-ERR 0, bugcheck/DOUBLE_FAULT 0, CR2=0x10 0. One `exit_group(11)` fired **after** png-write during FF shutdown — pre-existing class, also observed pre-PNG on the *unfixed* kernel, render-inert here.

Two further `--no-build` verification boots are in flight; results will be posted as a PR comment.

## Follow-ups (separate, pre-existing — not addressed here)
1. **Parent never notices a dead child's channel**: pid 3's exit tore down its socket (`[UNIX/TEARDOWN] id=8 peer=7 peer_connected=true`), the peer got `rx_eof/peer_closed`, yet pid 1 never closed its end (no teardown of id=7 ever), never reaped the zombie, never relaunched — on Linux the parent reaps + relaunches the socket process. Needs an NDE/aether look at peer-HUP readiness delivery into the parent's poller (or a gecko-side wait-path divergence).
2. `[TLB/TIMEOUT]` (10 M-iter unacked shootdowns, both directions) fires 54-152×/boot throughout — uncorrelated with this gate (classified OUT for this wedge), still deserves its own liveness investigation.
3. The late-shutdown `exit_group(11)` class above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)