### PR TITLE
sched: gate dead-kstack recycle on per-CPU context-switch generation (SMP #DB fix)

### DIFF
--- a/kernel/src/proc/usermode.rs
+++ b/kernel/src/proc/usermode.rs
@@ -282,6 +282,16 @@ fn create_user_process_impl(
 /// 3. Configures TSS.rsp[0] and SYSCALL_KERNEL_RSP for Ring 3 → Ring 0 transitions.
 /// 4. Performs IRETQ to enter Ring 3.
 pub fn user_mode_bootstrap() {
+    // A first-run thread reaches here via `switch_context_asm`'s `ret`, so
+    // this CPU has just completed a context switch onto this (the new)
+    // thread's kernel stack.  Bump the per-CPU switch generation — the
+    // resumed-kernel path bumps at the post-`switch_context` resume point in
+    // `schedule()`, but first-run threads never return there, so without
+    // this a CPU that only ever launches first-run threads would never
+    // advance its generation and the dead-stack quiescence gate's gen
+    // condition could stall.  See `sched::CPU_SWITCH_GEN`.
+    crate::sched::note_switch_completed();
+
     crate::serial_println!("[BOOT] tid={} entering bootstrap", crate::proc::current_tid());
 
     // Clear first_run immediately so that if this thread is ever re-scheduled

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1075,6 +1075,32 @@ pub fn pop_dead_stack_force() -> Option<(u64, u64)> {
     Some((entry.base, entry.size))
 }
 
+/// Test-only: evaluate the `entry_is_quiesced` decision for a synthetic
+/// cache entry with the supplied `(push_tick, last_cpu, last_cpu_gen)`.
+///
+/// Lets the kernel test suite verify the per-CPU switch-generation gate
+/// (`CPU_SWITCH_GEN`) in isolation without spawning real threads:
+///   * gen not advanced + tick gate met            → withheld (false)
+///   * gen advanced     + tick gate met            → eligible (true)
+///   * `last_cpu_gen == u64::MAX` (unknown CPU)     → gen gate vacuous
+///   * tick margin ≥ escape valve                   → eligible regardless
+#[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
+pub fn test_entry_quiesced(push_tick: u64, last_cpu: usize, last_cpu_gen: u64) -> bool {
+    entry_is_quiesced(&CachedDeadStack {
+        base: 0,
+        size: 0,
+        push_tick,
+        last_cpu,
+        last_cpu_gen,
+    })
+}
+
+/// Test-only: read the live switch generation of `cpu`.
+#[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
+pub fn test_cpu_switch_gen(cpu: usize) -> u64 {
+    cpu_switch_gen(cpu)
+}
+
 /// Schedule the next thread to run.
 ///
 /// This is the core scheduling function. It:

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -25,6 +25,70 @@ static TICKS_REMAINING: [AtomicU64; MAX_CPUS] =
 static NEED_RESCHEDULE: [AtomicBool; MAX_CPUS] =
     [const { AtomicBool::new(false) }; MAX_CPUS];
 
+/// Per-CPU context-switch generation counter.
+///
+/// Incremented by `note_switch_completed()` every time a CPU finishes a
+/// `switch_context_asm` and is running on the *incoming* thread's kernel
+/// stack — i.e. once per completed context switch, for both resumed-kernel
+/// threads (post-`switch_context` resume point in `schedule()`) and
+/// first-run threads (top of `proc::usermode::user_mode_bootstrap`).
+///
+/// This is the SMP-correct quiescence signal for kernel-stack recycling.
+/// `ctx_rsp_valid` proves the *dying* thread's CPU executed `mov [rdi],rsp;
+/// mov byte[rdx],1` (it saved the dead frame), but at that instant the CPU
+/// is still at `mov rsp,rsi; popfq; pop …; ret` — the restore epilogue,
+/// physically *on the dead stack's VA* until `mov rsp,rsi` retires, and a
+/// device/timer interrupt can still push an interrupt frame onto that VA via
+/// `TSS.RSP[0]` during a ring transition (Intel SDM Vol. 3A §6.14 "Interrupt
+/// and Exception Handling": the stack switch on interrupt delivery uses the
+/// TSS RSP for the target privilege level).  Re-issuing the stack to a new
+/// thread in that window lets the old CPU's epilogue/interrupt-frame writes
+/// tear the new thread's freshly-initialised `switch_context_asm` frame —
+/// observed as a torn saved-RFLAGS slot (TF=1 garbage) that `popfq` loads,
+/// single-stepping the next instruction into a kernel-mode `#DB` →
+/// `UNEXPECTED_KERNEL_MODE_TRAP` (0x7f) bugcheck.
+///
+/// A dead stack records `CPU_SWITCH_GEN[last_cpu]` at reap time; the cache
+/// withholds the entry from re-issue until that CPU's generation has
+/// advanced (proving `last_cpu` completed at least one *further* switch and
+/// is therefore no longer executing on, nor delivering interrupts to, the
+/// recycled stack VA).  This is the kernel-side realisation of the
+/// POSIX clone(2) "no CPU references the thread" lifecycle contract — the
+/// same invariant a reference monolithic kernel enforces by deferring the
+/// dead task's stack release into the *successor* task's post-switch
+/// cleanup (which by construction runs on a different stack).
+static CPU_SWITCH_GEN: [AtomicU64; MAX_CPUS] =
+    [const { AtomicU64::new(0) }; MAX_CPUS];
+
+/// Record that the calling CPU has completed a context switch and is now
+/// executing on the incoming thread's kernel stack.  Called from the two
+/// post-`switch_context` resume points (resumed-kernel in `schedule()` and
+/// first-run in `user_mode_bootstrap`).  Lock-free; safe with interrupts
+/// disabled.  See `CPU_SWITCH_GEN` for the full rationale.
+#[inline]
+pub fn note_switch_completed() {
+    let cpu = cpu_index();
+    if cpu < MAX_CPUS {
+        // Release: pair with the Acquire load in `entry_is_quiesced` so a
+        // reaper on another CPU that observes the advanced generation also
+        // observes all of this CPU's prior stack writes as retired.
+        CPU_SWITCH_GEN[cpu].fetch_add(1, Ordering::Release);
+    }
+}
+
+/// Read the current switch generation for `cpu` (Acquire).  Used both to
+/// snapshot at reap time and to test eligibility at pop time.
+#[inline]
+fn cpu_switch_gen(cpu: usize) -> u64 {
+    if cpu < MAX_CPUS {
+        CPU_SWITCH_GEN[cpu].load(Ordering::Acquire)
+    } else {
+        // Unknown CPU: return a value that can never be "advanced past",
+        // forcing the conservative wall-clock-tick fallback to govern.
+        0
+    }
+}
+
 /// Global "a timer due-wake scan was deferred" flag.
 ///
 /// The 100 Hz timer ISR (`wake_sleeping_threads`) is the driver that re-Readies
@@ -516,9 +580,10 @@ fn reap_dead_threads_sched() {
     // schedule() and runs this function (with a different current_tid).
     let current_tid = crate::proc::current_tid();
 
-    // Collect (stack_base, stack_pages) for each reapable thread, removing
-    // them from THREAD_TABLE in the same pass.
-    let stacks: alloc::vec::Vec<(u64, usize)> = {
+    // Collect (stack_base, stack_pages, last_cpu) for each reapable thread,
+    // removing them from THREAD_TABLE in the same pass.  `last_cpu` feeds the
+    // per-CPU switch-generation quiescence gate (see `CPU_SWITCH_GEN`).
+    let stacks: alloc::vec::Vec<(u64, usize, usize)> = {
         let mut threads = THREAD_TABLE.lock();
         // A Dead thread is safe to reap only when ctx_rsp_valid == true, which
         // switch_context_asm sets AFTER saving the thread's RSP (meaning the CPU
@@ -543,9 +608,10 @@ fn reap_dead_threads_sched() {
             let pages = if t.kernel_stack_size > 0 {
                 (t.kernel_stack_size as usize + 4095) / 4096
             } else { 0 };
+            let last_cpu = t.last_cpu as usize;
             threads.swap_remove(idx);
             if base > 0 && pages > 0 {
-                out.push((base, pages));
+                out.push((base, pages, last_cpu));
             }
         }
         out
@@ -566,10 +632,10 @@ fn reap_dead_threads_sched() {
     // STACK_CANARY_CORRUPT closure rationale.  Overflow (cache full,
     // or push rejected by the defensive size check) falls through to
     // per-page PMM free as before.
-    for (stack_base, stack_pages) in stacks {
+    for (stack_base, stack_pages, last_cpu) in stacks {
         if stack_pages == crate::proc::KERNEL_STACK_PAGES_PUB {
             let stack_size_bytes = (stack_pages as u64) * 0x1000;
-            if push_dead_stack(stack_base, stack_size_bytes) {
+            if push_dead_stack(stack_base, stack_size_bytes, last_cpu) {
                 #[cfg(feature = "test-mode")]
                 {
                     let len = DEAD_STACK_CACHE.lock().len();
@@ -691,6 +757,19 @@ struct CachedDeadStack {
     /// `TIMER_ISR_PER_CPU` snapshot — see the struct-level doc comment
     /// for the rationale.
     push_tick: u64,
+
+    /// The CPU that last ran the dead thread (`Thread::last_cpu`) and the
+    /// value of `CPU_SWITCH_GEN[last_cpu]` at reap time.  The cache
+    /// withholds this entry until that CPU's switch generation has advanced
+    /// past `last_cpu_gen` — proving `last_cpu` completed at least one
+    /// further `switch_context_asm` since the thread died and is therefore
+    /// no longer executing on (or delivering interrupts to) this stack VA.
+    /// This closes the torn-`switch_context_asm`-frame `#DB` race that a
+    /// pure wall-clock-tick gate can miss when a context switch and a
+    /// recycle land inside the same tick under a clone-thread spawn burst.
+    /// See `CPU_SWITCH_GEN`.
+    last_cpu: usize,
+    last_cpu_gen: u64,
 }
 
 static DEAD_STACK_CACHE: spin::Mutex<alloc::vec::Vec<CachedDeadStack>> =
@@ -712,8 +791,40 @@ fn current_tick_for_quiesce() -> u64 {
 /// `CachedDeadStack` struct doc for the full rationale.
 #[inline]
 fn entry_is_quiesced(entry: &CachedDeadStack) -> bool {
+    // Gate 1 (per-CPU switch generation — the primary, race-tight signal):
+    // the CPU that last ran the dead thread must have completed at least one
+    // further context switch since the thread died, proving it is no longer
+    // executing `switch_context_asm`'s restore epilogue on this stack VA and
+    // can no longer land an interrupt frame on it via TSS.RSP[0].  See
+    // `CPU_SWITCH_GEN`.  A snapshot of `u64::MAX` (set when `last_cpu` was
+    // unknown at reap) makes this gate vacuously pass so the tick gate
+    // governs alone — never under-waits, only the tick fallback applies.
+    let gen_ok = entry.last_cpu_gen == u64::MAX
+        || cpu_switch_gen(entry.last_cpu) > entry.last_cpu_gen;
+
+    // Gate 2 (wall-clock tick — defence-in-depth): bounds the re-issue
+    // against any in-flight switch the generation counter cannot attribute
+    // to a specific CPU.  The minimum wait is `DEAD_STACK_QUIESCE_TICKS`.
     let now = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
-    now >= entry.push_tick.saturating_add(DEAD_STACK_QUIESCE_TICKS)
+    let tick_ok = now >= entry.push_tick.saturating_add(DEAD_STACK_QUIESCE_TICKS);
+
+    // Liveness escape valve: if `last_cpu` goes idle (parks in `sti;hlt;cli`
+    // with no Ready work) it stops bumping its switch generation, so a pure
+    // `gen_ok && tick_ok` rule would withhold the entry until that CPU next
+    // schedules — a *leak* (never a UAF) under a quiet system.  After a much
+    // larger margin (`DEAD_STACK_QUIESCE_TICKS * GEN_ESCAPE_MULT` ≈ 160 ms at
+    // TICK_HZ=100) the in-flight `switch_context_asm` epilogue (microseconds)
+    // has unquestionably retired on any non-wedged CPU, so the entry is safe
+    // to re-issue on the tick gate alone.  This bounds the cache occupancy
+    // without re-opening the race the gen gate closes for the common
+    // (busy-CPU) case.  Cite Intel SDM Vol. 3A §6.14: an interrupt's TSS-RSP
+    // stack switch and the switch epilogue both complete in bounded time.
+    const GEN_ESCAPE_MULT: u64 = 8;
+    let escape_ok = now
+        >= entry.push_tick
+            .saturating_add(DEAD_STACK_QUIESCE_TICKS.saturating_mul(GEN_ESCAPE_MULT));
+
+    (gen_ok && tick_ok) || escape_ok
 }
 
 /// Try to push a dead stack to the cache. Returns true if cached, false if full.
@@ -764,7 +875,11 @@ fn entry_is_quiesced(entry: &CachedDeadStack) -> bool {
 /// until `TICK_COUNT` has advanced by at least `DEAD_STACK_QUIESCE_TICKS`
 /// (wall-clock: 20 ms at TICK_HZ=100).  See `CachedDeadStack` for the
 /// rationale.
-fn push_dead_stack(stack_base_virt: u64, stack_size_bytes: u64) -> bool {
+fn push_dead_stack(
+    stack_base_virt: u64,
+    stack_size_bytes: u64,
+    last_cpu: usize,
+) -> bool {
     // Defensive: refuse zero-sized or absurdly-large entries.  Both shapes
     // are programmer errors at the call site — the cache must never
     // hand back a base whose true extent we cannot honour.  Treat as
@@ -809,6 +924,19 @@ fn push_dead_stack(stack_base_virt: u64, stack_size_bytes: u64) -> bool {
 
     let push_tick = current_tick_for_quiesce();
 
+    // Snapshot the switch generation of the CPU that last ran the dead
+    // thread.  Re-issue is withheld until that CPU's generation advances
+    // (it completes another switch onto a different stack).  A `last_cpu`
+    // outside the valid range (e.g. a never-scheduled thread) records a
+    // `u64::MAX` sentinel so `entry_is_quiesced`'s gen gate passes
+    // vacuously and the wall-clock-tick gate governs alone — conservative,
+    // never under-waits.  See `CPU_SWITCH_GEN`.
+    let (last_cpu_norm, last_cpu_gen) = if last_cpu < MAX_CPUS {
+        (last_cpu, cpu_switch_gen(last_cpu))
+    } else {
+        (0usize, u64::MAX)
+    };
+
     let mut cache = DEAD_STACK_CACHE.lock();
     if cache.len() >= MAX_DEAD_STACKS {
         return false;
@@ -817,6 +945,8 @@ fn push_dead_stack(stack_base_virt: u64, stack_size_bytes: u64) -> bool {
         base: stack_base_virt,
         size: stack_size_bytes,
         push_tick,
+        last_cpu: last_cpu_norm,
+        last_cpu_gen,
     });
     true
 }
@@ -862,10 +992,14 @@ pub fn pop_dead_stack() -> Option<(u64, u64)> {
     if idx_found.is_none() && !cache.is_empty() {
         let e = &cache[0];
         let now = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+        let cur_gen = cpu_switch_gen(e.last_cpu);
         crate::serial_println!(
-            "[KSTACK/QUIESCE] push_tick={} now={} need={} quiesced={}",
+            "[KSTACK/QUIESCE] push_tick={} now={} need={} tick_ok={} \
+             last_cpu={} snap_gen={} cur_gen={} gen_ok={}",
             e.push_tick, now, e.push_tick.saturating_add(DEAD_STACK_QUIESCE_TICKS),
-            now >= e.push_tick.saturating_add(DEAD_STACK_QUIESCE_TICKS));
+            now >= e.push_tick.saturating_add(DEAD_STACK_QUIESCE_TICKS),
+            e.last_cpu, e.last_cpu_gen, cur_gen,
+            e.last_cpu_gen == u64::MAX || cur_gen > e.last_cpu_gen);
     }
     let i = idx_found?;
     // `remove` is O(n) but n ≤ MAX_DEAD_STACKS = 64 and the call site
@@ -884,7 +1018,11 @@ pub fn pop_dead_stack() -> Option<(u64, u64)> {
 /// `push_dead_stack` with the honest `kernel_stack_size`.
 pub fn push_dead_stack_pub(stack_base_virt: u64) -> bool {
     let stack_size = (crate::proc::KERNEL_STACK_PAGES_PUB as u64) * 0x1000;
-    push_dead_stack(stack_base_virt, stack_size)
+    // Pre-allocated stacks never ran a thread, so there is no `last_cpu` that
+    // could still be switching off them.  Pass an out-of-range CPU index so
+    // `push_dead_stack` records the `u64::MAX` gen sentinel and only the
+    // wall-clock-tick gate governs eligibility.
+    push_dead_stack(stack_base_virt, stack_size, usize::MAX)
 }
 
 /// Test-only pop that bypasses the `DEAD_STACK_QUIESCE_TICKS` gate so a
@@ -1654,6 +1792,15 @@ was_emergency_4k={}",
 
     // ── Resumed after being rescheduled back onto this thread ───────
     // Interrupts are still disabled (CLI was set by whoever rescheduled us).
+
+    // This CPU has just completed a context switch and is now executing on
+    // the incoming thread's kernel stack.  Bump the per-CPU switch
+    // generation so any dead stack whose `last_cpu` is this CPU (and which
+    // was reaped before this switch) becomes eligible for recycle — it is
+    // now proven that this CPU is no longer on the recycled stack VA.  See
+    // `CPU_SWITCH_GEN` / `note_switch_completed`.  (First-run threads jump
+    // to `user_mode_bootstrap` and never reach this line; they bump there.)
+    note_switch_completed();
 
     // ── FPU/SSE state restore for incoming thread ───────────────────
     {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2229,6 +2229,19 @@ pub fn run() -> ! {
         if test_236_dead_stack_zeroing() { passed += 1; }
     }
 
+    // ── Test 294: dead-kstack per-CPU switch-generation quiescence gate ───
+    // Regression guard for the SMP clone-thread-spawn #DB race: a recycled
+    // kernel stack must be withheld until the CPU that last ran the dead
+    // thread has completed a further context switch (CPU_SWITCH_GEN).
+    // Verifies the gate decision across gen-not-advanced (withheld),
+    // gen-advanced (eligible), unknown-CPU sentinel, and the wall-clock
+    // escape valve.  Intel SDM Vol. 3A §6.14; Vol. 3B §17.3.1.4 (TF).
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_294_kstack_switch_gen_gate() { passed += 1; }
+    }
+
     // ── Test 237: IPv4 total_length clamp (H6) ───────────────────────────
     // RFC 791 §3.1 — verifies `clamp_payload_to_total_length` produces
     // the right byte offset across truncation, padding, and adversarial
@@ -42996,6 +43009,93 @@ fn test_236_dead_stack_zeroing() -> bool {
     }
 
     test_pass!("push_dead_stack → pop_dead_stack: full kstack zeroed (CWE-244)");
+    true
+}
+
+// ── Test 294: dead-kstack per-CPU switch-generation quiescence gate ────────
+//
+// The SMP clone-thread-spawn #DB race (UNEXPECTED_KERNEL_MODE_TRAP 0x7f) was
+// a recycled kernel stack being re-issued while the CPU that last ran the
+// dead thread was still in `switch_context_asm`'s restore epilogue on that
+// stack VA — tearing the new thread's saved-RFLAGS slot (TF=1 garbage →
+// popfq → kernel #DB).  The fix gates re-issue on a per-CPU context-switch
+// generation (`CPU_SWITCH_GEN`): the dead stack records
+// `CPU_SWITCH_GEN[last_cpu]` and is withheld until that CPU's generation
+// advances.  This verifies the gate decision directly through the test-only
+// `sched::test_entry_quiesced` surface.
+//
+// Refs: Intel SDM Vol. 3A §6.14 (TSS-RSP stack switch on interrupt);
+// Vol. 3B §17.3.1.4 (RFLAGS.TF single-step); POSIX clone(2).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_294_kstack_switch_gen_gate() -> bool {
+    test_header!("sched: dead-kstack switch-generation quiescence gate (SMP #DB)");
+
+    // Use a long-elapsed push_tick (0) so the wall-clock tick gate is always
+    // satisfied; this isolates the *generation* condition.  TICK_COUNT is well
+    // past the escape-valve margin by the time the test suite runs, so we
+    // pick a recent push_tick for the cases that must observe withholding.
+    let now = crate::arch::x86_64::irq::TICK_COUNT.load(core::sync::atomic::Ordering::Relaxed);
+    let cpu0_gen = crate::sched::test_cpu_switch_gen(0);
+
+    // Case A: gen NOT advanced (snapshot == live), recent push → WITHHELD.
+    // push_tick = now means only the 2-tick base gate is pending; even once
+    // that elapses, the gen gate must still hold because gen hasn't moved.
+    // We assert the *gen* component by using a push_tick far enough in the
+    // past that tick_ok is true but escape_ok is NOT (margin < 8×2 ticks).
+    // push_tick = now - 3 → tick_ok (>=2) true, escape_ok (>=16) false.
+    let recent = now.saturating_sub(3);
+    if crate::sched::test_entry_quiesced(recent, 0, cpu0_gen) {
+        test_fail!("test294",
+            "gen-not-advanced entry was eligible (snap={} live={}) — gate open",
+            cpu0_gen, crate::sched::test_cpu_switch_gen(0));
+        return false;
+    }
+    test_println!("  A: gen-not-advanced + tick-met + no-escape → withheld (ok)");
+
+    // Case B: gen ADVANCED (snapshot strictly below live) → ELIGIBLE.
+    // Use snapshot = cpu0_gen.saturating_sub(1) to model a snapshot taken
+    // before the CPU's most recent switch.
+    if cpu0_gen == 0 {
+        test_println!("  B: cpu0 gen still 0 (no switches yet) — skip strict-advance check");
+    } else if !crate::sched::test_entry_quiesced(recent, 0, cpu0_gen - 1) {
+        test_fail!("test294",
+            "gen-advanced entry was withheld (snap={} live={})",
+            cpu0_gen - 1, crate::sched::test_cpu_switch_gen(0));
+        return false;
+    } else {
+        test_println!("  B: gen-advanced + tick-met → eligible (ok)");
+    }
+
+    // Case C: unknown-CPU sentinel (last_cpu_gen == u64::MAX) → gen gate
+    // vacuous; eligibility governed by the tick gate alone.  recent push
+    // (tick_ok true) → eligible.
+    if !crate::sched::test_entry_quiesced(recent, 0, u64::MAX) {
+        test_fail!("test294", "u64::MAX sentinel entry withheld despite tick gate met");
+        return false;
+    }
+    test_println!("  C: unknown-CPU sentinel → tick-gate governs → eligible (ok)");
+
+    // Case D: escape valve — gen NOT advanced but a very old push (margin ≥
+    // 8×2 = 16 ticks) → eligible regardless of generation (bounds the leak
+    // if last_cpu parks idle).  push_tick = now - 100.
+    let very_old = now.saturating_sub(100);
+    if !crate::sched::test_entry_quiesced(very_old, 0, cpu0_gen) {
+        test_fail!("test294", "escape valve did not fire for stale entry (margin>=16t)");
+        return false;
+    }
+    test_println!("  D: gen-not-advanced + escape-margin → eligible via valve (ok)");
+
+    // Case E: too-recent push → base tick gate not met → WITHHELD even with
+    // the unknown-CPU sentinel.  push_tick = now → only 0 ticks elapsed.
+    if crate::sched::test_entry_quiesced(now, 0, u64::MAX) && now != 0 {
+        // now != 0 guard: at the very first tick the saturating arithmetic
+        // makes the 2-tick threshold equal to now, which is a benign edge.
+        test_fail!("test294", "too-recent entry (0 ticks) was eligible — tick gate open");
+        return false;
+    }
+    test_println!("  E: too-recent push → tick gate withholds (ok)");
+
+    test_pass!("switch-generation gate: withhold-until-advanced + escape valve correct");
     true
 }
 


### PR DESCRIPTION
## Problem

Under an SMP clone-thread spawn burst (e.g. Firefox spawning its thread pool while an AP is being brought online), a kernel stack could be reaped and re-issued from the dead-stack cache **before** the CPU that last ran the dead thread had finished `switch_context_asm`'s restore epilogue on that stack VA.

`ctx_rsp_valid` only proves the dying CPU executed `mov [rdi],rsp; mov byte[rdx],1` (it saved the dead frame). At that instant the CPU is still at `mov rsp,rsi; popfq; pop …; ret` — physically on the dead stack's virtual address until `mov rsp,rsi` retires, and an interrupt can still push a frame onto that VA via the TSS RSP during a ring transition (Intel SDM Vol. 3A §6.14). The existing wall-clock `DEAD_STACK_QUIESCE_TICKS=2` gate can be satisfied within a single tick when a context switch and a recycle land in the same tick under a spawn burst, so it does not close this window.

### Symptom

The old CPU's epilogue / interrupt-frame write tears the new thread's freshly-initialised `switch_context_asm` frame. The saved RFLAGS slot is overwritten with garbage that has **TF (bit 8) set**; the new thread's `popfq` loads it, single-stepping the next instruction into a kernel-mode **#DB** (Intel SDM Vol. 3B §17.3.1.4, EFLAGS.TF). The unconsumed kernel #DB falls through to `ke_bugcheck(UNEXPECTED_KERNEL_MODE_TRAP, 0x7f)`. The torn value differed run to run (e.g. `0x247b83` vs `0x9d7`), confirming a concurrent clobber rather than a constant init bug (`init_thread_stack` writes `0x202`).

## Fix

Add a per-CPU context-switch generation counter (`CPU_SWITCH_GEN`), bumped once per completed switch at both post-`switch_context` resume points (resumed-kernel in `schedule()`, first-run in `user_mode_bootstrap`). A reaped stack records `CPU_SWITCH_GEN[last_cpu]`; the cache withholds re-issue until that CPU's generation advances — proving `last_cpu` completed a further switch and is no longer on (or delivering interrupts to) the recycled stack VA. This is the kernel-side realisation of the POSIX clone(2) "no CPU references the thread" lifecycle contract.

A liveness escape valve (8× the base quiescence margin, ~160 ms) re-issues on the tick gate alone if `last_cpu` parks idle and stops bumping its generation — bounding cache occupancy (a leak, never a UAF) without re-opening the race for the busy-CPU case. The fix is Release/Acquire paired and adds **no new lock**; lock order is unchanged.

## Verification

- Built `firefox-test-core,kdb` and `test-mode` clean (pre-existing warnings only).
- **#DB gate cleared on 2/2 GUI-Firefox boots** (`--ff-gui`, `gui-complete.img`): 0 bugchecks, both passed the original failing TID 48→54 clone-spawn burst (boot1 reached TID 126, boot2 TID 76).
- Boot1 advanced to `[X11] MapWindow 0x700001 300x200` — a real Firefox/GTK toplevel mapped in the X11 server.
- New `test_294_kstack_switch_gen_gate` covers withhold-until-advanced, gen-advanced eligibility, the unknown-CPU sentinel, the escape valve, and the too-recent tick gate.

### Residual (out of scope)

Firefox does **not** yet paint content into the mapped window: after `MapWindow` it hits the pre-existing W101-class plateau (pid1 main thread `STUCK_IN_NR=20` / `writev` for ~20k ticks, sc + futex counters frozen) — the documented content/IPC livelock that is a separate, parked investigation. No PutImage/CopyArea ops are issued. The on-screen framebuffer shows the native AstryxOS desktop, not Firefox content. This PR closes the #DB gate only; it does not claim a Firefox paint.

## Refs

Intel SDM Vol. 3A §6.14 (TSS-RSP stack switch on interrupt); Vol. 3B §17.3.1.4 (RFLAGS.TF single-step); POSIX clone(2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)