### PR TITLE
x11: implement TranslateCoordinates (opcode 40)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -792,6 +792,11 @@ pub fn run() -> ! {
     total += 1;
     if test_x11_draw_cycle() { passed += 1; }
 
+    // ── X11 server — TranslateCoordinates (opcode 40) ────────────────────────
+
+    total += 1;
+    if test_x11_translate_coordinates() { passed += 1; }
+
     // ── Test 67: X11 server — key event injection + delivery ─────────────────
 
     total += 1;
@@ -18041,6 +18046,97 @@ fn test_x11_draw_cycle() -> bool {
 
     crate::net::unix::close(client);
     test_pass!("X11 CreateWindow + MapWindow + Draw cycle");
+    true
+}
+
+// ── X11 — TranslateCoordinates (opcode 40) ───────────────────────────────────
+//
+// Verifies the server answers TranslateCoordinates with a reply (not a
+// BadRequest error) and that the geometry is correct.  A point (60,70) in the
+// root window's coordinate space, translated into a child window whose origin
+// is (50,50), must come back as (10,20).  GDK issues this request during window
+// realization; before this op was wired the server replied BadRequest, which
+// the client (libX11 XTranslateCoordinates) reports as a failure.
+fn test_x11_translate_coordinates() -> bool {
+    test_header!("X11 TranslateCoordinates (opcode 40)");
+
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream, crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if client == u64::MAX {
+        test_fail!("x11_translate", "unix::create() failed");
+        return false;
+    }
+    if crate::net::unix::connect(client, b"/tmp/.X11-unix/X0\0", crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 }) < 0 {
+        test_fail!("x11_translate", "connect failed");
+        crate::net::unix::close(client);
+        return false;
+    }
+    let hello: [u8; 12] = [0x6C, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    crate::net::unix::write(client, &hello);
+    crate::x11::poll();
+    let mut setup_buf = [0u8; 128];
+    let n = crate::net::unix::read(client, &mut setup_buf);
+    if n < 8 || setup_buf[0] != 1 {
+        test_fail!("x11_translate", "setup failed (n={} byte0={})", n, setup_buf[0]);
+        crate::net::unix::close(client);
+        return false;
+    }
+
+    // CreateWindow: wid=0x00610001, parent=ROOT, origin (50,50), 200x100.
+    let mut reqs = [0u8; 40];
+    reqs[0]  = 1; reqs[2] = 10;
+    reqs[4]  = 0x01; reqs[5] = 0x00; reqs[6] = 0x61; // wid = 0x00610001 LE
+    reqs[8]  = 0x01;                                 // parent = ROOT
+    reqs[12] = 50; reqs[14] = 50;                    // x=50 y=50
+    reqs[16] = 200; reqs[18] = 100;                  // w=200 h=100
+    reqs[22] = 1;                                    // class = InputOutput
+    reqs[24] = 32;                                   // visual = ROOT_VISUAL
+    // vmask = 0 (no optional attrs)
+    if crate::net::unix::write(client, &reqs) != 40 {
+        test_fail!("x11_translate", "CreateWindow write failed");
+        crate::net::unix::close(client);
+        return false;
+    }
+    crate::x11::poll();
+
+    // TranslateCoordinates (4 words = 16 bytes):
+    //   [0] opcode=40  [2] len=4  [4..8] src=ROOT(1)  [8..12] dst=0x00610001
+    //   [12..14] src_x=60  [14..16] src_y=70
+    let mut tc = [0u8; 16];
+    tc[0]  = 40; tc[2] = 4;
+    tc[4]  = 0x01;                                   // src = ROOT
+    tc[8]  = 0x01; tc[9] = 0x00; tc[10] = 0x61;      // dst = 0x00610001 LE
+    tc[12] = 60; tc[14] = 70;                        // src_x=60 src_y=70
+    if crate::net::unix::write(client, &tc) != 16 {
+        test_fail!("x11_translate", "TranslateCoordinates write failed");
+        crate::net::unix::close(client);
+        return false;
+    }
+    crate::x11::poll();
+
+    let mut rep = [0u8; 32];
+    let n = crate::net::unix::read(client, &mut rep);
+    if n < 32 {
+        test_fail!("x11_translate", "reply read returned {} (expected 32)", n);
+        crate::net::unix::close(client);
+        return false;
+    }
+    // byte 0 == 1 (reply, not 0 = error) is the primary regression guard.
+    if rep[0] != 1 {
+        test_fail!("x11_translate", "got type={} (expected 1=reply; 0=BadRequest error)", rep[0]);
+        crate::net::unix::close(client);
+        return false;
+    }
+    let dst_x = i16::from_le_bytes([rep[16], rep[17]]);
+    let dst_y = i16::from_le_bytes([rep[18], rep[19]]);
+    if dst_x != 10 || dst_y != 20 {
+        test_fail!("x11_translate", "dst=({},{}) expected (10,20)", dst_x, dst_y);
+        crate::net::unix::close(client);
+        return false;
+    }
+    test_println!("  TranslateCoordinates root(60,70) -> child(10,20) ✓");
+
+    crate::net::unix::close(client);
+    test_pass!("X11 TranslateCoordinates (opcode 40)");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -18126,8 +18126,9 @@ fn test_x11_translate_coordinates() -> bool {
         crate::net::unix::close(client);
         return false;
     }
-    let dst_x = i16::from_le_bytes([rep[16], rep[17]]);
-    let dst_y = i16::from_le_bytes([rep[18], rep[19]]);
+    // Spec offsets: dst-x at byte 12, dst-y at byte 14 (X11 TranslateCoordinates reply).
+    let dst_x = i16::from_le_bytes([rep[12], rep[13]]);
+    let dst_y = i16::from_le_bytes([rep[14], rep[15]]);
     if dst_x != 10 || dst_y != 20 {
         test_fail!("x11_translate", "dst=({},{}) expected (10,20)", dst_x, dst_y);
         crate::net::unix::close(client);

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -591,6 +591,7 @@ fn handle_request(fd: u64, data: &[u8]) {
         proto::OP_GRAB_SERVER           => {}
         proto::OP_UNGRAB_SERVER         => {}
         proto::OP_QUERY_POINTER         => op_query_pointer(fd, seq),
+        proto::OP_TRANSLATE_COORDINATES => op_translate_coordinates(fd, data, seq),
         proto::OP_WARP_POINTER          => {}
         proto::OP_SET_INPUT_FOCUS       => op_set_input_focus(fd, data),
         proto::OP_GET_INPUT_FOCUS       => op_get_input_focus(fd, seq),
@@ -1391,6 +1392,84 @@ fn op_query_pointer(fd: u64, seq: u16) {
     w16(&mut b,20, proto::SCREEN_WIDTH/2);  // root-x
     w16(&mut b,22, proto::SCREEN_HEIGHT/2); // root-y
     with_client(fd, |c| c.send(&b));
+}
+
+// ── TranslateCoordinates (40) ────────────────────────────────────────────────
+//
+// Per X11 core protocol §TranslateCoordinates: given a point (src_x, src_y) in
+// the coordinate space of src_window, return the equivalent point (dst_x, dst_y)
+// in the coordinate space of dst_window, the `child` of dst_window that contains
+// the point (or None), and `same_screen`.  GDK calls this through
+// gdk_window_get_origin / gdk_x11_window_get_root_coords during window
+// realization and pointer handling; an unanswered request (the server replying
+// BadRequest) makes those return garbage coordinates.
+//
+// Request layout (4 words, 16 bytes):
+//   [0] opcode/unused/length   [4] src_window   [8] dst_window
+//   [12] src_x (CARD16)        [14] src_y (CARD16)
+//
+// Reply (32 bytes): byte 1 = same_screen (BOOL), word at 8 = child (WINDOW,
+// 0 = None), INT16 at 16 = dst_x, INT16 at 18 = dst_y.
+//
+// We translate via each window's absolute (root-relative) origin: the point in
+// root space is src_abs_origin + (src_x, src_y), and the result is that minus
+// dst_abs_origin.  This is exact for the flat-under-root window model the
+// server presents (toplevels positioned by their x/y, children offset by their
+// parents'); `child` is reported as None (0), which is a valid answer when no
+// mapped child of dst_window contains the point and is what GDK tolerates.
+
+/// Absolute (root-relative) origin of a window resource, walking the parent
+/// chain.  Returns (0,0) for the root window or an unknown drawable.
+fn window_abs_origin(c: &Client, wid: u32) -> (i32, i32) {
+    let mut ax = 0i32;
+    let mut ay = 0i32;
+    let mut cur = wid;
+    // Bound the walk to the resource-table size to defend against a malformed
+    // parent cycle; a legitimate hierarchy is at most a few levels deep.
+    for _ in 0..resource::MAX_RESOURCES {
+        if cur == proto::ROOT_WINDOW_ID || cur == 0 { break; }
+        let found = c.resources.entries.iter().filter_map(|s| s.as_ref())
+            .find(|r| r.id == cur)
+            .and_then(|r| match &r.body {
+                ResourceBody::Window(w) => Some((w.x as i32, w.y as i32, w.parent)),
+                _ => None,
+            });
+        match found {
+            Some((x, y, parent)) => { ax += x; ay += y; cur = parent; }
+            None => break,
+        }
+    }
+    (ax, ay)
+}
+
+fn op_translate_coordinates(fd: u64, data: &[u8], seq: u16) {
+    if data.len() < 16 { return; }
+    let src_win = r32(data, 4);
+    let dst_win = r32(data, 8);
+    let src_x   = r16(data, 12) as i16 as i32;
+    let src_y   = r16(data, 14) as i16 as i32;
+    with_client(fd, |c| {
+        let valid = |w: u32| w == proto::ROOT_WINDOW_ID || c.resources.has(w);
+        if !valid(src_win) {
+            c.send_error(proto::ERR_WINDOW, src_win, proto::OP_TRANSLATE_COORDINATES);
+            return;
+        }
+        if !valid(dst_win) {
+            c.send_error(proto::ERR_WINDOW, dst_win, proto::OP_TRANSLATE_COORDINATES);
+            return;
+        }
+        let (sox, soy) = window_abs_origin(c, src_win);
+        let (dox, doy) = window_abs_origin(c, dst_win);
+        let dst_x = (sox + src_x) - dox;
+        let dst_y = (soy + src_y) - doy;
+        let mut b = [0u8; 32];
+        b[0] = 1; b[1] = 1; // same_screen = True (single-screen server)
+        w16(&mut b, 2, seq);
+        // child = 0 (None); dst_x / dst_y as INT16.
+        w16(&mut b, 16, dst_x as i16 as u16);
+        w16(&mut b, 18, dst_y as i16 as u16);
+        c.send(&b);
+    });
 }
 
 // ── GrabPointer/GrabKeyboard reply ─────────────────────────────────────────

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -1465,9 +1465,10 @@ fn op_translate_coordinates(fd: u64, data: &[u8], seq: u16) {
         let mut b = [0u8; 32];
         b[0] = 1; b[1] = 1; // same_screen = True (single-screen server)
         w16(&mut b, 2, seq);
-        // child = 0 (None); dst_x / dst_y as INT16.
-        w16(&mut b, 16, dst_x as i16 as u16);
-        w16(&mut b, 18, dst_y as i16 as u16);
+        // child = 0 (None) at bytes 8-11; dst-x INT16 at byte 12, dst-y INT16 at
+        // byte 14 (X11 core protocol TranslateCoordinates reply encoding).
+        w16(&mut b, 12, dst_x as i16 as u16);
+        w16(&mut b, 14, dst_y as i16 as u16);
         c.send(&b);
     });
 }


### PR DESCRIPTION
## Summary

The Xastryx X11 server defined `OP_TRANSLATE_COORDINATES` (=40) in `proto.rs` but never wired it into the request dispatch — the request fell through to the unknown-opcode arm and the server replied `BadRequest`. Clients issue `TranslateCoordinates` during window realization and pointer handling (libX11 `XTranslateCoordinates`, which GDK's `gdk_window_get_origin` / `gdk_x11_window_get_root_coords` call); a `BadRequest` there makes those return garbage coordinates.

This implements the request per the **X11 core protocol §TranslateCoordinates**: given a point in `src_window`'s coordinate space, return the equivalent point in `dst_window`'s space, the `child` of `dst_window` containing the point (None here), and `same_screen`. Each window's absolute (root-relative) origin is computed by walking its parent chain; the result is `(src_abs_origin + src_xy) - dst_abs_origin`. The parent walk is bounded by the resource-table size to defend against a malformed cycle. `BadWindow` is returned for an unknown src/dst per the protocol.

## How this was found

Surfaced while auditing the GUI-Firefox (`--ff-gui`) present path: live X11 traces showed FF/GDK sending opcode 40 (`len=16`, a well-formed `TranslateCoordinates`) right after the toplevel maps, met with repeated `[X11] unknown opcode=40` -> `BadRequest`. Wiring the op removes the spurious protocol error during normal window realization.

> Note: this is a correctness fix, **not** the cause of the GUI-FF zero-present (FF proceeds past the `BadRequest`; the present gate is a separate, parked event-loop plateau reported out-of-band).

## Verification

- Builds clean (`firefox-test-core,kdb` and `test-mode`) on the current `master`.
- New `test_runner` case `test_x11_translate_coordinates`: child window at origin (50,50); root-point (60,70) -> child-point (10,20); asserts a reply (byte 0 == 1), not a `BadRequest`. **Passes.** All other X11 tests pass; the 5 unrelated failures are missing test-binary / timer env issues on this image.
- Runtime on the GUI build: `unknown opcode=40` events 6 -> 0 after the change (TranslateCoordinates now answered).

## Spec
X11 core protocol — TranslateCoordinates request/reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)