### PR TITLE
vfs: bounce backing-store read/write through a kernel buffer (fixes user-VA DMA virtqueue halt)

### DIFF
--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2868,7 +2868,42 @@ pub fn fd_write(pid: crate::proc::Pid, fd_num: usize, buf: *const u8, count: usi
         offset
     };
 
-    let n = fs.write(inode, write_offset, data)?;
+    // Bounce the write through a kernel-heap buffer for the same reason the
+    // read path does (see `fd_read`): a block-backed filesystem (ext2) services
+    // an aligned whole-block write by handing the source slice straight to the
+    // block device, which DMAs *from* it.  The virtio-blk descriptor's address
+    // field is a physical address derived from the buffer's virtual address by
+    // a fixed offset with no page-table walk, so a user virtual address gets
+    // written into the descriptor verbatim and the device reads from a bogus
+    // physical address — halting the virtqueue exactly as the read bug did.
+    // Copy each chunk of user bytes into a kernel-heap (physically-contiguous)
+    // buffer, then hand THAT to the filesystem.  Bounded to 256 KiB chunks so a
+    // huge write never allocates a count-sized kernel buffer.  In-memory
+    // filesystems (ramfs/tmpfs) memcpy and are unaffected; fat32 already
+    // bounces through its sector cache, and the ext2 partial-block tail RMWs
+    // through a kernel buffer — only the ext2 whole-block fast path leaked the
+    // user pointer, which this closes for every backing-store write.
+    let n = {
+        const BOUNCE_CHUNK: usize = 256 * 1024;
+        let chunk_cap = count.min(BOUNCE_CHUNK);
+        let mut bounce = alloc::vec![0u8; chunk_cap];
+        let mut done = 0usize;
+        loop {
+            if done >= count {
+                break;
+            }
+            let want = (count - done).min(chunk_cap);
+            // Copy the user bytes into the kernel bounce buffer (the read of
+            // `data` may fault the user pages in — MOUNTS already dropped).
+            bounce[..want].copy_from_slice(&data[done..done + want]);
+            let put = fs.write(inode, write_offset + done as u64, &bounce[..want])?;
+            done += put;
+            if put < want {
+                break; // short write — the backing store accepted no more.
+            }
+        }
+        done
+    };
 
     // Page-cache coherency: any process that previously mmap'd this file
     // has a cache-page-backed PTE that points at the pre-write bytes.

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2379,9 +2379,64 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
             // Drop MOUNTS before the FS read: the read may fault on the
             // user buffer pages (file-backed VMA), and the page-fault
             // handler also needs MOUNTS — same-thread recursion (#82).
+            //
+            // Bounce the read through a kernel-heap buffer instead of letting
+            // the filesystem fill the user buffer directly.  A block-backed
+            // filesystem (ext2/fat32) services a large aligned read by handing
+            // the destination slice to the block device, which DMAs into it.
+            // The virtio-blk descriptor's address field is a *physical*
+            // address; the driver derives it from the buffer's kernel virtual
+            // address by the fixed higher-half direct-map offset and has no
+            // page-table walker, so a *user* virtual address gets written into
+            // the descriptor verbatim as if it were physical.  The device then
+            // targets a bogus address far outside RAM, the host rejects the
+            // descriptor, and the virtqueue halts — wedging all further disk
+            // I/O (observed: a multi-page uncached read froze the device's
+            // used.idx, immune to doorbell re-kick and reset).
+            //
+            // The kernel heap occupies one physically-contiguous range, so a
+            // heap `Vec` always has a valid contiguous physical address the
+            // driver's offset derivation handles.  Read into the bounce buffer,
+            // then CPU-copy into the user buffer (the copy may fault the
+            // file-backed user pages in — which is why MOUNTS was dropped
+            // above).  In-memory filesystems (ramfs/tmpfs/procfs) memcpy and are
+            // unaffected by either path.  All read variants
+            // (read/pread/readv/preadv) funnel through fd_read, so this covers
+            // every backing-store read.
             let n = {
                 let fs = fs_at(mount_idx).ok_or(VfsError::NotFound)?.0;
-                fs.read(inode, offset, &mut buffer)?
+                // Bounce in bounded chunks so a single read(2) with a huge
+                // `count` never allocates a `count`-sized kernel buffer (which
+                // could exhaust the 384 MiB kernel heap).  256 KiB comfortably
+                // exceeds the block device's per-request span, so a chunk is
+                // still serviced by at most one coalesced device read.
+                const BOUNCE_CHUNK: usize = 256 * 1024;
+                let chunk_cap = count.min(BOUNCE_CHUNK);
+                let mut bounce = alloc::vec![0u8; chunk_cap];
+                let mut done = 0usize;
+                loop {
+                    if done >= count {
+                        break;
+                    }
+                    let want = (count - done).min(chunk_cap);
+                    let got = fs.read(
+                        inode,
+                        offset + done as u64,
+                        &mut bounce[..want],
+                    )?;
+                    if got == 0 {
+                        break; // EOF / short read — stop.
+                    }
+                    // SAFETY: `buffer` is the caller's destination of length
+                    // `count`; `done + got <= count` because `want <= count -
+                    // done` and `got <= want`.
+                    buffer[done..done + got].copy_from_slice(&bounce[..got]);
+                    done += got;
+                    if got < want {
+                        break; // short read — backing store has no more here.
+                    }
+                }
+                done
             };
 
             // Update offset.


### PR DESCRIPTION
## Summary

A `read(2)`/`write(2)` of a block-backed file (ext2) whose target/source is a userspace buffer was DMA'd by the block driver **directly into/out of the user buffer**, writing a user virtual address into the virtio-blk descriptor's physical-address field. The device then targets a bogus ~user-VA physical address far outside RAM, the host rejects the descriptor, and **the virtqueue halts** — wedging all further disk I/O. Not recoverable by re-ringing the doorbell or resetting the device under sustained load.

This PR fixes both the read and the (symmetric) write side. The write side was found by an adversarial review of the read fix.

## Root cause (descriptor autopsy)

Found by reading the live virtqueue rings + descriptor table during the wedge. The data-buffer descriptor for an uncached 40 KiB read of `/usr/share/X11/XErrorDB` during X11 init:

```
oldest-outstanding avail.ring[157] -> head desc #0
  desc #0: addr=0x18a04810     len=16    flags=NEXT          (request header — valid kernel phys)
  desc #1: addr=0x7efea25e8b30  len=40960 flags=NEXT|WRITE   <-- USER VA written as PHYS (~139 TiB)
  desc #2: addr=0x18a04a10      len=1     flags=WRITE         (status byte — valid kernel phys)
```

`fd_read`/`fd_write` built their buffer slice directly over the user pointer and passed it to `fs.read`/`fs.write`. On ext2 the aligned whole-block fast path hands the slice straight to `BlockDevice::read_sectors`/`write_sectors` → `virtio_blk::do_io`. `do_io` derives the descriptor's *physical* address from the buffer's virtual address by the fixed higher-half direct-map offset and has **no page-table walker**, so a user VA is written verbatim as if it were physical (identical for the T_IN read-into-buffer and T_OUT read-from-buffer cases).

The bug was latent because most reads are served from the page cache (the mmap demand-fault path already bounces through kernel-heap frames), and fat32 already bounces writes through its sector cache. It surfaces on an **aligned, uncached, multi-block read/write into/from a user buffer on ext2** — common during application startup (GTK/X11 init reading XErrorDB, fonts, cursors, themes).

## Fix

Read/write the backing store through a **kernel-heap bounce buffer** (the kernel heap is one physically-contiguous range, so a heap `Vec` always has a valid contiguous physical address the driver's offset derivation handles), then CPU-copy between the bounce and the user buffer. The block layer now only ever sees kernel buffers. Bounded to 256 KiB chunks so a single `read`/`write` with a huge `count` never allocates a `count`-sized kernel buffer. In-memory filesystems (ramfs/tmpfs/procfs) memcpy and are unaffected; all variants (read/pread/readv/preadv and write/pwrite/writev/pwritev) funnel through `fd_read`/`fd_write`.

## Verification

- **test-mode suite**: read tests (`dynamic_hello`, `socket_test`, `mmap_test`, a 1 MiB `busybox` via four chunks) and write tests (`FAT32 write`, `EXT2-DIR`, `EXT2-SB`, `EXT2-LINK`) pass with correct bytes; no corruption, no read/write-path regressions.
- **GUI Firefox** (`--ff-gui`, on the feature lineage where this was diagnosed): the device no longer wedges (0 `wait_completion` timeouts vs 17–65 before; `avail.idx == used.idx`, 0 outstanding), and Firefox advances past the XErrorDB read (`sc` ~16.5k → 23k) through full GTK/GDK/X11 init to the event-loop idle plateau.

## Reviewer-confirmed scope

An adversarial review confirmed the chunking exactly preserves POSIX `read(2)`/`write(2)` semantics (EOF, holes, short reads, zero-count), the slice bounds can never panic, and no other user-buffer→`read_sectors`/`write_sectors` path was missed. The write side was the review's headline finding and is fixed in this PR.

## Spec references

- VIRTIO 1.0 §2.4 (virtqueue/descriptor layout): the descriptor `addr` is a guest **physical** address.
- POSIX `read(2)`/`write(2)` (IEEE Std 1003.1-2017): chunked backing transfers are transparent to the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
