### PR TITLE
NDE-20: AF_NETLINK + NETLINK_ROUTE (rtnetlink) so `ip addr/link/route` work

### DIFF
--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -25,6 +25,7 @@ pub mod socket;
 pub mod dns;
 pub mod dhcp;
 pub mod unix;
+pub mod netlink;
 pub mod loopback;
 pub mod ipver;
 

--- a/kernel/src/net/netlink.rs
+++ b/kernel/src/net/netlink.rs
@@ -1,0 +1,609 @@
+//! AF_NETLINK / NETLINK_ROUTE (rtnetlink) — kernel-side socket family.
+//!
+//! Implements the minimum viable rtnetlink surface for interface, address,
+//! and route *introspection* — enough for `ip addr`, `ip link`, `ip route`
+//! and `ifconfig` (busybox / iproute2) to enumerate the host's network
+//! configuration.  The wire format follows the published netlink and
+//! rtnetlink UAPI (RFC 3549; `netlink(7)`, `rtnetlink(7)`, `sockaddr_nl(7)`):
+//!
+//!   * A netlink message is a fixed `nlmsghdr` (RFC 3549 §2.2) followed by a
+//!     family-specific payload, all padded to a 4-byte (`NLMSG_ALIGNTO`)
+//!     boundary.
+//!   * A "dump" request carries `NLM_F_REQUEST | NLM_F_DUMP` and elicits a
+//!     *multipart* reply: a run of `NLM_F_MULTI`-flagged messages, one per
+//!     object, terminated by a single `NLMSG_DONE` message whose payload is
+//!     the dump's terminating errno (0 = success) — RFC 3549 §2.3.2.
+//!   * Attributes are nested TLVs (`struct rtattr`, RFC 3549 §2.3.3), each a
+//!     `{ rta_len: u16, rta_type: u16 }` header followed by `rta_len -
+//!     RTA_LENGTH(0)` payload bytes, padded to `RTA_ALIGNTO` (4).
+//!
+//! Only the introspection request types `RTM_GETLINK`, `RTM_GETADDR`, and
+//! `RTM_GETROUTE` are serviced; everything else is acknowledged with an
+//! `NLMSG_ERROR` carrying `EOPNOTSUPP` (a real Linux host answers an unknown
+//! rtnetlink request the same way).  We never *write* config (no
+//! `RTM_NEWLINK`/`RTM_DELADDR` handling) — this is a read-only view.
+//!
+//! Design mirrors the AF_UNIX (`net::unix`) model: a global socket table
+//! keyed by a monotonic id, one entry per open file description, an
+//! open-file-description reference count so fork(2)/dup(2) sharing tears the
+//! socket down only on the last close, and a per-socket receive queue of
+//! ready-to-read reply bytes the recv/poll path drains.  Each request is
+//! processed synchronously on the sending thread (the dump is cheap — a
+//! handful of interfaces) and the full reply is enqueued atomically, so the
+//! socket is readable the instant `sendmsg`/`send` returns.
+
+extern crate alloc;
+
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use spin::Mutex;
+
+use super::{Ipv4Address, MacAddress};
+
+// ── netlink UAPI constants (RFC 3549; netlink(7), rtnetlink(7)) ───────────────
+
+/// Routing/device netlink protocol — `NETLINK_ROUTE` (rtnetlink(7)).
+pub const NETLINK_ROUTE: u32 = 0;
+
+// nlmsghdr.nlmsg_flags bits (RFC 3549 §2.3.1).
+const NLM_F_REQUEST: u16 = 0x01; // request message
+const NLM_F_MULTI:   u16 = 0x02; // multipart, terminated by NLMSG_DONE
+const NLM_F_ACK:     u16 = 0x04; // reply with ack (zero or error code)
+const NLM_F_DUMP:    u16 = 0x100 | 0x200; // NLM_F_ROOT | NLM_F_MATCH
+
+// Standard control message types (RFC 3549 §2.3.2).
+const NLMSG_NOOP:  u16 = 0x1;
+const NLMSG_ERROR: u16 = 0x2;
+const NLMSG_DONE:  u16 = 0x3;
+
+// rtnetlink message types (rtnetlink(7); RTM_BASE = 16).
+const RTM_NEWLINK:  u16 = 16;
+const RTM_GETLINK:  u16 = 18;
+const RTM_NEWADDR:  u16 = 20;
+const RTM_GETADDR:  u16 = 22;
+const RTM_NEWROUTE: u16 = 24;
+const RTM_GETROUTE: u16 = 26;
+
+// IFLA_* link attribute types (rtnetlink(7)).
+const IFLA_ADDRESS:  u16 = 1;
+const IFLA_IFNAME:   u16 = 3;
+const IFLA_MTU:      u16 = 4;
+const IFLA_TXQLEN:   u16 = 13;
+
+// IFA_* address attribute types (rtnetlink(7)).
+const IFA_ADDRESS:   u16 = 1;
+const IFA_LOCAL:     u16 = 2;
+const IFA_LABEL:     u16 = 3;
+
+// RTA_* route attribute types (rtnetlink(7)).
+const RTA_DST:       u16 = 1;
+const RTA_OIF:       u16 = 4;
+const RTA_GATEWAY:   u16 = 5;
+const RTA_PREFSRC:   u16 = 7;
+const RTA_TABLE:     u16 = 15;
+
+// Address families.
+const AF_INET: u8 = 2;
+
+// Route table / scope / proto / type constants (rtnetlink(7)).
+const RT_TABLE_MAIN:    u8 = 254;
+const RT_SCOPE_UNIVERSE: u8 = 0;
+const RT_SCOPE_LINK:    u8 = 253;
+const RTPROT_BOOT:      u8 = 3;
+const RTPROT_KERNEL:    u8 = 2;
+const RTN_UNICAST:      u8 = 1;
+
+// EOPNOTSUPP — returned (as a negative errno in NLMSG_ERROR) for any
+// rtnetlink request we do not service.
+const EOPNOTSUPP: i32 = 95;
+
+/// Alignment for both nlmsghdr-framed messages and rtattr TLVs — both use a
+/// 4-byte boundary (`NLMSG_ALIGNTO == RTA_ALIGNTO == 4`, RFC 3549).
+const ALIGN: usize = 4;
+
+#[inline]
+const fn align4(n: usize) -> usize {
+    (n + ALIGN - 1) & !(ALIGN - 1)
+}
+
+/// `sizeof(struct nlmsghdr)` — 16 bytes (RFC 3549 §2.2).
+const NLMSG_HDRLEN: usize = 16;
+
+// ── socket table ─────────────────────────────────────────────────────────────
+
+/// A single AF_NETLINK / NETLINK_ROUTE socket (one open file description).
+struct NetlinkSocket {
+    id: u64,
+    /// Netlink protocol selector (`NETLINK_ROUTE` only, for now).
+    #[allow(dead_code)]
+    protocol: u32,
+    /// Port id assigned to this socket (`nl_pid`).  Bound lazily on the first
+    /// `bind(2)` or first send; the auto-bind value defaults to the caller's
+    /// pid per netlink(7) ("If [nl_pid] is zero the kernel assigns one").
+    nl_pid: u32,
+    /// Whether `bind(2)` / first-send has assigned `nl_pid`.
+    bound: bool,
+    /// Ready-to-read reply bytes, one complete recvmsg's worth per entry.
+    /// Each entry is a self-contained multipart reply (one or more
+    /// nlmsghdr-framed messages, ending in NLMSG_DONE / NLMSG_ERROR).  recv
+    /// returns at most one entry's bytes per call (datagram semantics —
+    /// netlink is message-oriented, netlink(7)).
+    rx: VecDeque<Vec<u8>>,
+    /// Open-file-description reference count (fork/dup/SCM sharing).  Torn
+    /// down on the last close.  POSIX.1-2017 §close.
+    ref_count: u32,
+}
+
+static SOCKETS: Mutex<Vec<NetlinkSocket>> = Mutex::new(Vec::new());
+static NEXT_ID: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(1);
+
+/// Monotonic source of kernel-assigned `nl_pid` port ids for the case where
+/// neither the requested `nl_pid` nor the caller's pid yields a usable value
+/// (netlink(7): a kernel-auto-assigned port id is always non-zero and unique).
+/// Seeded high (0x8000_0000) so generated ids never collide with a real pid
+/// used as a first-socket port id, mirroring the kernel's disambiguation of
+/// multiple netlink sockets owned by one process.
+static NEXT_AUTO_PID: core::sync::atomic::AtomicU32 =
+    core::sync::atomic::AtomicU32::new(0x8000_0000);
+
+/// Resolve a port id for `bind`/auto-bind.  A non-zero requested `nl_pid` is
+/// honoured verbatim; otherwise the caller's pid is used (the conventional
+/// first-socket port id); if that is also 0 (e.g. a kernel-context caller) a
+/// unique non-zero value is generated.  The result is never 0, per netlink(7)
+/// ("If [nl_pid] is zero ... the kernel ... assigns ... a unique address").
+fn resolve_pid(nl_pid: u32, default_pid: u32) -> u32 {
+    if nl_pid != 0 {
+        return nl_pid;
+    }
+    if default_pid != 0 {
+        return default_pid;
+    }
+    NEXT_AUTO_PID.fetch_add(1, core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Create a new NETLINK_ROUTE socket.  Returns the socket id, or
+/// `u64::MAX` on table exhaustion (mapped to EMFILE by the caller).
+pub fn create(protocol: u32) -> u64 {
+    let id = NEXT_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let mut socks = SOCKETS.lock();
+    socks.push(NetlinkSocket {
+        id,
+        protocol,
+        nl_pid: 0,
+        bound: false,
+        rx: VecDeque::new(),
+        ref_count: 1,
+    });
+    id
+}
+
+/// Bind the socket to a `sockaddr_nl`.  `nl_pid == 0` requests a
+/// kernel-assigned port id (the conventional unicast nl_pid is the caller's
+/// pid; a kernel-context caller with pid 0 gets a generated unique non-zero
+/// value — a bound socket's port id is never 0, netlink(7)).  Any non-zero
+/// `nl_pid` is accepted verbatim.  `groups` is accepted but ignored (we
+/// deliver no multicast).  Returns 0 on success, -errno on a bad socket id
+/// (netlink(7), sockaddr_nl(7)).
+pub fn bind(id: u64, nl_pid: u32, _groups: u32, default_pid: u32) -> i32 {
+    let mut socks = SOCKETS.lock();
+    let s = match socks.iter_mut().find(|s| s.id == id) {
+        Some(s) => s,
+        None => return -9, // EBADF
+    };
+    s.nl_pid = resolve_pid(nl_pid, default_pid);
+    s.bound = true;
+    0
+}
+
+/// Ensure the socket has a port id, auto-binding to `default_pid` on first
+/// use (netlink(7): an unbound socket is auto-bound on the first send).
+/// Returns the resulting `nl_pid`.
+fn ensure_bound(socks: &mut Vec<NetlinkSocket>, id: u64, default_pid: u32) -> u32 {
+    if let Some(s) = socks.iter_mut().find(|s| s.id == id) {
+        if !s.bound {
+            s.nl_pid = resolve_pid(0, default_pid);
+            s.bound = true;
+        }
+        s.nl_pid
+    } else {
+        0
+    }
+}
+
+/// Return the socket's bound port id for `getsockname(2)` — a `sockaddr_nl`
+/// whose `nl_pid` is the assigned port id (0 when never bound).  Returns
+/// `None` for an unknown socket id.
+pub fn local_pid(id: u64) -> Option<u32> {
+    let socks = SOCKETS.lock();
+    socks.iter().find(|s| s.id == id).map(|s| s.nl_pid)
+}
+
+/// Add one open-file-description reference (fork/dup/SCM).  No-op if the id
+/// is gone.  Balances a later [`close`].
+pub fn inc_ref(id: u64) {
+    let mut socks = SOCKETS.lock();
+    if let Some(s) = socks.iter_mut().find(|s| s.id == id) {
+        s.ref_count = s.ref_count.saturating_add(1);
+    }
+}
+
+/// Drop one reference; free the socket on the last close (POSIX.1-2017
+/// §close: the open file description is released when the refcount hits 0).
+pub fn close(id: u64) {
+    let mut socks = SOCKETS.lock();
+    if let Some(idx) = socks.iter().position(|s| s.id == id) {
+        if socks[idx].ref_count > 1 {
+            socks[idx].ref_count -= 1;
+            return;
+        }
+        socks.remove(idx);
+    }
+}
+
+/// True when a reply is queued — the `poll(2)` / `epoll(7)` POLLIN gate.
+pub fn has_data(id: u64) -> bool {
+    let socks = SOCKETS.lock();
+    socks.iter().find(|s| s.id == id)
+        .map(|s| !s.rx.is_empty())
+        .unwrap_or(false)
+}
+
+/// A netlink socket is always writable (the send path is synchronous and
+/// never blocks) — the POLLOUT gate.
+pub fn writable(_id: u64) -> bool {
+    true
+}
+
+// ── send / request processing ────────────────────────────────────────────────
+
+/// Process one or more concatenated request messages sent by userspace.
+///
+/// `data` is the raw bytes of one `sendmsg`/`send`, which may pack several
+/// nlmsghdr-framed requests back to back (RFC 3549 §2.2 permits it; iproute2
+/// sends one per call but we tolerate batching).  Each request is parsed,
+/// dispatched, and its reply appended to a single multipart reply buffer that
+/// is enqueued atomically on the socket's receive queue.  Returns the number
+/// of request bytes consumed (always `data.len()` on success, so the caller
+/// reports a full write), or a negative errno.
+///
+/// `default_pid` is the caller's pid, used both to auto-bind an unbound
+/// socket and as the `nlmsg_pid` echoed back on replies (netlink(7)).
+pub fn send_request(id: u64, data: &[u8], default_pid: u32) -> i64 {
+    // Auto-bind on first use, and confirm the socket exists.
+    {
+        let mut socks = SOCKETS.lock();
+        if !socks.iter().any(|s| s.id == id) {
+            return -9; // EBADF
+        }
+        ensure_bound(&mut socks, id, default_pid);
+    }
+
+    // Build the reply for every request packed into this send.
+    let mut reply: Vec<u8> = Vec::new();
+    let mut off = 0usize;
+    while off + NLMSG_HDRLEN <= data.len() {
+        let nlmsg_len = u32::from_ne_bytes([
+            data[off], data[off + 1], data[off + 2], data[off + 3],
+        ]) as usize;
+        let nlmsg_type = u16::from_ne_bytes([data[off + 4], data[off + 5]]);
+        let nlmsg_flags = u16::from_ne_bytes([data[off + 6], data[off + 7]]);
+        let nlmsg_seq = u32::from_ne_bytes([
+            data[off + 8], data[off + 9], data[off + 10], data[off + 11],
+        ]);
+        // A malformed length (shorter than the header, or running past the
+        // buffer) terminates parsing — RFC 3549's NLMSG_OK guard.
+        if nlmsg_len < NLMSG_HDRLEN || off + nlmsg_len > data.len() {
+            break;
+        }
+
+        let is_dump = (nlmsg_flags & NLM_F_DUMP) == NLM_F_DUMP;
+        match nlmsg_type {
+            RTM_GETLINK => dump_links(&mut reply, nlmsg_seq, default_pid),
+            RTM_GETADDR => dump_addrs(&mut reply, nlmsg_seq, default_pid),
+            RTM_GETROUTE => dump_routes(&mut reply, nlmsg_seq, default_pid),
+            _ => {
+                // Any other request: a request that asked for an ACK, or any
+                // unknown type, gets an NLMSG_ERROR.  An unknown type is
+                // EOPNOTSUPP; an ACK-requested known-but-unhandled op would
+                // be 0 — we only handle the GET dumps, so everything else is
+                // EOPNOTSUPP (RFC 3549 §2.3.2.2 / netlink(7) NLMSG_ERROR).
+                let _ = is_dump;
+                push_error(&mut reply, nlmsg_seq, default_pid,
+                           nlmsg_type, nlmsg_flags, -EOPNOTSUPP, data, off, nlmsg_len);
+            }
+        }
+
+        // RTM_GET* dumps emit their own NLMSG_DONE terminator inside the
+        // dump_* helpers.  For a non-dump RTM_GET (rare) the single reply +
+        // DONE is still correct because the helpers always close with DONE.
+        off += align4(nlmsg_len);
+        if off <= data.len() && align4(nlmsg_len) == 0 {
+            break; // defensive: never spin on a zero-advance
+        }
+    }
+
+    // Enqueue the whole reply as one readable message.
+    let mut socks = SOCKETS.lock();
+    if let Some(s) = socks.iter_mut().find(|s| s.id == id) {
+        if !reply.is_empty() {
+            s.rx.push_back(reply);
+        }
+    }
+    data.len() as i64
+}
+
+/// Dequeue at most one reply buffer into `buf`.  Netlink is message-oriented:
+/// each recv returns one queued reply (which itself may contain several
+/// nlmsghdr-framed messages).  Returns `(bytes_copied, truncated)`; on an
+/// empty queue returns `(0, false)` which the syscall layer maps to -EAGAIN
+/// for a non-blocking recv or parks for a blocking one.
+pub fn recv(id: u64, buf: &mut [u8]) -> (usize, bool) {
+    let mut socks = SOCKETS.lock();
+    let s = match socks.iter_mut().find(|s| s.id == id) {
+        Some(s) => s,
+        None => return (0, false),
+    };
+    let msg = match s.rx.pop_front() {
+        Some(m) => m,
+        None => return (0, false),
+    };
+    let n = msg.len().min(buf.len());
+    buf[..n].copy_from_slice(&msg[..n]);
+    // A short user buffer truncates the message; per netlink(7) the excess is
+    // discarded (the kernel sets MSG_TRUNC) — we drop the remainder.
+    (n, n < msg.len())
+}
+
+// ── reply marshalling ────────────────────────────────────────────────────────
+
+/// Append a `struct nlmsghdr` to `out`, recording its byte offset so the
+/// length can be back-patched once the body and attrs are written.  Returns
+/// the offset of this header within `out`.
+fn put_nlmsghdr(out: &mut Vec<u8>, msg_type: u16, flags: u16, seq: u32, pid: u32) -> usize {
+    let hdr_off = out.len();
+    out.extend_from_slice(&0u32.to_ne_bytes());     // nlmsg_len (patched later)
+    out.extend_from_slice(&msg_type.to_ne_bytes()); // nlmsg_type
+    out.extend_from_slice(&flags.to_ne_bytes());    // nlmsg_flags
+    out.extend_from_slice(&seq.to_ne_bytes());      // nlmsg_seq
+    out.extend_from_slice(&pid.to_ne_bytes());      // nlmsg_pid
+    hdr_off
+}
+
+/// Back-patch `nlmsg_len` of the header at `hdr_off` to the true message
+/// length (`out.len() - hdr_off`), then pad `out` to the next 4-byte
+/// boundary so the following message starts aligned (RFC 3549 §2.2).
+fn finish_nlmsg(out: &mut Vec<u8>, hdr_off: usize) {
+    let len = (out.len() - hdr_off) as u32;
+    out[hdr_off..hdr_off + 4].copy_from_slice(&len.to_ne_bytes());
+    while out.len() % ALIGN != 0 {
+        out.push(0);
+    }
+}
+
+/// Append one `struct rtattr` TLV: `{ rta_len: u16, rta_type: u16 }` header
+/// followed by `payload`, padded to the next 4-byte boundary (RFC 3549
+/// §2.3.3).  `rta_len` excludes the trailing padding but includes the 4-byte
+/// attribute header (`RTA_LENGTH(payload.len())`).
+fn put_attr(out: &mut Vec<u8>, attr_type: u16, payload: &[u8]) {
+    let rta_len = (4 + payload.len()) as u16;
+    out.extend_from_slice(&rta_len.to_ne_bytes());
+    out.extend_from_slice(&attr_type.to_ne_bytes());
+    out.extend_from_slice(payload);
+    while out.len() % ALIGN != 0 {
+        out.push(0);
+    }
+}
+
+/// Append the terminating `NLMSG_DONE` (RFC 3549 §2.3.2): a header of type
+/// NLMSG_DONE carrying `NLM_F_MULTI`, with a 4-byte payload = the dump's
+/// terminating errno (0 = success).
+fn push_done(out: &mut Vec<u8>, seq: u32, pid: u32) {
+    let hdr_off = put_nlmsghdr(out, NLMSG_DONE, NLM_F_MULTI, seq, pid);
+    out.extend_from_slice(&0i32.to_ne_bytes()); // dump errno = 0
+    finish_nlmsg(out, hdr_off);
+}
+
+/// Append an `NLMSG_ERROR` message (RFC 3549 §2.3.2.2): `{ error: i32 }`
+/// followed by the original request header echoed back, per the UAPI
+/// `struct nlmsgerr`.  `error == 0` is the conventional "ACK"; a negative
+/// value reports a failure.
+fn push_error(
+    out: &mut Vec<u8>,
+    seq: u32,
+    pid: u32,
+    _req_type: u16,
+    _req_flags: u16,
+    error: i32,
+    req_data: &[u8],
+    req_off: usize,
+    req_len: usize,
+) {
+    let hdr_off = put_nlmsghdr(out, NLMSG_ERROR, 0, seq, pid);
+    out.extend_from_slice(&error.to_ne_bytes()); // nlmsgerr.error
+    // nlmsgerr.msg = the original request header (the first NLMSG_HDRLEN
+    // bytes of the offending request), per struct nlmsgerr.  Echo exactly
+    // NLMSG_HDRLEN bytes, zero-padding when the request was shorter than a
+    // full header (defensive — a well-formed request is >= 16 bytes).
+    let echo_end = (req_off + req_len.min(NLMSG_HDRLEN)).min(req_data.len());
+    let echoed = if echo_end > req_off {
+        out.extend_from_slice(&req_data[req_off..echo_end]);
+        echo_end - req_off
+    } else {
+        0
+    };
+    for _ in echoed..NLMSG_HDRLEN {
+        out.push(0);
+    }
+    finish_nlmsg(out, hdr_off);
+}
+
+// ── RTM_GETLINK → RTM_NEWLINK dump ───────────────────────────────────────────
+
+/// Emit one `RTM_NEWLINK` message per interface, then `NLMSG_DONE`
+/// (rtnetlink(7), RFC 3549 §2.3.2).  The link body is a `struct ifinfomsg`
+/// followed by `IFLA_IFNAME`, `IFLA_ADDRESS` (MAC), `IFLA_MTU`, and
+/// `IFLA_TXQLEN` attributes.
+fn dump_links(out: &mut Vec<u8>, seq: u32, pid: u32) {
+    for iface in super::list_ifaces() {
+        let hdr_off = put_nlmsghdr(out, RTM_NEWLINK, NLM_F_MULTI, seq, pid);
+        // struct ifinfomsg { u8 family; u8 pad; u16 type; i32 index; u32 flags; u32 change }
+        out.push(0);                                        // ifi_family (AF_UNSPEC)
+        out.push(0);                                        // __ifi_pad
+        out.extend_from_slice(&iface.iftype.to_ne_bytes()); // ifi_type (ARPHRD_*)
+        out.extend_from_slice(&(iface.ifindex as i32).to_ne_bytes()); // ifi_index
+        out.extend_from_slice(&iface.flags.to_ne_bytes());  // ifi_flags (IFF_*)
+        out.extend_from_slice(&0xffff_ffffu32.to_ne_bytes()); // ifi_change (all)
+
+        // IFLA_IFNAME — NUL-terminated interface name.
+        let mut name = iface.name.clone().into_bytes();
+        name.push(0);
+        put_attr(out, IFLA_IFNAME, &name);
+        // IFLA_ADDRESS — hardware (MAC) address.  Loopback has all-zero,
+        // which Linux still emits as a 6-byte zero IFLA_ADDRESS.
+        put_attr(out, IFLA_ADDRESS, &iface.mac);
+        // IFLA_MTU — u32.
+        put_attr(out, IFLA_MTU, &iface.mtu.to_ne_bytes());
+        // IFLA_TXQLEN — u32.  1000 is the conventional Ethernet default; 0 on
+        // loopback (no real transmit queue).
+        let txqlen: u32 = if iface.iftype == super::ARPHRD_LOOPBACK { 0 } else { 1000 };
+        put_attr(out, IFLA_TXQLEN, &txqlen.to_ne_bytes());
+
+        finish_nlmsg(out, hdr_off);
+    }
+    push_done(out, seq, pid);
+}
+
+// ── RTM_GETADDR → RTM_NEWADDR dump ───────────────────────────────────────────
+
+/// Emit one `RTM_NEWADDR` message per (interface, IPv4 address) pair, then
+/// `NLMSG_DONE`.  The body is a `struct ifaddrmsg` followed by `IFA_ADDRESS`,
+/// `IFA_LOCAL`, and `IFA_LABEL` attributes (rtnetlink(7)).
+fn dump_addrs(out: &mut Vec<u8>, seq: u32, pid: u32) {
+    // Build (ifindex, name, addr, prefixlen, scope) tuples from the live
+    // stack.  Loopback carries 127.0.0.1/8 (RFC 1122 §3.2.1.3); the hardware
+    // NIC carries the host's primary IPv4 with the configured prefix length.
+    let host_ip = super::our_ip();
+    let prefixlen = mask_to_prefixlen(super::subnet_mask());
+
+    for iface in super::list_ifaces() {
+        let (addr, plen, scope): (Ipv4Address, u8, u8) =
+            if iface.iftype == super::ARPHRD_LOOPBACK {
+                ([127, 0, 0, 1], 8, RT_SCOPE_HOST)
+            } else {
+                (host_ip, prefixlen, RT_SCOPE_UNIVERSE)
+            };
+        // Skip an unconfigured NIC (all-zero address) — nothing to report.
+        if iface.iftype != super::ARPHRD_LOOPBACK && addr == [0, 0, 0, 0] {
+            continue;
+        }
+
+        let hdr_off = put_nlmsghdr(out, RTM_NEWADDR, NLM_F_MULTI, seq, pid);
+        // struct ifaddrmsg { u8 family; u8 prefixlen; u8 flags; u8 scope; u32 index }
+        out.push(AF_INET);               // ifa_family
+        out.push(plen);                  // ifa_prefixlen
+        out.push(IFA_F_PERMANENT);       // ifa_flags
+        out.push(scope);                 // ifa_scope
+        out.extend_from_slice(&iface.ifindex.to_ne_bytes()); // ifa_index
+
+        // IFA_ADDRESS — the address of the prefix (== IFA_LOCAL for a normal,
+        // non-point-to-point interface).  IFA_LOCAL — the local address.
+        put_attr(out, IFA_ADDRESS, &addr);
+        put_attr(out, IFA_LOCAL, &addr);
+        // IFA_LABEL — the interface name (NUL-terminated), what `ip addr`
+        // prints after the address.
+        let mut label = iface.name.clone().into_bytes();
+        label.push(0);
+        put_attr(out, IFA_LABEL, &label);
+
+        finish_nlmsg(out, hdr_off);
+    }
+    push_done(out, seq, pid);
+}
+
+const RT_SCOPE_HOST: u8 = 254;
+const IFA_F_PERMANENT: u8 = 0x80;
+
+// ── RTM_GETROUTE → RTM_NEWROUTE dump ─────────────────────────────────────────
+
+/// Emit the IPv4 routing table — the on-link subnet route plus the default
+/// route — then `NLMSG_DONE`.  Each route is a `struct rtmsg` followed by
+/// `RTA_TABLE`, `RTA_DST`/`RTA_GATEWAY`, `RTA_PREFSRC`, and `RTA_OIF`
+/// attributes (rtnetlink(7)).
+fn dump_routes(out: &mut Vec<u8>, seq: u32, pid: u32) {
+    let host_ip = super::our_ip();
+    let gw = super::gateway_ip();
+    let prefixlen = mask_to_prefixlen(super::subnet_mask());
+
+    // The hardware NIC's ifindex (eth0 == 2 when present); routes are bound to
+    // it via RTA_OIF.  If no NIC is up there is nothing to route, so we still
+    // emit DONE (an empty table) rather than fabricating routes.
+    let oif = super::list_ifaces().iter()
+        .find(|i| i.iftype == super::ARPHRD_ETHER)
+        .map(|i| i.ifindex);
+
+    if let Some(oif) = oif {
+        if host_ip != [0, 0, 0, 0] {
+            // On-link subnet route: dst = host_ip & mask, dst_len = prefixlen,
+            // scope LINK, proto KERNEL (the route the kernel installs for a
+            // configured interface address).
+            let subnet = [
+                host_ip[0] & super::subnet_mask()[0],
+                host_ip[1] & super::subnet_mask()[1],
+                host_ip[2] & super::subnet_mask()[2],
+                host_ip[3] & super::subnet_mask()[3],
+            ];
+            let hdr_off = put_nlmsghdr(out, RTM_NEWROUTE, NLM_F_MULTI, seq, pid);
+            put_rtmsg(out, prefixlen, RT_SCOPE_LINK, RTPROT_KERNEL, RTN_UNICAST);
+            put_attr(out, RTA_TABLE, &(RT_TABLE_MAIN as u32).to_ne_bytes());
+            put_attr(out, RTA_DST, &subnet);
+            put_attr(out, RTA_PREFSRC, &host_ip);
+            put_attr(out, RTA_OIF, &oif.to_ne_bytes());
+            finish_nlmsg(out, hdr_off);
+        }
+
+        if gw != [0, 0, 0, 0] {
+            // Default route: dst_len = 0, via gw, scope UNIVERSE, proto BOOT.
+            let hdr_off = put_nlmsghdr(out, RTM_NEWROUTE, NLM_F_MULTI, seq, pid);
+            put_rtmsg(out, 0, RT_SCOPE_UNIVERSE, RTPROT_BOOT, RTN_UNICAST);
+            put_attr(out, RTA_TABLE, &(RT_TABLE_MAIN as u32).to_ne_bytes());
+            put_attr(out, RTA_GATEWAY, &gw);
+            put_attr(out, RTA_OIF, &oif.to_ne_bytes());
+            if host_ip != [0, 0, 0, 0] {
+                put_attr(out, RTA_PREFSRC, &host_ip);
+            }
+            finish_nlmsg(out, hdr_off);
+        }
+    }
+    push_done(out, seq, pid);
+}
+
+/// Append a `struct rtmsg` body (rtnetlink(7)): `rtm_family = AF_INET`,
+/// `rtm_dst_len = dst_len`, table MAIN, the given scope/proto/type.
+fn put_rtmsg(out: &mut Vec<u8>, dst_len: u8, scope: u8, proto: u8, rtype: u8) {
+    out.push(AF_INET);        // rtm_family
+    out.push(dst_len);        // rtm_dst_len
+    out.push(0);              // rtm_src_len
+    out.push(0);              // rtm_tos
+    out.push(RT_TABLE_MAIN);  // rtm_table
+    out.push(proto);          // rtm_protocol
+    out.push(scope);          // rtm_scope
+    out.push(rtype);          // rtm_type
+    out.extend_from_slice(&0u32.to_ne_bytes()); // rtm_flags
+}
+
+/// Convert a dotted IPv4 subnet mask to a CIDR prefix length (number of
+/// leading 1 bits).  e.g. 255.255.255.0 → 24.
+fn mask_to_prefixlen(mask: Ipv4Address) -> u8 {
+    let m = u32::from_be_bytes(mask);
+    m.count_ones() as u8
+}
+
+/// Format a MAC for the (compile-gated) trace logging.  Unused outside of
+/// debug builds — kept minimal.
+#[allow(dead_code)]
+fn fmt_mac(mac: &MacAddress) -> alloc::string::String {
+    alloc::format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    )
+}

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2191,19 +2191,20 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // promptly.  Iterate a snapshot to avoid holding PROCESS_TABLE while calling
     // into PIPE_TABLE / unix socket TABLE (lock ordering: resource table before
     // PROCESS_TABLE).
-    const SOCKET_FD_FLAG: u32 = 0x4000_0000; // bit 30: AF_UNIX or AF_INET socket fd
-    let (pipe_ends, socket_ids, inet_socket_ids, eventfd_ids, pty_ends): (
+    const SOCKET_FD_FLAG: u32 = 0x4000_0000; // bit 30: AF_UNIX/AF_INET/AF_NETLINK socket fd
+    let (pipe_ends, socket_ids, inet_socket_ids, netlink_socket_ids, eventfd_ids, pty_ends): (
         alloc::vec::Vec<(u64, bool)>,
+        alloc::vec::Vec<u64>,
         alloc::vec::Vec<u64>,
         alloc::vec::Vec<u64>,
         alloc::vec::Vec<u64>,
         alloc::vec::Vec<(u8, bool)>, // (pair_index, is_master)
     ) = {
         let procs = PROCESS_TABLE.lock();
-        let (mut pipes, mut sockets, mut inet_sockets, mut eventfds, mut ptys) =
+        let (mut pipes, mut sockets, mut inet_sockets, mut netlink_sockets, mut eventfds, mut ptys) =
             (alloc::vec::Vec::new(), alloc::vec::Vec::new(),
              alloc::vec::Vec::new(), alloc::vec::Vec::new(),
-             alloc::vec::Vec::new());
+             alloc::vec::Vec::new(), alloc::vec::Vec::new());
         if let Some(p) = procs.iter().find(|p| p.pid == pid) {
             for f in p.file_descriptors.iter().filter_map(|f| f.as_ref()) {
                 if f.file_type == crate::vfs::FileType::Pipe
@@ -2215,6 +2216,14 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
                     && f.flags & crate::syscall::UNIX_SOCKET_FLAG != 0
                 {
                     sockets.push(f.inode);
+                } else if f.mount_idx == usize::MAX
+                    && f.flags & SOCKET_FD_FLAG != 0
+                    && f.flags & crate::syscall::NETLINK_SOCKET_FLAG != 0
+                {
+                    // AF_NETLINK socket fd: drop one open-file-description ref so
+                    // an inherited socket the parent still holds survives this
+                    // process's exit (last-close frees the socket).
+                    netlink_sockets.push(f.inode);
                 } else if f.mount_idx == usize::MAX
                     && f.flags & SOCKET_FD_FLAG != 0
                     && f.flags & crate::syscall::UNIX_SOCKET_FLAG == 0
@@ -2232,7 +2241,7 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
                 }
             }
         }
-        (pipes, sockets, inet_sockets, eventfds, ptys)
+        (pipes, sockets, inet_sockets, netlink_sockets, eventfds, ptys)
     };
     for (pipe_id, is_write) in pipe_ends {
         if is_write {
@@ -2249,6 +2258,10 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // Same last-reference discipline for inherited AF_INET sockets.
     for socket_id in inet_socket_ids {
         crate::net::socket::socket_close(socket_id);
+    }
+    // And for inherited AF_NETLINK sockets — last close frees the socket.
+    for socket_id in netlink_socket_ids {
+        crate::net::netlink::close(socket_id);
     }
     // Drop the exiting process's eventfd open-file-description refs; the
     // slot is freed only when the last reference (parent's fd, in the
@@ -2897,6 +2910,13 @@ fn inc_socket_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
         // this bump the FIRST close in EITHER process destroys the socket for
         // both, dangling the survivor's fd (getpeername → ENOTCONN — the forked
         // dropbear session-child accepted-connection teardown bug).
+        // AF_NETLINK socket: bump the netlink-layer count so the first close
+        // in either process does not free the socket the other still holds.
+        } else if fd.mount_idx == usize::MAX
+            && fd.flags & SOCKET_FD_FLAG != 0
+            && fd.flags & crate::syscall::NETLINK_SOCKET_FLAG != 0
+        {
+            crate::net::netlink::inc_ref(fd.inode);
         } else if fd.mount_idx == usize::MAX
             && fd.flags & SOCKET_FD_FLAG != 0
             && fd.flags & crate::syscall::UNIX_SOCKET_FLAG == 0

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1367,6 +1367,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 crate::net::unix::close(unix_id);
+            // If it's an AF_NETLINK socket fd, close the underlying netlink socket.
+            } else if crate::syscall::is_netlink_socket_fd(pid, fd) {
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                crate::net::netlink::close(nl_id);
             // If it's an AF_INET socket fd, close the underlying socket.
             } else if crate::syscall::is_socket_fd(pid, fd) {
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
@@ -1753,7 +1757,23 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let cloexec  = (arg2 & 0x80000) != 0;
             let nonblock = (arg2 & 0x00800) != 0;
             let pid = crate::proc::current_pid_lockless();
-            if domain == 1 {
+            if domain == 16 {
+                // AF_NETLINK: routing/device introspection socket (NETLINK_ROUTE).
+                // `type` is SOCK_RAW (3) or SOCK_DGRAM (2) — netlink ignores the
+                // distinction (netlink(7)).  `protocol` (arg3) selects the netlink
+                // family; we only implement NETLINK_ROUTE (0).  Any other protocol
+                // is EPROTONOSUPPORT per socket(2).
+                let protocol = arg3 as u32;
+                if protocol != crate::net::netlink::NETLINK_ROUTE {
+                    return -93; // EPROTONOSUPPORT
+                }
+                if sock_type != 3 && sock_type != 2 {
+                    return -93; // EPROTONOSUPPORT — only SOCK_RAW/SOCK_DGRAM
+                }
+                let nl_id = crate::net::netlink::create(protocol);
+                if nl_id == u64::MAX { return -24; } // EMFILE
+                crate::syscall::alloc_netlink_socket_fd(pid, nl_id, cloexec, nonblock)
+            } else if domain == 1 {
                 // AF_UNIX: use net::unix module.
                 // SOCK_STREAM=1, SOCK_DGRAM=2, SOCK_SEQPACKET=5.
                 let kind = match sock_type {
@@ -2090,7 +2110,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 unsafe { core::slice::from_raw_parts(buf_ptr, len) }.to_vec()
             };
             let data: &[u8] = &data_owned;
-            if crate::syscall::is_unix_socket_fd(pid, fd) {
+            if crate::syscall::is_netlink_socket_fd(pid, fd) {
+                // AF_NETLINK sendto/send: the request payload is one or more
+                // nlmsghdr-framed messages; the destination sockaddr_nl is
+                // ignored (rtnetlink requests target the kernel, nl_pid 0).
+                // The reply is built synchronously and queued for recv.
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                crate::net::netlink::send_request(nl_id, data, pid as u32)
+            } else if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 crate::net::unix::write(unix_id, data)
             } else {
@@ -2166,6 +2193,50 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
             let msg_dontwait = (flags & 0x40) != 0;
             let addr_ptr     = arg5;
             let addrlen_ptr  = arg6 as *mut u32;
+            if crate::syscall::is_netlink_socket_fd(pid, fd) {
+                // AF_NETLINK recvfrom/recv: dequeue one queued reply (a
+                // multipart run of nlmsghdr-framed messages ending in
+                // NLMSG_DONE).  A blocking recv parks until a reply is queued;
+                // since our dump is produced synchronously on the send path,
+                // the reply is normally already present.  If the caller
+                // supplied a sockaddr, fill a sockaddr_nl whose nl_pid is 0
+                // (the message came from the kernel — sockaddr_nl(7)).
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                let blocking = !(msg_dontwait || fd_is_nonblocking(pid, fd));
+                if blocking {
+                    let deadline = crate::arch::x86_64::irq::get_ticks() + 3000;
+                    while !crate::net::netlink::has_data(nl_id) {
+                        if signal_pending(pid) { return -4; } // EINTR
+                        crate::net::poll();
+                        if crate::arch::x86_64::irq::get_ticks() >= deadline {
+                            return -11; // EAGAIN
+                        }
+                        crate::sched::yield_cpu();
+                    }
+                }
+                let (n, _trunc) = {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr, len) };
+                    crate::net::netlink::recv(nl_id, buf)
+                };
+                if n == 0 { return -11; } // EAGAIN — empty queue, non-blocking
+                // Fill the source sockaddr_nl (nl_pid = 0 = kernel) if asked.
+                if addr_ptr != 0 && !addrlen_ptr.is_null() {
+                    let cap = unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::read(addrlen_ptr)
+                    } as usize;
+                    let mut sa = [0u8; 12];
+                    sa[0] = 16; // AF_NETLINK
+                    let w = cap.min(12);
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(sa.as_ptr(), addr_ptr as *mut u8, w);
+                        core::ptr::write_unaligned(addrlen_ptr, 12u32);
+                    }
+                }
+                return n as i64;
+            }
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 // Per recvfrom(2) / unix(7): a recv on a socket without
@@ -2563,6 +2634,24 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 }
                 return total as i64;
             }
+            // AF_NETLINK sendmsg: gather all iovecs into one request buffer and
+            // process it as a single rtnetlink request batch.  A netlink message
+            // is self-framed by its nlmsghdr.nlmsg_len, so concatenation across
+            // iovecs is well-defined (netlink(7)).  The destination sockaddr_nl
+            // (msg_name) is ignored — rtnetlink requests target the kernel.
+            if crate::syscall::is_netlink_socket_fd(pid, fd) {
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                let mut req: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+                for iov in &iovecs_owned {
+                    let base = iov[0] as *const u8;
+                    let slen = iov[1] as usize;
+                    if slen == 0 { continue; }
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    req.extend_from_slice(unsafe { core::slice::from_raw_parts(base, slen) });
+                }
+                return crate::net::netlink::send_request(nl_id, &req, pid as u32);
+            }
+
             // Non-SCM fast path (AF_UNIX frame with no ancillary fds, or AF_INET):
             // push the frame's data bytes per-iovec.  An SCM_RIGHTS AF_UNIX frame
             // was already committed atomically above and returned; reaching here
@@ -2650,6 +2739,66 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 (iov[0][0] as *mut u8, iov[0][1] as usize)
             };
             let bytes_read: i64;
+            if crate::syscall::is_netlink_socket_fd(pid, fd) {
+                // AF_NETLINK recvmsg: drain one queued reply into iov[0].
+                // Each reply is a self-contained multipart run of nlmsghdr
+                // messages ending in NLMSG_DONE (netlink(7)).  Blocking recv
+                // parks until a reply is queued; the dump is produced
+                // synchronously on the send path so it is normally present.
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                let msg_dontwait = (arg3 & 0x40) != 0;
+                let blocking = !(msg_dontwait || fd_is_nonblocking(pid, fd));
+                if blocking {
+                    let deadline = crate::arch::x86_64::irq::get_ticks() + 3000;
+                    while !crate::net::netlink::has_data(nl_id) {
+                        if signal_pending(pid) { return -4; } // EINTR
+                        crate::net::poll();
+                        if crate::arch::x86_64::irq::get_ticks() >= deadline {
+                            return -11; // EAGAIN
+                        }
+                        crate::sched::yield_cpu();
+                    }
+                }
+                let (n, trunc) = {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    let buf = unsafe { core::slice::from_raw_parts_mut(dst, cap) };
+                    crate::net::netlink::recv(nl_id, buf)
+                };
+                if n == 0 {
+                    return -11; // EAGAIN — empty queue (non-blocking)
+                }
+                // Marshal the source sockaddr_nl (nl_pid = 0 = kernel) into
+                // msg_name when the caller supplied a buffer; set msg_namelen.
+                let (name_ptr, name_cap) = unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    (core::ptr::read_unaligned(msghdr_ptr.add(0)),
+                     core::ptr::read_unaligned(msghdr_ptr.add(1)) as u32 as usize)
+                };
+                if name_ptr != 0 {
+                    let mut sa = [0u8; 12];
+                    sa[0] = 16; // AF_NETLINK
+                    let w = name_cap.min(12);
+                    unsafe {
+                        let _g = crate::arch::x86_64::smap::UserGuard::new();
+                        core::ptr::copy_nonoverlapping(sa.as_ptr(), name_ptr as *mut u8, w);
+                        // msg_namelen is the socklen_t at byte offset 8.
+                        core::ptr::write_unaligned((arg2 + 8) as *mut u32, 12u32);
+                    }
+                }
+                // msg_flags (offset 48): set MSG_TRUNC (0x20) when the reply
+                // did not fit the supplied buffer (recvmsg(2)); else 0.
+                // msg_controllen (word5) = 0 — netlink carries no ancillary data.
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    let flags_val: u32 = if trunc { 0x20 } else { 0 };
+                    core::ptr::write_unaligned(msghdr_ptr.add(6) as *mut u32, flags_val);
+                    let ctrl_ptr = core::ptr::read_unaligned(msghdr_ptr.add(4));
+                    if ctrl_ptr != 0 {
+                        core::ptr::write_unaligned(msghdr_ptr.add(5) as *mut u64, 0u64);
+                    }
+                }
+                return n as i64;
+            }
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                 // Per recvmsg(2) / unix(7): a recv on a socket that is not in
@@ -3016,7 +3165,28 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let _g = crate::arch::x86_64::smap::UserGuard::new();
                 core::ptr::read_unaligned(addr_ptr as *const u16)
             };
-            if family == 1 {
+            if family == 16 {
+                // AF_NETLINK — sockaddr_nl { u16 nl_family; u16 nl_pad;
+                // u32 nl_pid; u32 nl_groups } (sockaddr_nl(7)).  nl_pid==0
+                // requests a kernel-assigned port id; any non-zero value is
+                // accepted verbatim.  groups are accepted but unused (we deliver
+                // no multicast).
+                if !crate::syscall::is_netlink_socket_fd(pid, fd) { return -9; }
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                let (nl_pid, nl_groups) = if addrlen >= 12 {
+                    let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+                    let pid_v = unsafe {
+                        core::ptr::read_unaligned((addr_ptr + 4) as *const u32)
+                    };
+                    let grp_v = unsafe {
+                        core::ptr::read_unaligned((addr_ptr + 8) as *const u32)
+                    };
+                    (pid_v, grp_v)
+                } else {
+                    (0u32, 0u32)
+                };
+                crate::net::netlink::bind(nl_id, nl_pid, nl_groups, pid as u32) as i64
+            } else if family == 1 {
                 // AF_UNIX — sockaddr_un
                 if !crate::syscall::is_unix_socket_fd(pid, fd) { return -9; }
                 let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
@@ -3103,6 +3273,28 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 core::ptr::read(addrlen_ptr)
             } as usize;
 
+            if crate::syscall::is_netlink_socket_fd(pid, fd) {
+                // AF_NETLINK getsockname — sockaddr_nl { u16 nl_family;
+                // u16 nl_pad; u32 nl_pid; u32 nl_groups } (sockaddr_nl(7)).
+                // Reports the bound port id in nl_pid; groups is 0 (we join
+                // no multicast groups).  A never-bound socket reports nl_pid=0.
+                let nl_id = crate::syscall::get_netlink_socket_id(pid, fd);
+                let nl_pid = crate::net::netlink::local_pid(nl_id).unwrap_or(0);
+                let want = 12usize; // sizeof(struct sockaddr_nl)
+                let mut tmp = [0u8; 12];
+                tmp[0] = 16; // nl_family = AF_NETLINK (lo)
+                tmp[1] = 0;  // AF_NETLINK hi
+                // nl_pad (offset 2) stays 0.
+                tmp[4..8].copy_from_slice(&nl_pid.to_ne_bytes()); // nl_pid
+                // nl_groups (offset 8) stays 0.
+                let n = cap.min(want);
+                unsafe {
+                    let _g = crate::arch::x86_64::smap::UserGuard::new();
+                    core::ptr::copy_nonoverlapping(tmp.as_ptr(), addr_ptr as *mut u8, n);
+                    core::ptr::write(addrlen_ptr, want as u32);
+                }
+                return 0;
+            }
             if crate::syscall::is_unix_socket_fd(pid, fd) {
                 // AF_UNIX sockaddr_un — minimal: family=1, empty path.
                 // Suffices for socketpair() peers and unnamed sockets;
@@ -6704,6 +6896,28 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
                 }
             }
         }
+    } else if crate::syscall::is_netlink_socket_fd(pid, fd as usize) {
+        // read(2) on an AF_NETLINK socket drains one queued reply, same as
+        // recv (netlink(7)).  Blocking read parks until a reply is queued.
+        let nl_id = crate::syscall::get_netlink_socket_id(pid, fd as usize);
+        let blocking = !fd_is_nonblocking(pid, fd as usize);
+        if blocking {
+            let deadline = crate::arch::x86_64::irq::get_ticks() + 3000;
+            while !crate::net::netlink::has_data(nl_id) {
+                if signal_pending(pid) { return -4; } // EINTR
+                crate::net::poll();
+                if crate::arch::x86_64::irq::get_ticks() >= deadline {
+                    return -11; // EAGAIN
+                }
+                crate::sched::yield_cpu();
+            }
+        }
+        let (n, _trunc) = {
+            let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
+            let buf_sl = unsafe { core::slice::from_raw_parts_mut(buf_ptr, count) };
+            crate::net::netlink::recv(nl_id, buf_sl)
+        };
+        return if n == 0 { -11 } else { n as i64 };
     } else if crate::syscall::is_unix_socket_fd(pid, fd as usize) {
         let unix_id = crate::syscall::get_unix_socket_id(pid, fd as usize);
         // Per read(2) / unix(7): read on a blocking AF_UNIX socket (no
@@ -7252,13 +7466,14 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
     // The VFS fd_write path below threads the raw user pointer through into
     // its own STAC/CLAC-bracketed copy helpers, so we don't need to snapshot
     // for that case — keeping the zero-copy fast path intact.
-    let is_pipe   = crate::syscall::is_pipe_fd(pid, fd as usize);
-    let is_unix   = !is_pipe && crate::syscall::is_unix_socket_fd(pid, fd as usize);
-    let is_inet   = !is_pipe && !is_unix && crate::syscall::is_socket_fd(pid, fd as usize);
-    let is_evfd   = !is_pipe && !is_unix && !is_inet
+    let is_pipe    = crate::syscall::is_pipe_fd(pid, fd as usize);
+    let is_unix    = !is_pipe && crate::syscall::is_unix_socket_fd(pid, fd as usize);
+    let is_netlink = !is_pipe && !is_unix && crate::syscall::is_netlink_socket_fd(pid, fd as usize);
+    let is_inet    = !is_pipe && !is_unix && !is_netlink && crate::syscall::is_socket_fd(pid, fd as usize);
+    let is_evfd    = !is_pipe && !is_unix && !is_netlink && !is_inet
                     && crate::syscall::is_eventfd_fd(pid, fd as usize);
 
-    if is_pipe || is_unix || is_inet || is_evfd {
+    if is_pipe || is_unix || is_netlink || is_inet || is_evfd {
         // User-pointer check: required for real user-space callers to prevent
         // ring-0 from writing kernel memory on behalf of a user process (CWE-823).
         // Bypassed when called from dispatch_linux_kernel (KernelDispatchGuard),
@@ -7288,6 +7503,13 @@ pub fn sys_write_linux(fd: u64, buf: u64, count: u64) -> i64 {
         if is_unix {
             let unix_id = crate::syscall::get_unix_socket_id(pid, fd as usize);
             return crate::net::unix::write(unix_id, data);
+        }
+        if is_netlink {
+            // write(2) on an AF_NETLINK socket is equivalent to a send of the
+            // request payload (netlink(7)): process the rtnetlink request and
+            // queue the reply.
+            let nl_id = crate::syscall::get_netlink_socket_id(pid, fd as usize);
+            return crate::net::netlink::send_request(nl_id, data, pid as u32);
         }
         if is_inet {
             let socket_id = crate::syscall::get_socket_id(pid, fd as usize);
@@ -11327,10 +11549,11 @@ pub(crate) fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
         })
     };
 
-    const SOCKET_FD_BIT:  u32 = 0x4000_0000;
-    const UNIX_SOCK_BIT:  u32 = 0x0080_0000;
-    const PIPE_FD_BIT:    u32 = 0x8000_0000;
-    const O_WRONLY_BIT:   u32 = 0x01;
+    const SOCKET_FD_BIT:   u32 = 0x4000_0000;
+    const UNIX_SOCK_BIT:   u32 = 0x0080_0000;
+    const NETLINK_SOCK_BIT: u32 = 0x0040_0000;
+    const PIPE_FD_BIT:     u32 = 0x8000_0000;
+    const O_WRONLY_BIT:    u32 = 0x01;
 
     match info {
         None => match fd { 0 => 0, 1 | 2 => EPOLLOUT, _ => EPOLLERR },
@@ -11389,7 +11612,14 @@ pub(crate) fn epoll_poll_events(pid: u64, fd: usize) -> u32 {
                 //
                 // AF_INET goes through the protocol's `socket_has_data`
                 // — same shape, distinct backend.
-                if flags & UNIX_SOCK_BIT != 0 {
+                if flags & NETLINK_SOCK_BIT != 0 {
+                    // AF_NETLINK: EPOLLIN iff a reply is queued; EPOLLOUT
+                    // always (synchronous send never blocks) — netlink(7),
+                    // epoll(7).  No EPOLLHUP/EPOLLRDHUP (connectionless).
+                    let mut ev = EPOLLOUT;
+                    if crate::net::netlink::has_data(inode) { ev |= EPOLLIN; }
+                    ev
+                } else if flags & UNIX_SOCK_BIT != 0 {
                     // EPOLLOUT only when a `write()` would make progress — the
                     // peer's recv ring has room, or the write side can no
                     // longer block (SHUT_WR / peer-gone / not-connected, where

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1851,6 +1851,15 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
                             crate::net::unix::close(f.inode);
                         } else if f.mount_idx == usize::MAX
                             && f.flags & 0x4000_0000 != 0
+                            && f.flags & crate::syscall::NETLINK_SOCKET_FLAG != 0
+                        {
+                            // CLOEXEC-marked AF_NETLINK socket: drop one ref so
+                            // the post-execve image releasing it does not destroy
+                            // a socket the forking parent still holds (last-close
+                            // semantics, parallel to the AF_UNIX arm above).
+                            crate::net::netlink::close(f.inode);
+                        } else if f.mount_idx == usize::MAX
+                            && f.flags & 0x4000_0000 != 0
                             && f.flags & crate::syscall::UNIX_SOCKET_FLAG == 0
                         {
                             // CLOEXEC-marked AF_INET socket: drop one ref so the
@@ -4554,6 +4563,14 @@ pub(crate) fn sys_dup(old_fd: usize) -> i64 {
         crate::net::unix::inc_ref(fd_clone.inode);
     } else if fd_clone.mount_idx == usize::MAX
         && fd_clone.flags & 0x4000_0000 != 0
+        && fd_clone.flags & NETLINK_SOCKET_FLAG != 0
+    {
+        // AF_NETLINK socket: the duplicate is one more reference to the same
+        // open file description; close(2) on either fd must not destroy the
+        // shared socket until the last reference drops.
+        crate::net::netlink::inc_ref(fd_clone.inode);
+    } else if fd_clone.mount_idx == usize::MAX
+        && fd_clone.flags & 0x4000_0000 != 0
         && fd_clone.flags & UNIX_SOCKET_FLAG == 0
     {
         // AF_INET socket: the duplicate is one more reference to the same open
@@ -4640,6 +4657,13 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
         crate::net::unix::inc_ref(fd_clone.inode);
     } else if fd_clone.mount_idx == usize::MAX
         && fd_clone.flags & 0x4000_0000 != 0
+        && fd_clone.flags & NETLINK_SOCKET_FLAG != 0
+    {
+        // AF_NETLINK socket: the duplicate is one more open-file-description
+        // reference.  Balanced by the close on either fd.
+        crate::net::netlink::inc_ref(fd_clone.inode);
+    } else if fd_clone.mount_idx == usize::MAX
+        && fd_clone.flags & 0x4000_0000 != 0
         && fd_clone.flags & UNIX_SOCKET_FLAG == 0
     {
         // AF_INET socket: the duplicate is one more open-file-description
@@ -4687,6 +4711,12 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
             && prev.flags & UNIX_SOCKET_FLAG != 0
         {
             crate::net::unix::close(prev.inode);
+        } else if prev.mount_idx == usize::MAX
+            && prev.flags & 0x4000_0000 != 0
+            && prev.flags & NETLINK_SOCKET_FLAG != 0
+        {
+            // Displaced AF_NETLINK socket fd loses one open-file-description ref.
+            crate::net::netlink::close(prev.inode);
         } else if prev.mount_idx == usize::MAX
             && prev.flags & 0x4000_0000 != 0
             && prev.flags & UNIX_SOCKET_FLAG == 0
@@ -4829,7 +4859,13 @@ pub(crate) fn is_socket_fd(pid: u64, fd_num: usize) -> bool {
     procs.iter().find(|p| p.pid == pid)
         .and_then(|p| p.file_descriptors.get(fd_num))
         .and_then(|f| f.as_ref())
-        .map(|f| f.mount_idx == usize::MAX && f.flags & 0x4000_0000 != 0)
+        // The AF_INET/AF_INET6 path is the SOCKET_FD marker WITHOUT the
+        // AF_NETLINK subtype bit (the AF_UNIX bit lives in a separate slot,
+        // and the unix dispatch arms are checked first; netlink fds set bit
+        // 22 and must NOT be treated as AF_INET sockets here).
+        .map(|f| f.mount_idx == usize::MAX
+              && f.flags & 0x4000_0000 != 0
+              && f.flags & NETLINK_SOCKET_FLAG == 0)
         .unwrap_or(false)
 }
 
@@ -5007,6 +5043,15 @@ pub(crate) fn poll_revents(pid: u64, fd: usize, events: u16) -> u16 {
     }
     if is_eventfd_fd(pid, fd) {
         if crate::ipc::eventfd::is_readable(get_eventfd_id(pid, fd)) { events & POLLIN } else { 0 }
+    } else if is_netlink_socket_fd(pid, fd) {
+        // AF_NETLINK readiness: POLLIN iff a reply is queued; POLLOUT always
+        // (the send path is synchronous and never blocks) — netlink(7),
+        // poll(2).  No POLLHUP/POLLRDHUP concept (netlink is connectionless).
+        let nid = get_netlink_socket_id(pid, fd);
+        let mut rev = 0u16;
+        if crate::net::netlink::has_data(nid) { rev |= events & POLLIN; }
+        if crate::net::netlink::writable(nid) { rev |= events & POLLOUT; }
+        rev
     } else if is_unix_socket_fd(pid, fd) {
         let uid = get_unix_socket_id(pid, fd);
         let has_d = crate::net::unix::has_data(uid);
@@ -5234,6 +5279,74 @@ pub(crate) fn alloc_unix_socket_fd(pid: u64, unix_id: u64, cloexec: bool, nonblo
     let fd = crate::vfs::FileDescriptor {
         mount_idx: usize::MAX,
         inode: unix_id,
+        offset: 0,
+        flags: flag_bits,
+        is_console: false,
+        cloexec,
+        file_type: crate::vfs::FileType::Socket,
+        open_path: alloc::string::String::new(),
+    };
+    let mut procs = crate::proc::PROCESS_TABLE.lock();
+    let proc = match procs.iter_mut().find(|p| p.pid == pid) {
+        Some(p) => p,
+        None => return -3,
+    };
+    for i in 0..proc.file_descriptors.len() {
+        if proc.file_descriptors[i].is_none() {
+            proc.file_descriptors[i] = Some(fd);
+            return i as i64;
+        }
+    }
+    if proc.file_descriptors.len() < crate::vfs::MAX_FDS_PER_PROCESS {
+        let idx = proc.file_descriptors.len();
+        proc.file_descriptors.push(Some(fd));
+        idx as i64
+    } else {
+        -24 // EMFILE
+    }
+}
+
+// ── AF_NETLINK socket helpers ──────────────────────────────────────────────────
+
+/// Bit 22 of the fd flags word: this socket fd is an AF_NETLINK socket.  It
+/// shares the generic SOCKET_FD marker (0x4000_0000) with AF_UNIX/AF_INET but
+/// carries this subtype bit so the dispatch arms route it to `net::netlink`
+/// rather than the AF_INET socket path.  Distinct from `UNIX_SOCKET_FLAG`
+/// (bit 23), so the three families are mutually exclusive.
+pub(crate) const NETLINK_SOCKET_FLAG: u32 = 0x0040_0000;
+
+/// Check if a file descriptor is an AF_NETLINK socket.
+pub(crate) fn is_netlink_socket_fd(pid: u64, fd_num: usize) -> bool {
+    let procs = crate::proc::PROCESS_TABLE.lock();
+    procs.iter().find(|p| p.pid == pid)
+        .and_then(|p| p.file_descriptors.get(fd_num))
+        .and_then(|f| f.as_ref())
+        .map(|f| f.mount_idx == usize::MAX
+              && f.flags & 0x4000_0000 != 0
+              && f.flags & NETLINK_SOCKET_FLAG != 0)
+        .unwrap_or(false)
+}
+
+/// Get the netlink socket id for a file descriptor.
+pub(crate) fn get_netlink_socket_id(pid: u64, fd_num: usize) -> u64 {
+    let procs = crate::proc::PROCESS_TABLE.lock();
+    procs.iter().find(|p| p.pid == pid)
+        .and_then(|p| p.file_descriptors.get(fd_num))
+        .and_then(|f| f.as_ref())
+        .map(|f| f.inode)
+        .unwrap_or(u64::MAX)
+}
+
+/// Allocate a new AF_NETLINK socket fd, returning the fd number or negative
+/// errno.  `cloexec` sets FD_CLOEXEC; `nonblock` sets O_NONBLOCK in the fd's
+/// status flags so subsequent recv calls return -EAGAIN instead of blocking
+/// (socket(2) SOCK_CLOEXEC / SOCK_NONBLOCK).
+pub(crate) fn alloc_netlink_socket_fd(pid: u64, netlink_id: u64, cloexec: bool, nonblock: bool) -> i64 {
+    let mut flag_bits: u32 = 0x4000_0000 | NETLINK_SOCKET_FLAG; // SOCKET_FD | NETLINK
+    if nonblock { flag_bits |= 0x0800; }
+    let fd = crate::vfs::FileDescriptor {
+        mount_idx: usize::MAX,
+        inode: netlink_id,
         offset: 0,
         flags: flag_bits,
         is_console: false,

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -3161,6 +3161,14 @@ pub fn run() -> ! {
         if test_520_wakeup_preemption_kick() { passed += 1; }
     }
 
+    // ── Test 300: AF_NETLINK / NETLINK_ROUTE RTM_GETLINK dump ─────────────
+    // socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) → bind → sendmsg(RTM_GETLINK
+    // dump) → recvmsg must return ≥1 RTM_NEWLINK message and an NLMSG_DONE
+    // terminator (RFC 3549; netlink(7), rtnetlink(7)).  Enough for busybox
+    // `ip addr`/`ip link`/`ip route` to enumerate interfaces.
+    total += 1;
+    if test_300_netlink_rtm_getlink_dump() { passed += 1; }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -40177,6 +40185,149 @@ fn test_recvmsg_msg_flags_overwrite() -> bool {
         returned_flags);
 
     test_pass!("recvmsg msg_flags overwrite — sentinel must not survive (PR #129 caveat)");
+    true
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test 300 — AF_NETLINK / NETLINK_ROUTE RTM_GETLINK dump
+//
+// Drives the full rtnetlink introspection path through the Linux syscall
+// dispatcher exactly as busybox `ip link` does:
+//   socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) → bind(sockaddr_nl) →
+//   sendmsg({ nlmsghdr RTM_GETLINK | NLM_F_REQUEST|NLM_F_DUMP, ifinfomsg }) →
+//   recvmsg(reply).
+// The reply must contain at least one RTM_NEWLINK message (the loopback
+// interface is always present, RFC 1122 §3.2.1.3) and be terminated by an
+// NLMSG_DONE message (RFC 3549 §2.3.2 / netlink(7), rtnetlink(7)).
+// ──────────────────────────────────────────────────────────────────────────────
+fn test_300_netlink_rtm_getlink_dump() -> bool {
+    test_header!("AF_NETLINK RTM_GETLINK dump → RTM_NEWLINK + NLMSG_DONE (Test 300)");
+
+    const AF_NETLINK:    u64 = 16;
+    const SOCK_RAW:      u64 = 3;
+    const NETLINK_ROUTE: u64 = 0;
+    const NLM_F_REQUEST: u16 = 0x01;
+    const NLM_F_DUMP:    u16 = 0x100 | 0x200;
+    const RTM_GETLINK:   u16 = 18;
+    const RTM_NEWLINK:   u16 = 16;
+    const NLMSG_DONE:    u16 = 3;
+
+    // socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE)
+    let fd = crate::syscall::dispatch_linux_kernel(41, AF_NETLINK, SOCK_RAW, NETLINK_ROUTE, 0, 0, 0);
+    if fd < 0 {
+        test_fail!("netlink", "socket(AF_NETLINK,SOCK_RAW,NETLINK_ROUTE) returned {}", fd);
+        return false;
+    }
+    test_println!("  socket(AF_NETLINK) → fd={}", fd);
+
+    // bind(sockaddr_nl { nl_family=AF_NETLINK; nl_pid=0 (kernel-assign); groups=0 })
+    let mut sa_nl = [0u8; 12];
+    sa_nl[0] = 16; // nl_family = AF_NETLINK
+    let bret = crate::syscall::dispatch_linux_kernel(
+        49, fd as u64, sa_nl.as_ptr() as u64, 12, 0, 0, 0);
+    if bret != 0 {
+        test_fail!("netlink", "bind(sockaddr_nl) returned {}", bret);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  bind(sockaddr_nl) → 0 ✓");
+
+    // getsockname must report a non-zero assigned nl_pid.
+    let mut gn = [0u8; 12];
+    let mut gn_len: u32 = 12;
+    let gret = crate::syscall::dispatch_linux_kernel(
+        51, fd as u64, gn.as_mut_ptr() as u64,
+        (&mut gn_len as *mut u32) as u64, 0, 0, 0);
+    let nl_pid = u32::from_ne_bytes([gn[4], gn[5], gn[6], gn[7]]);
+    if gret != 0 || gn[0] != 16 || nl_pid == 0 {
+        test_fail!("netlink",
+            "getsockname ret={} family={} nl_pid={} (want fam=16, nl_pid!=0)",
+            gret, gn[0], nl_pid);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  getsockname → nl_pid={} ✓", nl_pid);
+
+    // Build the RTM_GETLINK dump request: nlmsghdr + ifinfomsg.
+    //   nlmsghdr { len=16+16=32; type=RTM_GETLINK; flags=REQUEST|DUMP; seq=1; pid=0 }
+    //   ifinfomsg { family=AF_UNSPEC(0); pad; type; index; flags; change } (16 bytes)
+    let seq: u32 = 0x1234;
+    let mut req = [0u8; 32];
+    let total_len: u32 = 32;
+    req[0..4].copy_from_slice(&total_len.to_ne_bytes());          // nlmsg_len
+    req[4..6].copy_from_slice(&RTM_GETLINK.to_ne_bytes());        // nlmsg_type
+    req[6..8].copy_from_slice(&(NLM_F_REQUEST | NLM_F_DUMP).to_ne_bytes()); // flags
+    req[8..12].copy_from_slice(&seq.to_ne_bytes());              // nlmsg_seq
+    // nlmsg_pid (12..16) = 0; ifinfomsg (16..32) all zero (AF_UNSPEC, dump all).
+
+    // sendmsg(fd, msghdr{iov=[req]}, 0)
+    let mut iov: [u64; 2] = [req.as_mut_ptr() as u64, 32];
+    let mut shdr = [0u64; 7];
+    shdr[2] = iov.as_mut_ptr() as u64; // msg_iov at offset 16
+    shdr[3] = 1u64;                    // msg_iovlen = 1
+    let sret = crate::syscall::dispatch_linux_kernel(
+        46, fd as u64, shdr.as_mut_ptr() as u64, 0, 0, 0, 0);
+    if sret != 32 {
+        test_fail!("netlink", "sendmsg(RTM_GETLINK) returned {} (want 32)", sret);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  sendmsg(RTM_GETLINK dump) → {} bytes ✓", sret);
+
+    // recvmsg(fd, msghdr{iov=[rxbuf]}, 0)
+    let mut rxbuf = [0u8; 4096];
+    let mut riov: [u64; 2] = [rxbuf.as_mut_ptr() as u64, 4096];
+    let mut rhdr = [0u64; 7];
+    rhdr[2] = riov.as_mut_ptr() as u64;
+    rhdr[3] = 1u64;
+    let rret = crate::syscall::dispatch_linux_kernel(
+        47, fd as u64, rhdr.as_mut_ptr() as u64, 0, 0, 0, 0);
+    if rret <= 0 {
+        test_fail!("netlink", "recvmsg returned {} (want > 0)", rret);
+        let _ = crate::syscall::dispatch_linux_kernel(3, fd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    let n = rret as usize;
+    test_println!("  recvmsg → {} bytes of reply", n);
+
+    // Parse the reply: walk nlmsghdr-framed messages.  Count RTM_NEWLINK
+    // messages and confirm an NLMSG_DONE terminator.  Verify each reply
+    // message echoes our request seq (netlink(7): replies carry nlmsg_seq).
+    let mut newlinks = 0usize;
+    let mut saw_done = false;
+    let mut seq_ok = true;
+    let mut off = 0usize;
+    while off + 16 <= n {
+        let mlen = u32::from_ne_bytes([rxbuf[off], rxbuf[off+1], rxbuf[off+2], rxbuf[off+3]]) as usize;
+        let mtype = u16::from_ne_bytes([rxbuf[off+4], rxbuf[off+5]]);
+        let mseq = u32::from_ne_bytes([rxbuf[off+8], rxbuf[off+9], rxbuf[off+10], rxbuf[off+11]]);
+        if mlen < 16 || off + mlen > n { break; }
+        if mseq != seq { seq_ok = false; }
+        if mtype == RTM_NEWLINK { newlinks += 1; }
+        if mtype == NLMSG_DONE { saw_done = true; }
+        // 4-byte (NLMSG_ALIGNTO) alignment to the next message.
+        off += (mlen + 3) & !3;
+    }
+    test_println!("  parsed: RTM_NEWLINK x{}, NLMSG_DONE={}, seq_ok={}",
+        newlinks, saw_done, seq_ok);
+
+    // Cleanup.
+    let _ = crate::syscall::dispatch_linux_kernel(3, fd as u64, 0, 0, 0, 0, 0);
+
+    if newlinks == 0 {
+        test_fail!("netlink", "no RTM_NEWLINK messages in dump (want >= 1)");
+        return false;
+    }
+    if !saw_done {
+        test_fail!("netlink", "dump not terminated by NLMSG_DONE");
+        return false;
+    }
+    if !seq_ok {
+        test_fail!("netlink", "a reply message did not echo the request seq {:#x}", seq);
+        return false;
+    }
+
+    test_pass!("AF_NETLINK RTM_GETLINK dump → RTM_NEWLINK + NLMSG_DONE (Test 300)");
     true
 }
 


### PR DESCRIPTION
## Summary

Implements a kernel-side **AF_NETLINK / NETLINK_ROUTE (rtnetlink)** socket family so iproute2-style tools (busybox `ip addr` / `ip link` / `ip route`) can enumerate the host's interfaces, addresses, and routes. Previously `socket(AF_NETLINK, SOCK_RAW|SOCK_DGRAM, NETLINK_ROUTE)` returned `EINVAL`.

New module `kernel/src/net/netlink.rs` provides the minimum viable **read-only** rtnetlink surface, following the published wire format (RFC 3549; `netlink(7)`, `rtnetlink(7)`, `sockaddr_nl(7)`):

- `nlmsghdr`-framed messages on a 4-byte `NLMSG_ALIGNTO` boundary (RFC 3549 §2.2).
- `NLM_F_DUMP` requests elicit a multipart `NLM_F_MULTI` reply terminated by a single `NLMSG_DONE` whose payload is the dump errno (RFC 3549 §2.3.2).
- `rtattr` TLVs padded to `RTA_ALIGNTO` (RFC 3549 §2.3.3).
- `RTM_GETLINK` → `RTM_NEWLINK` (`ifinfomsg` + `IFLA_IFNAME/ADDRESS/MTU/TXQLEN`)
- `RTM_GETADDR` → `RTM_NEWADDR` (`ifaddrmsg` + `IFA_ADDRESS/LOCAL/LABEL`)
- `RTM_GETROUTE` → `RTM_NEWROUTE` (`rtmsg` + `RTA_TABLE/DST/GATEWAY/PREFSRC/OIF`)
- Any other request → `NLMSG_ERROR` `EOPNOTSUPP`.

Live data is pulled from the existing `net::list_ifaces()` source plus `our_ip()`/`gateway_ip()`/`subnet_mask()` — nothing is hardcoded (lo always present; eth0 when a NIC is up, with live MAC/MTU/flags/ifindex).

## Socket-family wiring

- `NETLINK_SOCKET_FLAG` (bit 22) under the shared `SOCKET_FD` marker, distinct from `UNIX_SOCKET_FLAG` (bit 23); `is_socket_fd()` amended to exclude netlink fds from the AF_INET path. The three families are mutually exclusive and every dispatch arm checks the netlink subtype first.
- Full open-file-description refcount discipline across fork/dup/dup2/execve-CLOEXEC/process-exit, mirroring the AF_UNIX path (POSIX.1-2017 close).
- `socket`/`bind`/`getsockname`/`sendto`/`send`/`sendmsg`/`recvfrom`/`recvmsg`/`read`/`write`/`close` plus `poll` and `epoll` readiness (POLLIN iff a reply is queued, POLLOUT always — the dump is produced synchronously on the send path, so a netlink-only poll never parks).
- Per `netlink(7)`, a bound socket's `nl_pid` is never zero: `bind(nl_pid=0)` requests a kernel-assigned, guaranteed-non-zero port id so `getsockname` reports a valid value.

## Tests

`test_300_netlink_rtm_getlink_dump` in `test_runner.rs` drives `socket → bind → getsockname → sendmsg(RTM_GETLINK dump) → recvmsg` and asserts ≥1 `RTM_NEWLINK` plus an `NLMSG_DONE` terminator with the request seq echoed back. (The full test-mode suite currently wedges in an unrelated, pre-existing pipe blocking-write sub-test before Test 300 is reached; verified the test PASSes by temporarily running it first — 2× RTM_NEWLINK + NLMSG_DONE — then reverting the hook.)

## End-to-end verification (busybox `ip` over SSH)

```
$ ssh root@guest 'ip addr'
1: lo: <LOOPBACK,UP> mtu 65536
    link/loopback 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
2: eth0: <BROADCAST,MULTICAST,UP> mtu 1500
    link/ether 52:54:00:12:34:56
    inet 10.0.2.15/24 scope global eth0

$ ssh root@guest 'ip route'
10.0.2.0/24 dev eth0 scope link  src 10.0.2.15
default via 10.0.2.2 dev eth0  src 10.0.2.15
```

busybox parsed all of our `nlmsghdr`/`ifinfomsg`/`ifaddrmsg`/`rtmsg` framing, attributes, and `NLMSG_DONE` terminators correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)