### PR TITLE
mm/tlb: retire stale entries left by a timed-out non-freeing shootdown (dual-core store-visibility SIGSEGV)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1689,6 +1689,9 @@ fn op_tlb_stats(out: &mut String) {
     // ── H2 diagnostic counters ─────────────────────────────────────────────
     let _ = write!(out, r#""shootdown_clean_ack_late":{},"#, s.clean_ack_late);
     let _ = write!(out, r#""shootdown_unclean_total":{},"#,  s.unclean_total);
+    // ── Deferred force-flush (timeout self-healing) ────────────────────────
+    let _ = write!(out, r#""force_flush_posted":{},"#,    s.force_flush_posted);
+    let _ = write!(out, r#""force_flush_serviced":{},"#,  s.force_flush_serviced);
     let _ = write!(out, r#""pmm_alloc_recent_free":{}"#,     pmm_recent);
     out.push('}');
 }

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -215,6 +215,49 @@ pub(crate) static STAT_UNCLEAN_TOTAL: AtomicU64 = AtomicU64::new(0);
 static SHOOTDOWN_DONE_FLAGS: [AtomicU8; apic::MAX_CPUS] =
     [const { AtomicU8::new(0) }; apic::MAX_CPUS];
 
+/// Per-CPU "deferred force-flush" request, indexed by `cpu_index()`.
+///
+/// Set to 1 by a *sender* that timed out waiting for this CPU to acknowledge a
+/// shootdown (the target was IF-masked in a critical section that is neither the
+/// ack-spin nor able to take the `TLB_SHOOTDOWN_VECTOR` IPI).  A timed-out
+/// shootdown abandons its per-CPU slot, so when the masked CPU later becomes
+/// serviceable and takes some *other* IPI, the slot no longer names the range
+/// that was abandoned — the stale TLB entry for that range would otherwise
+/// survive until the next CR3 reload (context switch or timer tick).
+///
+/// On a CPU whose LAPIC periodic timer has gone silent (a KVM failure mode —
+/// see `crate::arch::x86_64::irq::poke_stale_siblings`), the per-tick
+/// `on_cpu_tick` full flush never runs, so that fallback is *unavailable* for
+/// exactly the CPU most likely to be the timeout target.  Without an explicit
+/// retirement the stale-but-present entry persists until the CPU happens to
+/// reload CR3 — and x86-64 does **not** re-fault a present-but-stale TLB entry
+/// (Intel SDM Vol. 3A §4.10.2.3), so the CPU silently reads the old frame: a
+/// wrong-content read (a CoW page whose private copy it never saw, a make-
+/// writable transition, an `mprotect` permission change), surfacing as a torn
+/// object or a not-present read of an apparently-present code page.
+///
+/// The flag is drained — a full TLB flush via CR3 reload, then clear — by
+/// [`drain_pending_force_flush`], called from [`handle_shootdown_ipi`] (the
+/// frequent serviceable point a dead-timer CPU reaches whenever it next takes a
+/// shootdown IPI), from the ack-spin self-service iteration, and from
+/// [`on_cpu_tick`].  Whichever the CPU reaches first retires the stale entry,
+/// bounding the staleness window to "until the masked CPU is next interruptible"
+/// rather than "until the masked CPU's possibly-dead timer next fires".
+///
+/// Per Intel SDM Vol. 3A §4.10.4.1 (MOV to CR3 invalidates all non-global TLB
+/// entries; AstryxOS uses PCID 0 so this is a complete drop) the flush is
+/// strictly conservative: it retires *every* entry on the CPU, so it covers the
+/// abandoned range regardless of which range the timeout was for.
+static FORCE_FLUSH_PENDING: [AtomicU8; apic::MAX_CPUS] =
+    [const { AtomicU8::new(0) }; apic::MAX_CPUS];
+
+/// Statistic: number of deferred force-flush requests posted (sender side, one
+/// per unacked target CPU per timeout).
+static STAT_FORCE_FLUSH_POSTED: AtomicU64 = AtomicU64::new(0);
+
+/// Statistic: number of deferred force-flushes actually serviced (target side).
+static STAT_FORCE_FLUSH_SERVICED: AtomicU64 = AtomicU64::new(0);
+
 // ── Quarantine-free ring ─────────────────────────────────────────────────────
 //
 // Physical frames that cannot be immediately returned to the PMM because
@@ -586,6 +629,10 @@ fn shootdown_range_inner(cr3: u64, va_lo: u64, va_hi: u64) -> bool {
         // until both burn the full ACK_BOUND.  See
         // `service_local_shootdown_slot` for the full rationale.
         service_local_shootdown_slot(self_cpu);
+        // Also retire any deferred force-flush posted to us: a CPU spinning here
+        // is serviceable for shootdown bookkeeping, so this is a valid drain
+        // point for a stale entry an earlier timeout left on this CPU.
+        drain_pending_force_flush(self_cpu);
 
         let mut still = 0u64;
         let mut r = remaining;
@@ -626,6 +673,16 @@ fn shootdown_range_inner(cr3: u64, va_lo: u64, va_hi: u64) -> bool {
             SHOOTDOWN_SLOTS[bit].pending.store(0, Ordering::Release);
             tgt_count += 1;
         }
+        // Post a deferred force-flush to every CPU that did not ack.  The slot
+        // we just cleared no longer names the abandoned range, so when this
+        // masked target later becomes serviceable it must retire the stale
+        // entry explicitly — otherwise (x86-64 does NOT re-fault a present-but-
+        // stale TLB entry, Intel SDM Vol. 3A §4.10.2.3) it silently reads the
+        // old frame for a CoW/make-writable/mprotect transition: a wrong-content
+        // read.  Frame-FREEING callers additionally route the affected frame
+        // through `quarantine_free` (return value below); this force-flush makes
+        // the NON-freeing callers (which ignore the return value) equally safe.
+        post_force_flush(remaining);
         crate::serial_println!(
             "[TLB/TIMEOUT] cpu={} target_mask={:#x} unacked_cpus={} \
              va=[{:#x}..{:#x}) iters={} total_timeouts={}",
@@ -822,6 +879,15 @@ pub fn on_cpu_tick(current_tick: u64) {
     let cpu = apic::cpu_index();
     if cpu < apic::MAX_CPUS {
         CPU_LAST_TICK[cpu].store(current_tick, Ordering::Relaxed);
+        // The unconditional flush above already retired every stale entry on
+        // this CPU, so a deferred force-flush request posted to us is satisfied:
+        // clear it (counting the service) without a redundant second CR3 reload.
+        if FORCE_FLUSH_PENDING[cpu]
+            .compare_exchange(1, 0, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            STAT_FORCE_FLUSH_SERVICED.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     // Fast path: quarantine ring is empty.
@@ -953,6 +1019,62 @@ fn service_local_shootdown_slot(cpu: usize) -> bool {
     true
 }
 
+/// Post a deferred force-flush request to every CPU named in `mask`.
+///
+/// Called by a sender from the timeout branch of [`shootdown_range_inner`] for
+/// the set of CPUs that failed to acknowledge.  Each target retires the flag —
+/// with a full TLB flush — the next time it reaches [`drain_pending_force_flush`]
+/// (a shootdown IPI, an ack-spin iteration, or a timer tick).  Idempotent: a CPU
+/// already carrying a pending request is left as-is (a single full flush retires
+/// every stale entry regardless of how many timeouts targeted it).
+#[inline]
+fn post_force_flush(mask: u64) {
+    let mut r = mask;
+    while r != 0 {
+        let bit = r.trailing_zeros() as usize;
+        r &= r - 1;
+        if bit >= apic::MAX_CPUS {
+            continue;
+        }
+        // Release so the target's Acquire drain observes this post.  A prior
+        // unserviced request remaining set is harmless — one flush covers all.
+        if FORCE_FLUSH_PENDING[bit].swap(1, Ordering::Release) == 0 {
+            STAT_FORCE_FLUSH_POSTED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Drain this CPU's deferred force-flush request, if any.
+///
+/// If a sender previously timed out waiting for `cpu` to acknowledge a
+/// shootdown, this performs a full TLB flush (CR3 reload) and clears the flag,
+/// retiring any stale-but-present entry the abandoned shootdown left behind.
+///
+/// Safe to call with interrupts disabled: it takes no locks and performs no IPI
+/// sends — only a `compare_exchange` on the per-CPU flag and (on a hit) a CR3
+/// reload.  Per Intel SDM Vol. 3A §4.10.4.1 the MOV-to-CR3 invalidates all
+/// non-global TLB entries (PCID 0 → complete drop), so the single flush covers
+/// the abandoned range whatever it was.  Called from [`handle_shootdown_ipi`],
+/// the ack-spin self-service iteration, and [`on_cpu_tick`].
+#[inline]
+fn drain_pending_force_flush(cpu: usize) {
+    if cpu >= apic::MAX_CPUS {
+        return;
+    }
+    // Acquire pairs with the sender's Release in `post_force_flush`.  Only the
+    // winner of the 1→0 transition does the (single, idempotent) flush; a
+    // concurrent drain on the same CPU is impossible (the flag is per-CPU and
+    // drained only by that CPU), but the compare_exchange keeps the bookkeeping
+    // exact under a racing post.
+    if FORCE_FLUSH_PENDING[cpu]
+        .compare_exchange(1, 0, Ordering::AcqRel, Ordering::Relaxed)
+        .is_ok()
+    {
+        crate::mm::vmm::flush_tlb();
+        STAT_FORCE_FLUSH_SERVICED.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 pub extern "C" fn handle_shootdown_ipi() {
     let cpu = apic::cpu_index();
     // Service this CPU's slot.  The compare_exchange inside guards against a
@@ -961,6 +1083,15 @@ pub extern "C" fn handle_shootdown_ipi() {
     // or after the inline self-service path already handled it) — it is
     // observably handled exactly once.
     service_local_shootdown_slot(cpu);
+
+    // Retire any deferred force-flush a sender posted to us after a prior
+    // shootdown to this CPU timed out (we were IF-masked then and missed it).
+    // This is the frequent serviceable point a dead-LAPIC-timer CPU reaches:
+    // whenever it next becomes interruptible and takes ANY shootdown IPI, the
+    // abandoned range's stale entry is retired here — bounding the staleness
+    // window to "until this CPU is next interruptible" instead of "until its
+    // (possibly dead) periodic timer next fires".
+    drain_pending_force_flush(cpu);
 
     apic::lapic_eoi();
 }
@@ -1028,6 +1159,60 @@ pub fn test_self_service_drains_own_slot() -> (bool, bool) {
     (first, second)
 }
 
+/// Test-only harness for the deferred force-flush self-healing path.
+///
+/// Posts a force-flush request to THIS CPU (as a timed-out sender would), then
+/// drains it twice via [`drain_pending_force_flush`] — the same code path the
+/// IPI handler runs.  Returns `(first_serviced, second_serviced)` where
+/// `first_serviced` must be `true` (the posted request was retired exactly
+/// once, with a real CR3 reload) and `second_serviced` must be `false`
+/// (idempotent — a cleared flag is a no-op).  Exercises the fix for the
+/// non-freeing-shootdown-timeout stale-translation hazard without needing a
+/// genuinely masked second CPU.
+///
+/// Interrupts are masked across the publish + double-drain so a real
+/// cross-CPU force-flush post cannot race the synthetic one on this slot.
+#[doc(hidden)]
+pub fn test_force_flush_post_drain() -> (bool, bool) {
+    let cpu = apic::cpu_index();
+    if cpu >= apic::MAX_CPUS {
+        return (true, false);
+    }
+
+    let prior_if: u64;
+    unsafe {
+        core::arch::asm!(
+            "pushfq", "pop {f}", "cli",
+            f = out(reg) prior_if,
+            options(nomem, preserves_flags),
+        );
+    }
+
+    let serviced_before = STAT_FORCE_FLUSH_SERVICED.load(Ordering::Relaxed);
+
+    // Post a force-flush to our own CPU (the self_mask bit a real sender would
+    // never target; here we post directly to exercise the drain).
+    post_force_flush(1u64 << (cpu as u64));
+
+    // First drain must service it (CR3 reload + counter advance); second must
+    // observe the flag already cleared and no-op.
+    drain_pending_force_flush(cpu);
+    let serviced_mid = STAT_FORCE_FLUSH_SERVICED.load(Ordering::Relaxed);
+    drain_pending_force_flush(cpu);
+    let serviced_after = STAT_FORCE_FLUSH_SERVICED.load(Ordering::Relaxed);
+
+    // Leave the flag pristine for any real shootdown timeout to this CPU.
+    FORCE_FLUSH_PENDING[cpu].store(0, Ordering::Release);
+
+    if prior_if & (1 << 9) != 0 {
+        unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)); }
+    }
+
+    let first = serviced_mid.wrapping_sub(serviced_before) >= 1;
+    let second = serviced_after != serviced_mid;
+    (first, second)
+}
+
 /// Diagnostic snapshot for kdb / introspection.
 #[derive(Debug, Clone, Copy)]
 pub struct Stats {
@@ -1049,6 +1234,15 @@ pub struct Stats {
     /// (unclean → quarantine).  Baseline rate for the above counter.
     /// Always 0 in non-firefox-test builds.
     pub unclean_total: u64,
+    /// Deferred force-flush requests posted (one per unacked target CPU per
+    /// timeout).  A non-zero value means at least one shootdown timed out and a
+    /// stale-entry retirement was deferred to the target's next serviceable
+    /// point — the new safety net for the non-freeing PTE-mutation callers.
+    pub force_flush_posted: u64,
+    /// Deferred force-flushes serviced (target side).  Should track
+    /// `force_flush_posted`; a persistent gap means a target is not reaching any
+    /// drain point (a wedged, never-interruptible CPU).
+    pub force_flush_serviced: u64,
 }
 
 /// Return a snapshot of the running shootdown statistics.
@@ -1069,5 +1263,7 @@ pub fn stats() -> Stats {
         unclean_total: STAT_UNCLEAN_TOTAL.load(Ordering::Relaxed),
         #[cfg(not(feature = "firefox-test-core"))]
         unclean_total: 0,
+        force_flush_posted: STAT_FORCE_FLUSH_POSTED.load(Ordering::Relaxed),
+        force_flush_serviced: STAT_FORCE_FLUSH_SERVICED.load(Ordering::Relaxed),
     }
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2188,6 +2188,14 @@ pub fn run() -> ! {
     total += 1;
     if test_tlb_self_service_drain() { passed += 1; }
 
+    // Deferred force-flush self-healing: a timed-out non-freeing shootdown
+    // (CoW / make-writable / mprotect) posts a force-flush that the masked
+    // target retires at its next drain point, closing the stale-translation
+    // window x86-64's no-re-fault-on-present-stale semantics would otherwise
+    // leave open.  Unit-exercises post → drain → idempotent redrain.
+    total += 1;
+    if test_tlb_timeout_force_flush() { passed += 1; }
+
     // ── Test 217: /proc/<N>/maps returns target PID's VMA table (W216) ──
     // Verifies three properties:
     //   1. open(/proc/<target>/maps) from a different caller PID succeeds
@@ -43138,6 +43146,59 @@ fn test_tlb_self_service_drain() -> bool {
     }
 
     test_pass!("TLB shootdown ACK-spin self-service drain");
+    true
+}
+
+// ── TLB shootdown timeout → deferred force-flush self-healing ───────────────
+//
+// On a true-dual-core system a cross-CPU shootdown can time out when the target
+// CPU is IF-masked in a critical section that is neither the ACK-spin nor able
+// to take the shootdown IPI (the recurring KVM dead-LAPIC-timer profile).  The
+// timed-out shootdown abandons its per-CPU slot, so the stale-but-present TLB
+// entry it failed to invalidate would otherwise survive until the next CR3
+// reload — and x86-64 does NOT re-fault a present-but-stale entry (Intel SDM
+// Vol. 3A §4.10.2.3), so a CoW / make-writable / mprotect transition silently
+// reads the old frame.  The fix posts a deferred force-flush to each unacked
+// CPU; that CPU retires the stale entry with a full CR3 reload the next time it
+// reaches a drain point (a shootdown IPI, an ACK-spin iteration, or a tick).
+//
+// This test exercises the post → drain → idempotent-redrain cycle on the local
+// CPU without needing a genuinely masked sibling: it asserts the first drain
+// services the request (counter advances) and the second is a no-op.
+fn test_tlb_timeout_force_flush() -> bool {
+    test_header!("TLB shootdown timeout deferred force-flush self-healing");
+
+    use crate::mm::tlb;
+
+    let s_before = tlb::stats();
+    let (first, second) = tlb::test_force_flush_post_drain();
+    let s_after = tlb::stats();
+
+    if !first {
+        test_fail!("tlb/force-flush", "first drain did not service the posted request");
+        return false;
+    }
+    if second {
+        test_fail!("tlb/force-flush", "second drain re-serviced a cleared flag (not idempotent)");
+        return false;
+    }
+    // A post must have been recorded, and a service must have advanced.  Both
+    // are ≥1 monotonic bounds (a concurrent real timeout on another CPU could
+    // add more).
+    let posted_delta = s_after.force_flush_posted.wrapping_sub(s_before.force_flush_posted);
+    if posted_delta < 1 {
+        test_fail!("tlb/force-flush",
+                   "force_flush_posted did not advance (delta={})", posted_delta);
+        return false;
+    }
+    let serviced_delta = s_after.force_flush_serviced.wrapping_sub(s_before.force_flush_serviced);
+    if serviced_delta < 1 {
+        test_fail!("tlb/force-flush",
+                   "force_flush_serviced did not advance (delta={})", serviced_delta);
+        return false;
+    }
+
+    test_pass!("TLB shootdown timeout deferred force-flush self-healing");
     true
 }
 


### PR DESCRIPTION
## Summary

Fixes a **true-dual-core-only** store-visibility fault: under `smp=2` with heavy copy-on-write churn (e.g. a GUI browser starting up), ~1 in 3 KVM boots took a SIGSEGV with a runtime instruction stream that didn't match the on-disk code page, or a torn object — the classic signature of a sibling CPU reading the **wrong physical frame through a stale TLB entry**. It never reproduces under serialised (TCG) execution.

## Root cause

The cross-CPU TLB shootdown protocol bounds its ACK-spin and, on timeout, **abandons the per-CPU shootdown slot**. A shootdown times out when the target CPU is masked (RFLAGS.IF = 0, per an interrupt-gate entry — Intel SDM Vol. 3A §6.12.1.2) in a critical section that is neither the ACK-spin nor able to take the `TLB_SHOOTDOWN_VECTOR` IPI. On the recurring KVM profile where a vCPU's LAPIC periodic timer goes silent, that CPU also never reaches the per-tick TLB flush in `on_cpu_tick`, so its only flush backstop is the sibling-poke IPI (taken only when IF = 1).

The **frame-freeing** shootdown callers already handle a timeout safely: they check the return value and route the frame through `quarantine_free`. But the **non-freeing PTE-mutation** callers — CoW private-copy install, CoW make-writable, and `mprotect` permission changes — issue the shootdown and **discard the return value**. When their shootdown times out, the sibling keeps a translation that now points at the pre-CoW shared frame (or the old permissions). x86-64 does **not** re-fault a present-but-stale TLB entry (Intel SDM Vol. 3A §4.10.2.3), so the sibling silently reads the old frame — a torn object, or a code page whose runtime bytes no longer match the page table.

Measured on a live run: 2358 shootdowns, 121 timeouts (5.1%), all on non-freeing paths (quarantine depth 0), with one CPU's LAPIC timer dead (0 of its heartbeats).

## Fix

On timeout, post a deferred force-flush to each unacked CPU. That CPU retires **every** stale entry with a full CR3 reload (Intel SDM Vol. 3A §4.10.4.1: MOV-to-CR3 invalidates all non-global TLB entries; AstryxOS uses PCID 0 ⇒ complete drop) the next time it reaches a drain point — the shootdown-IPI handler, an ACK-spin iteration, or `on_cpu_tick`. Because a masked CPU takes some interrupt (page fault, syscall return, sibling-poke IPI) very soon after it becomes interruptible, the staleness window collapses from "until the target's possibly-dead periodic timer next fires" to "until the target is next interruptible", and the fix holds even if the sibling-poke is ever dropped. This makes the non-freeing callers as safe on timeout as the freeing ones, **without** raising `ACK_BOUND` (which would reintroduce the per-timeout latency tax and still not eliminate the hazard).

## Verification

- New `tlb-stats` fields `force_flush_posted` / `force_flush_serviced`; a persistent posted > serviced gap would name a CPU that never reaches a drain point.
- New unit regression `test_tlb_timeout_force_flush` (post → drain → idempotent re-drain) — PASS. Existing `test_tlb_self_service_drain` — PASS.
- **8-boot KVM soak** (GUI browser, heavy CoW): `force_flush_posted == force_flush_serviced` exactly on every boot that reached CoW churn (e.g. 224/224, 155/155, 117/117 — gap 0 under 52–226 timeouts/boot) → every stale translation actively retired, no CPU stranded. **0 wrong-frame/near-null SIGSEGVs across all 8 boots** (vs ~1/3 pre-fix). The remaining handled SIGSEGVs are a deterministic, browser-self-raised probe fault (caught via `SA_SIGINFO`, process survives), unrelated to this race.
- Builds clean: default, `firefox-test-core,kdb`, `test-mode,kdb`.

Diff is +260 lines across 3 files (the bulk is doc comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)