### PR TITLE
Gate-2 TLS Finished-latency: kdb observer fix, sched wake telemetry, gated one-shot event-wake boost

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1088,6 +1088,7 @@ pub extern "C" fn ap_rust_entry() -> ! {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            wake_boosted: false,
             ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: 0,
             fork_user_regs: crate::proc::ForkUserRegs::default(),

--- a/kernel/src/ipc/waitlist.rs
+++ b/kernel/src/ipc/waitlist.rs
@@ -128,13 +128,26 @@ pub fn wake_tids(tids: &[u64]) {
         return;
     }
     let mut threads = crate::proc::THREAD_TABLE.lock();
+    // Event wake: boost-and-ready each parked waiter, tracking the highest
+    // effective priority so the wakeup-preemption kick below can ask any
+    // CPU running lower-priority work to reschedule promptly instead of
+    // letting the woken thread wait out a full quantum (see
+    // `sched::kick_preempt_for_wake`).
+    let mut max_prio: u8 = 0;
+    let mut any_woken = false;
     for &t in tids {
         if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
             if th.state == crate::proc::ThreadState::Blocked {
-                th.state = crate::proc::ThreadState::Ready;
-                th.wake_tick = 0;
+                crate::proc::wake_ready_event(th);
+                if th.priority > max_prio {
+                    max_prio = th.priority;
+                }
+                any_woken = true;
             }
         }
+    }
+    if any_woken {
+        crate::sched::kick_preempt_for_wake(&threads, max_prio);
     }
 }
 

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1561,7 +1561,11 @@ fn op_sched_stats(out: &mut String) {
     out.push_str("],");
     let _ = write!(out, r#""wake_kicks":{},"#,    crate::sched::wake_kick_count());
     let _ = write!(out, r#""starve_forces":{},"#, crate::sched::starve_force_count());
-    let _ = write!(out, r#""ready_depth":{}"#,    crate::sched::ready_depth());
+    let _ = write!(out, r#""ready_depth":{},"#,   crate::sched::ready_depth());
+    let _ = write!(out, r#""wake_boost_enabled":{},"#,
+        crate::sched::wake_boost_enabled());
+    let _ = write!(out, r#""wake_kick_enabled":{}"#,
+        crate::sched::WAKE_KICK_ENABLED.load(core::sync::atomic::Ordering::Relaxed));
     out.push('}');
 }
 

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -74,6 +74,12 @@ struct PendingSession {
     local_port:  u16,
     buf:         Vec<u8>,
     responded:   bool,
+    /// A request line has been claimed for dispatch but the response has not
+    /// been sent yet.  Set under `KDB_SESSIONS` before the dispatcher runs
+    /// OUTSIDE the lock; prevents a concurrent pump caller from re-dispatching
+    /// the same line, and keeps the deferred-close logic (which keys off
+    /// `responded`) from FIN-ing the connection mid-dispatch.
+    dispatching: bool,
 }
 
 static KDB_SESSIONS: Mutex<Vec<PendingSession>> = Mutex::new(Vec::new());
@@ -182,7 +188,7 @@ pub fn pump() {
             if !ss.iter().any(|s| s.remote_ip == *rip && s.remote_port == *rp) {
                 ss.push(PendingSession {
                     remote_ip: *rip, remote_port: *rp, local_port: KDB_PORT,
-                    buf: Vec::new(), responded: false,
+                    buf: Vec::new(), responded: false, dispatching: false,
                 });
             }
         }
@@ -214,19 +220,42 @@ pub fn pump() {
     // connection by its full 4-tuple — closing by `local_port` alone would
     // FIN whichever TCB on KDB_PORT matches first (typically the listener
     // itself), permanently disabling kdb after the very first response.
+    //
+    // CRITICAL: `handle_request` runs OUTSIDE the `KDB_SESSIONS` lock.  kdb
+    // ops can run for seconds (`rip-trace <tid> <ms>` busy-samples for the
+    // full requested window; `thread-park-audit` walks every thread + FD
+    // table).  `pump()` is called concurrently from the BSP main loop and
+    // the dedicated pump thread on the other CPU; holding `KDB_SESSIONS`
+    // (a non-yielding spinlock) across the dispatcher therefore pinned the
+    // sibling CPU in a Ring-0 pause-spin for the entire op — measured
+    // 2026-06-12 via GDB-stub sampling: ~95% of BOTH CPUs inside the
+    // `KDB_SESSIONS` acquire spin during a 3 s `rip-trace`, freezing
+    // net::poll/X11/compositor and grossly distorting any latency being
+    // measured.  The claim/dispatch/commit split below bounds lock hold
+    // times to the buffer scans only.
+    let mut work: Vec<([u8; 4], u16, u16, Vec<u8>)> = Vec::new();
     {
         let mut ss = KDB_SESSIONS.lock();
         for s in ss.iter_mut() {
-            if s.responded { continue; }
+            if s.responded || s.dispatching { continue; }
             if let Some(nl) = s.buf.iter().position(|&b| b == b'\n') {
                 let line = s.buf[..nl].to_vec();
-                let resp = handle_request(&line);
-                let _ = tcp::send_data_to(
-                    s.local_port, s.remote_ip, s.remote_port, resp.as_bytes(),
-                );
-                s.responded = true;
+                s.dispatching = true;
+                work.push((s.remote_ip, s.remote_port, s.local_port, line));
             }
         }
+    }
+    for (rip, rp, lp, line) in work {
+        let resp = handle_request(&line);
+        let _ = tcp::send_data_to(lp, rip, rp, resp.as_bytes());
+        let mut ss = KDB_SESSIONS.lock();
+        if let Some(s) = ss.iter_mut().find(|s| {
+            s.remote_ip == rip && s.remote_port == rp && s.local_port == lp
+        }) {
+            s.responded = true;
+        }
+        // Session reaped mid-dispatch (TCP side closed) → nothing to mark;
+        // the response bytes were already handed to TCP best-effort.
     }
 
     // Close only sessions whose response has fully drained out of the
@@ -373,6 +402,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "fault-cache-keys" => op_fault_cache_keys(out),
         "w215-cache-residency" => op_w215_cache_residency(out),
         "tlb-stats"        => op_tlb_stats(out),
+        "sched-stats"      => op_sched_stats(out),
         "heap-stats"       => op_heap_stats(out),
         "w215-diag"        => op_w215_diag(out),
         "w215-cow-witness" => op_w215_cow_witness(req, out),
@@ -1506,6 +1536,33 @@ fn op_arm_phys(req: &str, out: &mut String) {
         let _ = req;
         out.push_str(r#"{"armed":false,"error":"requires_w215_diag"}"#);
     }
+}
+
+// ── sched-stats ───────────────────────────────────────────────────────────────
+//
+// One-shot scheduler-latency readout:
+//   pick_wait_hist — log2 histogram (ticks @100 Hz) of how long each picked
+//                    thread sat Ready before getting the CPU.  Buckets:
+//                    0, 1, 2-3, 4-7, 8-15, 16-31, 32-63, 64-127, >=128.
+//   wake_kicks     — wakeup-preemption kicks issued (event wake readied a
+//                    higher-priority thread than one currently running).
+//   starve_forces  — anti-starvation backstop force-selects.
+//   ready_depth    — last observed non-idle Ready-peer count (run-queue depth).
+fn op_sched_stats(out: &mut String) {
+    use core::fmt::Write;
+
+    let hist = crate::sched::pick_wait_hist();
+    out.push('{');
+    out.push_str(r#""pick_wait_hist":["#);
+    for (i, v) in hist.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        let _ = write!(out, "{}", v);
+    }
+    out.push_str("],");
+    let _ = write!(out, r#""wake_kicks":{},"#,    crate::sched::wake_kick_count());
+    let _ = write!(out, r#""starve_forces":{},"#, crate::sched::starve_force_count());
+    let _ = write!(out, r#""ready_depth":{}"#,    crate::sched::ready_depth());
+    out.push('}');
 }
 
 fn op_tlb_stats(out: &mut String) {

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -366,6 +366,13 @@ pub fn wake_ready_event(th: &mut Thread) {
     }
     th.state = ThreadState::Ready;
     th.wake_tick = 0;
+    // Boost is runtime-gated (default ON only for firefox-test-core builds;
+    // see `sched::WAKE_BOOST_ENABLED` for the measured rationale).  With the
+    // gate off this function is behaviourally identical to the historical
+    // plain Blocked→Ready flip.
+    if !crate::sched::wake_boost_enabled() {
+        return;
+    }
     let cap = th.base_priority.saturating_add(PRIORITY_BOOST_WAIT);
     if th.priority < cap {
         th.priority = (th.priority + PRIORITY_BOOST_WAIT).min(cap);

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -231,6 +231,18 @@ pub struct Thread {
     /// runnable task accrues owed service the longer it is passed over and
     /// eventually becomes the highest-priority choice (longest-waiting wins).
     pub ready_since_tick: u64,
+    /// True while the thread carries an UNCONSUMED event-wake priority boost
+    /// (see `wake_ready_event`).  The boost is a one-shot queue-jump: the
+    /// picker clears `priority` back to `base_priority` (and this flag) the
+    /// moment the thread is dispatched.  Without the one-shot rule a
+    /// wake-frequent population ratchets to a permanently higher priority
+    /// class and starves base-priority CPU-bound threads — measured
+    /// 2026-06-12 on the Firefox/BBC workload as multi-second force-select
+    /// waits (tid 0: 557 ticks; worker tids: 229–353 ticks) and a WORSE
+    /// TLS-handshake latency distribution than no boost at all.  One-shot
+    /// consumption bounds the privilege to the wakeup-preemption window
+    /// while leaving steady-state CPU shares fair.
+    pub wake_boosted: bool,
     /// True when context.rsp holds a valid saved kernel RSP.
     ///
     /// Set to `false` in schedule() just before marking the thread Ready,
@@ -333,6 +345,33 @@ pub const PRIORITY_MAX: u8 = 31;
 pub const PRIORITY_BOOST_WAIT: u8 = 2;
 /// Priority boost given on I/O completion.
 pub const PRIORITY_BOOST_IO: u8 = 1;
+
+/// Flip a `Blocked` thread to `Ready` because the EVENT it was waiting for
+/// occurred (futex wake, fd readiness, poll bell) — as opposed to a timeout.
+///
+/// Applies a ONE-SHOT wait-satisfied priority boost, capped at
+/// `base_priority + PRIORITY_BOOST_WAIT` so repeated wakes cannot escalate a
+/// thread indefinitely.  The boost is a queue-jump only: the picker resets
+/// `priority` to `base_priority` at dispatch (see `Thread::wake_boosted`),
+/// so the privilege covers exactly the wakeup-preemption window and cannot
+/// turn wake frequency into a persistent priority class.  Callers should
+/// follow up with `sched::kick_preempt_for_wake` while still holding
+/// `THREAD_TABLE` so a CPU running lower-priority work actually reschedules.
+///
+/// No-op if the thread is not currently `Blocked`.
+#[inline]
+pub fn wake_ready_event(th: &mut Thread) {
+    if th.state != ThreadState::Blocked {
+        return;
+    }
+    th.state = ThreadState::Ready;
+    th.wake_tick = 0;
+    let cap = th.base_priority.saturating_add(PRIORITY_BOOST_WAIT);
+    if th.priority < cap {
+        th.priority = (th.priority + PRIORITY_BOOST_WAIT).min(cap);
+        th.wake_boosted = true;
+    }
+}
 
 /// 512-byte FXSAVE area, 16-byte aligned.
 #[repr(C, align(16))]
@@ -931,6 +970,7 @@ pub fn init() {
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -1230,6 +1270,7 @@ fn create_kernel_process_inner(name: &str, entry_point: u64, initial_state: Thre
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -1301,6 +1342,7 @@ pub fn create_thread(pid: Pid, name: &str, entry_point: u64) -> Option<Tid> {
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -1376,6 +1418,7 @@ pub fn create_thread_blocked(pid: Pid, name: &str, entry_point: u64) -> Option<T
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -3074,6 +3117,7 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
         last_cpu: 0,
         first_run: true, // goes through user_mode_bootstrap (CR3 switch, TSS, TLS)
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         // Propagate parent's callee-saved regs (RBP/RBX/R12-R15) into the child.
@@ -3330,6 +3374,7 @@ pub fn fork_process_share_vm(
         last_cpu: 0,
         first_run: true,
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: *parent_regs,
@@ -4025,6 +4070,7 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
         last_cpu: 0,
         first_run: true,  // Goes through user_mode_bootstrap (handles CR3, TSS, TLS)
         ready_since_tick: 0,
+        wake_boosted: false,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         // Propagate parent callee-saved regs into the vfork child for the same

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -390,6 +390,34 @@ pub fn set_wake_kick(v: bool) {
     WAKE_KICK_ENABLED.store(v, Ordering::Relaxed);
 }
 
+/// Runtime gate for the one-shot event-wake BOOST (`proc::wake_ready_event`).
+///
+/// Default ON for `firefox-test-core` builds (the workload it was measured
+/// on), OFF otherwise — same gating pattern as the futex cluster-wake
+/// compensation.  Measured 2026-06-12 on the BBC real-website demo: with the
+/// boost, TLS client-Finished latency on the image-CDN conns dropped to
+/// median 1.3–5.5 s (one boot: 26/27 akamai handshakes complete, median
+/// 1.30 s, max 4.55 s — all inside the CDN FIN deadline) and the page wrote
+/// its first full PNG of the session at ~93 s wall.  The boost also
+/// re-orders dispatch around the long-standing flaky libxul
+/// navigation-phase crash family, whose hit-rate in the measured sample
+/// rose (1 PNG / 3 known-family crashes in 4 boots vs ~1/3 failures
+/// baseline, n too small for significance) — keep this toggleable until
+/// that family is root-caused.
+pub static WAKE_BOOST_ENABLED: AtomicBool =
+    AtomicBool::new(cfg!(feature = "firefox-test-core"));
+
+/// Flip the one-shot event-wake boost at runtime.
+pub fn set_wake_boost(v: bool) {
+    WAKE_BOOST_ENABLED.store(v, Ordering::Relaxed);
+}
+
+/// Read the boost gate (used by `proc::wake_ready_event`).
+#[inline]
+pub fn wake_boost_enabled() -> bool {
+    WAKE_BOOST_ENABLED.load(Ordering::Relaxed)
+}
+
 /// Total wake-kicks issued (a CPU was asked to reschedule because an event
 /// wake readied a higher-priority thread).  Diagnostic; exposed via kdb.
 pub static SCHED_WAKE_KICK_TOTAL: AtomicU64 = AtomicU64::new(0);

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -344,6 +344,119 @@ pub fn starve_force_count() -> u64 {
     SCHED_STARVE_FORCE_TOTAL.load(Ordering::Relaxed)
 }
 
+// ── Wakeup preemption (event-wake → reschedule kick) ─────────────────────────
+//
+// POSIX SCHED_OTHER expects an unblocked thread to contend for the CPU
+// promptly (sched(7)); mature schedulers implement this as *wakeup
+// preemption*: the wake path compares the woken task against each CPU's
+// currently-running task and requests a reschedule when the woken task
+// should win.  Without this, a woken thread waits for a full quantum expiry
+// (`TIME_SLICE` = 50 ms) on some CPU before it can even compete — and a
+// multi-hop wake chain (IPC → worker pool → IPC → poller) pays that latency
+// PER HOP.  Measured on the Firefox/BBC workload (2026-06-12): 13–29
+// runnable threads on 2 CPUs turned each hop into hundreds of ms and the
+// 6-hop TLS cert-verify chain into 2–6.5 s of client-Finished latency.
+//
+// `kick_preempt_for_wake` is called by event-wake paths (poll-bell/fd wait
+// lists, futex wakes) AFTER flipping waiters to Ready, with `THREAD_TABLE`
+// still held.  It scans the table for Running threads whose effective
+// priority is strictly below the woken thread's and marks their CPU for
+// reschedule.  The actual switch happens at that CPU's next preemption
+// point — timer-ISR Ring-3 return (≤1 tick), syscall dispatcher tail, or
+// #PF exit — so the kick adds no new IPI machinery and cannot interrupt a
+// kernel-mode critical section.
+//
+// Timer/timeout wakes (`due_wake_scan`) deliberately do NOT kick: a timeout
+// is not a productive event and boosting it would let periodic pollers
+// preempt real work.
+
+/// Runtime gate for the preemption-KICK half of wakeup preemption.
+///
+/// Default OFF — measured 2026-06-12 on the Firefox/BBC workload: kicking on
+/// every event wake evicts whichever thread is running, and on this kernel
+/// that is very often TID 0 (the BSP main loop at PRIORITY_IDLE, which pumps
+/// `net::poll` / X11 / the compositor continuously while it holds the CPU).
+/// Evicting the IO pump on every wake collapsed TCP processing throughput:
+/// TLS client-Finished latency went from median 0.99 s (baseline) to 11.8 s
+/// (kick + ratcheting boost) / 12.3 s akamai-median (kick + one-shot boost),
+/// with stalled-handshake counts exploding 3 → 20-29.  The one-shot wake
+/// BOOST alone (queue-jump at natural reschedule points, nobody evicted
+/// mid-quantum) is the default mechanism; the kick stays available behind
+/// this gate for experiments via `set_wake_kick`.
+pub static WAKE_KICK_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Flip the wakeup-preemption kick at runtime (diagnostic/experiment hook).
+pub fn set_wake_kick(v: bool) {
+    WAKE_KICK_ENABLED.store(v, Ordering::Relaxed);
+}
+
+/// Total wake-kicks issued (a CPU was asked to reschedule because an event
+/// wake readied a higher-priority thread).  Diagnostic; exposed via kdb.
+pub static SCHED_WAKE_KICK_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Snapshot of [`SCHED_WAKE_KICK_TOTAL`].
+pub fn wake_kick_count() -> u64 {
+    SCHED_WAKE_KICK_TOTAL.load(Ordering::Relaxed)
+}
+
+/// Ask every CPU currently running a thread of strictly lower priority than
+/// `woken_prio` to reschedule at its next preemption point.
+///
+/// Caller MUST hold `THREAD_TABLE` (the slice passed in is the locked
+/// table), and must have already flipped the woken thread(s) to `Ready` —
+/// the kicked CPU's picker needs to see them.  Returns the number of CPUs
+/// kicked (diagnostic / testable).
+pub fn kick_preempt_for_wake(threads: &[proc::Thread], woken_prio: u8) -> u32 {
+    if !WAKE_KICK_ENABLED.load(Ordering::Relaxed) {
+        return 0;
+    }
+    let mut kicked = 0u32;
+    for t in threads.iter() {
+        if t.state == ThreadState::Running && t.priority < woken_prio {
+            let cpu = t.last_cpu as usize;
+            if cpu < MAX_CPUS && !NEED_RESCHEDULE[cpu].swap(true, Ordering::Release) {
+                kicked += 1;
+            }
+        }
+    }
+    if kicked > 0 {
+        SCHED_WAKE_KICK_TOTAL.fetch_add(kicked as u64, Ordering::Relaxed);
+    }
+    kicked
+}
+
+/// Test/diagnostic read of a CPU's NEED_RESCHEDULE flag (does not clear it).
+pub fn need_reschedule_flag(cpu: usize) -> bool {
+    cpu < MAX_CPUS && NEED_RESCHEDULE[cpu].load(Ordering::Acquire)
+}
+
+// ── Run-queue wait (wake-to-run) latency histogram ───────────────────────────
+//
+// At pick time the picker knows exactly how long the chosen thread sat
+// Ready (`now - ready_since_tick`).  Bucketing that wait into a log2
+// histogram gives a direct, cheap measurement of scheduling latency — the
+// quantity the wakeup-preemption change above is meant to collapse.
+// Buckets (ticks @100 Hz): 0, 1, 2-3, 4-7, 8-15, 16-31, 32-63, 64-127, ≥128.
+pub const PICK_WAIT_BUCKETS: usize = 9;
+pub static SCHED_PICK_WAIT_HIST: [AtomicU64; PICK_WAIT_BUCKETS] =
+    [const { AtomicU64::new(0) }; PICK_WAIT_BUCKETS];
+
+#[inline]
+fn record_pick_wait(age_ticks: u64) {
+    let idx = if age_ticks == 0 { 0 }
+              else { (64 - (age_ticks.min(255)).leading_zeros() as usize).min(PICK_WAIT_BUCKETS - 1) };
+    SCHED_PICK_WAIT_HIST[idx].fetch_add(1, Ordering::Relaxed);
+}
+
+/// Snapshot the pick-wait histogram (kdb `sched-stats`).
+pub fn pick_wait_hist() -> [u64; PICK_WAIT_BUCKETS] {
+    let mut out = [0u64; PICK_WAIT_BUCKETS];
+    for (i, b) in SCHED_PICK_WAIT_HIST.iter().enumerate() {
+        out[i] = b.load(Ordering::Relaxed);
+    }
+    out
+}
+
 /// Pure helper: the anti-starvation score bonus for a Ready thread that has
 /// been waiting `age` ticks (`age = now - ready_since_tick`, saturating).
 ///
@@ -1736,6 +1849,21 @@ was_emergency_4k={}",
                 // Mark next thread as Running and record which CPU it's on.
                 threads[idx].state = ThreadState::Running;
                 threads[idx].last_cpu = cpu;
+                // Record the run-queue wait this pick ends (wake-to-run
+                // latency histogram; see `SCHED_PICK_WAIT_HIST`).
+                if threads[idx].ready_since_tick != 0 {
+                    record_pick_wait(now.saturating_sub(threads[idx].ready_since_tick));
+                }
+                // Consume a one-shot event-wake boost at dispatch: the boost
+                // exists to win THIS pick (the wakeup-preemption window), not
+                // to privilege the thread's subsequent CPU time.  Leaving it
+                // live lets wake-frequent threads ratchet into a permanently
+                // higher-priority class and starve base-priority work (see
+                // `Thread::wake_boosted` for the measured failure mode).
+                if threads[idx].wake_boosted {
+                    threads[idx].wake_boosted = false;
+                    threads[idx].priority = threads[idx].base_priority;
+                }
                 // This thread got the CPU — its run-queue wait is over.  Clear
                 // the stamp so any escalating anti-starvation bonus resets and
                 // its NEXT Ready episode times a fresh wait from zero.

--- a/kernel/src/subsys/linux/futex_cluster.rs
+++ b/kernel/src/subsys/linux/futex_cluster.rs
@@ -421,10 +421,13 @@ fn wake_one_candidate(pid: u64, cand: &Candidate) -> Option<u64> {
     };
 
     let mut threads = crate::proc::THREAD_TABLE.lock();
-    if let Some(th) = threads.iter_mut().find(|th| th.tid == tid) {
-        if th.state == crate::proc::ThreadState::Blocked {
-            th.state    = crate::proc::ThreadState::Ready;
-            th.wake_tick = 0;
+    if let Some(idx) = threads.iter().position(|th| th.tid == tid) {
+        if threads[idx].state == crate::proc::ThreadState::Blocked {
+            // Shared event-wake semantics: boost + wakeup-preemption kick
+            // (see `proc::wake_ready_event` / `sched::kick_preempt_for_wake`).
+            crate::proc::wake_ready_event(&mut threads[idx]);
+            let prio = threads[idx].priority;
+            crate::sched::kick_preempt_for_wake(&threads, prio);
         }
     }
     Some(tid)

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -10002,17 +10002,9 @@ pub fn sys_futex_linux(
                 }
             };
 
-            {
-                let mut threads = crate::proc::THREAD_TABLE.lock();
-                for &t in &tids_to_wake {
-                    if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
-                        if th.state == crate::proc::ThreadState::Blocked {
-                            th.state = crate::proc::ThreadState::Ready;
-                            th.wake_tick = 0;
-                        }
-                    }
-                }
-            }
+            // Boost-and-ready each waiter + wakeup-preemption kick (shared
+            // event-wake path; see `ipc::waitlist::wake_tids`).
+            crate::ipc::waitlist::wake_tids(&tids_to_wake);
 
             // Diagnostic: every FUTEX_WAKE is a candidate root cause for a
             // missing-wakeup deadlock.  Logging the (uaddr, woken count, max
@@ -10281,17 +10273,9 @@ pub fn sys_futex_linux(
                 let _ = tids_to_requeue; // live in the waiters map; used above
             }
 
-            {
-                let mut threads = crate::proc::THREAD_TABLE.lock();
-                for &t in &tids_to_wake {
-                    if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
-                        if th.state == crate::proc::ThreadState::Blocked {
-                            th.state = crate::proc::ThreadState::Ready;
-                            th.wake_tick = 0;
-                        }
-                    }
-                }
-            }
+            // Boost-and-ready each waiter + wakeup-preemption kick (shared
+            // event-wake path; see `ipc::waitlist::wake_tids`).
+            crate::ipc::waitlist::wake_tids(&tids_to_wake);
 
             // Return woken count only — not woken+requeued.  Per futex(2).
             woken as i64
@@ -10408,18 +10392,9 @@ pub fn sys_futex_linux(
             drop(waiters);
 
             // Flip every drained TID Blocked → Ready under one THREAD_TABLE
-            // acquisition (same post-drain pattern as FUTEX_WAKE).
-            {
-                let mut threads = crate::proc::THREAD_TABLE.lock();
-                for &t in &tids_to_wake {
-                    if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
-                        if th.state == crate::proc::ThreadState::Blocked {
-                            th.state = crate::proc::ThreadState::Ready;
-                            th.wake_tick = 0;
-                        }
-                    }
-                }
-            }
+            // acquisition (same post-drain pattern as FUTEX_WAKE), with the
+            // shared boost + wakeup-preemption kick.
+            crate::ipc::waitlist::wake_tids(&tids_to_wake);
 
             tids_to_wake.len() as i64
         }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2396,14 +2396,23 @@ pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
             pid, uaddr, key, key_present, tids_to_wake, other_keys
         );
     }
-    // Wake the threads (no lock held).
+    // Wake the threads (no lock held).  Shared event-wake semantics:
+    // boost + wakeup-preemption kick (see `proc::wake_ready_event` /
+    // `sched::kick_preempt_for_wake`).
     let mut threads = crate::proc::THREAD_TABLE.lock();
+    let mut max_prio: u8 = 0;
+    let mut any_woken = false;
     for wake_tid in tids_to_wake {
         if let Some(t) = threads.iter_mut().find(|t| t.tid == wake_tid) {
             if t.state == crate::proc::ThreadState::Blocked {
-                t.state = crate::proc::ThreadState::Ready;
+                crate::proc::wake_ready_event(t);
+                if t.priority > max_prio { max_prio = t.priority; }
+                any_woken = true;
             }
         }
+    }
+    if any_woken {
+        crate::sched::kick_preempt_for_wake(&threads, max_prio);
     }
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -47965,6 +47965,12 @@ fn test_520_wakeup_preemption_kick() -> bool {
         }
     };
 
+    // The boost is runtime-gated (default ON only in firefox-test-core
+    // builds); enable it for the assertions and restore the prior value
+    // before returning so the rest of the suite sees the build default.
+    let boost_was = crate::sched::wake_boost_enabled();
+    crate::sched::set_wake_boost(true);
+
     // ── (a) boost + cap semantics, single critical section ──────────────────
     let boost_verdict: Result<(u8, u8), &'static str> = {
         let mut threads = THREAD_TABLE.lock();
@@ -48004,6 +48010,8 @@ fn test_520_wakeup_preemption_kick() -> bool {
         }
         res
     };
+    // Restore the build-default boost gate before any return path.
+    crate::sched::set_wake_boost(boost_was);
     match boost_verdict {
         Ok((base, prio)) => {
             test_println!("  wake boost: base={} → boosted={} (capped, idempotent) ✓",

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -3005,6 +3005,14 @@ pub fn run() -> ! {
         if test_285_anti_starvation_aging() { passed += 1; }
     }
 
+    // ── Test 520: event-wake boost + wakeup-preemption kick ────────────
+    // (see test fn header; POSIX sched(7) prompt-contention contract)
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_520_wakeup_preemption_kick() { passed += 1; }
+    }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -47920,6 +47928,142 @@ fn test_285_anti_starvation_aging() -> bool {
     true
 }
 
+// ── Test 520: event-wake boost + wakeup-preemption kick ──────────────────────
+//
+// Covers the two halves of the wakeup-preemption path (the mechanism that
+// bounds wake-to-run latency for event wakes — futex wake, poll bell, fd
+// readiness — to one timer tick instead of a full quantum):
+//
+//   (a) `proc::wake_ready_event` — a Blocked thread woken by an EVENT becomes
+//       Ready with a temporary priority boost capped at
+//       `base_priority + PRIORITY_BOOST_WAIT`; repeat wakes cannot escalate
+//       past the cap, and a wake of a non-Blocked thread is a no-op.
+//   (b) `sched::kick_preempt_for_wake` — after such a wake, any CPU running a
+//       strictly-lower-priority thread is marked NEED_RESCHEDULE; a
+//       woken-priority of 0 can never kick (no u8 is < 0).
+//
+// Cite POSIX sched(7): under SCHED_OTHER an unblocked thread contends for
+// the CPU promptly; pthread_cond_signal(3p) requires the unblocked thread to
+// contend for the associated mutex as if it had called pthread_mutex_lock()
+// — i.e. wakes must translate into scheduling opportunities, not quantum
+// waits.
+//
+// The synthetic thread (entry=0) is manipulated and marked Dead in ONE
+// THREAD_TABLE critical section so the sibling CPU's picker can never
+// observe it Ready and dispatch it into a jump-to-0.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_520_wakeup_preemption_kick() -> bool {
+    use crate::proc::{ThreadState, THREAD_TABLE, PRIORITY_BOOST_WAIT};
+
+    test_header!("event-wake boost + wakeup-preemption kick");
+
+    let tid = match crate::proc::create_thread_blocked(0, "wake-kick-t", 0) {
+        Some(t) => t,
+        None => {
+            test_fail!("test520", "create_thread_blocked failed");
+            return false;
+        }
+    };
+
+    // ── (a) boost + cap semantics, single critical section ──────────────────
+    let boost_verdict: Result<(u8, u8), &'static str> = {
+        let mut threads = THREAD_TABLE.lock();
+        let res = match threads.iter_mut().find(|t| t.tid == tid) {
+            None => Err("synthetic thread vanished"),
+            Some(th) => {
+                let base = th.base_priority;
+                let cap = base + PRIORITY_BOOST_WAIT;
+                crate::proc::wake_ready_event(th);
+                if th.state != ThreadState::Ready {
+                    Err("wake of Blocked thread did not flip to Ready")
+                } else if th.priority != cap {
+                    Err("wake boost != base + PRIORITY_BOOST_WAIT")
+                } else if !th.wake_boosted {
+                    Err("wake boost did not mark wake_boosted (one-shot flag)")
+                } else {
+                    // Re-wake while Ready: must be a no-op.
+                    crate::proc::wake_ready_event(th);
+                    if th.priority != cap {
+                        Err("wake of non-Blocked thread changed priority")
+                    } else {
+                        // Re-block and wake again: cap must hold (no escalation).
+                        th.state = ThreadState::Blocked;
+                        crate::proc::wake_ready_event(th);
+                        if th.priority != cap {
+                            Err("repeat wake escalated past base + boost cap")
+                        } else {
+                            Ok((base, th.priority))
+                        }
+                    }
+                }
+            }
+        };
+        // Retire the synthetic thread BEFORE the lock drops (see header).
+        if let Some(th) = threads.iter_mut().find(|t| t.tid == tid) {
+            th.state = ThreadState::Dead;
+        }
+        res
+    };
+    match boost_verdict {
+        Ok((base, prio)) => {
+            test_println!("  wake boost: base={} → boosted={} (capped, idempotent) ✓",
+                base, prio);
+        }
+        Err(msg) => {
+            test_fail!("test520", "{}", msg);
+            return false;
+        }
+    }
+
+    // ── (b) kick semantics against the live table ────────────────────────────
+    // The kick is gated OFF by default (see `sched::WAKE_KICK_ENABLED`);
+    // enable it for the assertions below, restore OFF after.
+    crate::sched::set_wake_kick(true);
+    // woken_prio = 0: structurally no thread satisfies `priority < 0`.
+    let kicked_zero = {
+        let threads = THREAD_TABLE.lock();
+        crate::sched::kick_preempt_for_wake(&threads, 0)
+    };
+    if kicked_zero != 0 {
+        crate::sched::set_wake_kick(false);
+        test_fail!("test520", "woken_prio=0 kicked {} CPUs (expected 0)", kicked_zero);
+        return false;
+    }
+    // woken_prio = 255: every Running thread (priority <= PRIORITY_MAX=31)
+    // qualifies — including THIS test-runner thread.  After the call, this
+    // CPU's NEED_RESCHEDULE flag MUST be observable regardless of whether we
+    // or a concurrent timer tick set it (the flag is only consumed by this
+    // CPU's own reschedule points, none of which run inside this test).
+    {
+        let threads = THREAD_TABLE.lock();
+        let _ = crate::sched::kick_preempt_for_wake(&threads, 255);
+    }
+    let cpu = crate::arch::x86_64::apic::cpu_index();
+    let flag_set = crate::sched::need_reschedule_flag(cpu);
+    // Gate restored before any early return so the suite's default behaviour
+    // (kick disabled) is preserved for subsequent tests.
+    crate::sched::set_wake_kick(false);
+    if !flag_set {
+        test_fail!("test520",
+            "woken_prio=255 did not set NEED_RESCHEDULE on cpu {} (running thread qualifies)",
+            cpu);
+        return false;
+    }
+    // Gated-off contract: with the gate restored OFF the kick must be inert.
+    let kicked_gated = {
+        let threads = THREAD_TABLE.lock();
+        crate::sched::kick_preempt_for_wake(&threads, 255)
+    };
+    if kicked_gated != 0 {
+        test_fail!("test520", "kick fired while gated OFF ({} CPUs)", kicked_gated);
+        return false;
+    }
+    test_println!("  kick: prio 0 → 0; prio 255 → NEED_RESCHEDULE[{}] set; gated-off inert ✓", cpu);
+
+    test_pass!("event-wake boost + wakeup-preemption kick");
+    true
+}
+
 // ── Test 264: vfork-child TLS page layout (musl posix_spawn unblocker) ───────
 //
 // `proc::alloc_vfork_child_tls(parent_pid)` provisions a per-vfork-child
@@ -48619,6 +48763,7 @@ fn test_268_exit_group_clears_sibling_cleartid() -> bool {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            wake_boosted: false,
             ctx_rsp_valid: alloc::boxed::Box::new(
                 core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: cct,
@@ -48909,6 +49054,7 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            wake_boosted: false,
             ctx_rsp_valid: alloc::boxed::Box::new(
                 core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: cct,

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -5932,6 +5932,7 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
               "bell-stats", "cache-audit", "cache-aliasing",
               "fault-cache-keys", "w215-cache-residency",
               "tlb-stats", "heap-stats", "w215-diag",
+              "sched-stats",
               "coverage-flush", "proc-metrics",
               "futex-stats",
               # net-rxstats: receive-path health snapshot (per-conn recv_next
@@ -11821,6 +11822,7 @@ def main():
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "trace-status",
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
+        "sched-stats",
         "arm-phys",
         # blk-trace: drain the virtio-blk LBA ring (JSON) / re-emit `[BLK]`
         # serial lines for the heatmap. Also exposed as the `blk-trace`


### PR DESCRIPTION
## What this is

Three coupled changes from the Gate-2 (blank image slots / TLS client-Finished latency) investigation. **Do not merge without coordinator review** — the boost half is a measured-but-gated mechanism with an honest caveat (below).

### 1. kdb pump: dispatch outside `KDB_SESSIONS` (observer-effect fix — proven)

`kdb::pump()` ran `handle_request` while holding the `KDB_SESSIONS` spinlock. `pump()` is entered concurrently by the BSP main loop (`net::poll`) and the dedicated PRIORITY_HIGH pump thread, so any long op (a 3 s `rip-trace`, a `thread-park-audit` walking every thread + fd table) pinned the **sibling CPU in a Ring-0 pause-spin for the entire op**. GDB-stub sampling (no guest cooperation): 134/160 samples = ~95% of BOTH CPUs inside the `KDB_SESSIONS` acquire spin at `pump+0x92` during one rip-trace.

Consequence for past data: stall-triggered kdb probe batteries **amplified the very TLS stalls being measured**. Probed boots: client-Finished median 4.4–7.2 s. Unprobed boot, same kernel: **0.99 s**. Any historical latency number taken under heavy kdb load needs re-grading.

Fix: claim/dispatch/commit split (new `dispatching` session flag); lock hold times are now buffer-scans only. kdb is usable as a non-perturbing probe again.

### 2. `sched-stats` telemetry (additive)

New kdb op: log2 **pick-wait histogram** (run-queue wait of every dispatched thread, recorded at pick time), wake-kick + starve-force counters, ready-queue depth, gate states. Harness whitelist extended (additive).

### 3. One-shot event-wake boost (gated; default ON only for `firefox-test-core`)

All event wakes (futex `WAKE/WAKE_OP/REQUEUE`, CLEARTID exit wake, cluster compensation, per-fd waitlists / poll bell) now go through `proc::wake_ready_event`: the existing `PRIORITY_BOOST_WAIT` bump, capped at `base+2`, **consumed entirely at dispatch** (`Thread::wake_boosted`, cleared by the picker). Pure queue-jump for the wakeup-preemption window; steady-state shares stay fair. Per POSIX sched(7) (SCHED_OTHER prompt contention) and pthread_cond_signal(3p).

Two stronger variants were built and **rejected by measurement**:
| variant | result |
|---|---|
| decaying (ratcheting) boost + reschedule kick | wake-frequent threads became a permanent priority class; force-select waits up to 557 ticks on tid 0; TLS median 0.99 s → **11.8 s**, stalled handshakes 3 → 29 |
| one-shot boost + kick | the kick evicts the BSP IO-pump (tid 0) on virtually every wake → TCP processing collapse; image-CDN median **12.3 s** |
| **one-shot boost, no kick** | **shipped** (kick machinery kept behind `WAKE_KICK_ENABLED`, default OFF) |

Measured with the shipped variant (BBC `/news`, smp=2 KVM, 4 boots):
- First full-page PNG of the session at **~93 s wall** (974 KB, 1366×7475) — previous baseline retest: 0/3 PNGs in 9-minute windows.
- Wire (pcap, pre-crash where applicable): client-Finished median 0.61–3.10 s; image-CDN (akamai) median 1.30–5.45 s, best boot 26/27 handshakes complete, max 4.55 s — all inside the CDN FIN deadline; stalled 1–14 (vs 3–29 before).

**Caveat (why it's gated):** 3 of 4 boost-only boots ended in the *known* flaky libxul navigation-phase crash family (three distinct fault sites, all documented before this work; `exit_group(11)`). vs ~1/3 failures at base (n=3) this is directionally worse but not significant (n too small). The boost re-orders dispatch and plausibly raises the latent race's hit rate. Hence: default ON only for `firefox-test-core`, OFF for production/test-mode, runtime `set_wake_boost` / kdb-visible gate state for cheap A/B. Root-causing that crash family is the right next dispatch and is **pre-existing scope**, not introduced here.

### Images verdict (Gate-2 status)

Narrowed, **not closed**: the PNG from the successful boot still has blank image bands. Wire timeline shows the first image-CDN burst (7 parallel ClientHellos during the page-busy phase) making zero handshake progress for ~11 s until the CDN FINs; retries complete (one pulled 1.41 MB) but land after the snapshot fires. Remaining lead: socket-process TLS continuation stalls during the busy phase (cert-verify proxied to the busy parent is the prime suspect) — now cheaply probeable since kdb no longer freezes a CPU.

### Tests

- New test 520: boost cap/idempotence/one-shot flag, kick gating (inert when off, NEED_RESCHEDULE when on), prio-0-never-kicks.
- Full test-mode suite: **401-402/411 with the changes vs 401/410 at base** — identical failure lists (environmental data.img gaps + known test518b flake + tcp_ooo_fin_guard seen on both arms). One single-run flake observed once in four suite runs (`eventfd2_nonblock` got fd 0 + cross-context EBADF, with another process's #PF interleaved) — pre-existing fragility class; the boost is compiled-default-OFF in test-mode so the wake path there is behaviourally historical.

Artifacts: pcaps `/tmp/gate2_pse_*.pcap`, distribution tool `/tmp/finlat.py`, PNG `/tmp/gate2_run4_out.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)