### PR TITLE
kernel: implement syslog(2)/klogctl (nr 103) + a kernel dmesg ring

### DIFF
--- a/kernel/src/drivers/serial.rs
+++ b/kernel/src/drivers/serial.rs
@@ -454,6 +454,16 @@ pub fn _serial_print(args: fmt::Arguments) {
 
     impl<'a> fmt::Write for WriteAdapter<'a> {
         fn write_str(&mut self, s: &str) -> fmt::Result {
+            // Tee every line that reaches COM1 into the kernel log ring so
+            // that userspace `syslog(2)`/`klogctl` and `/proc/kmsg` can read
+            // the boot log without a serial console.  Best-effort: a failed
+            // `try_lock` (concurrent reader or cross-CPU writer) drops the
+            // chunk rather than block, which is safe inside this IRQ-disabled
+            // critical section.  We tee the raw `s` (before the inline
+            // "\r\n" expansion below) so the ring holds clean "\n"-terminated
+            // lines.
+            crate::util::dmesg::write_str(s);
+
             // Stack-allocated batching buffer.  Bytes accumulate here until
             // we hit FIFO_DEPTH or the input is exhausted; then we commit.
             // Newlines expand to "\r\n" inline, which means a single input

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -40,44 +40,11 @@ const MAX_RESP_BYTES: usize = 256 * 1024;
 
 // ── Dmesg ring buffer ────────────────────────────────────────────────────────
 //
-// 64 KiB byte ring.  Intended to mirror COM1 output; currently populated
-// only by explicit `dmesg_write_str()` callers.  Wiring a mirror hook
-// into `drivers::serial::_serial_print` is a follow-up.
+// The log ring lives in `crate::util::dmesg` (always compiled, so the
+// `syslog(2)` handler can read it in non-kdb builds).  kdb's `dmesg` op reads
+// the same ring via the re-export below.
 
-const DMESG_CAP: usize = 64 * 1024;
-
-struct DmesgRing { buf: [u8; DMESG_CAP], head: usize, filled: bool }
-
-impl DmesgRing {
-    const fn new() -> Self { Self { buf: [0u8; DMESG_CAP], head: 0, filled: false } }
-    fn write(&mut self, bytes: &[u8]) {
-        for &b in bytes {
-            self.buf[self.head] = b;
-            self.head += 1;
-            if self.head == DMESG_CAP { self.head = 0; self.filled = true; }
-        }
-    }
-    fn snapshot(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(if self.filled { DMESG_CAP } else { self.head });
-        if self.filled {
-            out.extend_from_slice(&self.buf[self.head..]);
-            out.extend_from_slice(&self.buf[..self.head]);
-        } else {
-            out.extend_from_slice(&self.buf[..self.head]);
-        }
-        out
-    }
-}
-
-pub(crate) static DMESG: Mutex<DmesgRing> = Mutex::new(DmesgRing::new());
-
-/// Feed bytes into the in-kernel log ring.  Tiny / no alloc.
-/// Currently only callable from within this crate; kept public so a
-/// future serial-mirror hook can forward into it without refactoring.
-#[allow(dead_code)]
-pub fn dmesg_write_str(s: &str) {
-    if let Some(mut r) = DMESG.try_lock() { r.write(s.as_bytes()); }
-}
+use crate::util::dmesg::DMESG;
 
 // ── Listener state machine ───────────────────────────────────────────────────
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -4330,6 +4330,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
         }
         // 102: getuid
         102 => crate::syscall::sys_getuid(),
+        // 103: syslog(type, bufp, len) — read/clear the kernel log ring.
+        // The user buffer is validated per-action inside the handler (only
+        // the READ family dereferences it), so no blanket pre-check here.
+        103 => crate::syscall::sys_syslog(arg1, arg2, arg3),
         // 104: getgid
         104 => crate::syscall::sys_getgid(),
         // 107: geteuid

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -5671,6 +5671,133 @@ pub(crate) fn sys_getrandom(buf: *mut u8, count: usize, flags: u32) -> i64 {
     count as i64
 }
 
+// ── syslog(2) / klogctl — read the kernel log ring ──────────────────────────
+//
+// `type` (action) values per the published klog ABI (`<sys/klog.h>`,
+// syslog(2) man page).  `dmesg` uses READ_ALL by default; that path is the
+// one that must be correct.  The kernel log ring lives in
+// `crate::util::dmesg` and is fed by a tee in the serial print path.
+const SYSLOG_ACTION_CLOSE:         u64 = 0;
+const SYSLOG_ACTION_OPEN:          u64 = 1;
+const SYSLOG_ACTION_READ:          u64 = 2;
+const SYSLOG_ACTION_READ_ALL:      u64 = 3;
+const SYSLOG_ACTION_READ_CLEAR:    u64 = 4;
+const SYSLOG_ACTION_CLEAR:         u64 = 5;
+const SYSLOG_ACTION_CONSOLE_OFF:   u64 = 6;
+const SYSLOG_ACTION_CONSOLE_ON:    u64 = 7;
+const SYSLOG_ACTION_CONSOLE_LEVEL: u64 = 8;
+const SYSLOG_ACTION_SIZE_UNREAD:   u64 = 9;
+const SYSLOG_ACTION_SIZE_BUFFER:   u64 = 10;
+
+/// syslog(2)/klogctl: read and/or clear the kernel message ring buffer.
+///
+/// `buf`/`len` are only meaningful for the READ family and CONSOLE_LEVEL;
+/// other actions ignore them.  This is a single-user box, so CAP_SYSLOG is
+/// not enforced (per the dispatch decision).
+///
+/// `arg_buf` is the raw user pointer, `arg_len` the raw `int len` argument
+/// (signed in the ABI — a negative `len` is EINVAL for the READ family).
+pub(crate) fn sys_syslog(action: u64, arg_buf: u64, arg_len: u64) -> i64 {
+    // `len` is `int` in the ABI; sign-extend the low 32 bits.
+    let len_signed = (arg_len as u32) as i32 as i64;
+
+    // Helper: copy `bytes` into the user buffer with full validation +
+    // SMAP bracket.  Returns bytes copied or a negative errno.  Only the
+    // first `cap` bytes (the user-supplied `len`) are ever written.
+    fn copy_out(buf: u64, cap: usize, bytes: &[u8]) -> i64 {
+        let n = bytes.len().min(cap);
+        if n == 0 {
+            return 0;
+        }
+        if !crate::syscall::user_ptr_check_bypassed()
+            && !crate::syscall::validate_user_ptr(buf, n)
+        {
+            return -14; // EFAULT
+        }
+        // SAFETY: `n` ≤ `cap`, the destination was range-validated above as a
+        // wholly-user buffer, and `bytes` is a kernel-owned snapshot Vec that
+        // outlives the copy.  The SMAP bracket permits the user write.
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf as *mut u8, n);
+        }
+        n as i64
+    }
+
+    match action {
+        // No-ops: kept for ABI completeness.  Real Linux opens/closes a
+        // /dev/kmsg-style cursor here; we have a single shared ring, so
+        // there is nothing to open or close.
+        SYSLOG_ACTION_CLOSE | SYSLOG_ACTION_OPEN => 0,
+
+        // READ: consume up to `len` unread bytes (oldest unread first).
+        SYSLOG_ACTION_READ => {
+            if arg_buf == 0 || len_signed < 0 {
+                return -22; // EINVAL
+            }
+            if len_signed == 0 {
+                return 0;
+            }
+            let cap = len_signed as usize;
+            let consumed = crate::util::dmesg::DMESG.lock().read_consume(cap);
+            copy_out(arg_buf, cap, &consumed)
+        }
+
+        // READ_ALL / READ_CLEAR: copy the LAST `len` bytes currently in the
+        // ring (non-destructive for READ_ALL; clear afterward for
+        // READ_CLEAR).  This is the action `dmesg` uses by default.
+        SYSLOG_ACTION_READ_ALL | SYSLOG_ACTION_READ_CLEAR => {
+            if arg_buf == 0 || len_signed < 0 {
+                return -22; // EINVAL
+            }
+            if len_signed == 0 {
+                return 0;
+            }
+            let cap = len_signed as usize;
+            // Snapshot then take the trailing `cap` bytes.
+            let (snap, do_clear) = {
+                let r = crate::util::dmesg::DMESG.lock();
+                (r.snapshot(), action == SYSLOG_ACTION_READ_CLEAR)
+            };
+            let start = snap.len().saturating_sub(cap);
+            let tail = &snap[start..];
+            let copied = copy_out(arg_buf, cap, tail);
+            if copied >= 0 && do_clear {
+                crate::util::dmesg::DMESG.lock().clear();
+            }
+            copied
+        }
+
+        // CLEAR: drop the ring contents.
+        SYSLOG_ACTION_CLEAR => {
+            crate::util::dmesg::DMESG.lock().clear();
+            0
+        }
+
+        // Console-level controls: accepted, no enforcement (we have no
+        // per-level console gating).  CONSOLE_LEVEL validates its range like
+        // the kernel does (1..=8) so callers get the documented EINVAL.
+        SYSLOG_ACTION_CONSOLE_OFF | SYSLOG_ACTION_CONSOLE_ON => 0,
+        SYSLOG_ACTION_CONSOLE_LEVEL => {
+            if len_signed < 1 || len_signed > 8 {
+                return -22; // EINVAL
+            }
+            0
+        }
+
+        // SIZE_UNREAD: bytes available to a consuming READ.
+        SYSLOG_ACTION_SIZE_UNREAD => {
+            crate::util::dmesg::DMESG.lock().unread_len() as i64
+        }
+
+        // SIZE_BUFFER: total ring capacity.
+        SYSLOG_ACTION_SIZE_BUFFER => crate::util::dmesg::DMESG_CAP as i64,
+
+        // Unknown action.
+        _ => -22, // EINVAL
+    }
+}
+
 // ===== Linux Syscall ABI Compatibility Layer ================================
 //
 // The Linux dispatch body and all Linux-specific helpers have moved to

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -3087,6 +3087,13 @@ pub fn run() -> ! {
     total += 1;
     if test_299_mmap_placement_race_repick() { passed += 1; }
 
+    // ── Test 300: syslog(2)/klogctl reads the kernel log ring ──────────────
+    // `dmesg` reads the kernel log via syslog(2) READ_ALL.  Verifies the
+    // action surface (READ_ALL/READ_CLEAR/CLEAR/SIZE_BUFFER/SIZE_UNREAD) and
+    // the EINVAL gates.  Refs: syslog(2)/klogctl man page; published klog ABI.
+    total += 1;
+    if test_300_syslog_klogctl_reads_log_ring() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -54879,6 +54886,186 @@ fn test_299_mmap_placement_race_repick() -> bool {
         test_pass!("mmap re-picks a fresh base on lost placement race (Test 299)");
     }
     ok
+}
+
+// ── Test 300: syslog(2)/klogctl reads the kernel log ring ────────────────────
+//
+// `dmesg` (busybox/util-linux) reads the kernel log via syslog(2) with
+// SYSLOG_ACTION_READ_ALL (type 3): copy the LAST `len` bytes currently in the
+// ring buffer into the user buffer, non-destructively.  This test writes a
+// known marker into the ring, then exercises the action surface:
+//
+//   - SYSLOG_ACTION_SIZE_BUFFER (10)  → total ring capacity (DMESG_CAP)
+//   - SYSLOG_ACTION_READ_ALL  (3)     → marker present in the returned tail
+//   - SYSLOG_ACTION_READ_CLEAR(4)     → marker present, then ring cleared
+//   - SYSLOG_ACTION_CLEAR (5) + SIZE_UNREAD (9) → empty after clear
+//   - unknown action → -EINVAL
+//
+// The handler validates the user buffer via `validate_user_ptr` + the SMAP
+// `UserGuard` bracket.  This test runs in kernel context with a kernel-VA
+// stack buffer, so the calls are wrapped in `KernelDispatchGuard` to set the
+// per-CPU user-pointer-check bypass — the same pattern as the other in-kernel
+// copy-to-user syscall tests.  Refs: syslog(2)/klogctl man page; published
+// klog ABI (`<sys/klog.h>` SYSLOG_ACTION_*).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_300_syslog_klogctl_reads_log_ring() -> bool {
+    test_header!("syslog(2)/klogctl reads the kernel log ring (Test 300)");
+    let mut ok = true;
+
+    const READ:       u64 = 2;
+    const READ_ALL:   u64 = 3;
+    const READ_CLEAR: u64 = 4;
+    const CLEAR:      u64 = 5;
+    const SIZE_UNREAD: u64 = 9;
+    const SIZE_BUFFER: u64 = 10;
+
+    // Seed a unique marker into the ring directly (the same ring the serial
+    // tee feeds).  Use a needle that won't collide with normal boot output.
+    const MARKER: &str = "[TEST300-DMESG-MARKER] kernel log ring needle\n";
+    crate::util::dmesg::DMESG.lock().clear();
+    crate::util::dmesg::write_str(MARKER);
+
+    // SIZE_BUFFER → capacity.  buf/len ignored for this action.
+    {
+        let cap = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(SIZE_BUFFER, 0, 0)
+        };
+        test_println!("  SIZE_BUFFER → {}", cap);
+        if cap != crate::util::dmesg::DMESG_CAP as i64 {
+            test_fail!("syslog", "SIZE_BUFFER returned {} (want {})",
+                cap, crate::util::dmesg::DMESG_CAP);
+            ok = false;
+        }
+    }
+
+    // SIZE_UNREAD reflects the seeded marker (consuming-read accounting).
+    {
+        let unread = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(SIZE_UNREAD, 0, 0)
+        };
+        test_println!("  SIZE_UNREAD → {}", unread);
+        if unread < MARKER.len() as i64 {
+            test_fail!("syslog", "SIZE_UNREAD {} < marker len {}", unread, MARKER.len());
+            ok = false;
+        }
+    }
+
+    // READ_ALL → the marker must appear in the returned tail.
+    {
+        let mut buf = [0u8; 1024];
+        let n = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(READ_ALL, buf.as_mut_ptr() as u64, buf.len() as u64)
+        };
+        test_println!("  READ_ALL → {} bytes", n);
+        if n < 0 {
+            test_fail!("syslog", "READ_ALL returned errno {}", n);
+            ok = false;
+        } else {
+            let got = &buf[..n as usize];
+            if find_subslice(got, MARKER.as_bytes()).is_none() {
+                test_fail!("syslog", "READ_ALL did not contain the marker");
+                ok = false;
+            } else {
+                test_println!("  READ_ALL contains the marker (OK)");
+            }
+        }
+    }
+
+    // EINVAL surface: null buffer + non-zero len, negative len, unknown action.
+    {
+        let einval_cases: &[(u64, u64, u64, &str)] = &[
+            (READ_ALL, 0, 64, "READ_ALL null-buf"),
+            (READ, 0, 64, "READ null-buf"),
+            (READ_ALL, 0x1000, u64::MAX, "READ_ALL negative-len"),
+            (9999, 0, 0, "unknown-action"),
+        ];
+        for &(act, b, l, label) in einval_cases {
+            let r = unsafe {
+                let _g = crate::syscall::KernelDispatchGuard::new();
+                crate::syscall::sys_syslog(act, b, l)
+            };
+            if r != -22 {
+                test_fail!("syslog", "{} returned {} (want -22 EINVAL)", label, r);
+                ok = false;
+            } else {
+                test_println!("  {} → -EINVAL (OK)", label);
+            }
+        }
+    }
+
+    // READ_CLEAR → marker present, then ring emptied.
+    {
+        let mut buf = [0u8; 1024];
+        let n = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(READ_CLEAR, buf.as_mut_ptr() as u64, buf.len() as u64)
+        };
+        if n < 0 || find_subslice(&buf[..n.max(0) as usize], MARKER.as_bytes()).is_none() {
+            test_fail!("syslog", "READ_CLEAR did not return the marker (n={})", n);
+            ok = false;
+        }
+        // After READ_CLEAR the ring is cleared.  Assert the unique marker is
+        // GONE rather than the ring being byte-empty: concurrent kernel/serial
+        // logging on another CPU may append fresh bytes between the internal
+        // clear and this follow-up read, but the unique marker can never
+        // reappear once cleared.
+        let after = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(READ_ALL, buf.as_mut_ptr() as u64, buf.len() as u64)
+        };
+        test_println!("  READ_CLEAR then READ_ALL → {} bytes", after);
+        if after > 0
+            && find_subslice(&buf[..after as usize], MARKER.as_bytes()).is_some()
+        {
+            test_fail!("syslog", "marker still present after READ_CLEAR (READ_ALL={})", after);
+            ok = false;
+        }
+    }
+
+    // CLEAR explicit: seed again, CLEAR, then the marker is gone.  CLEAR
+    // returns 0 unconditionally; we assert the unique marker disappears
+    // rather than SIZE_UNREAD being byte-zero, since concurrent serial
+    // logging on another CPU may append fresh bytes right after the clear.
+    {
+        crate::util::dmesg::write_str(MARKER);
+        let cleared = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(CLEAR, 0, 0)
+        };
+        let unread = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(SIZE_UNREAD, 0, 0)
+        };
+        test_println!("  CLEAR → {}, SIZE_UNREAD → {}", cleared, unread);
+        let mut buf = [0u8; 1024];
+        let after = unsafe {
+            let _g = crate::syscall::KernelDispatchGuard::new();
+            crate::syscall::sys_syslog(READ_ALL, buf.as_mut_ptr() as u64, buf.len() as u64)
+        };
+        let marker_gone = after <= 0
+            || find_subslice(&buf[..after as usize], MARKER.as_bytes()).is_none();
+        if cleared != 0 || !marker_gone {
+            test_fail!("syslog", "CLEAR ret={} marker_gone={}", cleared, marker_gone);
+            ok = false;
+        }
+    }
+
+    if ok {
+        test_pass!("syslog(2)/klogctl: READ_ALL/READ_CLEAR/CLEAR/SIZE_* + EINVAL (Test 300)");
+    }
+    ok
+}
+
+/// Find the first occurrence of `needle` in `hay`; returns the start index.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn find_subslice(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > hay.len() {
+        return None;
+    }
+    hay.windows(needle.len()).position(|w| w == needle)
 }
 
 // ── Test 295: cross-process SHARED futex keying (memfd MAP_SHARED) ───────────

--- a/kernel/src/util/dmesg.rs
+++ b/kernel/src/util/dmesg.rs
@@ -1,0 +1,125 @@
+//! Kernel log ring buffer (`dmesg`).
+//!
+//! A fixed-capacity byte ring that mirrors the kernel's serial log output so
+//! that userspace `syslog(2)`/`klogctl` (and `/proc/kmsg`) can read the boot
+//! log without a serial console.  This is the canonical, always-compiled home
+//! of the ring; `kdb` and the `syslog(2)` handler both read from it.
+//!
+//! The ring is fed by a tee in the serial print path
+//! (`drivers::serial::_serial_print`) so every line that reaches COM1 also
+//! lands here.  Writes are best-effort: a `try_lock` that loses the race (a
+//! concurrent reader, or a cross-CPU writer) simply drops the chunk rather
+//! than block.  Log fidelity is therefore "almost always complete"; this is
+//! the standard trade-off for an in-kernel log ring and matches how a
+//! best-effort console buffer behaves.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use spin::Mutex;
+
+/// Ring capacity in bytes.  64 KiB holds the full boot log for a typical run
+/// with room to spare; once full, the oldest bytes are overwritten (the most
+/// recent 64 KiB are always retained — the bytes `dmesg` cares about).
+pub const DMESG_CAP: usize = 64 * 1024;
+
+/// A simple overwrite-on-wrap byte ring.
+///
+/// `head` is the next write position; `filled` becomes true once the ring has
+/// wrapped at least once (i.e. `buf` is fully populated and the logical start
+/// of the log is at `head`, not 0).
+pub struct DmesgRing {
+    buf: [u8; DMESG_CAP],
+    head: usize,
+    filled: bool,
+    /// Read cursor for `SYSLOG_ACTION_READ` (consuming reads).  Counts bytes
+    /// already consumed since the last clear; the number of unread bytes is
+    /// `len() - read_consumed`.  Reset to 0 on clear.
+    read_consumed: usize,
+}
+
+impl DmesgRing {
+    pub const fn new() -> Self {
+        Self { buf: [0u8; DMESG_CAP], head: 0, filled: false, read_consumed: 0 }
+    }
+
+    /// Append bytes, overwriting the oldest on wrap.
+    pub fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.buf[self.head] = b;
+            self.head += 1;
+            if self.head == DMESG_CAP {
+                self.head = 0;
+                self.filled = true;
+            }
+        }
+        // New bytes are "unread"; never let the consume cursor run past the
+        // logical length.  (It can only shrink here when the ring wraps and
+        // the cursor's record falls off the back; clamp defensively.)
+        let total = self.logical_len();
+        if self.read_consumed > total {
+            self.read_consumed = total;
+        }
+    }
+
+    /// Number of bytes logically present in the ring (≤ `DMESG_CAP`).
+    fn logical_len(&self) -> usize {
+        if self.filled { DMESG_CAP } else { self.head }
+    }
+
+    /// Copy the entire ring (oldest → newest) into a fresh `Vec`.
+    /// Backs `SYSLOG_ACTION_READ_ALL` and `/proc/kmsg`.
+    pub fn snapshot(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.logical_len());
+        if self.filled {
+            out.extend_from_slice(&self.buf[self.head..]);
+            out.extend_from_slice(&self.buf[..self.head]);
+        } else {
+            out.extend_from_slice(&self.buf[..self.head]);
+        }
+        out
+    }
+
+    /// Bytes available to a consuming `SYSLOG_ACTION_READ` (unread tail).
+    /// Backs `SYSLOG_ACTION_SIZE_UNREAD`.
+    pub fn unread_len(&self) -> usize {
+        self.logical_len().saturating_sub(self.read_consumed)
+    }
+
+    /// Consume up to `max` unread bytes (oldest unread first), advancing the
+    /// read cursor.  Returns the consumed bytes.  Backs the consuming
+    /// `SYSLOG_ACTION_READ`.
+    pub fn read_consume(&mut self, max: usize) -> Vec<u8> {
+        let snap = self.snapshot();
+        let start = self.read_consumed.min(snap.len());
+        let end = (start + max).min(snap.len());
+        let out = snap[start..end].to_vec();
+        self.read_consumed = end;
+        out
+    }
+
+    /// Drop all content and reset cursors.  Backs `SYSLOG_ACTION_CLEAR`.
+    pub fn clear(&mut self) {
+        self.head = 0;
+        self.filled = false;
+        self.read_consumed = 0;
+    }
+}
+
+/// The global kernel log ring.
+pub static DMESG: Mutex<DmesgRing> = Mutex::new(DmesgRing::new());
+
+/// Tee a string into the log ring.  Allocation-free; best-effort under
+/// contention (a failed `try_lock` drops the chunk rather than blocking, which
+/// is safe to call from the IRQ-disabled serial critical section).
+#[inline]
+pub fn write_str(s: &str) {
+    if let Some(mut r) = DMESG.try_lock() {
+        r.write(s.as_bytes());
+    }
+}
+
+/// Snapshot the whole ring (oldest → newest).  Used by `/proc/kmsg` and kdb.
+pub fn snapshot() -> Vec<u8> {
+    DMESG.lock().snapshot()
+}

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -2,3 +2,4 @@
 //! safety contracts.
 
 pub mod no_alloc_fmt;
+pub mod dmesg;

--- a/kernel/src/vfs/procfs.rs
+++ b/kernel/src/vfs/procfs.rs
@@ -64,6 +64,7 @@ const INO_UPTIME:            u64 = 2003;
 const INO_VERSION:           u64 = 2004;
 const INO_MOUNTS:            u64 = 2005;
 const INO_CMDLINE:           u64 = 2006;
+const INO_KMSG:              u64 = 2008; // /proc/kmsg — kernel log ring snapshot
 const INO_SELF_DIR:          u64 = 2010;
 const INO_SELF_MAPS:         u64 = 2011;
 const INO_SELF_STATUS:       u64 = 2012;
@@ -148,6 +149,7 @@ impl ProcFs {
             | INO_VERSION
             | INO_MOUNTS
             | INO_CMDLINE
+            | INO_KMSG
             | INO_STAT
             | INO_SELF_MAPS
             | INO_SELF_STATUS
@@ -193,6 +195,11 @@ impl ProcFs {
             INO_MOUNTS  => Some(generate_mounts()),
             INO_STAT    => Some(generate_stat()),
             INO_CMDLINE => Some(b"astryx_kernel root=/dev/ramdisk0 console=fb0\n".to_vec()),
+            // /proc/kmsg — snapshot of the kernel log ring (the same ring
+            // syslog(2)/klogctl reads).  A non-streaming snapshot read: each
+            // open returns the current ring contents.  Backed by the shared
+            // ring in `crate::util::dmesg`.
+            INO_KMSG => Some(crate::util::dmesg::snapshot()),
             // /proc/self/maps — real content from the calling process's VMA table.
             // fd_read() intercepts this path first (see vfs/mod.rs) and delegates
             // to generate_proc_maps() with the caller's PID.  This arm is the
@@ -262,6 +269,7 @@ impl FileSystemOps for ProcFs {
             (INO_ROOT, "version")           => Ok(INO_VERSION),
             (INO_ROOT, "mounts")            => Ok(INO_MOUNTS),
             (INO_ROOT, "cmdline")           => Ok(INO_CMDLINE),
+            (INO_ROOT, "kmsg")              => Ok(INO_KMSG),
             (INO_ROOT, "stat")              => Ok(INO_STAT),
             (INO_ROOT, "self")              => Ok(INO_SELF_DIR),
             (INO_ROOT, "sys")               => Ok(INO_SYS_DIR),
@@ -406,6 +414,7 @@ impl FileSystemOps for ProcFs {
                 f!("version",  INO_VERSION),
                 f!("mounts",   INO_MOUNTS),
                 f!("cmdline",  INO_CMDLINE),
+                f!("kmsg",     INO_KMSG),
                 f!("stat",     INO_STAT),
                 d!("self",     INO_SELF_DIR),
                 d!("sys",      INO_SYS_DIR),


### PR DESCRIPTION
## Summary

`busybox dmesg` was failing with `dmesg: klogctl: Function not implemented` — the Linux personality had no `syslog(2)` (x86-64 nr **103**). This wires it to a new kernel log ring so userspace can read the boot log without a serial console.

## What's here

- **`util/dmesg.rs`** (new): a 64 KiB overwrite-on-wrap byte ring (`DMESG`), always compiled. Fed by a best-effort tee in `drivers::serial::_serial_print` so every line that reaches COM1 also lands in the ring. A failed `try_lock` drops the chunk rather than block — safe inside the IRQ-disabled serial critical section.
- **`sys_syslog(type, bufp, len)`** in `syscall/mod.rs`, dispatched at Linux syscall 103. Implements the published klog action surface (syslog(2) man page; `SYSLOG_ACTION_*`):
  - `READ_ALL`(3) — copy the trailing `len` bytes non-destructively (the action `dmesg` uses; it queries `SIZE_BUFFER` first to size the read)
  - `READ`(2) — consume up to `len` unread bytes (read cursor)
  - `READ_CLEAR`(4) — READ_ALL then clear; `CLEAR`(5)
  - `SIZE_UNREAD`(9), `SIZE_BUFFER`(10)
  - `OPEN`/`CLOSE`/`CONSOLE_*` — accepted no-ops (`CONSOLE_LEVEL` validates 1..=8)
  - `EINVAL` for null-buf + non-zero len, negative `int len`, unknown action
  - The READ family validates the user buffer via `validate_user_ptr` and brackets the copy with the SMAP `UserGuard`. CAP_SYSLOG is not enforced (single-user box).
- **`/proc/kmsg`** exposes a snapshot of the same ring.
- **kdb**: its previously-private (and unfed) dmesg ring is folded into this shared one, so the kdb `dmesg` op now returns real boot log.

## Test

**Test 300** (`test_runner.rs`) exercises the full action surface end-to-end against a kernel-VA buffer. Verified PASS in a real test-mode boot:

```
  TEST: syslog(2)/klogctl reads the kernel log ring (Test 300)
  SIZE_BUFFER → 65536
  SIZE_UNREAD → 70
  READ_ALL → 91 bytes
  READ_ALL contains the marker (OK)
  READ_ALL null-buf → -EINVAL (OK)
  READ null-buf → -EINVAL (OK)
  READ_ALL negative-len → -EINVAL (OK)
  unknown-action → -EINVAL (OK)
  READ_CLEAR then READ_ALL → 0 bytes
  CLEAR → 0, SIZE_UNREAD → 0
[PASS] syslog(2)/klogctl: READ_ALL/READ_CLEAR/CLEAR/SIZE_* + EINVAL (Test 300)
```

Both `test-mode` and production (no-feature) builds compile clean. The change is orthogonal to the pre-existing pipe-writer sub-test (Test 0b) wedge on this base lineage, which is being addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)