### PR TITLE
gui: land the windowed-Firefox (--ff-gui) substrate on master

### DIFF
--- a/kernel/src/boot_config.rs
+++ b/kernel/src/boot_config.rs
@@ -1,0 +1,298 @@
+//! Boot-time configuration read from the QEMU `fw_cfg` device.
+//!
+//! The firefox-test workload's target URL was historically a compile-time
+//! constant (`main.rs` `CMDLINE_MUSL_*`), so every site change forced a full
+//! kernel rebuild.  This module reads an optional `astryx.ff_url=<url>` token
+//! from the QEMU `opt/astryx/cmdline` `fw_cfg` blob so the harness can deliver
+//! a new URL at boot WITHOUT a rebuild (it passes
+//! `-fw_cfg name=opt/astryx/cmdline,string=astryx.ff_url=<url>`).
+//!
+//! When the token is absent — production boot, non-QEMU host, or the harness
+//! did not pass `--ff-url` — the firefox-test launch path falls back to the
+//! compiled default, so existing behaviour is byte-for-byte unchanged.
+//!
+//! ## Transport: QEMU fw_cfg
+//!
+//! We read the blob directly via the legacy `fw_cfg` I/O ports 0x510
+//! (selector) / 0x511 (data) — no bootloader changes required.  The well-known
+//! file-directory selector 0x0019 lists named blobs that QEMU was launched with
+//! via `-fw_cfg name=...`; we scan it for `opt/astryx/cmdline`, read its bytes,
+//! and extract the `astryx.ff_url=` value.  See QEMU
+//! `docs/specs/fw_cfg.txt` for the selector/data port protocol.
+//!
+//! This is the same transport `record_replay::init_early()` uses for
+//! `astryx.rng_seed=`, but that module is gated behind the `record-replay`
+//! feature (off for the firefox-test profile), so the small reader is
+//! duplicated here rather than cross-coupling the two feature gates.
+//!
+//! ## Validation
+//!
+//! The extracted URL is validated before use: the scheme must be one of
+//! `http://`, `https://`, or `file://` (per RFC 3986 §3.1, scheme is the
+//! leading component before `:`), the length is bounded, and only printable
+//! ASCII (no whitespace/control bytes, which would break the single-string
+//! command line) is accepted.  A token that fails validation is ignored and
+//! the compiled default is used.
+//!
+//! ## References
+//! - QEMU `docs/specs/fw_cfg.txt` — selector/data port protocol.
+//! - RFC 3986 §3.1 — URI scheme syntax.
+
+extern crate alloc;
+
+use alloc::string::String;
+
+// ───── QEMU fw_cfg legacy I/O port protocol ─────────────────────────────────
+//
+// Selector at 0x510 (16-bit write), data at 0x511 (8-bit read).  The
+// file-directory selector 0x0019 returns:
+//   u32 BE     count
+//   repeated (count times):
+//     u32 BE   size
+//     u16 BE   select
+//     u16      reserved
+//     char[56] name (NUL-padded)
+#[cfg(feature = "firefox-test-core")]
+const FW_CFG_PORT_SEL:  u16 = 0x510;
+#[cfg(feature = "firefox-test-core")]
+const FW_CFG_PORT_DATA: u16 = 0x511;
+#[cfg(feature = "firefox-test-core")]
+const FW_CFG_SIG_SEL:   u16 = 0x0000;
+#[cfg(feature = "firefox-test-core")]
+const FW_CFG_FILE_DIR:  u16 = 0x0019;
+#[cfg(feature = "firefox-test-core")]
+const FW_CFG_SIG_MAGIC: [u8; 4] = *b"QEMU";
+
+/// Maximum cmdline blob we accept from fw_cfg.  4 KiB is far more than enough
+/// for the handful of `astryx.foo=bar` tokens this mechanism carries.
+#[cfg(feature = "firefox-test-core")]
+const MAX_CMDLINE_LEN: usize = 4096;
+
+/// Maximum fw_cfg directory entries we scan (bounds a malformed device).
+#[cfg(feature = "firefox-test-core")]
+const MAX_FW_CFG_ENTRIES: u32 = 256;
+
+/// Upper bound on an accepted URL.  RFC 3986 sets no hard limit, but a real
+/// browser command-line URL is well under this; bounding it protects the
+/// fixed-size cmdline buffer in the launch path.
+const MAX_URL_LEN: usize = 2048;
+
+/// Key for the runtime target URL token.
+const FF_URL_KEY: &[u8] = b"astryx.ff_url=";
+
+/// Read the QEMU `opt/astryx/cmdline` fw_cfg blob and extract a validated
+/// `astryx.ff_url=<url>` value.  Returns `None` when the blob is missing,
+/// the token is absent, or the value fails validation — callers fall back to
+/// the compiled default in that case.
+///
+/// Stack-only fw_cfg read; the single returned `String` is the only heap
+/// allocation, so this is safe to call from the firefox-test launch path
+/// (heap is up long before then).
+///
+/// Only reachable from the FF launch path; under a pure `test-mode` build the
+/// parser self-tests still run, but the I/O entry point is unused.
+#[cfg(feature = "firefox-test-core")]
+pub fn ff_url_override() -> Option<String> {
+    // Confirm the fw_cfg device is present (selector 0x0000 returns "QEMU").
+    let mut sig = [0u8; 4];
+    unsafe {
+        fw_cfg_select(FW_CFG_SIG_SEL);
+        for b in sig.iter_mut() {
+            *b = crate::hal::inb(FW_CFG_PORT_DATA);
+        }
+    }
+    if sig != FW_CFG_SIG_MAGIC {
+        return None;
+    }
+
+    let mut buf = [0u8; MAX_CMDLINE_LEN];
+    let n = fw_cfg_read_file(b"opt/astryx/cmdline", &mut buf)?;
+    parse_ff_url(&buf[..n])
+}
+
+/// Extract and validate the `astryx.ff_url=` value from a cmdline blob.
+/// Exposed for unit tests; see [`self_tests`].
+fn parse_ff_url(buf: &[u8]) -> Option<String> {
+    let start = find_token(buf, FF_URL_KEY)?;
+    let val_start = start + FF_URL_KEY.len();
+    // The value runs to the first whitespace, control byte, or NUL — a URL
+    // never contains those, and they would also break the single-string
+    // command line the launch path builds.
+    let mut end = val_start;
+    while end < buf.len() {
+        let b = buf[end];
+        if b == 0 || b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+            break;
+        }
+        end += 1;
+    }
+    let val = &buf[val_start..end];
+    if !url_is_valid(val) {
+        return None;
+    }
+    // SAFETY: url_is_valid guarantees printable ASCII (each byte 0x21..=0x7e).
+    Some(String::from_utf8_lossy(val).into_owned())
+}
+
+/// Find the first occurrence of `key` in `buf`; returns the start index.
+fn find_token(buf: &[u8], key: &[u8]) -> Option<usize> {
+    if key.is_empty() || key.len() > buf.len() {
+        return None;
+    }
+    buf.windows(key.len()).position(|w| w == key)
+}
+
+/// Validate a candidate URL: non-empty, ≤ [`MAX_URL_LEN`], printable ASCII
+/// only (no whitespace/control bytes), and a scheme of `http`, `https`, or
+/// `file` (RFC 3986 §3.1).  Rejecting anything else keeps an untrusted blob
+/// from injecting an arbitrary argv token into the launch command line.
+fn url_is_valid(val: &[u8]) -> bool {
+    if val.is_empty() || val.len() > MAX_URL_LEN {
+        return false;
+    }
+    // Printable ASCII only — `url_is_valid` is the single gate, so be strict.
+    if !val.iter().all(|&b| (0x21..=0x7e).contains(&b)) {
+        return false;
+    }
+    val.starts_with(b"http://")
+        || val.starts_with(b"https://")
+        || val.starts_with(b"file://")
+}
+
+// ───── fw_cfg helpers (stack-only) ─────────────────────────────────────────
+//
+// Only reached via `ff_url_override` (FF launch path); the test-mode build
+// runs the pure parser self-tests and never touches the I/O ports.
+#[cfg(feature = "firefox-test-core")]
+#[inline]
+unsafe fn fw_cfg_select(selector: u16) {
+    crate::hal::outw(FW_CFG_PORT_SEL, selector);
+}
+
+#[cfg(feature = "firefox-test-core")]
+#[inline]
+unsafe fn fw_cfg_read_u32_be() -> u32 {
+    let mut buf = [0u8; 4];
+    for b in buf.iter_mut() {
+        *b = crate::hal::inb(FW_CFG_PORT_DATA);
+    }
+    u32::from_be_bytes(buf)
+}
+
+#[cfg(feature = "firefox-test-core")]
+#[inline]
+unsafe fn fw_cfg_read_u16_be() -> u16 {
+    let mut buf = [0u8; 2];
+    for b in buf.iter_mut() {
+        *b = crate::hal::inb(FW_CFG_PORT_DATA);
+    }
+    u16::from_be_bytes(buf)
+}
+
+/// Locate the named blob in the fw_cfg file directory and read it into `out`.
+/// Returns `Some(n)` (bytes written, clamped to `out.len()`), or `None` if the
+/// blob is not present.
+#[cfg(feature = "firefox-test-core")]
+fn fw_cfg_read_file(name: &[u8], out: &mut [u8]) -> Option<usize> {
+    unsafe {
+        fw_cfg_select(FW_CFG_FILE_DIR);
+        let count = fw_cfg_read_u32_be();
+        if count == 0 || count > MAX_FW_CFG_ENTRIES {
+            return None;
+        }
+        let mut found_sel:  Option<u16> = None;
+        let mut found_size: u32         = 0;
+        for _ in 0..count {
+            let size = fw_cfg_read_u32_be();
+            let sel  = fw_cfg_read_u16_be();
+            let _res = fw_cfg_read_u16_be(); // reserved
+            let mut nbuf = [0u8; 56];
+            for b in nbuf.iter_mut() {
+                *b = crate::hal::inb(FW_CFG_PORT_DATA);
+            }
+            if found_sel.is_some() {
+                continue; // drain the rest of the directory, ignore further hits
+            }
+            let name_len = nbuf.iter().position(|&b| b == 0).unwrap_or(nbuf.len());
+            if &nbuf[..name_len] == name {
+                found_sel  = Some(sel);
+                found_size = size;
+            }
+        }
+        let sel = found_sel?;
+        let want = (found_size as usize).min(out.len());
+        fw_cfg_select(sel);
+        for byte in out.iter_mut().take(want) {
+            *byte = crate::hal::inb(FW_CFG_PORT_DATA);
+        }
+        Some(want)
+    }
+}
+
+// ───── Self-tests ───────────────────────────────────────────────────────────
+
+/// In-kernel parser self-tests.  Returns the number of assertions made.
+/// Driven by the firefox-test runner; pure (no I/O), so safe in any context.
+pub fn self_tests() -> usize {
+    let mut n = 0usize;
+    macro_rules! check {
+        ($cond:expr, $name:expr) => {{
+            n += 1;
+            if !($cond) {
+                crate::serial_println!("[BOOTCFG/SELFTEST] FAIL: {}", $name);
+            }
+        }};
+    }
+
+    // Happy paths — all three accepted schemes.
+    check!(
+        parse_ff_url(b"astryx.ff_url=https://bbc.com/news").as_deref()
+            == Some("https://bbc.com/news"),
+        "https extracted"
+    );
+    check!(
+        parse_ff_url(b"astryx.ff_url=http://example.com/").as_deref()
+            == Some("http://example.com/"),
+        "http extracted"
+    );
+    check!(
+        parse_ff_url(b"astryx.ff_url=file:///tmp/hello.html").as_deref()
+            == Some("file:///tmp/hello.html"),
+        "file extracted"
+    );
+    // Value terminated by whitespace and by NUL.
+    check!(
+        parse_ff_url(b"astryx.rng_seed=42 astryx.ff_url=https://a.io/ quiet")
+            .as_deref()
+            == Some("https://a.io/"),
+        "space-terminated, token after another"
+    );
+    check!(
+        parse_ff_url(b"astryx.ff_url=https://b.io/\0junk").as_deref()
+            == Some("https://b.io/"),
+        "NUL-terminated"
+    );
+    // Rejections.
+    check!(parse_ff_url(b"foo=bar").is_none(), "absent token");
+    check!(
+        parse_ff_url(b"astryx.ff_url=ftp://x/").is_none(),
+        "disallowed scheme rejected"
+    );
+    check!(
+        parse_ff_url(b"astryx.ff_url=").is_none(),
+        "empty value rejected"
+    );
+    check!(
+        parse_ff_url(b"astryx.ff_url=javascript:alert(1)").is_none(),
+        "non-allowed scheme rejected"
+    );
+    // A value with an embedded space is truncated at the space, but the head
+    // ("https://a") still validates as a well-formed allowed-scheme URL.
+    check!(
+        parse_ff_url(b"astryx.ff_url=https://a b").as_deref() == Some("https://a"),
+        "space truncates value"
+    );
+
+    crate::serial_println!("[BOOTCFG/SELFTEST] PASS ({} asserts)", n);
+    n
+}

--- a/kernel/src/boot_config.rs
+++ b/kernel/src/boot_config.rs
@@ -80,6 +80,12 @@ const MAX_URL_LEN: usize = 2048;
 /// Key for the runtime target URL token.
 const FF_URL_KEY: &[u8] = b"astryx.ff_url=";
 
+/// Key for the runtime GUI-mode token.  When present as `astryx.ff_gui=1` in
+/// the `opt/astryx/cmdline` blob, the launch path runs Firefox in X11/GUI mode
+/// (no `--headless`, no `--screenshot`, `MOZ_HEADLESS` unset) so it connects to
+/// the in-kernel Xastryx server on `DISPLAY=:0` and paints into a real window.
+const FF_GUI_KEY: &[u8] = b"astryx.ff_gui=1";
+
 /// Read the QEMU `opt/astryx/cmdline` fw_cfg blob and extract a validated
 /// `astryx.ff_url=<url>` value.  Returns `None` when the blob is missing,
 /// the token is absent, or the value fails validation — callers fall back to
@@ -108,6 +114,41 @@ pub fn ff_url_override() -> Option<String> {
     let mut buf = [0u8; MAX_CMDLINE_LEN];
     let n = fw_cfg_read_file(b"opt/astryx/cmdline", &mut buf)?;
     parse_ff_url(&buf[..n])
+}
+
+/// Read the QEMU `opt/astryx/cmdline` fw_cfg blob and report whether the
+/// `astryx.ff_gui=1` token is present.  Returns `false` when the blob is
+/// missing or the token is absent (the default headless behaviour).
+///
+/// Like [`ff_url_override`] this is a stack-only fw_cfg read with no heap
+/// allocation, safe to call from the firefox-test launch path.  The token is
+/// carried in the SAME `opt/astryx/cmdline` blob as `astryx.ff_url=` (fw_cfg
+/// permits a single named entry), so the harness appends both into one string.
+#[cfg(feature = "firefox-test-core")]
+pub fn ff_gui_mode() -> bool {
+    // Confirm the fw_cfg device is present (selector 0x0000 returns "QEMU").
+    let mut sig = [0u8; 4];
+    unsafe {
+        fw_cfg_select(FW_CFG_SIG_SEL);
+        for b in sig.iter_mut() {
+            *b = crate::hal::inb(FW_CFG_PORT_DATA);
+        }
+    }
+    if sig != FW_CFG_SIG_MAGIC {
+        return false;
+    }
+
+    let mut buf = [0u8; MAX_CMDLINE_LEN];
+    match fw_cfg_read_file(b"opt/astryx/cmdline", &mut buf) {
+        Some(n) => parse_ff_gui(&buf[..n]),
+        None => false,
+    }
+}
+
+/// Return `true` iff the `astryx.ff_gui=1` token appears in the cmdline blob.
+/// Exposed for unit tests; see [`self_tests`].
+fn parse_ff_gui(buf: &[u8]) -> bool {
+    find_token(buf, FF_GUI_KEY).is_some()
 }
 
 /// Extract and validate the `astryx.ff_url=` value from a cmdline blob.
@@ -292,6 +333,15 @@ pub fn self_tests() -> usize {
         parse_ff_url(b"astryx.ff_url=https://a b").as_deref() == Some("https://a"),
         "space truncates value"
     );
+
+    // GUI-mode token detection (carried in the same cmdline blob).
+    check!(parse_ff_gui(b"astryx.ff_gui=1"), "gui token present");
+    check!(
+        parse_ff_gui(b"astryx.ff_url=https://lite.cnn.com astryx.ff_gui=1"),
+        "gui token alongside url"
+    );
+    check!(!parse_ff_gui(b"astryx.ff_url=https://lite.cnn.com"), "gui token absent");
+    check!(!parse_ff_gui(b"astryx.ff_gui=0"), "gui token explicitly off");
 
     crate::serial_println!("[BOOTCFG/SELFTEST] PASS ({} asserts)", n);
     n

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -925,6 +925,13 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // In GUI mode this is intentionally omitted so libxul opens the
         // display and renders into an X11 window on the Xastryx server.
         envp_vec.push("MOZ_HEADLESS=1");
+        // Headless software-render only: keep the GPU/compositor work in the
+        // parent process (no out-of-process GPU child).  This is the
+        // gfx-testing gate Mozilla uses to force in-process compositing; it is
+        // correct for the headless screenshot path but must NOT leak into the
+        // windowed path, where the GPU/compositor child participates in
+        // allocating and presenting the real toplevel surface.
+        envp_vec.push("MOZ_GFX_TESTING_NO_CHILD_PROCESS=1");
     } else {
         // GUI (windowed) mode: collapse the command-line tab to in-process.
         //
@@ -1002,8 +1009,13 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // channel, the content actor renders the fragment, and its reply
         // drives drawSnapshot to the PNG.
         // See: https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
-        // Skip GPU/glxtest process — software rendering only.
-        "MOZ_GFX_TESTING_NO_CHILD_PROCESS=1",
+        //
+        // NB: MOZ_GFX_TESTING_NO_CHILD_PROCESS is set ONLY in headless mode
+        // (pushed in the `if !gui_mode` block above).  It is a gfx-test gate
+        // that forces the GPU/compositor work in-process; in the windowed
+        // path the out-of-process GPU/compositor child is part of how the
+        // toplevel surface is allocated and presented, so we must not suppress
+        // it here.
         "MOZ_X11_EGL=0",
         "MOZ_ACCELERATED=0",
         "LIBGL_ALWAYS_SOFTWARE=1",

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -18,6 +18,14 @@ use spin::Mutex;
 /// mutex acquisition in the common idle case.
 static EXEC_RUNNING: AtomicBool = AtomicBool::new(false);
 
+/// When `true`, Firefox (and any subsequently launched GUI client) runs in
+/// X11/GUI mode: `spawn_async` omits `MOZ_HEADLESS=1` from the child envp so
+/// libxul takes the `gdk_display_open()` / `XOpenDisplay()` branch and paints
+/// into a real window on the in-kernel Xastryx server (`DISPLAY=:0`) instead of
+/// the headless screenshot path.  Set once at FF launch from the boot-config
+/// `astryx.ff_gui=1` fw_cfg token; default `false` (headless).
+pub static FF_GUI_MODE: AtomicBool = AtomicBool::new(false);
+
 /// PID of the most recently launched async child process.  0 = none.
 /// Stored so that `is_firefox_running()` can consult the thread table
 /// directly and detect exit even before `poll_output()` has reaped the
@@ -888,13 +896,22 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         _ => LD_PATH_GLIBC,
     };
 
-    let envp: &[&str] = &[
+    // GUI mode (astryx.ff_gui=1): run Firefox connected to the in-kernel
+    // Xastryx X11 server and paint into a real window, instead of the headless
+    // screenshot path.  The only env-var difference is MOZ_HEADLESS, which is
+    // omitted in GUI mode (see the conditional push below); everything else is
+    // identical.  Built as a Vec so the single variable can be included or
+    // skipped without duplicating the whole block.
+    let gui_mode = FF_GUI_MODE.load(Ordering::Acquire);
+    let mut envp_vec: alloc::vec::Vec<&str> = alloc::vec![
         "HOME=/home/user",
         "PATH=/bin:/disk/bin",
         "TCCDIR=/disk/lib/tcc",
         "TMPDIR=/tmp",
         "DISPLAY=:0",
         "GDK_BACKEND=x11",
+    ];
+    if !gui_mode {
         // Tell Firefox to run headless even when DISPLAY is set.  libxul
         // checks gfxPlatform::IsHeadless() / nsAppRunner XRE_main and skips
         // gdk_display_open() / XOpenDisplay() entirely on this branch.  Our
@@ -904,7 +921,12 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // (and the equivalent `--headless` argv flag) as the canonical
         // headless-mode trigger.
         // See: https://firefox-source-docs.mozilla.org/widget/headless.html
-        "MOZ_HEADLESS=1",
+        //
+        // In GUI mode this is intentionally omitted so libxul opens the
+        // display and renders into an X11 window on the Xastryx server.
+        envp_vec.push("MOZ_HEADLESS=1");
+    }
+    envp_vec.extend_from_slice(&[
         "MOZ_DISABLE_CONTENT_SANDBOX=1",
         "MOZ_DISABLE_NONLOCAL_CONNECTIONS=1",
         "MOZ_DISABLE_AUTO_SAFE_MODE=1",
@@ -989,7 +1011,8 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // Defined by glibc's dynamic linker; see ld.so(8) §LD_DEBUG.
         "LD_DEBUG=files",
         "LD_DEBUG_OUTPUT=/tmp/lddbg",
-    ];
+    ]);
+    let envp: &[&str] = &envp_vec;
 
     // Spawn blocked so we can attach the pipe before the child can run.
     // linux_abi / subsystem are set inside create_user_process_with_args_blocked.

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -950,6 +950,31 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // switch cleanly selects the in-process tab.
         // See: https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
         envp_vec.push("MOZ_FORCE_DISABLE_E10S=1");
+        // GUI-mode (windowed) runtime data that headless mode never needs.
+        // When libxul opens the display it brings up GTK/GDK, which loads
+        // image data through GdkPixbuf and resolves fonts through fontconfig.
+        // Both libraries read a generated index/config file at init time; if
+        // the file is absent they degrade to an EMPTY loader/config set and
+        // later return NULL where a non-NULL object is required — GTK then
+        // asserts `GDK_IS_PIXBUF (pixbuf)` / faults on the NULL deref before a
+        // toplevel is ever realized.  Naming the files explicitly via the
+        // documented environment variables is the robust, path-independent way
+        // to point each library at the data-disk copy.
+        //
+        //   GDK_PIXBUF_MODULE_FILE — absolute path to the loaders cache that
+        //     lists the available image-loader modules.  Documented by
+        //     GdkPixbuf (gdk_pixbuf_io_init / gdk-pixbuf-query-loaders(1)); it
+        //     overrides the compiled-in default cache location.
+        //   FONTCONFIG_FILE / FONTCONFIG_PATH — name the fontconfig
+        //     configuration file and directory.  Documented in
+        //     fonts-conf(5); without them real libfontconfig cannot resolve
+        //     its compiled sysconfdir default on this layout and reports
+        //     "Cannot load default config file".
+        envp_vec.push(
+            "GDK_PIXBUF_MODULE_FILE=/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+        );
+        envp_vec.push("FONTCONFIG_FILE=/etc/fonts/fonts.conf");
+        envp_vec.push("FONTCONFIG_PATH=/etc/fonts");
     }
     envp_vec.extend_from_slice(&[
         "MOZ_DISABLE_CONTENT_SANDBOX=1",

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -925,6 +925,31 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // In GUI mode this is intentionally omitted so libxul opens the
         // display and renders into an X11 window on the Xastryx server.
         envp_vec.push("MOZ_HEADLESS=1");
+    } else {
+        // GUI (windowed) mode: collapse the command-line tab to in-process.
+        //
+        // The windowed path opens the command-line URL as an ordinary browser
+        // tab.  An ordinary tab's process model follows the window's
+        // multi-process state, which is seeded from the documented
+        // `MOZ_FORCE_DISABLE_E10S` switch: with the switch set, the chrome
+        // window is created without the remote flag, so the tab's <browser>
+        // is non-remote and its document is parsed, laid out, and rendered
+        // entirely in the parent process.  Because the X11/MOZ_X11 software
+        // compositor already runs in-process (the out-of-process GPU/compositor
+        // child is off by default on this widget backend), the whole pipeline
+        // — layer tree, compositing, and the X11 present — happens in one
+        // process with no cross-process content-init handshake to complete.
+        //
+        // This is the same single-process render path the headless
+        // screenshot path exercises, and it is deliberately NOT applied to
+        // that path: the headless `--screenshot` capture <browser> is created
+        // with an explicit remoteness that an environment default cannot
+        // override (see the note in the shared block below), so forcing the
+        // default off there would only desynchronise its actor routing.  In
+        // windowed mode there is no such explicit-remote browser, so the
+        // switch cleanly selects the in-process tab.
+        // See: https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
+        envp_vec.push("MOZ_FORCE_DISABLE_E10S=1");
     }
     envp_vec.extend_from_slice(&[
         "MOZ_DISABLE_CONTENT_SANDBOX=1",

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -955,8 +955,22 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         // default off there would only desynchronise its actor routing.  In
         // windowed mode there is no such explicit-remote browser, so the
         // switch cleanly selects the in-process tab.
+        //
+        // IMPORTANT: on an official release/ESR build the
+        // `MOZ_FORCE_DISABLE_E10S` switch is itself gated behind the
+        // automation-mode flag — it is honoured ONLY when non-local
+        // connections are also disabled (a build hardening: the switch must
+        // not be flippable on a network-facing browser).  So pairing it with
+        // `MOZ_DISABLE_NONLOCAL_CONNECTIONS` is mandatory for the in-process
+        // collapse to take effect; with the latter unset the e10s-disable is
+        // silently ignored and the tab stays remote.  That pairing is only
+        // sound for a local (`file://`) target, which needs no network; the
+        // GUI demo loads exactly such a page, so the restriction is harmless
+        // here.  For a network URL the two are mutually exclusive and the
+        // windowed path necessarily runs the normal multi-process tree.
         // See: https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html
         envp_vec.push("MOZ_FORCE_DISABLE_E10S=1");
+        envp_vec.push("MOZ_DISABLE_NONLOCAL_CONNECTIONS=1");
         // GUI-mode (windowed) runtime data that headless mode never needs.
         // When libxul opens the display it brings up GTK/GDK, which loads
         // image data through GdkPixbuf and resolves fonts through fontconfig.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1342,10 +1342,29 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // compiled default.  Announce which source won so a forensic reader
             // of a render boot can tell at a glance whether the harness's
             // `--ff-url` actually took effect.
+            // GUI (windowed) mode pairs MOZ_DISABLE_NONLOCAL_CONNECTIONS=1 with
+            // the e10s-disable switch (mandatory for the in-process tab
+            // collapse — that switch is honoured only in automation/non-local
+            // mode).  The gate refuses every non-loopback connection in-process
+            // before any SYN, so a network URL (the https default) can never be
+            // fetched and the tab stays on an empty document — no reflow, no
+            // first paint requested.  A local file:// target needs no network
+            // and loads under the gate, so it is the correct compiled default
+            // for GUI mode.  An explicit astryx.ff_url= override still wins for
+            // callers that have arranged a reachable target.  RFC 8089 (the
+            // file URI scheme) covers the local-page form used here.
+            const GUI_DEFAULT_FF_URL: &str = "file:///tmp/hello.html";
             let ff_url: alloc::string::String = match boot_config::ff_url_override() {
                 Some(u) => {
                     serial_println!("[FFTEST] target URL (fw_cfg override): {}", u);
                     u
+                }
+                None if gui_mode => {
+                    serial_println!(
+                        "[FFTEST] target URL (GUI compiled default): {}",
+                        GUI_DEFAULT_FF_URL
+                    );
+                    alloc::string::String::from(GUI_DEFAULT_FF_URL)
                 }
                 None => {
                     serial_println!("[FFTEST] target URL (compiled default): {}", DEFAULT_FF_URL);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -17,6 +17,10 @@
 #![feature(abi_x86_interrupt)]
 #![allow(dead_code, unused_imports)]
 
+// The crate root needs `alloc` in scope for the firefox-test launch path,
+// which builds an owned `String` command line (runtime `--ff-url` substitution).
+extern crate alloc;
+
 mod arch;
 mod config;
 mod drivers;
@@ -76,6 +80,11 @@ mod pivot_e_tui_demo;
 mod pivot_e_git_demo;
 #[cfg(feature = "firefox-test-core")]
 mod ff_out_png;
+// Boot-time fw_cfg config (firefox-test target URL).  Compiled under the FF
+// profile (where ff_url_override() is called from the launch path) AND under
+// test-mode (where the test runner exercises the pure parser self-tests).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+mod boot_config;
 
 use astryx_shared::{BootInfo, BOOT_INFO_MAGIC};
 
@@ -1261,9 +1270,28 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // addr2line / gdb resolve C++ names natively (no Mozilla tecken
             // dependency).  All three fall through to the same --headless
             // --screenshot pipeline.
-            const CMDLINE_MUSL_132: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
-            const CMDLINE_MUSL_ESR: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
-            const CMDLINE_GLIBC:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png file:///tmp/hello.html";
+            // The target URL is a runtime option: the harness can pass
+            // `astryx.ff_url=<url>` through the QEMU `opt/astryx/cmdline`
+            // `fw_cfg` blob (harness flag `--ff-url`), and `boot_config` reads it
+            // at launch.  When present (and validated as http/https/file per
+            // RFC 3986 §3.1) it REPLACES the trailing URL token below WITHOUT a
+            // rebuild; when absent, the compiled default stands.  The cmdline is
+            // therefore an owned `String` rather than a `&'static str`.
+            //
+            // Each base ends just before the URL; the chosen base + " " + URL
+            // forms the launched command line.  The `--screenshot` PATH token is
+            // fixed (`/tmp/out.png`) and is registered with the VFS so the
+            // close-after-write hook can emit the `[GATE] png-write` marker for
+            // exactly that file.
+            const CMDLINE_MUSL_132_BASE: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png";
+            const CMDLINE_MUSL_ESR_BASE: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png";
+            const CMDLINE_GLIBC_BASE:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png";
+            // Compiled default target URL (used when no `astryx.ff_url=` override
+            // is supplied via fw_cfg).  The local demo page keeps DNS/network
+            // out of the default path; pass `--ff-url` for a website render.
+            const DEFAULT_FF_URL: &str = "file:///tmp/hello.html";
+            // Fixed screenshot output path (the token after `--screenshot`).
+            const FF_SCREENSHOT_PATH: &str = "/tmp/out.png";
             // Use stat() (resolve_path + FileSystemOps::stat) for the existence
             // probe instead of read_file().  read_file() allocates a Vec sized
             // to the full file (~795 KB for firefox-bin), reads every byte, and
@@ -1282,13 +1310,35 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 musl_esr_stat.as_ref().map(|s| s.size).map_err(|e| *e),
                 glibc_stat.as_ref().map(|s| s.size).map_err(|e| *e),
             );
-            let cmdline = if musl_132_stat.is_ok() {
-                CMDLINE_MUSL_132
+            let cmdline_base = if musl_132_stat.is_ok() {
+                CMDLINE_MUSL_132_BASE
             } else if musl_esr_stat.is_ok() {
-                CMDLINE_MUSL_ESR
+                CMDLINE_MUSL_ESR_BASE
             } else {
-                CMDLINE_GLIBC
+                CMDLINE_GLIBC_BASE
             };
+            // Resolve the target URL: runtime fw_cfg override (validated) or the
+            // compiled default.  Announce which source won so a forensic reader
+            // of a render boot can tell at a glance whether the harness's
+            // `--ff-url` actually took effect.
+            let ff_url: alloc::string::String = match boot_config::ff_url_override() {
+                Some(u) => {
+                    serial_println!("[FFTEST] target URL (fw_cfg override): {}", u);
+                    u
+                }
+                None => {
+                    serial_println!("[FFTEST] target URL (compiled default): {}", DEFAULT_FF_URL);
+                    alloc::string::String::from(DEFAULT_FF_URL)
+                }
+            };
+            // The launched command line: <base> <space> <url>.  Owned String so
+            // the runtime URL substitution requires no rebuild.
+            let cmdline = alloc::format!("{} {}", cmdline_base, ff_url);
+            let cmdline: &str = &cmdline;
+            // Register the screenshot output path so the VFS close-after-write
+            // hook can emit `[GATE] png-write` for exactly this file (and only
+            // on a genuine written-and-closed event, not on opens/resolves).
+            crate::vfs::set_screenshot_gate_path(FF_SCREENSHOT_PATH);
             serial_println!("[FFTEST] Launching {} ...", cmdline.split(' ').next().unwrap_or(""));
             // Headless mode: pass `--headless` so libxul takes the IsHeadless()
             // path and does not call XOpenDisplay() / gdk_display_open().  With
@@ -1518,6 +1568,20 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                             "[FFTEST] Firefox exited after {} ticks (status={:?}, png={})",
                             elapsed, status, png_ok
                         );
+                        // Emit the clean-exit gate marker so the harness /
+                        // serial-web UI can classify a winning boot WITHOUT
+                        // grepping the [FFTEST] prose.  Fires once, on the pid-1
+                        // (Firefox-root) group exit in firefox-test mode.  The
+                        // code is the recorded exit status (0 for a clean
+                        // exit_group(0); the latched code when a screenshot was
+                        // produced before a late teardown fault).  Emitted only
+                        // on the non-crashed terminal branch — a relaunch-budget-
+                        // exhausted crash does NOT fire it.
+                        let exit_code = match status {
+                            crate::gui::terminal::ExecExit::Crashed(c) => c,
+                            _ => 0,
+                        };
+                        serial_println!("[GATE] ff-exit-clean code={}", exit_code);
                     }
                     firefox_exited = true;
                     break;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1283,9 +1283,21 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
             // fixed (`/tmp/out.png`) and is registered with the VFS so the
             // close-after-write hook can emit the `[GATE] png-write` marker for
             // exactly that file.
-            const CMDLINE_MUSL_132_BASE: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png";
-            const CMDLINE_MUSL_ESR_BASE: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png";
-            const CMDLINE_GLIBC_BASE:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --screenshot /tmp/out.png";
+            const CMDLINE_MUSL_132_BASE: &str = "/disk/usr/lib/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --window-size 1366,8000 --screenshot /tmp/out.png";
+            const CMDLINE_MUSL_ESR_BASE: &str = "/disk/usr/lib/firefox-esr/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --window-size 1366,8000 --screenshot /tmp/out.png";
+            const CMDLINE_GLIBC_BASE:    &str = "/disk/opt/firefox/firefox-bin --headless --no-remote --profile /tmp/ff-profile --new-instance --window-size 1366,8000 --screenshot /tmp/out.png";
+            // GUI/X11 variants: NO `--headless` (so libxul calls XOpenDisplay /
+            // gdk_display_open and connects to the in-kernel Xastryx server on
+            // DISPLAY=:0) and NO `--screenshot` (the headless-only output flag).
+            // A real top-level window is created, mapped, and painted via X11
+            // PutImage into the compositor framebuffer.  Selected at runtime by
+            // the `astryx.ff_gui=1` fw_cfg token (boot_config::ff_gui_mode), so
+            // the same build serves both headless and GUI demos with no rebuild.
+            // The --window-size is kept to a single-screen size (the SVGA
+            // framebuffer is 1366×768 by default) so the window fits the display.
+            const CMDLINE_MUSL_132_GUI: &str = "/disk/usr/lib/firefox/firefox-bin --no-remote --profile /tmp/ff-profile --new-instance --window-size 1280,720";
+            const CMDLINE_MUSL_ESR_GUI: &str = "/disk/usr/lib/firefox-esr/firefox-bin --no-remote --profile /tmp/ff-profile --new-instance --window-size 1280,720";
+            const CMDLINE_GLIBC_GUI:    &str = "/disk/opt/firefox/firefox-bin --no-remote --profile /tmp/ff-profile --new-instance --window-size 1280,720";
             // Compiled default target URL (used when no `astryx.ff_url=` override
             // is supplied via fw_cfg).  The local demo page keeps DNS/network
             // out of the default path; pass `--ff-url` for a website render.
@@ -1310,10 +1322,19 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 musl_esr_stat.as_ref().map(|s| s.size).map_err(|e| *e),
                 glibc_stat.as_ref().map(|s| s.size).map_err(|e| *e),
             );
+            // Runtime GUI-mode selection (astryx.ff_gui=1).  When set, run the
+            // X11/windowed variant of whichever binary is present and tell the
+            // spawn path to omit MOZ_HEADLESS so libxul opens the display.
+            let gui_mode = boot_config::ff_gui_mode();
+            crate::gui::terminal::FF_GUI_MODE
+                .store(gui_mode, core::sync::atomic::Ordering::Release);
+            serial_println!("[FFTEST] launch mode: {}", if gui_mode { "GUI/X11" } else { "headless" });
             let cmdline_base = if musl_132_stat.is_ok() {
-                CMDLINE_MUSL_132_BASE
+                if gui_mode { CMDLINE_MUSL_132_GUI } else { CMDLINE_MUSL_132_BASE }
             } else if musl_esr_stat.is_ok() {
-                CMDLINE_MUSL_ESR_BASE
+                if gui_mode { CMDLINE_MUSL_ESR_GUI } else { CMDLINE_MUSL_ESR_BASE }
+            } else if gui_mode {
+                CMDLINE_GLIBC_GUI
             } else {
                 CMDLINE_GLIBC_BASE
             };

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -187,6 +187,23 @@ pub fn run() -> ! {
         }
     }
 
+    // ── Test R0b: boot-config fw_cfg URL-parser self-tests ───────────────
+    // Pure-Rust unit tests for the `astryx.ff_url=<url>` parser + the
+    // scheme/length/printable validation that gates an untrusted fw_cfg
+    // blob (boot_config.rs).  No serial I/O cost when the module is absent
+    // (the module compiles under firefox-test-core OR test-mode; this
+    // arm only fires under test-mode where the runner itself exists).
+    {
+        total += 1;
+        let n = crate::boot_config::self_tests();
+        if n >= 10 {
+            passed += 1;
+            test_println!("  Test R0b: boot-config URL-parser self-tests passed ({} asserts)", n);
+        } else {
+            test_println!("  Test R0b: boot-config URL-parser self-tests FAILED ({} asserts ran)", n);
+        }
+    }
+
     // ── Test 0-heap: Heap free-list validation + canaries — healthy churn ─
     // Runs FIRST (before any test that could itself perturb the heap) so it
     // is a clean no-false-positive assertion for the hardened allocator: the

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -27126,14 +27126,20 @@ fn test_x11_xkb_use_extension() -> bool {
         crate::net::unix::close(fd);
         return false;
     }
-    // b[1] = supported flag
-    if krep[1] != 1 {
-        test_fail!("x11_xkb", "XkbUseExtension supported={} (expected 1)", krep[1]);
+    // b[1] = supported flag. The XKEYBOARD extension is advertised as present
+    // (QueryExtension above), but XkbUseExtension deliberately reports
+    // supported=0: per the X Keyboard Extension Protocol Specification
+    // §UseExtension, a client that sees supported=0 falls back to the *core*
+    // keyboard protocol (GetKeyboardMapping/GetModifierMapping). This is the
+    // intended contract — assert it so a future flip to a stubbed supported=1
+    // (which would hand clients empty XKB keymaps) is caught.
+    if krep[1] != 0 {
+        test_fail!("x11_xkb", "XkbUseExtension supported={} (expected 0: core-keyboard fallback)", krep[1]);
         crate::net::unix::close(fd);
         return false;
     }
     let server_major = u16::from_le_bytes([krep[8], krep[9]]);
-    test_println!("  XkbUseExtension: supported=1 serverMajor={} ✓", server_major);
+    test_println!("  XkbUseExtension: supported=0 (core-keyboard fallback) serverMajor={} ✓", server_major);
 
     crate::net::unix::close(fd);
     test_pass!("X11 XKB extension");

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -232,6 +232,60 @@ fn inode_is_pinned(mount_idx: usize, inode: u64) -> bool {
     PINNED_INODES.lock().iter().any(|(m, n, c)| *m == mount_idx && *n == inode && *c > 0)
 }
 
+// ───── firefox-test screenshot-write gate ───────────────────────────────────
+//
+// The firefox-test workload renders to a `--screenshot <PATH>` file.  There is
+// no genuine "PNG written" serial marker in the fast (core) build, so winning
+// boots are mis-classified as stalled at the screenshot-IPC stage.  The launch
+// path registers the screenshot PATH here; [`close`] then emits exactly one
+// `[GATE] png-write path=<p> bytes=<n>` line the first time that file is closed
+// after a write (the file is complete the moment the renderer closes it).  The
+// marker is keyed on a write-mode close of a non-empty file, NOT on opens or
+// path resolves, so a probe/stat of the path never false-fires.
+
+/// Registered screenshot output path (full open path, e.g. `/tmp/out.png`), or
+/// empty when unset.  Set once by the launch path via
+/// [`set_screenshot_gate_path`]; read on every regular-file close.
+static SCREENSHOT_GATE_PATH: Mutex<String> = Mutex::new(String::new());
+
+/// True once the `[GATE] png-write` line has been emitted this boot, so a later
+/// re-write/close of the same path (e.g. a relaunch overwriting the file) does
+/// not double-fire.  The first complete write is the demo-success signal.
+static SCREENSHOT_GATE_FIRED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Register the firefox-test `--screenshot` output path so [`close`] can emit
+/// the `[GATE] png-write` marker for exactly that file.  Idempotent; the last
+/// caller wins (the launch path calls it once before launching Firefox).
+pub fn set_screenshot_gate_path(path: &str) {
+    *SCREENSHOT_GATE_PATH.lock() = String::from(path);
+    SCREENSHOT_GATE_FIRED.store(false, Ordering::Relaxed);
+}
+
+/// On a write-mode close of the registered screenshot path with `bytes > 0`,
+/// emit one `[GATE] png-write path=<p> bytes=<n>` line (first arrival only).
+/// `bytes` is the file's write offset at close — a non-zero offset proves the
+/// renderer wrote content before closing.  Cheap: a single atomic load short-
+/// circuits once fired or when no path is registered.
+fn maybe_emit_png_write_gate(open_path: &str, writable: bool, bytes: u64) {
+    if !writable || bytes == 0 {
+        return;
+    }
+    if SCREENSHOT_GATE_FIRED.load(Ordering::Relaxed) {
+        return;
+    }
+    {
+        let p = SCREENSHOT_GATE_PATH.lock();
+        if p.is_empty() || p.as_str() != open_path {
+            return;
+        }
+    }
+    // First arrival claims the flag; only that caller emits the line.
+    if !SCREENSHOT_GATE_FIRED.swap(true, Ordering::Relaxed) {
+        crate::serial_println!("[GATE] png-write path={} bytes={}", open_path, bytes);
+    }
+}
+
 /// A held POSIX byte-range lock.
 #[derive(Clone)]
 pub struct FileLockEntry {
@@ -2091,11 +2145,11 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
         let fd_opt = &mut proc.file_descriptors[fd_num];
         if fd_opt.is_none() { return Err(VfsError::BadFd); }
         fd_opt.take().map(|fd| {
-            (fd.mount_idx, fd.inode, fd.is_console, fd.file_type, fd.flags, fd.open_path.clone())
+            (fd.mount_idx, fd.inode, fd.is_console, fd.file_type, fd.flags, fd.open_path.clone(), fd.offset)
         })
     };
 
-    if let Some((mount_idx, inode, is_console, file_type, open_flags, open_path)) = closed {
+    if let Some((mount_idx, inode, is_console, file_type, open_flags, open_path, write_off)) = closed {
         // Release POSIX locks held by this pid on the closed inode (C1).
         if !is_console && mount_idx != usize::MAX {
             FILE_LOCKS.lock().retain(|l| !(l.mount_idx == mount_idx && l.inode == inode && l.pid == pid));
@@ -2162,6 +2216,14 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
             };
             let (parent_dir, filename) = split_parent_name(&open_path);
             crate::ipc::inotify::notify_event(parent_dir, filename, close_mask, 0);
+
+            // firefox-test screenshot-write gate: the renderer just closed a
+            // file it wrote to.  If it is the registered `--screenshot` path
+            // and carries bytes, emit `[GATE] png-write` exactly once — the
+            // genuine "the PNG was written and closed" signal (vs the stat/
+            // resolve probes that previously stood in for it).  `write_off`
+            // is the fd's offset at close: non-zero ⇒ content was written.
+            maybe_emit_png_write_gate(&open_path, writable, write_off);
         }
     }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -582,6 +582,18 @@ pub fn init() {
     let _ = symlink("/etc/ssl",            "/disk/etc/ssl");
     let _ = symlink("/etc/pki/tls/certs",  "/disk/etc/pki/tls/certs");
 
+    // fontconfig reads its configuration from /etc/fonts/fonts.conf at FcInit
+    // time (the library's compiled-in sysconfdir default; see fonts-conf(5)).
+    // The real config tree is staged on the data disk at /disk/etc/fonts/, so
+    // point /etc/fonts at it the same way /etc/ssl is handled above.  Without
+    // this every GTK/Firefox process — including the e10s content children,
+    // which do not reliably inherit FONTCONFIG_* — fails the default-config
+    // load ("Cannot load default config file: No such file") and degrades to
+    // fontconfig's minimal built-in fallback, breaking text/glyph rendering
+    // and the windowed (--ff-gui) paint path.  The longest-prefix symlink
+    // walker leaves the rest of the /etc tmpfs (hostname, hosts, ...) intact.
+    let _ = symlink("/etc/fonts",          "/disk/etc/fonts");
+
     // Create /dev/null and /dev/console.
     let _ = create_file("/dev/null");
     let _ = create_file("/dev/zero");

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -2786,12 +2786,30 @@ fn op_xkeyboard(fd: u64, data: &[u8], seq: u16) {
     let minor = data[1];
     #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
     crate::serial_println!("[X11XKB] minor={} seq={} len={}", minor, seq, data.len());
-    // XKB minor opcodes that need replies:
-    // 0=UseExtension, 4=GetState, 6=GetControls, 9=ListComponents,
-    // 10=GetMap, 17=GetCompatMap, 21=GetNames, 24=GetDeviceInfo, 31=SetDebuggingFlags
-    // No-reply: 1=SelectEvents, 3=DeviceBell, 5=SetControls, 7=LockControls, 11=SetMap, etc.
+    // XKB request minor-opcodes per the X Keyboard Extension Protocol
+    // Specification §New Requests (X.Org kbproto; the canonical X_kb* numbering
+    // also published in X11/extensions/XKB.h):
+    //   0  UseExtension*        1  SelectEvents       3  Bell
+    //   4  GetState*            5  LatchLockState     6  GetControls*
+    //   7  SetControls          8  GetMap*            9  SetMap
+    //   10 GetCompatMap*        11 SetCompatMap       12 GetIndicatorState*
+    //   13 GetIndicatorMap*     14 SetIndicatorMap    15 GetNamedIndicator*
+    //   16 SetNamedIndicator    17 GetNames*          18 SetNames
+    //   19 GetGeometry*         20 SetGeometry        21 PerClientFlags*
+    //   22 ListComponents*      23 GetKbdByName*      24 GetDeviceInfo*
+    //   25 SetDeviceInfo        101 SetDebuggingFlags*
+    // Starred (*) opcodes generate a 32-byte reply the client BLOCKS on; the
+    // others are request-only (no reply).  Sending a reply for a no-reply
+    // opcode — or, worse, withholding a reply for a reply opcode — desyncs the
+    // client's request/reply sequence accounting and wedges its event loop.
+    // GTK/GDK issues GetMap(8), GetNames(17) and PerClientFlags(21) during
+    // keymap initialization inside gdk_display_open(), so each MUST be
+    // answered or the toplevel is never realized.  We return well-formed but
+    // empty (no-components) replies — sufficient for a software-rendered,
+    // no-physical-keyboard display.
     match minor {
         0 => {
+            // GetMap is a no-op for us, but UseExtension must report support.
             // XkbUseExtension: supported=1, serverMajor=1, serverMinor=0
             let mut b = [0u8; 32];
             b[0] = 1; b[1] = 1; w16(&mut b, 2, seq);
@@ -2807,43 +2825,58 @@ fn op_xkeyboard(fd: u64, data: &[u8], seq: u16) {
             // ptr_btn_state=0, compat_state=0, etc.
             with_client(fd, |c| c.send(&b));
         }
-        6 | 31 => {
-            // XkbGetControls / SetDebuggingFlags: send empty 32-byte reply
-            let mut b = [0u8; 32]; b[0] = 1; w16(&mut b, 2, seq);
-            with_client(fd, |c| c.send(&b));
-        }
-        10 => {
-            // XkbGetMap: send empty map reply.
-            // Reply header: type=1, deviceID=0, seq, length=0
-            // minKeyCode at b[8], maxKeyCode at b[9] (8..255 typical)
-            // present=0 (no components), firstType=0, nTypes=0, ...
-            let mut b = [0u8; 32]; b[0] = 1; w16(&mut b, 2, seq);
+        8 => {
+            // XkbGetMap (opcode 8): send an empty map reply.
+            // 32-byte reply header: type=1, deviceID, seq, length=0 (no
+            // trailing map components since present=0).  Per the XKB protocol
+            // the reply carries minKeyCode/maxKeyCode then a `present` bitmask
+            // selecting which map components follow; present=0 means the body
+            // is exactly the 32-byte header.
+            //   b[8]  minKeyCode   b[9]  maxKeyCode
+            //   b[10..12] present (CARD16) = 0 → no components → length=0
+            let mut b = [0u8; 32]; b[0] = 1; b[1] = 1; w16(&mut b, 2, seq);
             b[8] = 8; b[9] = 255; // min/max keycode
-            // present=0 → no map components → length stays 0
+            // present=0 (b[10..12]) → no map components → length stays 0
             with_client(fd, |c| c.send(&b));
         }
-        21 => {
-            // XkbGetNames: send reply with which=0 (no name components).
-            // The reply MUST have the correct format or Xlib reads beyond
-            // the 32-byte header, desynchronizing the XCB stream.
-            // Reply: type=1, deviceID=0, seq, length=0
-            //   b[8..12]  = which (CARD32) = 0 → no name components
-            //   b[12..16] = minKeyCode, maxKeyCode, nTypes, groupNames
-            //   b[16..20] = virtualMods, firstKey, nKeys, indicators
-            //   b[20..24] = nKTLevels, ...
-            let mut b = [0u8; 32]; b[0] = 1; w16(&mut b, 2, seq);
-            // which=0 at offset 8 (all zeros) → Xlib reads 0 extra bytes
+        17 => {
+            // XkbGetNames (opcode 17): reply with which=0 (no name components).
+            // The reply MUST have the correct format or the client reads beyond
+            // the 32-byte header, desynchronizing the request stream.
+            // Reply: type=1, deviceID, seq, length=0
+            //   b[8..12]  = which (CARD32) = 0 → no name components follow
+            //   b[12]=minKeyCode, b[13]=maxKeyCode, then nTypes/groupNames/...
+            let mut b = [0u8; 32]; b[0] = 1; b[1] = 1; w16(&mut b, 2, seq);
+            // which=0 at offset 8 (all zeros) → client reads 0 extra bytes
             b[12] = 8;  // minKeyCode
             b[13] = 255; // maxKeyCode
             with_client(fd, |c| c.send(&b));
         }
-        9 | 17 | 24 => {
-            // XkbListComponents / GetCompatMap / GetDeviceInfo:
-            // Send minimal reply with length=0 (no extra data).
-            let mut b = [0u8; 32]; b[0] = 1; w16(&mut b, 2, seq);
+        21 => {
+            // XkbPerClientFlags (opcode 21): reply echoing the (now-zero)
+            // supported/value flag set.  GDK uses this to enable
+            // detectable-autorepeat; an empty 32-byte reply (all flags 0) is a
+            // valid "nothing changed" response and unblocks the caller.
+            let mut b = [0u8; 32]; b[0] = 1; b[1] = 1; w16(&mut b, 2, seq);
             with_client(fd, |c| c.send(&b));
         }
-        // No-reply opcodes (1=SelectEvents, 3=DeviceBell, 5=SetControls, etc.): ignore
+        6 | 10 | 12 | 13 | 15 | 19 | 22 | 23 | 24 | 101 => {
+            // Remaining reply-generating opcodes:
+            //   6  GetControls     10 GetCompatMap     12 GetIndicatorState
+            //   13 GetIndicatorMap 15 GetNamedIndicator 19 GetGeometry
+            //   22 ListComponents  23 GetKbdByName     24 GetDeviceInfo
+            //   101 SetDebuggingFlags
+            // Each blocks the client on a 32-byte reply; for a stub keyboard a
+            // minimal header with no trailing data (length=0) is a well-formed
+            // "empty / not-found / defaults" reply.  GetGeometry's `found`
+            // (b[1]) is left 0 = no geometry, which clients tolerate.
+            let mut b = [0u8; 32]; b[0] = 1; b[1] = 1; w16(&mut b, 2, seq);
+            with_client(fd, |c| c.send(&b));
+        }
+        // Request-only opcodes (1 SelectEvents, 3 Bell, 5 LatchLockState,
+        // 7 SetControls, 9 SetMap, 11 SetCompatMap, 14 SetIndicatorMap,
+        // 16 SetNamedIndicator, 18 SetNames, 20 SetGeometry, 25 SetDeviceInfo):
+        // no reply — sending one would desync the client.  Ignore.
         _ => {}
     }
 }

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -2809,10 +2809,34 @@ fn op_xkeyboard(fd: u64, data: &[u8], seq: u16) {
     // no-physical-keyboard display.
     match minor {
         0 => {
-            // GetMap is a no-op for us, but UseExtension must report support.
-            // XkbUseExtension: supported=1, serverMajor=1, serverMinor=0
+            // XkbUseExtension: report the extension as NOT supported for the
+            // client's requested version (the `supported` BOOL in byte 1 is 0).
+            //
+            // Per the X Keyboard Extension Protocol Specification §UseExtension,
+            // a client (libX11's XkbQueryExtension / XkbUseExtension) that sees
+            // supported=0 falls back to the *core* keyboard protocol — it stops
+            // issuing XkbGetMap and instead builds its keymap from
+            // GetKeyboardMapping(101) + GetModifierMapping(119), both of which
+            // this server answers with a complete, non-empty map (see
+            // op_get_keyboard_mapping / op_get_modifier_mapping).  GDK mirrors
+            // this: gdkkeys-x11 sets use_xkb=FALSE and uses the core path.
+            //
+            // We deliberately do NOT try to synthesize a full XkbGetMap reply.
+            // A *complete* XKB client map (key types, the per-keycode
+            // key_sym_map array, modifier maps) is required for correctness:
+            // libX11's XkbKeysymToModifiers walks
+            //   xkb->map->key_sym_map[kc] -> ->kt_index -> xkb->map->types[...]
+            // and dereferences those arrays unconditionally.  An "empty"
+            // (present=0) GetMap reply leaves them NULL, so the very next
+            // GTK keymap query faults on a NULL deref (NULL+4).  Reporting the
+            // extension unsupported routes the client onto the core protocol
+            // we already serve correctly, avoiding a large, fragile XKB map
+            // serializer for a display that has no physical keyboard.
+            //
+            // serverMajor/serverMinor still report a valid version (1.0) so
+            // the negotiation itself is well-formed.
             let mut b = [0u8; 32];
-            b[0] = 1; b[1] = 1; w16(&mut b, 2, seq);
+            b[0] = 1; b[1] = 0; w16(&mut b, 2, seq);
             w16(&mut b, 8, 1); w16(&mut b, 10, 0);
             with_client(fd, |c| c.send(&b));
         }

--- a/scripts/ff_gates.yaml
+++ b/scripts/ff_gates.yaml
@@ -64,6 +64,21 @@ gates:
     desc: "drawSnapshot invoked — paint of the target page begins"
 
   - id: png-write
-    marker_regex: 'Screenshot saved|out\.png|\[SCREENSHOT-B64:'
+    # Authoritative PNG-write signal: the kernel emits `[GATE] png-write
+    # path=<p> bytes=<n>` (vfs/mod.rs) on the close-after-write of the
+    # cmdline's --screenshot file — a genuine "the PNG was written and
+    # closed" event, NOT a stat/resolve probe.  The legacy substrings
+    # (`[FF-OUT-PNG:` host-extract header, the supervisor's `/tmp/out.png
+    # present` line) are kept as fallbacks for full-trace boots and the
+    # post-exit extract path.  `[SCREENSHOT-B64:` is intentionally DROPPED
+    # here — it is the QEMU VGA framebuffer stream (boot splash), not
+    # Firefox's render, and was a false positive that mis-flagged a stalled
+    # boot as a PNG win.
+    marker_regex: '\[GATE\]\s+png-write\b|\[FF-OUT-PNG:path=|/tmp/out\.png present|Screenshot saved'
     kind: line
-    desc: "PNG encoded / written — demo SUCCESS"
+    desc: "PNG written-and-closed ([GATE] png-write) — demo SUCCESS"
+
+  - id: ff-exit-clean
+    marker_regex: '\[GATE\]\s+ff-exit-clean\b'
+    kind: line
+    desc: "Firefox (pid 1) group-exited cleanly in firefox-test mode"

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -378,8 +378,69 @@ rm -rf "${DISK_USR_LIB}/apk" 2>/dev/null || true
 # gdk-pixbuf-query-loaders(1).  If qemu-user is unavailable the step is
 # skipped (non-fatal) and the GUI path falls back to whatever loaders are
 # statically built into libgdk_pixbuf.
+#
+# CRITICAL — built-in loaders are MISSING from the query-tool output.  This
+# build of libgdk_pixbuf links the PNG and JPEG decoders directly into the
+# main library (DT_NEEDED libpng16/libjpeg, no separate
+# libpixbufloader-png.so / -jpeg.so under loaders/).  Such loaders are
+# resolved at runtime by *module name*: a cache stanza named "png" or "jpeg"
+# makes gdk-pixbuf fill the loader vtable from the in-library symbol and never
+# dlopen()s the listed path.  But gdk-pixbuf-query-loaders only scans the
+# external loaders/ directory, so its output lists bmp/gif/ico/tiff/... and
+# omits png/jpeg entirely.  GdkPixbuf then has no "png" loader registered, the
+# very first image GTK decodes for the titlebar (a PNG symbolic icon out of
+# the in-memory GResource) returns NULL, and gdk_cairo_surface_create_from_*
+# faults on the NULL pixbuf before any toplevel is realized.  We therefore
+# append the canonical "png" and "jpeg" stanzas to the generated cache.  The
+# stanza format and the magic-signature escaping are per
+# gdk-pixbuf-query-loaders(1); the module-path line is a placeholder (it is
+# never opened for a name-matched built-in) but is kept non-empty so the
+# parser accepts the stanza.
 GDKP_DIR="${DISK_USR_LIB}/gdk-pixbuf-2.0/2.10.0"
 GDKP_QUERY="${ROOTFS}/usr/bin/gdk-pixbuf-query-loaders"
+GDKP_LIB="${DISK_USR_LIB}/libgdk_pixbuf-2.0.so.0"
+
+# Emit the loaders.cache stanzas for image formats whose decoder is linked
+# into libgdk_pixbuf itself (built-in / "included" loaders).  We only emit a
+# stanza when the corresponding decoder library is actually a DT_NEEDED of the
+# staged libgdk_pixbuf, so the cache never advertises a format the runtime
+# cannot decode.  Values (flags 5 = WRITABLE|THREADSAFE, mime/extension/magic)
+# match what an in-tree gdk-pixbuf-query-loaders emits for these formats.
+append_builtin_loader_stanzas() {
+    cache_file="$1"
+    added=0
+    # PNG — required for the GTK titlebar symbolic icons.  Magic per the PNG
+    # signature (ISO/IEC 15948): 89 50 4E 47 0D 0A 1A 0A.
+    if [ -f "${GDKP_LIB}" ] && \
+       readelf -dW "${GDKP_LIB}" 2>/dev/null | grep -q 'NEEDED.*libpng16'; then
+        if ! grep -q '^"png"' "${cache_file}" 2>/dev/null; then
+            printf '%s\n' \
+'"/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-png.so"' \
+'"png" 5 "gdk-pixbuf" "PNG" "LGPL"' \
+'"image/png" ""' \
+'"png" ""' \
+'"\211PNG\r\n\032\n" "" 100' \
+'' >> "${cache_file}"
+            added=$((added + 1))
+        fi
+    fi
+    # JPEG — magic FF D8 (JFIF/Exif SOI marker).
+    if [ -f "${GDKP_LIB}" ] && \
+       readelf -dW "${GDKP_LIB}" 2>/dev/null | grep -q 'NEEDED.*libjpeg'; then
+        if ! grep -q '^"jpeg"' "${cache_file}" 2>/dev/null; then
+            printf '%s\n' \
+'"/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-jpeg.so"' \
+'"jpeg" 5 "gdk-pixbuf" "JPEG" "LGPL"' \
+'"image/jpeg" ""' \
+'"jpeg" "jpe" "jpg" ""' \
+'"\377\330" "" 100' \
+'' >> "${cache_file}"
+            added=$((added + 1))
+        fi
+    fi
+    echo "${added}"
+}
+
 if [ -d "${GDKP_DIR}/loaders" ] && [ -x "${GDKP_QUERY}" ] && \
    command -v qemu-x86_64 >/dev/null 2>&1; then
     if qemu-x86_64 -L "${ROOTFS}" \
@@ -389,14 +450,33 @@ if [ -d "${GDKP_DIR}/loaders" ] && [ -x "${GDKP_QUERY}" ] && \
               s|^# LoaderDir = ${ROOTFS}|# LoaderDir = |" \
          > "${GDKP_DIR}/loaders.cache.tmp" 2>/dev/null \
        && grep -q '^"/usr/lib/gdk-pixbuf-2.0' "${GDKP_DIR}/loaders.cache.tmp"; then
+        builtin_added="$(append_builtin_loader_stanzas "${GDKP_DIR}/loaders.cache.tmp")"
         mv -f "${GDKP_DIR}/loaders.cache.tmp" "${GDKP_DIR}/loaders.cache"
-        echo "[install-firefox-musl] generated GdkPixbuf loaders.cache ($(grep -c '^"/usr/lib' "${GDKP_DIR}/loaders.cache") loaders)"
+        echo "[install-firefox-musl] generated GdkPixbuf loaders.cache ($(grep -c '^"/usr/lib' "${GDKP_DIR}/loaders.cache") loaders incl. ${builtin_added} built-in)"
     else
         rm -f "${GDKP_DIR}/loaders.cache.tmp" 2>/dev/null || true
         echo "[install-firefox-musl] WARNING: gdk-pixbuf-query-loaders produced no usable cache — GUI image loading may degrade"
     fi
 elif [ -d "${GDKP_DIR}/loaders" ]; then
-    echo "[install-firefox-musl] NOTE: qemu-x86_64 (qemu-user) not found; skipping GdkPixbuf loaders.cache generation (install with: apt-get install qemu-user)"
+    # qemu-user unavailable: we cannot enumerate the external loaders, but the
+    # built-in PNG/JPEG decoders are linked into libgdk_pixbuf and are all the
+    # windowed titlebar path needs.  Write a minimal cache with just those so
+    # GUI Firefox can still decode its PNG symbolic icons without crashing.
+    mkdir -p "${GDKP_DIR}"
+    {
+        echo '# GdkPixbuf Image Loader Modules file'
+        echo '# Automatically generated file, do not edit'
+        echo '# Created by install-firefox-musl.sh (built-in loaders only)'
+        echo '#'
+    } > "${GDKP_DIR}/loaders.cache.tmp"
+    builtin_added="$(append_builtin_loader_stanzas "${GDKP_DIR}/loaders.cache.tmp")"
+    if [ "${builtin_added}" -gt 0 ]; then
+        mv -f "${GDKP_DIR}/loaders.cache.tmp" "${GDKP_DIR}/loaders.cache"
+        echo "[install-firefox-musl] qemu-x86_64 absent; wrote built-in-only GdkPixbuf loaders.cache (${builtin_added} loaders)"
+    else
+        rm -f "${GDKP_DIR}/loaders.cache.tmp" 2>/dev/null || true
+        echo "[install-firefox-musl] NOTE: qemu-x86_64 absent and no built-in image loaders detected; skipping GdkPixbuf loaders.cache"
+    fi
 fi
 
 # (c2) Auxiliary data trees under /usr/share/.  Several Alpine packages
@@ -440,6 +520,67 @@ if [ -d "${ROOTFS}/usr/share" ]; then
                 "${DISK_USR_SHARE}/${share_subdir}/" 2>/dev/null || true
         fi
     done
+fi
+
+# (c3) Compile the GSettings schema cache and the shared-MIME database.
+#
+# Both of these are BINARY index files that Alpine's apk packages ship as a
+# post-install trigger output, not as a packaged file.  Because we extract
+# apks without firing their triggers (same reason loaders.cache is absent in
+# (c1)), only the human-readable sources land on the data disk:
+#
+#   /usr/share/glib-2.0/schemas/*.gschema.xml   but NOT gschemas.compiled
+#   /usr/share/mime/                            but NOT mime.cache
+#
+# Consequences on the windowed (--ff-gui) Firefox path:
+#
+#   * gschemas.compiled — GSettings (GIO) reads the compiled cache, never the
+#     XML.  With it absent, g_settings_new("org.gtk.Settings.*") finds no
+#     schema, GtkSettings cannot resolve its keys (gtk-theme-name,
+#     gtk-icon-theme-name, gtk-font-name, ...), and GTK emits the
+#     "Settings schema 'org.gtk.Settings.FileChooser' is not installed"-class
+#     warnings the GUI path was observed printing.  Theme/icon resolution then
+#     falls back to compiled-in defaults inconsistently.  The schema-compiler
+#     output format is defined by GSettings; see g_settings_schema_source.
+#
+#   * mime.cache — GIO/GTK content-type queries (g_content_type_guess and the
+#     GtkFileChooser/app-info machinery) read the compiled mime.cache.  Without
+#     it, GdkPixbuf/GTK log "Failed to load module"/MIME warnings at startup.
+#     The cache format is defined by the freedesktop.org Shared MIME-info
+#     Database specification.
+#
+# Run the staged musl tools under qemu-x86_64 user-mode emulation (with the
+# Alpine rootfs as sysroot), exactly as (c1) runs gdk-pixbuf-query-loaders.
+# Both steps are non-fatal: if qemu-user is unavailable the GUI path keeps
+# working with degraded settings/MIME behaviour, so a host without qemu-user
+# can still produce a bootable (headless) image.
+if command -v qemu-x86_64 >/dev/null 2>&1; then
+    # GSettings schema cache.
+    GSCHEMA_DIR="${DISK_USR_SHARE}/glib-2.0/schemas"
+    GSCHEMA_COMPILE="${ROOTFS}/usr/bin/glib-compile-schemas"
+    if [ -d "${GSCHEMA_DIR}" ] && [ -x "${GSCHEMA_COMPILE}" ] && \
+       ls "${GSCHEMA_DIR}"/*.gschema.xml >/dev/null 2>&1; then
+        if qemu-x86_64 -L "${ROOTFS}" "${GSCHEMA_COMPILE}" "${GSCHEMA_DIR}" \
+             >/dev/null 2>&1 && [ -f "${GSCHEMA_DIR}/gschemas.compiled" ]; then
+            echo "[install-firefox-musl] compiled GSettings schema cache ($(stat -c %s "${GSCHEMA_DIR}/gschemas.compiled") bytes)"
+        else
+            echo "[install-firefox-musl] WARNING: glib-compile-schemas failed — GtkSettings keys will be unresolved on the GUI path"
+        fi
+    fi
+
+    # Shared-MIME database cache.
+    MIME_DIR="${DISK_USR_SHARE}/mime"
+    MIME_UPDATE="${ROOTFS}/usr/bin/update-mime-database"
+    if [ -d "${MIME_DIR}" ] && [ -x "${MIME_UPDATE}" ]; then
+        if qemu-x86_64 -L "${ROOTFS}" "${MIME_UPDATE}" "${MIME_DIR}" \
+             >/dev/null 2>&1 && [ -f "${MIME_DIR}/mime.cache" ]; then
+            echo "[install-firefox-musl] compiled shared-MIME database ($(stat -c %s "${MIME_DIR}/mime.cache") bytes)"
+        else
+            echo "[install-firefox-musl] WARNING: update-mime-database failed — GIO MIME queries will warn on the GUI path"
+        fi
+    fi
+else
+    echo "[install-firefox-musl] NOTE: qemu-x86_64 absent; skipping gschemas.compiled / mime.cache generation (install with: apt-get install qemu-user)"
 fi
 
 # Within ${DISK_FF_TREE}: ensure both "firefox-bin" and "firefox" sentinel

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -361,6 +361,44 @@ cp -aL "${ROOTFS}/usr/lib/." "${DISK_USR_LIB}/" 2>/dev/null || true
 # Drop apk's bookkeeping; not useful at runtime.
 rm -rf "${DISK_USR_LIB}/apk" 2>/dev/null || true
 
+# (c1) Generate the GdkPixbuf loaders cache.  Alpine's apk post-install
+# trigger normally runs gdk-pixbuf-query-loaders to build
+# /usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache, which indexes the image
+# loader modules in loaders/.  Extracting apks (as we do) does not fire that
+# trigger, so the cache is absent and GdkPixbuf comes up with an EMPTY loader
+# set — gdk_pixbuf_new_from_* then returns NULL and GTK asserts
+# `GDK_IS_PIXBUF (pixbuf)` / faults on the NULL deref before any toplevel is
+# realized on the windowed (--ff-gui) Firefox path.
+#
+# The query tool dlopens each loader to read its format metadata, so it must
+# run against the musl modules.  We run the staged musl
+# gdk-pixbuf-query-loaders under qemu-x86_64 user-mode emulation (with the
+# Alpine rootfs as the sysroot) and rewrite the emitted module paths to the
+# on-target absolute path.  The cache format is documented by
+# gdk-pixbuf-query-loaders(1).  If qemu-user is unavailable the step is
+# skipped (non-fatal) and the GUI path falls back to whatever loaders are
+# statically built into libgdk_pixbuf.
+GDKP_DIR="${DISK_USR_LIB}/gdk-pixbuf-2.0/2.10.0"
+GDKP_QUERY="${ROOTFS}/usr/bin/gdk-pixbuf-query-loaders"
+if [ -d "${GDKP_DIR}/loaders" ] && [ -x "${GDKP_QUERY}" ] && \
+   command -v qemu-x86_64 >/dev/null 2>&1; then
+    if qemu-x86_64 -L "${ROOTFS}" \
+         -E GDK_PIXBUF_MODULEDIR="${ROOTFS}/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders" \
+         "${GDKP_QUERY}" 2>/dev/null \
+       | sed "s|${ROOTFS}/usr/lib/gdk-pixbuf-2.0|/usr/lib/gdk-pixbuf-2.0|g; \
+              s|^# LoaderDir = ${ROOTFS}|# LoaderDir = |" \
+         > "${GDKP_DIR}/loaders.cache.tmp" 2>/dev/null \
+       && grep -q '^"/usr/lib/gdk-pixbuf-2.0' "${GDKP_DIR}/loaders.cache.tmp"; then
+        mv -f "${GDKP_DIR}/loaders.cache.tmp" "${GDKP_DIR}/loaders.cache"
+        echo "[install-firefox-musl] generated GdkPixbuf loaders.cache ($(grep -c '^"/usr/lib' "${GDKP_DIR}/loaders.cache") loaders)"
+    else
+        rm -f "${GDKP_DIR}/loaders.cache.tmp" 2>/dev/null || true
+        echo "[install-firefox-musl] WARNING: gdk-pixbuf-query-loaders produced no usable cache — GUI image loading may degrade"
+    fi
+elif [ -d "${GDKP_DIR}/loaders" ]; then
+    echo "[install-firefox-musl] NOTE: qemu-x86_64 (qemu-user) not found; skipping GdkPixbuf loaders.cache generation (install with: apt-get install qemu-user)"
+fi
+
 # (c2) Auxiliary data trees under /usr/share/.  Several Alpine packages
 # split runtime data from the .so files: the dynamic loader resolves the
 # stub library by SONAME, but the library reads its real payload from a

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -3824,12 +3824,25 @@ def cmd_start(args):
     # kernel reads at boot (boot_config.rs reads `astryx.ff_url=<url>`), so a
     # site change needs no rebuild.  `ff_url` was already validated (scheme /
     # length / printable / no-comma) near the top of cmd_start.
+    # Both the URL override and the GUI-mode flag ride in the SAME
+    # opt/astryx/cmdline fw_cfg blob (fw_cfg permits one entry per name), so
+    # assemble a single space-separated token string and emit one -fw_cfg.
+    ff_gui = bool(getattr(args, "ff_gui", False))
+    cmdline_tokens = []
     if ff_url:
+        cmdline_tokens.append(f"astryx.ff_url={ff_url}")
+    if ff_gui:
+        cmdline_tokens.append("astryx.ff_gui=1")
+    if cmdline_tokens:
+        blob = " ".join(cmdline_tokens)
         extra_qemu_args += [
             "-fw_cfg",
-            f"name=opt/astryx/cmdline,string=astryx.ff_url={ff_url}",
+            f"name=opt/astryx/cmdline,string={blob}",
         ]
-        print(f"[HARNESS] ff-url override: {ff_url}", file=sys.stderr)
+        if ff_url:
+            print(f"[HARNESS] ff-url override: {ff_url}", file=sys.stderr)
+        if ff_gui:
+            print("[HARNESS] ff-gui mode: ON (Firefox X11/windowed)", file=sys.stderr)
 
     # When `xeyes-test` is in the feature set, the kernel boots an Alpine
     # X11 binary that needs a real framebuffer for any visible window to
@@ -3937,6 +3950,9 @@ def cmd_start(args):
         # Runtime firefox-test target URL (--ff-url), delivered via fw_cfg.
         # "" / absent when the compiled CMDLINE_* default is used.  Additive.
         "ff_url":       ff_url or "",
+        # Runtime firefox-test GUI/X11 windowed mode (--ff-gui), delivered via
+        # the same fw_cfg cmdline blob.  False = headless (compiled default).
+        "ff_gui":       bool(getattr(args, "ff_gui", False)),
         # PIVOT-I2 Phase D — host stub Conflux for oracle-daemon-test.
         # If oracle_stub_pid is 0 the stub wasn't launched (default).
         "oracle_stub_port": oracle_stub_port,
@@ -12416,6 +12432,20 @@ def main():
                                "fast local-render win, or --ff-url "
                                "https://bbc.com/news.  Additive: omit to keep "
                                "the compiled CMDLINE_* default.")
+    p_start.add_argument("--ff-gui", action="store_true", dest="ff_gui",
+                          help="Run Firefox in X11/GUI (windowed) mode instead "
+                               "of headless.  The harness appends "
+                               "`astryx.ff_gui=1` to the SAME opt/astryx/cmdline "
+                               "fw_cfg blob (combined with --ff-url), and the "
+                               "kernel (boot_config::ff_gui_mode) drops "
+                               "`--headless`/`--screenshot` from the Firefox "
+                               "command line and omits MOZ_HEADLESS so libxul "
+                               "calls XOpenDisplay() and paints into a real "
+                               "window on the in-kernel Xastryx server "
+                               "(DISPLAY=:0).  Capture the composited desktop "
+                               "with `screendump <sid> <out.png>`.  No rebuild "
+                               "needed (same firefox-test-core build serves "
+                               "both modes).")
     p_start.add_argument("--pcap", action="store_true", dest="pcap",
                           help="FORCE host-side packet capture ON for this "
                                "boot, even a non-FF one.  Captures ALL guest "

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -3852,7 +3852,14 @@ def cmd_start(args):
     # via astryx_qemu._display_args) so the kernel framebuffer compositor
     # has somewhere to write and QMP can pull the image.  Idempotent guard
     # so an explicit caller-supplied `-vga` is not duplicated.
-    if "xeyes-test" in feats and not any(a == "-vga" for a in extra_qemu_args):
+    if ("xeyes-test" in feats or ff_gui) and not any(a == "-vga" for a in extra_qemu_args):
+        # The windowed (--ff-gui) Firefox path drives the in-kernel Xastryx
+        # server, whose compositor blits into the VMware SVGA II framebuffer
+        # (kernel/src/gui/compositor.rs).  Without a VGA card QEMU comes up
+        # with `-display none` and no framebuffer, so the X11 present has
+        # nowhere to land and QMP `screendump` returns an empty frame.  Inject
+        # the same `-vga vmware` device the gui-test / firefox-test paths use
+        # so the chrome the browser paints is visible to a screendump.
         extra_qemu_args += ["-vga", "vmware"]
 
     # Host-side packet capture on the e1000/SLIRP netdev (net0).

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -3221,6 +3221,24 @@ def cmd_start(args):
     features_str = (args.features or "")
     feats = [f.strip() for f in features_str.split(",")]
 
+    # ── --ff-url: validate EARLY (before the expensive build) ────────────────
+    # A bad URL must fail fast, not after a multi-minute kernel rebuild.  The
+    # fw_cfg argv token is appended later (where extra_qemu_args is composed);
+    # here we only reject malformed input.  Validation mirrors the kernel-side
+    # boot_config::url_is_valid gate (defence in depth): scheme http/https/file
+    # (RFC 3986 §3.1), printable ASCII only, ≤2048 chars, and no comma (the
+    # `-fw_cfg ...,string=...` argument is comma-delimited).
+    ff_url = getattr(args, "ff_url", None)
+    if ff_url:
+        if not ff_url.startswith(("http://", "https://", "file://")):
+            _err(f"--ff-url: scheme must be http/https/file (got {ff_url!r})")
+        if not all(0x21 <= ord(c) <= 0x7e for c in ff_url) or len(ff_url) > 2048:
+            _err(f"--ff-url: must be printable ASCII, no whitespace, <=2048 "
+                 f"chars (got {ff_url!r})")
+        if "," in ff_url:
+            _err("--ff-url: a comma in the URL is not supported (it delimits "
+                 "the -fw_cfg argument); percent-encode it as %2C")
+
     # ── Firefox serial profile (perf vs trace) ───────────────────────────────
     # Two profiles share the same functional kernel:
     #
@@ -3800,6 +3818,19 @@ def cmd_start(args):
     )
 
     extra_qemu_args = list(getattr(args, "extra_qemu_args", None) or [])
+
+    # ── --ff-url: append the fw_cfg argv token (validated early above) ───────
+    # Delivers the URL through the QEMU `opt/astryx/cmdline` fw_cfg blob the
+    # kernel reads at boot (boot_config.rs reads `astryx.ff_url=<url>`), so a
+    # site change needs no rebuild.  `ff_url` was already validated (scheme /
+    # length / printable / no-comma) near the top of cmd_start.
+    if ff_url:
+        extra_qemu_args += [
+            "-fw_cfg",
+            f"name=opt/astryx/cmdline,string=astryx.ff_url={ff_url}",
+        ]
+        print(f"[HARNESS] ff-url override: {ff_url}", file=sys.stderr)
+
     # When `xeyes-test` is in the feature set, the kernel boots an Alpine
     # X11 binary that needs a real framebuffer for any visible window to
     # show up.  `_launch_qemu_harness` is hard-wired to mode="test", which
@@ -3903,6 +3934,9 @@ def cmd_start(args):
         "pcap_path":    pcap_path,
         "pcap_enabled": pcap_enabled,
         "pcap_reason":  pcap_reason,
+        # Runtime firefox-test target URL (--ff-url), delivered via fw_cfg.
+        # "" / absent when the compiled CMDLINE_* default is used.  Additive.
+        "ff_url":       ff_url or "",
         # PIVOT-I2 Phase D — host stub Conflux for oracle-daemon-test.
         # If oracle_stub_pid is 0 the stub wasn't launched (default).
         "oracle_stub_port": oracle_stub_port,
@@ -4415,10 +4449,14 @@ def _classify_exit_cause(serial_log: str, running: bool) -> str:
       1. `BUGCHECK 0xNNNN` → `bugcheck:0xNNNN`
       2. `SCHEDULER_DEADLOCK` → `scheduler_deadlock`
       3. `PANIC:` / `panicked at` → `panic`
-      4. `[FFTEST] DONE` → `firefox_exited_clean`
-      5. `[FFTEST] Firefox exited after N ticks` → `firefox_exited:ticks=N`
-      6. Still running (process alive) → `running`
-      7. Nothing of the above → `unknown_exit`
+      4. `[GATE] ff-exit-clean code=C` → `firefox_exited_clean:code=C`
+         (authoritative kernel marker on the pid-1 group exit; fires on the
+         fast `firefox-test-core` profile, where the prose lines below may be
+         compiled out)
+      5. `[FFTEST] DONE` → `firefox_exited_clean`
+      6. `[FFTEST] Firefox exited after N ticks` → `firefox_exited:ticks=N`
+      7. Still running (process alive) → `running`
+      8. Nothing of the above → `unknown_exit`
 
     We read only the last ~256 KiB of the log; the causal marker is always
     near the end. Reading from the tail keeps latency O(1) regardless of
@@ -4442,6 +4480,9 @@ def _classify_exit_cause(serial_log: str, running: bool) -> str:
         return "scheduler_deadlock"
     if re.search(r"PANIC:|panicked at", tail):
         return "panic"
+    m = re.search(r"\[GATE\]\s+ff-exit-clean\s+code=(-?\d+)", tail)
+    if m:
+        return f"firefox_exited_clean:code={m.group(1)}"
     if re.search(r"\[FFTEST\]\s+DONE", tail):
         return "firefox_exited_clean"
     m = re.search(r"\[FFTEST\]\s+Firefox exited after\s+(\d+)\s+ticks", tail)
@@ -4477,7 +4518,8 @@ def _load_ff_gates() -> list[dict]:
         {"id": "content-proc",      "marker_regex": rb"\[FF/write\]\s+pid=2\b", "kind": "line"},
         {"id": "screenshot-actors", "marker_regex": rb"ScreenshotParent|getDimensions|sendQuery", "kind": "ipc-body"},
         {"id": "draw-snapshot",     "marker_regex": rb"drawSnapshot", "kind": "ipc-body"},
-        {"id": "png-write",         "marker_regex": rb"Screenshot saved|out\.png|\[SCREENSHOT-B64:", "kind": "line"},
+        {"id": "png-write",         "marker_regex": rb"\[GATE\]\s+png-write\b|\[FF-OUT-PNG:path=|/tmp/out\.png present|Screenshot saved", "kind": "line"},
+        {"id": "ff-exit-clean",     "marker_regex": rb"\[GATE\]\s+ff-exit-clean\b", "kind": "line"},
     ]
     raw = None
     if _FF_GATES_PATH.exists():
@@ -4584,6 +4626,9 @@ def cmd_ff_progress(args):
     alive = _pid_alive(pid) if pid else False
     terminal_cause = _classify_exit_cause(serial_log, alive)
     reached_png = "png-write" in seen
+    # `[GATE] ff-exit-clean` — the kernel's authoritative clean-exit marker
+    # on the pid-1 group exit (fires on the fast firefox-test-core profile).
+    reached_exit_clean = "ff-exit-clean" in seen
 
     _out({
         "sid":            args.sid,
@@ -4592,6 +4637,7 @@ def cmd_ff_progress(args):
         "deepest_index":  deepest_index,
         "max_sc":         max_sc,
         "reached_png":    reached_png,
+        "reached_exit_clean": reached_exit_clean,
         "terminal_cause": terminal_cause,
         "total_lines":    line_no,
         "gates":          gate_rows,
@@ -5473,7 +5519,7 @@ def _ff_gate_label(sid: str) -> dict:
                 info["max_sc"] = max(scs)
             # Cheap gate hints (matches ff-progress vocabulary, additive).
             for label, pat in (
-                ("png-write",      r"Screenshot saved|out\.png"),
+                ("png-write",      r"\[GATE\]\s+png-write\b|\[FF-OUT-PNG:path=|/tmp/out\.png present|Screenshot saved"),
                 ("draw-snapshot",  r"drawSnapshot|DrawSnapshot"),
                 ("content-proc",   r"content process|contentproc|HeadlessShell"),
                 ("compositor",     r"Compositor"),
@@ -12355,6 +12401,21 @@ def main():
                           help="Disable the livelock auto-reap guard for this "
                                "session entirely. Use for a debugging/autopsy "
                                "hold you WANT to keep spinning for inspection.")
+    p_start.add_argument("--ff-url", dest="ff_url", default=None, metavar="URL",
+                          help="firefox-test target URL delivered to the kernel "
+                               "at boot WITHOUT a rebuild.  The harness appends "
+                               "`-fw_cfg name=opt/astryx/cmdline,"
+                               "string=astryx.ff_url=<URL>` so the kernel's "
+                               "firefox-test launch path (boot_config.rs) reads "
+                               "and substitutes it into the Firefox command "
+                               "line, falling back to the compiled default when "
+                               "absent.  The scheme must be http/https/file "
+                               "(RFC 3986 3.1) and the value is validated "
+                               "kernel-side; an invalid value is ignored.  "
+                               "Example: --ff-url file:///tmp/hello.html for a "
+                               "fast local-render win, or --ff-url "
+                               "https://bbc.com/news.  Additive: omit to keep "
+                               "the compiled CMDLINE_* default.")
     p_start.add_argument("--pcap", action="store_true", dest="pcap",
                           help="FORCE host-side packet capture ON for this "
                                "boot, even a non-FF one.  Captures ALL guest "


### PR DESCRIPTION
## Summary

Brings the GUI-Firefox (`--ff-gui`) windowed-launch substrate onto the shipping master lineage as a clean, self-contained graft of 10 commits. Previously this infrastructure lived only on a long-diverged integration branch (~130 commits behind master) that **predated the merged virtio-blk user-buffer DMA fix and the TranslateCoordinates fix**. On that stale branch, windowed Firefox died deterministically on page-cache corruption (the parent process executed corrupted code pages of libxul before any toplevel window could map).

**This graft proves that corruption was a stale-branch artifact:** rebuilt and booted on current master (which carries the VFS-layer DMA bounce + the spec-correct TranslateCoordinates reply offsets), the corruption is gone — **0 fault markers across 3 sequential `--ff-gui` boots**, where the stale branch reproduced it deterministically.

## What's included (10 commits, dependency-ordered)

- `--ff-url` runtime target via fw_cfg + PNG-write / clean-exit gate markers (predecessor needed by the GUI launch path)
- `--ff-gui` GUI/X11 windowed launch mode + snapshot dimension cap
- X11: stop advertising the MIT-SHM extension (forces the core `PutImage` path)
- GUI: collapse the windowed command-line tab to in-process (single-process e10s)
- X11: route XKB minor-opcodes per the **X Keyboard Extension Protocol**
- GUI: windowed toplevel-paint substrate — XKB core-keymap fallback, fontconfig + GdkPixbuf loader provisioning
- GUI: scope the gfx-testing env to the headless launch
- GUI: disable non-local connections for the windowed launch
- GUI: default the windowed target to a local `file://` page
- data-disk: stage `gschemas.compiled` + `mime.cache` + built-in GdkPixbuf loaders (per the freedesktop **GSettings** and **shared-mime-info** specs) so GTK initialises cleanly

Redundant branch-local copies of the virtio-blk DMA bounce and the TranslateCoordinates fix were **dropped** in favour of master's already-merged versions (verified intact).

## Verification

- `firefox-test-core,kdb` build: green. Default desktop build: green (non-FF path unaffected).
- `--ff-gui` boot: **3/3 byte-clean** — zero `[FAULT/PHYS]` / `[FAULT/CACHE-KEY]` / `[FAULT/MOZCRASH]`; parent never executes corrupt pages; content/helper processes exit cleanly.
- Clean descendant of `origin/master` (verified `merge-base --is-ancestor`).

## Known limitation (not a regression)

The windowed toplevel does **not yet paint** (`put_image=0`): after the corruption is gone, the parent thread parks at the pre-existing W101 userspace plateau. That is a **separate, downstream gate** from the corruption this PR resolves, and is unaffected either way by landing this substrate. This PR's claim is narrow and verified: the GUI substrate builds and boots cleanly on master, and the windowed-FF page-cache corruption does not reproduce on the shipping lineage.