### PR TITLE
gui: default to a local file:// URL when non-local connections are disabled

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1347,10 +1347,29 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // compiled default.  Announce which source won so a forensic reader
             // of a render boot can tell at a glance whether the harness's
             // `--ff-url` actually took effect.
+            // GUI (windowed) mode pairs MOZ_DISABLE_NONLOCAL_CONNECTIONS=1 with
+            // the e10s-disable switch (mandatory for the in-process tab
+            // collapse — that switch is honoured only in automation/non-local
+            // mode).  The gate refuses every non-loopback connection in-process
+            // before any SYN, so a network URL (the https default) can never be
+            // fetched and the tab stays on an empty document — no reflow, no
+            // first paint requested.  A local file:// target needs no network
+            // and loads under the gate, so it is the correct compiled default
+            // for GUI mode.  An explicit astryx.ff_url= override still wins for
+            // callers that have arranged a reachable target.  RFC 8089 (the
+            // file URI scheme) covers the local-page form used here.
+            const GUI_DEFAULT_FF_URL: &str = "file:///tmp/hello.html";
             let ff_url: alloc::string::String = match boot_config::ff_url_override() {
                 Some(u) => {
                     serial_println!("[FFTEST] target URL (fw_cfg override): {}", u);
                     u
+                }
+                None if gui_mode => {
+                    serial_println!(
+                        "[FFTEST] target URL (GUI compiled default): {}",
+                        GUI_DEFAULT_FF_URL
+                    );
+                    alloc::string::String::from(GUI_DEFAULT_FF_URL)
                 }
                 None => {
                     serial_println!("[FFTEST] target URL (compiled default): {}", DEFAULT_FF_URL);


### PR DESCRIPTION
GUI-mode Firefox pairs `MOZ_DISABLE_NONLOCAL_CONNECTIONS=1` (required so the e10s-disable switch is honoured on the official ESR build) with `DEFAULT_FF_URL = https://1.1.1.1/` — mutually exclusive: necko rejects the non-local load before any SYN, so the demo page never loads. When GUI mode is active with no explicit `astryx.ff_url=`, default the target to `file:///tmp/hello.html` (the page the kernel already stages to the ramdisk at boot), which loads with no network. +19 lines, kernel/src/main.rs. Builds green; confirmed at runtime: `[FFTEST] target URL (GUI compiled default): file:///tmp/hello.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)