### PR TITLE
x11: spec-correct window-map event sequence (MapNotify→ConfigureNotify→Expose)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -813,6 +813,11 @@ pub fn run() -> ! {
     total += 1;
     if test_x11_draw_cycle() { passed += 1; }
 
+    // ── X11 server — map event sequence (MapNotify→ConfigureNotify→Expose) ───
+
+    total += 1;
+    if test_x11_map_event_sequence() { passed += 1; }
+
     // ── X11 server — TranslateCoordinates (opcode 40) ────────────────────────
 
     total += 1;
@@ -18067,6 +18072,121 @@ fn test_x11_draw_cycle() -> bool {
 
     crate::net::unix::close(client);
     test_pass!("X11 CreateWindow + MapWindow + Draw cycle");
+    true
+}
+
+// ── X11 — map event sequence (MapNotify → ConfigureNotify → Expose) ──────────
+//
+// Per the X11 core protocol, mapping a window that selected StructureNotify +
+// Exposure must generate, in this order:
+//   1. MapNotify     (StructureNotify) — the window is now mapped
+//   2. ConfigureNotify(StructureNotify) — reports the window geometry
+//   3. Expose        (Exposure)        — the window became viewable
+// and the geometry carried by ConfigureNotify/Expose must match the window's
+// real size.  Toolkits (libXt's XtRealizeWidget) depend on this sequence to
+// learn the realized geometry of the shell and run their first layout/redisplay
+// pass.  This test maps a top-level window (parent = root, always mapped, so the
+// window is immediately viewable) and asserts the three events arrive in order
+// with the correct window id and 200×100 geometry.
+fn test_x11_map_event_sequence() -> bool {
+    test_header!("X11 map event sequence (MapNotify→ConfigureNotify→Expose)");
+
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream,
+        crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if client == u64::MAX { test_fail!("x11_mapseq", "unix::create() failed"); return false; }
+    if crate::net::unix::connect(client, b"/tmp/.X11-unix/X0\0",
+        crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 }) < 0 {
+        test_fail!("x11_mapseq", "connect failed");
+        crate::net::unix::close(client);
+        return false;
+    }
+    let hello: [u8; 12] = [0x6C, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    crate::net::unix::write(client, &hello);
+    crate::x11::poll();
+    let mut setup_buf = [0u8; 128];
+    let n = crate::net::unix::read(client, &mut setup_buf);
+    if n < 8 || setup_buf[0] != 1 {
+        test_fail!("x11_mapseq", "setup failed (n={} byte0={})", n, setup_buf[0]);
+        crate::net::unix::close(client);
+        return false;
+    }
+
+    // CreateWindow (40 bytes): wid=0x00610001, parent=root(1), 200x100 at (30,40),
+    // event_mask = STRUCTURE_NOTIFY(0x20000) | EXPOSURE(0x8000) = 0x28000.
+    let mut reqs = [0u8; 48];
+    reqs[0]  = 1; reqs[2] = 10;
+    reqs[4]  = 0x01; reqs[5] = 0x00; reqs[6] = 0x61; // wid = 0x00610001
+    reqs[8]  = 0x01;                                  // parent = ROOT
+    reqs[12] = 30; reqs[14] = 40;                     // x=30 y=40
+    reqs[16] = 200; reqs[18] = 100;                   // 200x100
+    reqs[22] = 1;                                     // class = InputOutput
+    reqs[24] = 32;                                    // visual = ROOT_VISUAL
+    reqs[28] = 0x00; reqs[29] = 0x08;                 // vmask = CW_EVENT_MASK(0x0800)
+    reqs[32] = 0x00; reqs[33] = 0x80; reqs[34] = 0x02; reqs[35] = 0x00; // event_mask=0x00028000
+    // MapWindow at offset 40
+    reqs[40] = 8; reqs[42] = 2;
+    reqs[44] = 0x01; reqs[45] = 0x00; reqs[46] = 0x61; // wid
+    crate::net::unix::write(client, &reqs);
+    crate::x11::poll();
+
+    // Read the three queued events back as a single contiguous stream.
+    let mut buf = [0u8; 96];
+    let n = crate::net::unix::read(client, &mut buf);
+    if n < 96 {
+        test_fail!("x11_mapseq", "read returned {} (expected 96 = 3 events)", n);
+        crate::net::unix::close(client);
+        return false;
+    }
+    let wid = |o: usize| u32::from_le_bytes([buf[o], buf[o+1], buf[o+2], buf[o+3]]);
+    let u16le = |o: usize| u16::from_le_bytes([buf[o], buf[o+1]]);
+
+    // Event 0: MapNotify (19), window = 0x610001.
+    if buf[0] != 19 {
+        test_fail!("x11_mapseq", "event0 type={} (expected 19=MapNotify)", buf[0]);
+        crate::net::unix::close(client); return false;
+    }
+    if wid(8) != 0x00610001 {
+        test_fail!("x11_mapseq", "MapNotify window={:#x} (expected 0x610001)", wid(8));
+        crate::net::unix::close(client); return false;
+    }
+    test_println!("  [0] MapNotify window={:#x} ✓", wid(8));
+
+    // Event 1: ConfigureNotify (22), window = 0x610001, width=200 height=100.
+    if buf[32] != 22 {
+        test_fail!("x11_mapseq", "event1 type={} (expected 22=ConfigureNotify)", buf[32]);
+        crate::net::unix::close(client); return false;
+    }
+    if wid(32 + 8) != 0x00610001 {
+        test_fail!("x11_mapseq", "ConfigureNotify window={:#x} (expected 0x610001)", wid(32 + 8));
+        crate::net::unix::close(client); return false;
+    }
+    let cw = u16le(32 + 20);
+    let ch = u16le(32 + 22);
+    if cw != 200 || ch != 100 {
+        test_fail!("x11_mapseq", "ConfigureNotify size={}x{} (expected 200x100)", cw, ch);
+        crate::net::unix::close(client); return false;
+    }
+    test_println!("  [1] ConfigureNotify window={:#x} {}x{} ✓", wid(32 + 8), cw, ch);
+
+    // Event 2: Expose (12), window = 0x610001, width=200 height=100, count=0.
+    if buf[64] != 12 {
+        test_fail!("x11_mapseq", "event2 type={} (expected 12=Expose)", buf[64]);
+        crate::net::unix::close(client); return false;
+    }
+    if wid(64 + 4) != 0x00610001 {
+        test_fail!("x11_mapseq", "Expose window={:#x} (expected 0x610001)", wid(64 + 4));
+        crate::net::unix::close(client); return false;
+    }
+    let ew = u16le(64 + 12);
+    let eh = u16le(64 + 14);
+    if ew != 200 || eh != 100 {
+        test_fail!("x11_mapseq", "Expose size={}x{} (expected 200x100)", ew, eh);
+        crate::net::unix::close(client); return false;
+    }
+    test_println!("  [2] Expose window={:#x} {}x{} ✓", wid(64 + 4), ew, eh);
+
+    crate::net::unix::close(client);
+    test_pass!("X11 map event sequence (MapNotify→ConfigureNotify→Expose)");
     true
 }
 

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -990,24 +990,135 @@ fn op_destroy_window(fd: u64, data: &[u8], seq: u16) {
     });
 }
 
+// ── Window viewability + exposure helpers ─────────────────────────────────────
+//
+// Per the X11 core protocol, a mapped window is "viewable" only if it AND all
+// of its ancestors are mapped.  Exposure (Expose) events are generated when a
+// window *becomes viewable*, not merely when its own MapWindow request is
+// processed — a window mapped while an ancestor is still unmapped is
+// "Unviewable" and gets no Expose until the ancestor maps.  These helpers let
+// the map handlers obey that rule: MapNotify fires on the window's own map
+// (StructureNotify), but Expose fires for the whole now-viewable subtree only
+// once the window is actually viewable.
+
+/// Snapshot of the fields needed for exposure processing, keyed by window id.
+#[derive(Clone, Copy)]
+struct WinInfo { id: u32, parent: u32, mapped: bool, evmask: u32,
+                 x: i16, y: i16, w: u16, h: u16, bw: u16 }
+
+/// Look up a window's exposure-relevant fields without holding a mutable borrow.
+fn win_info(c: &Client, wid: u32) -> Option<WinInfo> {
+    for r in c.resources.entries.iter().filter_map(|s| s.as_ref()) {
+        if r.id == wid {
+            if let ResourceBody::Window(ref w) = r.body {
+                return Some(WinInfo { id: wid, parent: w.parent, mapped: w.mapped,
+                    evmask: w.event_mask, x: w.x, y: w.y, w: w.width, h: w.height,
+                    bw: w.border_width });
+            }
+        }
+    }
+    None
+}
+
+/// True if `wid` is viewable: it is mapped and every ancestor up to (and
+/// including the implicit) root is mapped.  The root window has no per-client
+/// resource entry and is always mapped, so reaching it (or an unknown
+/// ancestor that is the root) terminates the walk successfully.  A depth cap
+/// guards against malformed parent cycles.
+fn is_viewable(c: &Client, wid: u32) -> bool {
+    let mut cur = wid;
+    for _ in 0..64 {
+        if cur == proto::ROOT_WINDOW_ID { return true; }
+        match win_info(c, cur) {
+            Some(wi) => {
+                if !wi.mapped { return false; }
+                cur = wi.parent;
+            }
+            // Parent not in our table (e.g. reparented under the root/WM frame)
+            // — treat as the always-mapped root boundary.
+            None => return true,
+        }
+    }
+    false
+}
+
+/// Run exposure processing for the subtree rooted at `root_wid`: send an Expose
+/// to `root_wid` and to every descendant that has just become viewable and has
+/// selected Exposure.  MapNotify is emitted separately by the caller before
+/// this runs (the protocol orders MapNotify before Expose).
+fn expose_viewable_subtree(c: &Client, root_wid: u32, seq: u16) {
+    // Collect the subtree (root + transitive descendants) from the flat table.
+    let mut subtree: alloc::vec::Vec<WinInfo> = alloc::vec::Vec::new();
+    if let Some(root) = win_info(c, root_wid) { subtree.push(root); }
+    let mut i = 0;
+    while i < subtree.len() {
+        let pid = subtree[i].id;
+        for r in c.resources.entries.iter().filter_map(|s| s.as_ref()) {
+            if let ResourceBody::Window(ref w) = r.body {
+                if w.parent == pid && !subtree.iter().any(|s| s.id == r.id) {
+                    subtree.push(WinInfo { id: r.id, parent: w.parent, mapped: w.mapped,
+                        evmask: w.event_mask, x: w.x, y: w.y, w: w.width, h: w.height,
+                        bw: w.border_width });
+                }
+            }
+        }
+        i += 1;
+    }
+    for wi in &subtree {
+        if wi.mapped
+            && wi.evmask & proto::EVENT_MASK_EXPOSURE != 0
+            && is_viewable(c, wi.id)
+        {
+            c.send(&event::encode_expose(seq, wi.id, wi.x, wi.y, wi.w, wi.h));
+        }
+    }
+}
+
+/// Send a ConfigureNotify to `wid` reporting its current geometry, if it
+/// selected StructureNotify.  Per the X11 core protocol map sequence, a window
+/// that selected StructureNotify receives MapNotify and then, before Expose, a
+/// ConfigureNotify describing its on-screen geometry.  Toolkits (libXt) use
+/// this to learn the realized size of the shell before running their first
+/// layout/redisplay pass; without it the widget tree can stay un-configured and
+/// never paint.
+fn configure_notify_if_selected(c: &Client, wid: u32, seq: u16) {
+    if let Some(wi) = win_info(c, wid) {
+        if wi.evmask & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
+            c.send(&event::encode_configure_notify(seq, wid, wi.x, wi.y, wi.w, wi.h, wi.bw));
+        }
+    }
+}
+
 // ── MapWindow (8) ─────────────────────────────────────────────────────────────
 
 fn op_map_window(fd: u64, data: &[u8], seq: u16) {
     if data.len() < 8 { return; }
     let wid = r32(data, 4);
     with_client(fd, |c| {
-        if let Some(w) = c.resources.get_window_mut(wid) {
-            let (x,y,width,height,evmask) = (w.x, w.y, w.width, w.height, w.event_mask);
-            w.mapped = true;
-            w.ensure_pixels(); // Allocate pixel buffer for compositor
-            if evmask & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
-                c.send(&event::encode_map_notify(seq, wid));
+        let (width, height, evmask) = match c.resources.get_window_mut(wid) {
+            Some(w) => {
+                let dims = (w.width, w.height, w.event_mask);
+                w.mapped = true;
+                w.ensure_pixels(); // Allocate pixel buffer for compositor
+                dims
             }
-            if evmask & proto::EVENT_MASK_EXPOSURE != 0 {
-                c.send(&event::encode_expose(seq, wid, x, y, width, height));
-            }
-            crate::serial_println!("[X11] MapWindow {:#x} {}x{}+{},{}", wid, width, height, x, y);
-        } else { c.send_error(proto::ERR_WINDOW, wid, proto::OP_MAP_WINDOW); }
+            None => { c.send_error(proto::ERR_WINDOW, wid, proto::OP_MAP_WINDOW); return; }
+        };
+        // StructureNotify: MapNotify always fires on the window's own map,
+        // followed by a ConfigureNotify reporting the window's geometry — the
+        // X11 core-protocol map sequence is MapNotify → ConfigureNotify →
+        // Expose for a window that selected StructureNotify.
+        if evmask & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
+            c.send(&event::encode_map_notify(seq, wid));
+        }
+        configure_notify_if_selected(c, wid, seq);
+        // Exposure: mapping this window may have made it AND a subtree of
+        // already-mapped descendants viewable for the first time.  Send Expose
+        // to every window in that subtree that is now viewable and selected
+        // Exposure — this is where a child mapped earlier (while this ancestor
+        // was unmapped) finally gets its Expose.
+        expose_viewable_subtree(c, wid, seq);
+        crate::serial_println!("[X11] MapWindow {:#x} {}x{}", wid, width, height);
     });
 }
 
@@ -1016,8 +1127,11 @@ fn op_map_window(fd: u64, data: &[u8], seq: u16) {
 // Map every unmapped child of `parent` in bottom-to-top order, as required by
 // the X11 core protocol: toolkits (libXt's XtRealizeWidget, GTK) map the
 // container then call MapSubwindows to map the leaf widget windows.  Each newly
-// mapped child gets its pixel buffer allocated and, per its event mask, a
-// MapNotify and an initial Expose so the client paints it.
+// mapped child gets its pixel buffer allocated and a MapNotify (per its event
+// mask).  Expose is generated only for children that have actually become
+// viewable — i.e. only when `parent` is itself viewable.  If `parent` is still
+// unmapped, the children are mapped-but-Unviewable and their Expose is deferred
+// until the parent maps (handled by MapWindow's subtree exposure pass).
 fn op_map_subwindows(fd: u64, data: &[u8], seq: u16) {
     if data.len() < 8 { return; }
     let parent = r32(data, 4);
@@ -1035,19 +1149,31 @@ fn op_map_subwindows(fd: u64, data: &[u8], seq: u16) {
             }
         }
         for &cid in &children {
-            if let Some(w) = c.resources.get_window_mut(cid) {
-                let (x, y, width, height, evmask) = (w.x, w.y, w.width, w.height, w.event_mask);
-                w.mapped = true;
-                w.ensure_pixels();
-                if evmask & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
-                    c.send(&event::encode_map_notify(seq, cid));
+            let (width, height, evmask) = match c.resources.get_window_mut(cid) {
+                Some(w) => {
+                    let dims = (w.width, w.height, w.event_mask);
+                    w.mapped = true;
+                    w.ensure_pixels();
+                    dims
                 }
-                if evmask & proto::EVENT_MASK_EXPOSURE != 0 {
-                    c.send(&event::encode_expose(seq, cid, x, y, width, height));
-                }
-                crate::serial_println!("[X11] MapSubwindow {:#x} (parent {:#x}) {}x{}+{},{}",
-                    cid, parent, width, height, x, y);
+                None => continue,
+            };
+            // StructureNotify: MapNotify (then ConfigureNotify) fires on the
+            // child's own map regardless of viewability (it is genuinely now
+            // mapped) — the X11 core-protocol map sequence.
+            if evmask & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
+                c.send(&event::encode_map_notify(seq, cid));
             }
+            configure_notify_if_selected(c, cid, seq);
+            crate::serial_println!("[X11] MapSubwindow {:#x} (parent {:#x}) {}x{}",
+                cid, parent, width, height);
+        }
+        // Exposure: only the children that became viewable get an Expose.  If
+        // the parent is unmapped they are Unviewable and Expose is deferred to
+        // the parent's MapWindow.  Run the subtree pass per mapped child so
+        // grandchildren are covered too.
+        for &cid in &children {
+            expose_viewable_subtree(c, cid, seq);
         }
     });
 }


### PR DESCRIPTION
## Summary

The in-kernel X server emitted `Expose` to a window the instant its own
`MapWindow` / `MapSubwindows` request was processed, ignoring **viewability**
and the **StructureNotify ordering** the X11 core protocol requires. This made
the server's window-map event stream diverge from every real X server in two
ways:

1. **Premature Expose to an Unviewable window.** libXt's `XtRealizeWidget` maps
   children first (`XMapSubwindows(parent)`) and the shell last
   (`XMapWindow(shell)`). The server sent the child its `Expose` during
   `MapSubwindows`, while the parent was still unmapped — i.e. while the child
   was *Unviewable* (a window is viewable only when it **and all ancestors** are
   mapped; X11 core protocol, `GetWindowAttributes` map-state). Per the
   protocol, an Unviewable window gets **no** Expose; the Expose must be
   generated when the ancestor maps and the descendant becomes viewable. The
   legitimate post-map Expose was never sent.

2. **Missing ConfigureNotify.** A window that selected StructureNotify got
   `MapNotify` but no `ConfigureNotify`. The canonical map sequence is
   **MapNotify → ConfigureNotify → Expose**; toolkits use the ConfigureNotify
   to learn the shell's realized geometry before their first layout pass.

## Fix

- **Viewability** is computed by walking the parent chain to the always-mapped
  root. `Expose` is sent only to windows that are now viewable **and** selected
  Exposure. `MapWindow` runs exposure processing over the entire subtree that
  just became viewable, so a child mapped earlier under an unmapped ancestor
  gets its `Expose` exactly when the ancestor maps.
- A window that selected StructureNotify now receives `MapNotify` then a
  `ConfigureNotify` reporting its real geometry, **before** any `Expose` — the
  spec-correct order.

## Verification

Live `xeyes-test` boot, server-side event trace (instrumentation removed before
this PR):

```
Before fix:  Expose(child, seq=72) [Unviewable!]  then  MapNotify(toplevel, seq=73)
After fix:   MapNotify(toplevel)  →  ConfigureNotify(toplevel)  →  Expose(child, now viewable)
```

The post-fix stream matches the X11 core-protocol map sequence; `xeyes` reads
all three events (confirmed via the AF_UNIX `recvmsg` path).

## Tests

- New headless regression test (`test_runner`): maps a window selecting
  StructureNotify+Exposure and asserts the server queues `MapNotify(19)` →
  `ConfigureNotify(22)` → `Expose(12)` in order, each for the correct window
  with the correct 200×100 geometry. **PASS.**
- Full X11 suite green (connection setup, InternAtom, **Draw cycle**,
  TranslateCoordinates, key events, **RENDER query + draw**, extensions,
  selection) — no regression. The unrelated failures in the run are pre-existing
  environmental issues (missing `/disk/bin/*` staging binaries + a timer-IRQ
  flake), not X11.

## Scope note

This is a necessary, spec-correctness fix to the map event sequence. It does
**not** by itself make `xeyes` paint its eyes: with the corrected sequence,
`xeyes` reads `MapNotify`+`ConfigureNotify`+`Expose` but its libXt redisplay
still produces zero draw requests and parks in `poll(-1)`. That residual gate is
downstream of (and not caused by) event delivery — the event stream is now
spec-faithful. See the PR discussion / handoff for the precise residual signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)