### PR TITLE
NDE-18: Linux-parity pipe capacity + decoupled launcher-pipe drain (Gate-2 stderr convoy)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -35,8 +35,36 @@ static EXEC_PID: AtomicU64 = AtomicU64::new(0);
 static LAST_RENDER_TICK: AtomicU64 = AtomicU64::new(0);
 static RENDER_DIRTY: AtomicBool = AtomicBool::new(false);
 
-/// One-shot guard for the dedicated launcher-pipe drain thread.
+/// One-shot guard for the dedicated launcher-pipe drain thread, and the
+/// single source of truth for drain OWNERSHIP of the launcher pipe.
+///
+/// Exactly one consumer may dequeue bytes from a pipe at a time; two
+/// drainers appending to the terminal grid under separate TERMINAL-lock
+/// acquisitions produce interleaved (out-of-order) output.  Once this flag
+/// is `true` the dedicated `output_drain_thread` owns byte consumption of
+/// whatever `running_exec` currently points at, and `poll_output()` must
+/// NOT dequeue from that pipe (it keeps reaping + throttled rendering only).
+///
+/// There is never a window in which NO drainer is responsible for the pipe
+/// (the deadlock class #551 closed): the drain thread never exits — it parks
+/// when no exec is running and re-snapshots `running_exec` on every wake — so
+/// "flag is true" ⟺ "a live drainer owns the pipe".  At exit teardown
+/// `poll_output()` reclaims the final-byte drain by clearing `running_exec`
+/// FIRST (the drain thread then snapshots `None` and releases the pipe) and
+/// only then doing the synchronous tail read.  `PIPE_TABLE`'s lock makes
+/// every read indivisible, so a drain-thread iteration already in flight at
+/// that instant cannot lose or duplicate a byte with the tail read; the only
+/// residual is a possible ordering blip on the very last exit chunk — never
+/// the steady-state interleave this model exists to prevent.
 static DRAIN_THREAD_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// True when the dedicated drain thread owns byte consumption of the
+/// launcher pipe (so `poll_output()` must skip its own dequeue).  See
+/// [`DRAIN_THREAD_STARTED`] for the ownership model.
+#[inline]
+fn drain_thread_owns_pipe() -> bool {
+    DRAIN_THREAD_STARTED.load(Ordering::Acquire)
+}
 
 /// Dedicated kernel-thread drain loop for the launcher stdout/stderr pipe.
 ///
@@ -1102,17 +1130,20 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
 
     // Attach pipe to stdout/stderr while the child is still blocked.
     let pipe_id = crate::ipc::pipe::create_pipe();
-    // The launcher pipe's ONLY reader is `poll_output()` on the BSP main
-    // loop, whose iteration latency is unbounded under load (it shares the
-    // loop with VFS probes, the compositor, and net polling — observed
-    // gaps of tens of seconds during a Firefox page load).  Since POSIX
-    // write(2) blocks a writer on a full pipe, an undersized ring turns
-    // the child's stderr into a synchronization point: every thread that
-    // logs a warning parks behind the libc stderr FILE lock until the BSP
-    // loop next drains (observed: the necko socket thread frozen for 8.7 s
-    // mid-TLS-handshake).  Provision the maximum capacity (fcntl(2)
-    // F_SETPIPE_SZ ceiling) so a whole page-load's diagnostic burst fits
-    // without ever blocking the writer.
+    // The launcher pipe is drained by the dedicated `output_drain_thread`
+    // (see `ensure_output_drain_thread`), which owns byte consumption once
+    // started; `poll_output()` then only reaps the child and renders the
+    // grid (drain ownership is single — see `DRAIN_THREAD_STARTED`).  The
+    // earlier design drained solely on the BSP main loop, whose iteration
+    // latency is unbounded under load (it shares the loop with VFS probes,
+    // the compositor, and net polling — observed gaps of tens of seconds
+    // during a Firefox page load).  Since POSIX write(2) blocks a writer on
+    // a full pipe, an undersized ring turns the child's stderr into a
+    // synchronization point: every thread that logs a warning parks behind
+    // the libc stderr FILE lock until the pipe next drains (observed: the
+    // necko socket thread frozen for 8.7 s mid-TLS-handshake).  Provision
+    // the maximum capacity (fcntl(2) F_SETPIPE_SZ ceiling) so a whole
+    // page-load's diagnostic burst fits without ever blocking the writer.
     let _ = crate::ipc::pipe::pipe_set_capacity(
         pipe_id, crate::ipc::pipe::PIPE_MAX_CAPACITY);
     crate::proc::attach_stdout_pipe(pid, pipe_id);
@@ -1353,19 +1384,29 @@ pub fn poll_output() {
     let mut raw = [0u8; 4096];
     let mut any_data = false;
 
-    // First pass: read all available data before locking TERMINAL.
-    // `pipe_read_wake` (NOT raw `pipe_read`): this drain is the ONLY
-    // consumer of the launcher pipe, and the child-side writers block on a
-    // full pipe per POSIX write(2)/pipe(7).  A drain that frees room
+    // Steady-state drain ownership: when the dedicated `output_drain_thread`
+    // owns the launcher pipe it is the SOLE byte consumer (see
+    // `DRAIN_THREAD_STARTED`); `poll_output()` must NOT also dequeue, or the
+    // two drainers append to the terminal grid under separate TERMINAL-lock
+    // acquisitions with no ordering and the output interleaves.  In that
+    // mode `poll_output()` does only the throttled render (the drain thread
+    // sets `RENDER_DIRTY`) plus the reap/teardown below.  When no drain
+    // thread owns the pipe (e.g. an exec launched before one was started, or
+    // a build without it) `poll_output()` remains the drainer.
+    //
+    // `pipe_read_wake` (NOT raw `pipe_read`): the child-side writers block on
+    // a full pipe per POSIX.1-2017 write(2)/pipe(7).  A drain that frees room
     // without waking the parked writers strands every child stdout/stderr
     // writer forever (observed live as all Firefox processes wedged in
     // writev(fd=2) once the 4 KiB pipe filled).
     let mut chunks: alloc::vec::Vec<alloc::vec::Vec<u8>> = alloc::vec::Vec::new();
-    loop {
-        let n = crate::ipc::pipe::pipe_read_wake(pipe_id, &mut raw).unwrap_or(0);
-        if n == 0 { break; }
-        chunks.push(raw[..n].to_vec());
-        any_data = true;
+    if !drain_thread_owns_pipe() {
+        loop {
+            let n = crate::ipc::pipe::pipe_read_wake(pipe_id, &mut raw).unwrap_or(0);
+            if n == 0 { break; }
+            chunks.push(raw[..n].to_vec());
+            any_data = true;
+        }
     }
 
     // Non-blocking waitpid: did the child become a zombie?
@@ -1406,7 +1447,22 @@ pub fn poll_output() {
     }
 
     if let Some((_reaped, code)) = exit_status {
-        // Drain any final bytes the child wrote before exiting.
+        // Exit-teardown ownership handoff: the child is reaped and will write
+        // no more, but the dedicated drain thread may still own the pipe.
+        // Clear `running_exec` FIRST (under the TERMINAL lock) so the drain
+        // thread's NEXT snapshot returns `None` and it releases this pipe;
+        // `poll_output()` then performs the synchronous final-byte read.
+        //
+        // `PIPE_TABLE`'s lock makes every read indivisible, so the brief
+        // window in which a drain-thread iteration already in flight (it
+        // snapshotted `Some(pipe_id)` before this clear) and this tail read
+        // overlap cannot lose or duplicate a byte — whichever acquires the
+        // pipe lock first consumes the remaining bytes and the other reads
+        // zero.  Ordering matters only for the very last chunk at exit, and
+        // both consumers append in arrival order; the steady-state interleave
+        // (the display regression this ownership model fixes) cannot occur
+        // because in steady state `poll_output()` does not dequeue at all.
+        state.running_exec = None;
         drop(guard); // release TERMINAL before pipe_read
         let mut tail = [0u8; 4096];
         let tn = crate::ipc::pipe::pipe_read_wake(pipe_id, &mut tail).unwrap_or(0);
@@ -1427,6 +1483,8 @@ pub fn poll_output() {
         } else {
             state2.write_str_colored("\r\n", DEFAULT_FG);
         }
+        // `running_exec` was already cleared above (the ownership handoff);
+        // this re-assert is idempotent and keeps the teardown self-evident.
         state2.running_exec = None;
         // Latch the reaped child's exit code BEFORE clearing EXEC_PID so a
         // crash-recovery supervisor can read it after the zombie is gone.

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -27,6 +27,93 @@ static EXEC_RUNNING: AtomicBool = AtomicBool::new(false);
 /// therefore the earliest possible signal of process termination.
 static EXEC_PID: AtomicU64 = AtomicU64::new(0);
 
+/// Render-throttle state for `poll_output()`: tick of the last
+/// framebuffer repaint, and whether drained-but-unrendered text is
+/// pending.  See the throttle comment in `poll_output` — draining the
+/// launcher pipe (which unblocks POSIX-blocked writers) must not be
+/// rate-limited by framebuffer blit speed.
+static LAST_RENDER_TICK: AtomicU64 = AtomicU64::new(0);
+static RENDER_DIRTY: AtomicBool = AtomicBool::new(false);
+
+/// One-shot guard for the dedicated launcher-pipe drain thread.
+static DRAIN_THREAD_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Dedicated kernel-thread drain loop for the launcher stdout/stderr pipe.
+///
+/// `poll_output()` runs only on the BSP main loop, whose iteration latency
+/// is unbounded under load (observed gaps of tens of seconds during a
+/// Firefox page load while the loop was busy elsewhere).  POSIX write(2)
+/// blocks a writer on a full pipe, so when the child's diagnostic output
+/// outruns the BSP drain (observed: >1 MiB of stderr in the first ~40 s of
+/// a page load), every stderr writer in the child parks — including, via
+/// the libc stderr FILE lock, threads that never even hit the full pipe.
+///
+/// This thread decouples drain capacity from the BSP loop: it parks on the
+/// pipe's reader wait-list (`wait_readable`) and is woken DIRECTLY by the
+/// child's `write(2)` (`wake_readers_all`), so the scheduler's fairness —
+/// not the BSP loop's iteration rate — bounds drain latency.  Drained text
+/// is appended to the terminal grid under the TERMINAL lock; rendering
+/// stays with `poll_output()`'s throttled repaint (the RENDER_DIRTY flag).
+fn output_drain_thread() {
+    crate::hal::enable_interrupts();
+    let mut raw = [0u8; 4096];
+    loop {
+        // Snapshot the live exec target (same discipline as poll_output —
+        // never hold TERMINAL across pipe/scheduler calls).
+        let pipe_id = {
+            let guard = TERMINAL.lock();
+            guard.as_ref().and_then(|s| s.running_exec).map(|(_, p)| p)
+        };
+        let Some(pipe_id) = pipe_id else {
+            // No exec running — park on the global poll bell with a 100 ms
+            // resync deadline (bounded sleep; an early bell ring just
+            // re-checks sooner, which is harmless).
+            let now = crate::arch::x86_64::irq::get_ticks();
+            crate::ipc::waitlist::wait_poll_event(now + 10, || false);
+            continue;
+        };
+
+        let n = crate::ipc::pipe::pipe_read_wake(pipe_id, &mut raw).unwrap_or(0);
+        if n > 0 {
+            let mut guard = TERMINAL.lock();
+            if let Some(state) = guard.as_mut() {
+                let text = core::str::from_utf8(&raw[..n]).unwrap_or("\u{FFFD}");
+                state.write_ansi_str(text);
+            }
+            drop(guard);
+            RENDER_DIRTY.store(true, Ordering::Release);
+            continue; // keep draining while data is flowing
+        }
+
+        // Empty: park until the child's next write wakes us (bounded by a
+        // 1 s resync so an exec swap or missed wake can never strand us).
+        let now = crate::arch::x86_64::irq::get_ticks();
+        match crate::ipc::pipe::wait_readable(pipe_id, now + 100) {
+            crate::ipc::pipe::WaitOutcome::Ready => continue,
+            crate::ipc::pipe::WaitOutcome::Gone => {
+                // Pipe vanished (exec teardown) — bounded idle, then re-snap.
+                crate::ipc::waitlist::wait_poll_event(now + 10, || false);
+            }
+            crate::ipc::pipe::WaitOutcome::Enqueued => {
+                crate::sched::schedule();
+                crate::ipc::pipe::waiter_cleanup_reader(
+                    pipe_id, crate::proc::current_tid());
+            }
+        }
+    }
+}
+
+/// Start the launcher-pipe drain thread (idempotent — first exec wins).
+fn ensure_output_drain_thread() {
+    if DRAIN_THREAD_STARTED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        let _ = crate::proc::create_kernel_process(
+            "term_out_drain", output_drain_thread as *const () as u64);
+    }
+}
+
 /// Sentinel for "no exec exit code latched yet".  A live exec has not
 /// recorded a code; any value other than this is a real, observed exit
 /// status (including 0 for a clean exit).
@@ -1015,7 +1102,22 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
 
     // Attach pipe to stdout/stderr while the child is still blocked.
     let pipe_id = crate::ipc::pipe::create_pipe();
+    // The launcher pipe's ONLY reader is `poll_output()` on the BSP main
+    // loop, whose iteration latency is unbounded under load (it shares the
+    // loop with VFS probes, the compositor, and net polling — observed
+    // gaps of tens of seconds during a Firefox page load).  Since POSIX
+    // write(2) blocks a writer on a full pipe, an undersized ring turns
+    // the child's stderr into a synchronization point: every thread that
+    // logs a warning parks behind the libc stderr FILE lock until the BSP
+    // loop next drains (observed: the necko socket thread frozen for 8.7 s
+    // mid-TLS-handshake).  Provision the maximum capacity (fcntl(2)
+    // F_SETPIPE_SZ ceiling) so a whole page-load's diagnostic burst fits
+    // without ever blocking the writer.
+    let _ = crate::ipc::pipe::pipe_set_capacity(
+        pipe_id, crate::ipc::pipe::PIPE_MAX_CAPACITY);
     crate::proc::attach_stdout_pipe(pid, pipe_id);
+    // Decouple drain capacity from the BSP loop — see output_drain_thread.
+    ensure_output_drain_thread();
 
     // Now allow the scheduler to run the child.
     crate::proc::unblock_process(pid);
@@ -1276,12 +1378,30 @@ pub fn poll_output() {
         None => return,
     };
 
-    // Append ALL stdout bytes to the terminal grid, then render ONCE.
+    // Append ALL stdout bytes to the terminal grid, then render ONCE —
+    // throttled.  `render_to_surface()` repaints the whole terminal grid
+    // into the framebuffer; on a headless/automated boot nothing observes
+    // intermediate frames, and an unthrottled repaint per drain couples
+    // the pipe's drain throughput to framebuffer blit speed (the drain is
+    // what unblocks writers parked on a full pipe — POSIX write(2)).
+    // Drain ALWAYS; repaint at most once per RENDER_THROTTLE_TICKS, with
+    // a dirty flag so the next eligible call (or the exec-exit path,
+    // which renders unconditionally) shows the pending text.
     for chunk in &chunks {
         let text = core::str::from_utf8(chunk).unwrap_or("\u{FFFD}");
         state.write_ansi_str(text);
     }
     if any_data {
+        RENDER_DIRTY.store(true, Ordering::Release);
+    }
+    const RENDER_THROTTLE_TICKS: u64 = 5; // ≥ 50 ms between repaints (≤ 20 fps)
+    let now = crate::arch::x86_64::irq::get_ticks();
+    if RENDER_DIRTY.load(Ordering::Acquire)
+        && now.wrapping_sub(LAST_RENDER_TICK.load(Ordering::Relaxed))
+            >= RENDER_THROTTLE_TICKS
+    {
+        LAST_RENDER_TICK.store(now, Ordering::Relaxed);
+        RENDER_DIRTY.store(false, Ordering::Release);
         state.render_to_surface();
     }
 

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -231,8 +231,9 @@ pub fn pipe_read(pipe_id: u64, buf: &mut [u8]) -> Option<usize> {
     Some(pipe.read(buf))
 }
 
-/// Drain-and-wake helper for KERNEL-context pipe consumers (the exec
-/// supervisors' stdout/stderr drain loops in `gui::terminal::poll_output`
+/// Drain-and-wake helper for KERNEL-context pipe consumers (the launcher
+/// stdout/stderr drainer — the dedicated `gui::terminal::output_drain_thread`,
+/// with `gui::terminal::poll_output` as the fallback drainer and the reaper —
 /// and the demo supervisors).
 ///
 /// `pipe_read` deliberately only advances pipe state; the SYSCALL-layer
@@ -243,7 +244,7 @@ pub fn pipe_read(pipe_id: u64, buf: &mut [u8]) -> Option<usize> {
 /// pipe(7), a writer blocked on a full pipe must resume when the reader
 /// frees room, and the parked thread has no timeout.  (Observed live:
 /// every Firefox process wedged in `writev(2, …)` once the 4 KiB launcher
-/// pipe filled, because `poll_output` drained it to empty without ever
+/// pipe filled, because the drainer freed the pipe to empty without ever
 /// waking the parked writers.)  This wrapper makes drain-then-wake the
 /// one-call default for such consumers.
 ///

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -27,8 +27,34 @@ use spin::Mutex;
 
 use crate::ipc::waitlist::{ring_poll_bell_for, wake_tids, PollBellSource, WaitList};
 
-/// Pipe buffer size (4 KiB).
+/// POSIX write-atomicity threshold (`limits.h` `PIPE_BUF`; 4096 on Linux).
+/// Writes of at most this many bytes land all-or-nothing and never
+/// interleave with a concurrent writer's record (POSIX.1-2017 write(2),
+/// pipe(7)).  This is a *semantic* bound, distinct from the ring capacity
+/// below — POSIX only requires capacity >= PIPE_BUF.
 const PIPE_BUF_SIZE: usize = 4096;
+
+/// Default ring capacity for a newly created pipe — 64 KiB, matching the
+/// Linux default documented in pipe(7) ("Since Linux 2.6.11, the pipe
+/// capacity is 16 pages (i.e., 65,536 bytes ...)").
+///
+/// History: the ring used to be PIPE_BUF-sized (4 KiB, the bare POSIX
+/// minimum).  Combined with the POSIX block-on-full write contract, that
+/// 16×-smaller-than-Linux capacity turned any bursty stdout/stderr
+/// producer into a convoy: during a real-website Firefox page load the
+/// parent's diagnostic stderr (4–8 KiB warning bursts) filled the
+/// launcher pipe, writev(2) on fd 2 parked for seconds at a time, and —
+/// because stderr writes happen under the libc FILE lock — the necko
+/// socket thread serialized behind them, freezing TLS handshake
+/// continuations long enough for image-CDN servers to drop the
+/// connections (observed live: socket thread blocked in writev(fd=2) for
+/// up to 8.7 s mid-handshake while the 4 KiB pipe sat full).
+pub const PIPE_DEFAULT_CAPACITY: usize = 65536;
+
+/// Upper bound accepted from fcntl(F_SETPIPE_SZ), mirroring the default
+/// `/proc/sys/fs/pipe-max-size` limit (1 MiB) that applies to unprivileged
+/// callers on Linux (fcntl(2)).
+pub const PIPE_MAX_CAPACITY: usize = 1 << 20;
 
 /// Next pipe ID.
 static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
@@ -36,7 +62,11 @@ static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
 /// A kernel pipe — a bounded ring buffer.
 pub struct Pipe {
     pub id: u64,
-    buffer: [u8; PIPE_BUF_SIZE],
+    /// Ring storage.  Heap-allocated so capacity is per-pipe adjustable
+    /// (fcntl F_SETPIPE_SZ) and `PIPE_TABLE`'s `Vec<Pipe>` reallocations
+    /// stay cheap.  Invariant: `buffer.len()` is the pipe capacity, a
+    /// power of two ≥ `PIPE_BUF_SIZE`.
+    buffer: Vec<u8>,
     read_pos: usize,
     write_pos: usize,
     count: usize,
@@ -51,7 +81,7 @@ impl Pipe {
     fn new(id: u64) -> Self {
         Self {
             id,
-            buffer: [0; PIPE_BUF_SIZE],
+            buffer: alloc::vec![0; PIPE_DEFAULT_CAPACITY],
             read_pos: 0,
             write_pos: 0,
             count: 0,
@@ -61,8 +91,38 @@ impl Pipe {
         }
     }
 
+    /// Resize the ring to hold `want` bytes, per fcntl(2) F_SETPIPE_SZ:
+    /// the kernel rounds the request up to the next power of two (with a
+    /// floor of `PIPE_BUF_SIZE` — capacity may never drop below the POSIX
+    /// atomicity bound), refuses to exceed `PIPE_MAX_CAPACITY` with
+    /// `EPERM`, and refuses to shrink below the currently buffered byte
+    /// count with `EBUSY`.  Returns the actual capacity on success.
+    fn set_capacity(&mut self, want: usize) -> Result<usize, i32> {
+        let mut cap = PIPE_BUF_SIZE;
+        while cap < want {
+            cap <<= 1;
+            if cap > PIPE_MAX_CAPACITY {
+                return Err(-1); // EPERM — beyond pipe-max-size
+            }
+        }
+        if self.count > cap {
+            return Err(-16); // EBUSY — unread data would not fit
+        }
+        // Linearize the live bytes into the new ring.
+        let mut nb = alloc::vec![0u8; cap];
+        let old_len = self.buffer.len();
+        for i in 0..self.count {
+            nb[i] = self.buffer[(self.read_pos + i) % old_len];
+        }
+        self.buffer = nb;
+        self.read_pos = 0;
+        self.write_pos = self.count % cap;
+        Ok(cap)
+    }
+
     /// Read up to `buf.len()` bytes from the pipe. Returns bytes read.
     pub fn read(&mut self, buf: &mut [u8]) -> usize {
+        let cap = self.buffer.len();
         let to_read = buf.len().min(self.count);
         // SMAP bracket — `buf` typically points to user memory (the
         // syscall layer passes user `buf_ptr` through `from_raw_parts_mut`).
@@ -72,7 +132,7 @@ impl Pipe {
         let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for i in 0..to_read {
             buf[i] = self.buffer[self.read_pos];
-            self.read_pos = (self.read_pos + 1) % PIPE_BUF_SIZE;
+            self.read_pos = (self.read_pos + 1) % cap;
         }
         self.count -= to_read;
         to_read
@@ -80,13 +140,14 @@ impl Pipe {
 
     /// Write up to `data.len()` bytes into the pipe. Returns bytes written.
     pub fn write(&mut self, data: &[u8]) -> usize {
-        let space = PIPE_BUF_SIZE - self.count;
+        let cap = self.buffer.len();
+        let space = cap - self.count;
         let to_write = data.len().min(space);
         // SMAP bracket — `data` typically points to user memory.
         let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for i in 0..to_write {
             self.buffer[self.write_pos] = data[i];
-            self.write_pos = (self.write_pos + 1) % PIPE_BUF_SIZE;
+            self.write_pos = (self.write_pos + 1) % cap;
         }
         self.count += to_write;
         to_write
@@ -125,7 +186,12 @@ impl Pipe {
 
     /// Free space remaining in the ring buffer.
     pub fn space(&self) -> usize {
-        PIPE_BUF_SIZE - self.count
+        self.buffer.len() - self.count
+    }
+
+    /// Current ring capacity (fcntl F_GETPIPE_SZ).
+    pub fn capacity(&self) -> usize {
+        self.buffer.len()
     }
 }
 
@@ -322,6 +388,35 @@ pub fn pipe_close_reader(pipe_id: u64) {
         // dropped by `retain` above).
         wake_readers_all(pipe_id);
     }
+}
+
+/// Ring capacity of `pipe_id` (fcntl F_GETPIPE_SZ).  `None` = no such pipe.
+pub fn pipe_capacity(pipe_id: u64) -> Option<usize> {
+    let pipes = PIPE_TABLE.lock();
+    pipes.iter().find(|p| p.id == pipe_id).map(|p| p.capacity())
+}
+
+/// Set the ring capacity of `pipe_id` (fcntl F_SETPIPE_SZ semantics — see
+/// `Pipe::set_capacity` for the rounding/EBUSY/EPERM contract).  On a
+/// successful GROW, wakes any writer parked on the previously-full ring:
+/// new space is a write-readiness edge exactly like a reader drain, so the
+/// parked writer must re-evaluate (POSIX write(2) blocking contract).
+pub fn pipe_set_capacity(pipe_id: u64, want: usize) -> Result<usize, i32> {
+    let (res, grew) = {
+        let mut pipes = PIPE_TABLE.lock();
+        let pipe = match pipes.iter_mut().find(|p| p.id == pipe_id) {
+            Some(p) => p,
+            None => return Err(-9), // EBADF — pipe vanished
+        };
+        let before = pipe.capacity();
+        let res = pipe.set_capacity(want);
+        let grew = matches!(res, Ok(c) if c > before);
+        (res, grew)
+    };
+    if grew {
+        wake_writers_all(pipe_id);
+    }
+    res
 }
 
 /// Check if a pipe has data.

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -351,6 +351,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "dmesg"          => op_dmesg(req, out),
         "syms"           => op_syms(req, out),
         "mem"            => op_mem(req, out),
+        "user-mem"       => op_user_mem(req, out),
         "read-file"      => op_read_file(req, out),
         "trace-status"   => op_trace_status(out),
         // blk-trace: dump the virtio-blk LBA trace ring as JSON (out-of-band
@@ -882,6 +883,85 @@ fn op_mem(req: &str, out: &mut String) {
         let _ = write!(hex, "{:02x}", b);
     }
     out.push('{');
+    j_str(out, "addr"); out.push(':'); j_hex(out, addr); out.push(',');
+    j_kv(out, "len", &alloc::format!("{}", len));
+    j_kv_str(out, "hex", &hex);
+    j_trim_comma(out);
+    out.push('}');
+}
+
+// ── user-mem ─────────────────────────────────────────────────────────────────
+//
+// Request: {"op":"user-mem","pid":N,"addr":"0x...","len":L}  (L ≤ 4096)
+//
+// Read L bytes from PID N's *user* address space.  Translation walks the
+// target process's own PML4 (`virt_to_phys_in`, same walker procmaps uses)
+// page by page, then reads the backing frames through the kernel direct map
+// — no CR3 switch, no SMAP window, safe from the kdb pump regardless of
+// which process is currently scheduled.  Unmapped pages fail the request
+// (partial reads would silently mislead diagnostic decoding).
+//
+// Primary consumer: decoding a parked poller's live pollfd array — the
+// thread-park-audit reports `syscall.arg0` (pollfd*) and `syscall.arg1`
+// (nfds) for a thread inside poll(2); this op then answers "which fds is
+// that thread actually watching", which no fd-table view can.
+fn op_user_mem(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let pid = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(p) => p,
+        None => { out.push_str(r#"{"error":"missing or bad 'pid'"}"#); return; }
+    };
+    let addr = match extract_field(req, "addr").and_then(|s| parse_u64(&s)) {
+        Some(a) => a,
+        None => { out.push_str(r#"{"error":"missing 'addr'"}"#); return; }
+    };
+    let len = match extract_field(req, "len").and_then(|s| parse_u64(&s)) {
+        Some(l) if l > 0 && l <= MEM_MAX => l,
+        Some(_) => { out.push_str(r#"{"error":"len out of range (1..=4096)"}"#); return; }
+        None    => { out.push_str(r#"{"error":"missing 'len'"}"#); return; }
+    };
+    if is_kernel_address(addr) {
+        out.push_str(r#"{"error":"addr must be a user-half address (use 'mem' for kernel)"}"#);
+        return;
+    }
+    let Some(end) = addr.checked_add(len) else {
+        out.push_str(r#"{"error":"addr+len overflow"}"#); return;
+    };
+    let cr3 = match try_lock_brief(&PROCESS_TABLE) {
+        Some(g) => match g.iter().find(|p| p.pid == pid) {
+            Some(p) => p.cr3,
+            None => { let _ = write!(out, r#"{{"error":"no pid {}"}}"#, pid); return; }
+        },
+        None => { out.push_str(r#"{"error":"PROCESS_TABLE busy"}"#); return; }
+    };
+
+    // Translate + copy page by page through the direct map.  The direct
+    // map covers all physical RAM at KERNEL_VIRT_BASE (same convention as
+    // net/e1000.rs::phys_to_virt and mm/cache.rs::PHYS_OFFSET).
+    let mut hex = String::with_capacity((len as usize) * 2);
+    let mut p = addr;
+    while p < end {
+        let page_end = ((p & !0xFFF) + 0x1000).min(end);
+        let phys = match crate::mm::vmm::virt_to_phys_in(cr3, p) {
+            Some(ph) => ph,
+            None => {
+                out.clear();
+                out.push('{');
+                let _ = write!(out, r#""error":"unmapped user page","pid":{},"#, pid);
+                j_str(out, "at"); out.push(':'); j_hex(out, p & !0xFFF);
+                out.push('}');
+                return;
+            }
+        };
+        let kva = astryx_shared::KERNEL_VIRT_BASE + phys;
+        for off in 0..(page_end - p) {
+            let b = unsafe { core::ptr::read_volatile((kva + off) as *const u8) };
+            let _ = write!(hex, "{:02x}", b);
+        }
+        p = page_end;
+    }
+    out.push('{');
+    let _ = write!(out, r#""pid":{},"#, pid);
     j_str(out, "addr"); out.push(':'); j_hex(out, addr); out.push(',');
     j_kv(out, "len", &alloc::format!("{}", len));
     j_kv_str(out, "hex", &hex);
@@ -2575,6 +2655,12 @@ fn op_thread_park_audit(req: &str, out: &mut String) {
         state: &'static str, entry_rip: u64, rsp: u64,
         wake_tick: u64, clear_child_tid: u64,
         vfork_parent_tid: Option<u64>,
+        /// `Thread::ready_since_tick` — nonzero iff the thread is currently
+        /// waiting on a run queue (stamped Ready, not yet picked).  Exposed
+        /// so a diagnostic reader can compute the live run-queue wait age
+        /// and distinguish "starved Ready thread" from "bell-churn Ready
+        /// thread that runs and re-parks between samples".
+        ready_since_tick: u64,
     }
     let thread_snaps: Vec<ThreadSnap> = match try_lock_brief(&THREAD_TABLE) {
         Some(tt) => tt.iter()
@@ -2591,6 +2677,7 @@ fn op_thread_park_audit(req: &str, out: &mut String) {
                 wake_tick: t.wake_tick,
                 clear_child_tid: t.clear_child_tid,
                 vfork_parent_tid: t.vfork_parent_tid,
+                ready_since_tick: t.ready_since_tick,
             }).collect(),
         None => {
             out.push_str(r#"{"busy":"THREAD_TABLE held","threads":[]}"#);
@@ -2733,12 +2820,26 @@ fn op_thread_park_audit(req: &str, out: &mut String) {
             j_str(out, "rsp"); out.push(':'); j_hex(out, ts.rsp); out.push(',');
             let _ = write!(out, r#""wake_tick":{},"#, ts.wake_tick);
             let _ = write!(out, r#""blocked_for_ticks":{},"#, blocked_for);
+            // Live run-queue wait age: how long this thread has been
+            // continuously Ready without being picked.  0 = not currently
+            // waiting (running/blocked, or picked within the last stamp).
+            // The decisive starvation metric: a large value here means the
+            // anti-starvation escalation in the picker is NOT delivering
+            // CPU to this runnable thread.
+            let ready_for = if ts.ready_since_tick > 0 {
+                tick_now.saturating_sub(ts.ready_since_tick)
+            } else { 0 };
+            let _ = write!(out, r#""ready_for_ticks":{},"#, ready_for);
             match (nr_opt, arg0_opt) {
                 (Some(nr), Some(arg0)) => {
                     out.push_str(r#""syscall":{"#);
                     let _ = write!(out, r#""nr":{},"#, nr);
                     j_kv_str(out, "name", crate::perf::linux_syscall_name(nr));
-                    j_str(out, "arg0"); out.push(':'); j_hex(out, arg0);
+                    j_str(out, "arg0"); out.push(':'); j_hex(out, arg0); out.push(',');
+                    // arg1 (RSI): nfds for poll(2) — lets `user-mem` size the
+                    // pollfd-array read of a parked poller exactly.
+                    j_str(out, "arg1"); out.push(':');
+                    j_hex(out, sample.as_ref().map(|s| s.last_syscall_arg1).unwrap_or(0));
                     out.push_str("},");
                 }
                 _ => {

--- a/kernel/src/proc/sample.rs
+++ b/kernel/src/proc/sample.rs
@@ -94,6 +94,11 @@ struct TidSlot {
     /// poll/epoll_wait this is the fd-array pointer or epfd; for read/write
     /// it is the fd; for futex it is the uaddr.  Diagnostic-only.
     last_syscall_arg0: AtomicU64,
+    /// Second argument (RSI on x86_64) of the most recent syscall.  For
+    /// poll(2) this is `nfds` — together with `last_syscall_arg0` (the
+    /// pollfd array pointer) it lets the kdb `user-mem` op read and decode
+    /// the exact live pollfd set of a parked poller.  Diagnostic-only.
+    last_syscall_arg1: AtomicU64,
     /// Last user-mode RIP observed for this TID by the per-tick sampler.
     /// Updated every Ring-3 timer-ISR tick, regardless of the silent-for
     /// threshold that gates the serial `[SAMPLE]` emission.  Stays at 0
@@ -131,6 +136,7 @@ static TID_TABLE: [TidSlot; TID_SLOTS] = [
         last_sample_tick: AtomicU64::new(0),
         last_syscall_nr: AtomicU64::new(u64::MAX),
         last_syscall_arg0: AtomicU64::new(0),
+        last_syscall_arg1: AtomicU64::new(0),
         last_user_rip: AtomicU64::new(0),
         last_user_rbp: AtomicU64::new(0),
         last_user_rsp: AtomicU64::new(0),
@@ -157,12 +163,13 @@ fn slot_for(tid: u64) -> &'static TidSlot {
 /// ordering because all four atomics share a cache line (Intel SDM Vol 3A
 /// §8.2.3: WB total-store-order for same-line single-quadword writes).
 #[inline]
-pub fn record_syscall(tid: u64, tick: u64, nr: u64, arg0: u64) {
+pub fn record_syscall(tid: u64, tick: u64, nr: u64, arg0: u64, arg1: u64) {
     let slot = slot_for(tid);
     // Claim the slot (no CAS — last writer wins on hash collisions).
     slot.tid.store(tid, Ordering::Relaxed);
     slot.last_syscall_nr.store(nr, Ordering::Relaxed);
     slot.last_syscall_arg0.store(arg0, Ordering::Relaxed);
+    slot.last_syscall_arg1.store(arg1, Ordering::Relaxed);
     slot.last_syscall_tick.store(tick, Ordering::Relaxed);
 }
 
@@ -180,6 +187,7 @@ pub struct TidSyscallSample {
     pub last_syscall_tick: u64,
     pub last_syscall_nr: u64,
     pub last_syscall_arg0: u64,
+    pub last_syscall_arg1: u64,
     pub last_user_rip: u64,
     pub last_user_rbp: u64,
     pub rip_sample_seq: u64,
@@ -198,6 +206,7 @@ pub fn read_sample(tid: u64) -> Option<TidSyscallSample> {
     // may see a stale tick paired with new nr/arg0 — harmless for diag.
     let last_syscall_nr = slot.last_syscall_nr.load(Ordering::Relaxed);
     let last_syscall_arg0 = slot.last_syscall_arg0.load(Ordering::Relaxed);
+    let last_syscall_arg1 = slot.last_syscall_arg1.load(Ordering::Relaxed);
     let last_syscall_tick = slot.last_syscall_tick.load(Ordering::Relaxed);
     let last_user_rip = slot.last_user_rip.load(Ordering::Relaxed);
     let last_user_rbp = slot.last_user_rbp.load(Ordering::Relaxed);
@@ -208,6 +217,7 @@ pub fn read_sample(tid: u64) -> Option<TidSyscallSample> {
         last_syscall_tick,
         last_syscall_nr,
         last_syscall_arg0,
+        last_syscall_arg1,
         last_user_rip,
         last_user_rbp,
         rip_sample_seq,

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -8292,6 +8292,31 @@ fn sys_fcntl(fd: u64, cmd: u64, arg: u64) -> i64 {
             }
             -9 // EBADF
         }
+        // F_SETPIPE_SZ / F_GETPIPE_SZ — pipe capacity control (fcntl(2)).
+        //
+        // Per fcntl(2): F_SETPIPE_SZ changes the pipe's ring capacity; the
+        // kernel rounds the request up (power of two, floor PIPE_BUF) and
+        // returns the actual capacity.  EBUSY when the new capacity cannot
+        // hold the currently buffered bytes; EPERM when the request exceeds
+        // the pipe-max-size limit.  F_GETPIPE_SZ returns the capacity.
+        // Both return EBADF when the descriptor does not refer to a pipe.
+        1031 /* F_SETPIPE_SZ */ => {
+            if !crate::syscall::is_pipe_fd(pid, fd as usize) { return -9; } // EBADF
+            if arg == 0 { return -22; } // EINVAL
+            let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
+            match crate::ipc::pipe::pipe_set_capacity(pipe_id, arg as usize) {
+                Ok(cap) => cap as i64,
+                Err(e) => e as i64,
+            }
+        }
+        1032 /* F_GETPIPE_SZ */ => {
+            if !crate::syscall::is_pipe_fd(pid, fd as usize) { return -9; } // EBADF
+            let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
+            match crate::ipc::pipe::pipe_capacity(pipe_id) {
+                Some(cap) => cap as i64,
+                None => -9, // EBADF — pipe vanished
+            }
+        }
         // F_ADD_SEALS / F_GET_SEALS — memfd sealing API.
         //
         // Per fcntl(2): F_ADD_SEALS adds the seals in `arg` to the inode's

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1109,7 +1109,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         let tid = crate::proc::current_tid();
         let tick = crate::arch::x86_64::irq::TICK_COUNT
             .load(core::sync::atomic::Ordering::Relaxed);
-        crate::proc::sample::record_syscall(tid, tick, num, arg1);
+        crate::proc::sample::record_syscall(tid, tick, num, arg1, arg2);
     }
 
     let result = if crate::subsys::linux::syscall::is_linux_abi() {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -35878,6 +35878,79 @@ fn test_pipe_blocking_write_semantics() -> bool {
 
     test_header!("pipe blocking write — atomic / blocks-until-drained / EAGAIN / EPIPE");
 
+    // Pipes now default to the Linux 64 KiB capacity (pipe(7)); the
+    // exact-fill arithmetic throughout this test was written against the
+    // POSIX-minimum 4 KiB ring, so pin each test pipe back to 4 KiB via
+    // fcntl(2) F_SETPIPE_SZ (returns the actual capacity).
+    const F_SETPIPE_SZ: u64 = 1031;
+    const F_GETPIPE_SZ: u64 = 1032;
+    let pin4k = |wfd: u64| -> i64 {
+        crate::syscall::dispatch_linux_kernel(72 /*fcntl*/, wfd, F_SETPIPE_SZ, 4096, 0, 0, 0)
+    };
+
+    // ── Sub-test 0: capacity defaults + fcntl(F_SETPIPE_SZ/F_GETPIPE_SZ) ──
+    // pipe(7): "the pipe capacity is 16 pages (i.e., 65,536 bytes)".
+    // fcntl(2): F_SETPIPE_SZ rounds the request up (power of two, floor
+    // PIPE_BUF), fails with EBUSY when the new size cannot hold the
+    // buffered bytes, and EPERM beyond the pipe-max-size ceiling.
+    {
+        let mut fds0 = [0u32; 2];
+        let r = crate::syscall::dispatch_linux_kernel(
+            293 /*pipe2*/, fds0.as_mut_ptr() as u64, 0x0800 /*O_NONBLOCK*/, 0, 0, 0, 0);
+        if r != 0 {
+            test_fail!("pipe_blocking_write", "pipe2 for capacity sub-test returned {}", r);
+            return false;
+        }
+        let (rfd0, wfd0) = (fds0[0] as u64, fds0[1] as u64);
+        let cap = crate::syscall::dispatch_linux_kernel(72, wfd0, F_GETPIPE_SZ, 0, 0, 0, 0);
+        if cap != 65536 {
+            test_fail!("pipe_blocking_write",
+                "F_GETPIPE_SZ default returned {} (expected 65536 per pipe(7))", cap);
+            return false;
+        }
+        // Round-up: 5000 → 8192.
+        let cap2 = crate::syscall::dispatch_linux_kernel(72, wfd0, F_SETPIPE_SZ, 5000, 0, 0, 0);
+        if cap2 != 8192 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ(5000) returned {} (expected round-up to 8192)", cap2);
+            return false;
+        }
+        // EBUSY: buffer 5000 bytes, then try to shrink to 4096.
+        let big = alloc::vec![0x5Au8; 5000];
+        let wn = crate::syscall::dispatch_linux_kernel(
+            1 /*write*/, wfd0, big.as_ptr() as u64, big.len() as u64, 0, 0, 0);
+        if wn != 5000 {
+            test_fail!("pipe_blocking_write",
+                "capacity sub-test 5000B write returned {} (expected 5000 on an 8 KiB ring)", wn);
+            return false;
+        }
+        let shr = crate::syscall::dispatch_linux_kernel(72, wfd0, F_SETPIPE_SZ, 4096, 0, 0, 0);
+        if shr != -16 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ shrink below buffered bytes returned {} (expected -EBUSY)", shr);
+            return false;
+        }
+        // EPERM: beyond the 1 MiB pipe-max-size ceiling.
+        let huge = crate::syscall::dispatch_linux_kernel(
+            72, wfd0, F_SETPIPE_SZ, (1u64 << 20) + 1, 0, 0, 0);
+        if huge != -1 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ(>1MiB) returned {} (expected -EPERM)", huge);
+            return false;
+        }
+        // Non-pipe fd → EBADF.  (Use a never-opened high slot — fd 0 can
+        // legitimately be a pipe in the kernel-test harness context.)
+        let nonpipe = crate::syscall::dispatch_linux_kernel(72, 987, F_SETPIPE_SZ, 4096, 0, 0, 0);
+        if nonpipe != -9 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ on non-pipe fd returned {} (expected -EBADF)", nonpipe);
+            return false;
+        }
+        crate::syscall::dispatch_linux_kernel(3, rfd0, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd0, 0, 0, 0, 0, 0);
+        test_println!("  capacity: default 65536, round-up 5000→8192, shrink-EBUSY, >1MiB-EPERM, non-pipe-EBADF ✓");
+    }
+
     // ── Sub-test 1: O_NONBLOCK full pipe → -EAGAIN (atomicity preserved) ──
     // pipe2(O_NONBLOCK) so both ends are non-blocking.
     let mut fds = [0u32; 2];
@@ -35888,6 +35961,10 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd_nb, wfd_nb) = (fds[0] as u64, fds[1] as u64);
+    if pin4k(wfd_nb) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 1)");
+        return false;
+    }
 
     // Fill the 4 KiB ring exactly (one PIPE_BUF write fits atomically).
     let filler = [0xABu8; 4096];
@@ -36064,6 +36141,10 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd3, wfd3) = (fds3[0] as u64, fds3[1] as u64);
+    if pin4k(wfd3) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 3)");
+        return false;
+    }
     let pid = crate::proc::current_pid_lockless();
     let pipe_id = crate::syscall::get_pipe_id(pid, wfd3 as usize);
 
@@ -36148,6 +36229,10 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd4, wfd4) = (fds4[0] as u64, fds4[1] as u64);
+    if pin4k(wfd4) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 4)");
+        return false;
+    }
     let pipe_id4 = crate::syscall::get_pipe_id(pid, wfd4 as usize);
 
     // Pre-fill so that 0 < space < ATOMIC: write 3000 bytes (atomic, fits) →
@@ -36281,6 +36366,10 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd5, wfd5) = (fds5[0] as u64, fds5[1] as u64);
+    if pin4k(wfd5) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 5)");
+        return false;
+    }
     let pipe_id5 = crate::syscall::get_pipe_id(pid, wfd5 as usize);
     W5_PIPE_ID.store(pipe_id5, Ordering::SeqCst);
 
@@ -36481,6 +36570,10 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd6, wfd6) = (fds6[0] as u64, fds6[1] as u64);
+    if pin4k(wfd6) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 6)");
+        return false;
+    }
     let pipe_id6 = crate::syscall::get_pipe_id(pid, wfd6 as usize);
     W6_PIPE_ID.store(pipe_id6, Ordering::SeqCst);
     W6_PARK_OBSERVED.store(0, Ordering::SeqCst);
@@ -46130,7 +46223,7 @@ fn test_241_kdb_rip_trace_shape() -> bool {
     // (b) record_syscall claims the slot for `bogus_tid` but does NOT
     //     publish a Ring-3 sample.  read_user_rip should still return
     //     None because the rip_sample_seq stays 0.
-    crate::proc::sample::record_syscall(bogus_tid, /*tick*/ 100, /*nr*/ 1, /*arg0*/ 0);
+    crate::proc::sample::record_syscall(bogus_tid, /*tick*/ 100, /*nr*/ 1, /*arg0*/ 0, /*arg1*/ 0);
     let after = crate::proc::sample::read_user_rip(bogus_tid);
     test_println!("  (b) post-record_syscall read_user_rip = {:?}",
                   after.map(|(r, b, s)| (r, b, s)));


### PR DESCRIPTION
## What

Gate-2 investigation (blank image slots on the BBC real-website render). Live root-cause + fix for the first binding constraint found, plus the kdb diagnostics used to find it.

## Discriminator verdict (per dispatch)

**Neither** "FF event loss with kernel-readable data" **nor** "kernel readiness loss with queued rx data" — both were tested live and exonerated:

- Wire (pcap): every stalled conn shows the **full TLS server flight delivered and ACKed in <100 ms, no gaps, no retransmits** — then no client CCS/Finished until the server FINs (~5 s). Identical conns complete with Finished +0.9 s when the stall window is over.
- Kernel (kdb `poll-revents` tight-loop): level readiness is correct (POLLIN=true whenever bytes are queued); the poll bell + 1 s resync floor function; `net-rxstats` shows rx queues drained.
- Scheduler: `ready_for_ticks` (new diagnostic) stays ≤ 37 ticks during stalls — the anti-starvation force-select works.

The actual mechanism, caught live across 4 boots with `thread-park-audit`:

1. FF's pid-1 writes **>1 MiB of stderr in the first ~40 s** of a page load.
2. fd 2 is the kernel launcher pipe — a **4096-byte ring** (POSIX minimum; pipe(7) documents 65,536 default) drained **only by `poll_output()` on the BSP main loop**, whose iteration latency is unbounded under load (observed: 636 B undrained for 56 s; drain gaps of tens of seconds).
3. Per POSIX write(2) block-on-full (landed in #551), `writev(fd=2)` parks — the **necko socket thread was caught blocked 8.7 s inside one writev mid-TLS-handshake** (`thread-park-audit`: tid 9, nr=20, arg0=0x2).
4. The libc stderr FILE lock convoys everyone else: main thread caught blocked in writev(fd=2) 2.7 s; socket thread futex-waiting the same lock word when not the writer.
5. TLS continuations miss the CDN's ~5 s handshake deadline → server FIN → subresource fetch dies → blank slots. Completions batch on drain events (4 conns' Finished at the same 10 ms).

## Fix

- **ipc/pipe**: per-pipe heap ring, default capacity 65,536 (pipe(7)); `PIPE_BUF` stays 4096 (POSIX atomicity). `pipe_set_capacity()` with fcntl(2) F_SETPIPE_SZ semantics (power-of-two round-up, EBUSY, EPERM at the 1 MiB ceiling); grow wakes parked writers.
- **fcntl(2)**: F_SETPIPE_SZ / F_GETPIPE_SZ; EBADF on non-pipe fds.
- **gui/terminal**: launcher pipe provisioned at 1 MiB; dedicated kernel drain thread (`term_out_drain`) woken directly by the child's write(2) — drain latency now bounded by scheduler fairness, not BSP-loop cadence. Framebuffer repaint throttled (20 fps) and decoupled from drain.
- **kdb (additive)**: `user-mem` (read a pid's user memory via its own page tables — used to decode live pollfd arrays), `thread-park-audit` gains `ready_for_ticks` + `syscall.arg1`.
- **tests**: Test 519 pins its pipes to 4 KiB via F_SETPIPE_SZ (capacity-independent exact-fill arithmetic); new sub-test for default capacity / round-up / EBUSY / EPERM / EBADF.

## Verification

- Mechanism level (decisive): pre-fix the launcher pipe sat **full** (4096/4096; with capacity-only, 1,048,570/1,048,576) with writers parked; post-fix (drain thread) the same load reads **buffered=0, write_waiters=0, no thread in writev** at every probe.
- Kernel suite: green; `pipe_blocking_write` PASS incl. new capacity sub-test. (One wedge of its concurrent sub-test in 3 runs at smp=2, passing on rerun — same SMP-timing-flake class as the allow-failed test518b.)
- Regression sweep (BBC boots): gen-abort / MMAP-ERR / bugcheck / exit_group(11) / CKR_DEVICE_ERROR / STACK_CANARY all **zero**.
- BBC boots on the fix: PNG produced with clean exit (1366×7423, 978 KB) on the capacity-only boot; two further boots still in the page-load tail at report time.

## What this does NOT close (residual, evidence package)

Blank images persist: client-Finished latency is still 4–15 s (boot-B distribution across 31 completed conns: median 4.5 s, p90 12.5 s, max 18.2 s; <0.5 s on Linux), so short-deadline CDNs still FIN first. With stderr exonerated, the socket thread now cycles healthily (poll/connect/writev all sub-second) and sits **in poll while handshakes await their continuation** — pointing at the async cert-verification completion path. Strongest open lead: **3 pid-1 threads spinning in sched_yield(2) at a single shared RIP (page offset +0x8a6, FP-less) for 30+ s through every stall window, cross-boot reproducible** — module resolution via procmaps was kdb-starved at report time and is the first task of the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)