### PR TITLE
x11: stop advertising MIT-SHM (unbacked) → force the working core XPutImage path

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -411,6 +411,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "virtio-wait-spin"  => op_virtio_wait_spin(req, out),
         "virtio-wait-reset" => op_virtio_wait_reset(out),
         "bell-stats"       => op_bell_stats(out),
+        "x11-present"      => op_x11_present(out),
         "cache-audit"      => op_cache_audit(out),
         "cache-aliasing"   => op_cache_aliasing(out),
         "fault-cache-keys" => op_fault_cache_keys(out),
@@ -1366,6 +1367,20 @@ fn op_bell_stats(out: &mut String) {
         bell_wakes, resync_wakes, bell_ratio_permille, mask_filtered,
         drained_total, wasted_bell, mean_fanout_permille, wasted_ratio_permille
     );
+}
+
+// ── x11-present ───────────────────────────────────────────────────────────────
+// Cumulative Xastryx present-path opcode counts: core PutImage(72), core
+// CopyArea(62), and MIT-SHM ShmPutImage.  The discriminator for "does the X11
+// client actually paint, and via which present path?" — e.g. a windowed
+// Firefox that maps a toplevel but shows {"put_image":0,...} has not reached
+// its first frame.
+fn op_x11_present(out: &mut String) {
+    use core::fmt::Write;
+    let (put_image, copy_area, shm_put_image) = crate::x11::present_counts();
+    let _ = write!(out,
+        r#"{{"put_image":{},"copy_area":{},"shm_put_image":{}}}"#,
+        put_image, copy_area, shm_put_image);
 }
 // ── cache-aliasing ────────────────────────────────────────────────────────────
 //

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -991,6 +991,11 @@ pub fn run() -> ! {
     total += 1;
     if test_x11_extensions() { passed += 1; }
 
+    // ── Test 75b: MIT-SHM absent → core PutImage present path ────────────────
+
+    total += 1;
+    if test_x11_shm_absent_core_present() { passed += 1; }
+
     // ── Test 76: SIGSEGV signal handler infrastructure ────────────────────────
 
     total += 1;
@@ -20611,6 +20616,114 @@ fn test_x11_extensions() -> bool {
 
     crate::net::unix::close(cfd);
     test_pass!("X11 extension handlers — SHM / XFIXES / DAMAGE / XI2");
+    true
+}
+
+// ── Test 75b: MIT-SHM is reported absent → clients fall back to core present ───
+// The server has no shared-memory transport for ShmPutImage, so it must NOT
+// advertise MIT-SHM via QueryExtension (X11 core protocol §QueryExtension): a
+// client that negotiated it would push frames into a segment the server cannot
+// read and the window would stay blank.  Per the MIT-SHM extension spec a
+// client must use core XPutImage when the extension is absent, which the
+// counter half of this test confirms reaches op_put_image.
+fn test_x11_shm_absent_core_present() -> bool {
+    test_header!("X11 MIT-SHM reported absent → core PutImage present path");
+
+    let client = crate::net::unix::create(
+        crate::net::unix::SockKind::Stream,
+        crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if client == u64::MAX {
+        test_fail!("x11_shm_absent", "unix::create() failed");
+        return false;
+    }
+    if crate::net::unix::connect(client, b"/tmp/.X11-unix/X0\0",
+            crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 }) < 0 {
+        test_fail!("x11_shm_absent", "connect failed");
+        crate::net::unix::close(client);
+        return false;
+    }
+    let hello: [u8; 12] = [0x6C, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    crate::net::unix::write(client, &hello);
+    crate::x11::poll();
+    let mut setup_buf = [0u8; 128];
+    let n = crate::net::unix::read(client, &mut setup_buf);
+    if n < 8 || setup_buf[0] != 1 {
+        test_fail!("x11_shm_absent", "setup failed (n={} byte0={})", n, setup_buf[0]);
+        crate::net::unix::close(client);
+        return false;
+    }
+
+    // ── QueryExtension("MIT-SHM") must report present=0 ──────────────────────
+    // name="MIT-SHM" (7 bytes + 1 pad = 8); total = 16 bytes = 4 words.
+    let mut qe = [0u8; 16];
+    qe[0] = 98;   // OP_QUERY_EXTENSION
+    qe[2] = 4;    // request length = 4 words
+    qe[4] = 7;    // name length = 7
+    qe[8..15].copy_from_slice(b"MIT-SHM");
+    crate::net::unix::write(client, &qe);
+    crate::x11::poll();
+    let mut rep = [0u8; 32];
+    let n = crate::net::unix::read(client, &mut rep);
+    if n < 12 || rep[0] != 1 {
+        test_fail!("x11_shm_absent", "QueryExtension reply bad (n={} b0={})", n, rep[0]);
+        crate::net::unix::close(client);
+        return false;
+    }
+    if rep[8] != 0 {
+        test_fail!("x11_shm_absent", "MIT-SHM present={} (expected 0/absent)", rep[8]);
+        crate::net::unix::close(client);
+        return false;
+    }
+    test_println!("  QueryExtension(MIT-SHM) → present=0 ✓");
+
+    // ── A core PutImage(72) to a mapped window must reach op_put_image ────────
+    // Create a small window, map it, and PutImage a 2×2 ZPixmap.  The present
+    // counter (x11::present_counts) must observe the core PutImage so we know
+    // the XPutImage fallback path is live for clients that lost MIT-SHM.
+    let (pi_before, _, _) = crate::x11::present_counts();
+    // Client id-base is 0x0040_0000 (echoed in the setup reply); 0x0040_0055 is
+    // a valid client-allocated XID for this connection.
+    let wid: u32 = 0x0040_0055;
+    // CreateWindow(1): depth=24, wid, parent=root, x=0 y=0 w=2 h=2, bw=0,
+    // class=InputOutput(1), visual=root, value-mask=0 → 8 words = 32 bytes.
+    let mut cw = [0u8; 32];
+    cw[0] = 1; cw[1] = crate::x11::proto::ROOT_DEPTH; cw[2] = 8; // len = 8 words
+    cw[4..8].copy_from_slice(&wid.to_le_bytes());
+    cw[8..12].copy_from_slice(&crate::x11::proto::ROOT_WINDOW_ID.to_le_bytes());
+    cw[20..22].copy_from_slice(&2u16.to_le_bytes()); // width
+    cw[22..24].copy_from_slice(&2u16.to_le_bytes()); // height
+    cw[26] = 1; // class = InputOutput
+    crate::net::unix::write(client, &cw);
+    // MapWindow(8): wid → 2 words = 8 bytes.
+    let mut mw = [0u8; 8];
+    mw[0] = 8; mw[2] = 2;
+    mw[4..8].copy_from_slice(&wid.to_le_bytes());
+    crate::net::unix::write(client, &mw);
+    crate::x11::poll();
+    // PutImage(72): ZPixmap (format=2), drawable=wid, gc unused here, w=2 h=2,
+    // dst-x=0 dst-y=0, left-pad=0, depth=24; header = 24 bytes, then 2×2×4 = 16
+    // pixel bytes → total 40 bytes = 10 words.
+    let mut pimg = [0u8; 40];
+    pimg[0] = 72; pimg[1] = 2; // ZPixmap
+    pimg[2] = 10;              // request length = 10 words
+    pimg[4..8].copy_from_slice(&wid.to_le_bytes());
+    pimg[12..14].copy_from_slice(&2u16.to_le_bytes()); // width
+    pimg[14..16].copy_from_slice(&2u16.to_le_bytes()); // height
+    pimg[21] = crate::x11::proto::ROOT_DEPTH;           // depth = 24
+    // pixels (BGRA) zero-filled is fine — we only assert the op was dispatched.
+    crate::net::unix::write(client, &pimg);
+    crate::x11::poll();
+    let (pi_after, _, _) = crate::x11::present_counts();
+    if pi_after <= pi_before {
+        test_fail!("x11_shm_absent",
+            "core PutImage not dispatched (before={} after={})", pi_before, pi_after);
+        crate::net::unix::close(client);
+        return false;
+    }
+    test_println!("  core PutImage(72) dispatched: {} → {} ✓", pi_before, pi_after);
+
+    crate::net::unix::close(client);
+    test_pass!("X11 MIT-SHM absent → core PutImage present path");
     true
 }
 

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -136,6 +136,21 @@ impl Server {
 unsafe impl Send for Server {}
 static SERVER: Mutex<Server> = Mutex::new(Server::new());
 
+// Present-path opcode counters (diagnostic).  Incremented in the request
+// dispatcher to answer the "which present path does the client use?" question
+// at runtime without flooding the serial log.  Read via x11::present_counts().
+use core::sync::atomic::{AtomicU64, Ordering as PresentOrdering};
+static N_PUT_IMAGE:     AtomicU64 = AtomicU64::new(0);
+static N_COPY_AREA:     AtomicU64 = AtomicU64::new(0);
+static N_SHM_PUT_IMAGE: AtomicU64 = AtomicU64::new(0);
+
+/// (core PutImage, core CopyArea, MIT-SHM ShmPutImage) request counts.
+pub fn present_counts() -> (u64, u64, u64) {
+    (N_PUT_IMAGE.load(PresentOrdering::Relaxed),
+     N_COPY_AREA.load(PresentOrdering::Relaxed),
+     N_SHM_PUT_IMAGE.load(PresentOrdering::Relaxed))
+}
+
 // ── Wire helpers ─────────────────────────────────────────────────────────────
 
 #[inline] fn r16(b: &[u8], o: usize) -> u16  { proto::read_u16le(b, o) }
@@ -606,7 +621,7 @@ fn handle_request(fd: u64, data: &[u8]) {
         proto::OP_COPY_GC               => op_copy_gc(fd, data),
         proto::OP_FREE_GC               => op_free_gc(fd, data),
         proto::OP_CLEAR_AREA            => op_clear_area(fd, data),
-        proto::OP_COPY_AREA             => op_copy_area(fd, data),
+        proto::OP_COPY_AREA             => { N_COPY_AREA.fetch_add(1, PresentOrdering::Relaxed); op_copy_area(fd, data) }
         proto::RENDER_MAJOR_OPCODE      => op_render(fd, data, seq),
         proto::SHM_MAJOR_OPCODE        => op_shm(fd, data, seq),
         proto::BIGREQ_MAJOR_OPCODE     => op_bigreq(fd, data, seq),
@@ -634,7 +649,7 @@ fn handle_request(fd: u64, data: &[u8]) {
         proto::OP_FILL_POLY             => {}
         proto::OP_POLY_FILL_RECTANGLE   => op_poly_fill_rect(fd, data),
         proto::OP_POLY_FILL_ARC         => {}
-        proto::OP_PUT_IMAGE             => op_put_image(fd, data),
+        proto::OP_PUT_IMAGE             => { N_PUT_IMAGE.fetch_add(1, PresentOrdering::Relaxed); op_put_image(fd, data) }
         proto::OP_IMAGE_TEXT8           => op_image_text8(fd, data),
         proto::OP_IMAGE_TEXT16          => {}
         proto::OP_CREATE_COLORMAP       => {}
@@ -1924,7 +1939,14 @@ fn op_query_extension(fd: u64, data: &[u8], seq: u16) {
     let name = if data.len() >= 8+nlen { core::str::from_utf8(&data[8..8+nlen]).unwrap_or("") } else { "" };
     let mut b = [0u8;32]; b[0]=1; w16(&mut b,2,seq);
     match name {
-        "MIT-SHM"        => { b[8]=1; b[9]=proto::SHM_MAJOR_OPCODE;    b[10]=0; b[11]=0; }
+        // MIT-SHM is intentionally reported as NOT present.  This server has no
+        // shared-memory transport for ShmPutImage, so a client that negotiated
+        // MIT-SHM would push every frame into a segment we cannot read and the
+        // window would stay blank.  Per the MIT-SHM extension spec a client must
+        // fall back to core XPutImage when the extension is absent, which routes
+        // pixels inline through the protocol stream where PutImage(72) actually
+        // blits them.  X11 core protocol §QueryExtension: present=0 ⇒ absent.
+        "MIT-SHM"        => {} // not present
         "BIG-REQUESTS"   => { b[8]=1; b[9]=proto::BIGREQ_MAJOR_OPCODE; b[10]=0; b[11]=0; }
         "XKEYBOARD"      => { b[8]=1; b[9]=proto::XKEYBOARD_MAJOR_OPCODE; b[10]=0; b[11]=0; }
         "SHAPE"     => { b[8]=1; b[9]=proto::SHAPE_MAJOR_OPCODE;   b[10]=0; b[11]=0; }
@@ -1947,8 +1969,10 @@ fn op_query_extension(fd: u64, data: &[u8], seq: u16) {
 // ── ListExtensions (99) ──────────────────────────────────────────────────────
 
 fn op_list_extensions(fd: u64, seq: u16) {
+    // MIT-SHM is deliberately omitted — see op_query_extension; the server has
+    // no shared-memory transport, so clients must use core XPutImage instead.
     let names: &[&[u8]] = &[
-        b"MIT-SHM", b"BIG-REQUESTS", b"XKEYBOARD", b"SHAPE", b"RENDER",
+        b"BIG-REQUESTS", b"XKEYBOARD", b"SHAPE", b"RENDER",
         b"XFIXES", b"DAMAGE", b"XTEST", b"XInputExtension",
         b"DPMS", b"SYNC", b"COMPOSITE", b"RANDR",
     ];
@@ -2393,7 +2417,7 @@ fn op_shm(fd: u64, data: &[u8], seq: u16) {
         // SHM_ATTACH / SHM_DETACH: side-effect, accept silently
         proto::SHM_ATTACH | proto::SHM_DETACH => {}
         // SHM_PUT_IMAGE: stub — no real shared memory backing
-        proto::SHM_PUT_IMAGE => {}
+        proto::SHM_PUT_IMAGE => { N_SHM_PUT_IMAGE.fetch_add(1, PresentOrdering::Relaxed); }
         // SHM_GET_IMAGE: return unimplemented error
         proto::SHM_GET_IMAGE => {
             with_client(fd, |c| c.send_error(proto::ERR_IMPLEMENTATION, 0, proto::SHM_MAJOR_OPCODE));

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -5983,7 +5983,7 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
-              "bell-stats", "cache-audit", "cache-aliasing",
+              "bell-stats", "x11-present", "cache-audit", "cache-aliasing",
               "fault-cache-keys", "w215-cache-residency",
               "tlb-stats", "heap-stats", "w215-diag",
               "sched-stats",
@@ -11918,7 +11918,7 @@ def main():
         "unix-diag", "pipe-diag",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "trace-status",
-        "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
+        "bell-stats", "x11-present", "cache-audit", "cache-aliasing", "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
         "sched-stats",
         "arm-phys",


### PR DESCRIPTION
Latent bug found while tracing FF's GTK software-present path: the Xastryx server advertised MIT-SHM via QueryExtension/ListExtensions, but SHM_PUT_IMAGE was a silent no-op with no shared-memory backing (x11/mod.rs:2411). A client whose visual masks match B8G8R8X8 negotiates SHM and presents via SHM_PUT_IMAGE — every such frame is silently dropped → blank window.

Fix: report MIT-SHM as **absent**. Per the X11 core protocol (QueryExtension) and the MIT-SHM extension protocol, an absent extension forces the client onto the core XPutImage fallback, which op_put_image → blit_pixels_screen already paints.

Also adds `kdb x11-present` (present-opcode counter: put_image/copy_area/shm_put_image) as a GUI-paint debugging discriminator, and Test 75b (asserts MIT-SHM present=0 + core PutImage dispatch). 159 LOC / 4 files. Public specs only.

Note: latent fix — its runtime payoff (a painted window) is gated behind the separate, parked W101/GATE-B content-proc wedge; landing it removes the footgun and is a prerequisite for any future paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)