### PR TITLE
ipc/pipe: drain kernel-owned console pipe inline on writer park (FF console-writev wedge)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -1305,6 +1305,31 @@ pub fn exec_pid() -> u64 {
     EXEC_PID.load(Ordering::Acquire)
 }
 
+/// Pipe id of the kernel-owned console drain (the running async child's
+/// stdout/stderr pipe), or 0 when none is attached.
+///
+/// The read end of this pipe is owned by the kernel, not by any Linux process:
+/// `attach_stdout_pipe()` hands the child only the *write* ends at fd 1/2, and
+/// `poll_output()` is the sole reader.  A blocking `write(2)`/`writev(2)` from
+/// the child therefore depends entirely on the cooperatively-scheduled
+/// `poll_output()` drain to free buffer space — and under a heavy `clone(2)`
+/// burst (Firefox's ~70-thread startup) the in-kernel poll thread that runs
+/// `poll_output()` can be starved long enough for the 4 KiB pipe to fill and
+/// the writer to park with no timely wake (POSIX.1-2017 write(2); pipe(7)).
+///
+/// Exposing the drain pipe id lets the blocking-write path recognise this exact
+/// pipe and drain it INLINE from the writer's own syscall context before
+/// parking, so forward progress is independent of any poll-thread scheduling.
+/// Returns 0 when there is no console drain target (the common case: a normal
+/// Linux pipe between two user processes, which must NOT be drained by the
+/// writer — only its real peer reader removes data).
+pub fn console_drain_pipe_id() -> u64 {
+    if !EXEC_RUNNING.load(Ordering::Acquire) {
+        return 0;
+    }
+    EXEC_STDOUT_PIPE.load(Ordering::Acquire)
+}
+
 /// Test-only: install a synthetic EXEC_PID and mark an exec "running" so
 /// `exec_exit_status()` resolves against a hand-built PROCESS_TABLE record.
 /// Clears the latched exit code so step 3 (the Zombie scan) is exercised.
@@ -1313,6 +1338,16 @@ pub fn test_set_exec_pid(pid: u64) {
     LAST_EXEC_EXIT_CODE.store(NO_EXEC_EXIT, Ordering::Release);
     EXEC_PID.store(pid, Ordering::Release);
     EXEC_RUNNING.store(true, Ordering::Release);
+}
+
+/// Test-only: register `pipe_id` as the kernel-owned console drain so the
+/// blocking-write path's inline drain (`console_drain_pipe_id()`) recognises
+/// it, WITHOUT launching a real child.  Mirrors what `launch_process()` /
+/// `spawn_async()` publish at FF launch.  Pass `0` to clear.
+#[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
+pub fn test_set_console_drain_pipe(pipe_id: u64) {
+    EXEC_STDOUT_PIPE.store(pipe_id, Ordering::Release);
+    EXEC_RUNNING.store(pipe_id != 0, Ordering::Release);
 }
 
 /// Forcibly reset the async-exec tracking so a relaunch starts from a clean

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -298,6 +298,57 @@ pub fn pipe_close_reader(pipe_id: u64) {
     }
 }
 
+/// Drain — and DISCARD — all currently buffered bytes from `pipe_id`, mirroring
+/// them to the serial console under the Firefox bring-up feature so the harness
+/// still sees the child's stdout/stderr diagnostics.
+///
+/// This is the *inline* console-drain primitive used by the blocking-write path
+/// to guarantee forward progress when the kernel-owned console drain
+/// (`gui::terminal::poll_output`) is starved under heavy scheduler load: a
+/// writer about to park on a full console pipe drains it here from its OWN
+/// syscall context, freeing buffer space so its `write(2)` can proceed without
+/// depending on any cooperatively-scheduled poll thread (POSIX.1-2017 write(2);
+/// pipe(7)).
+///
+/// Returns the number of bytes drained.
+///
+/// Re-entrancy / locking: reads into a *kernel* buffer (no SMAP bracket, no
+/// recursion into the user-buffer write path) via `pipe_read`, which takes and
+/// DROPS `PIPE_TABLE` before returning — so no pipe lock is held across the
+/// serial mirror, and the drain cannot recurse into the writer.  No reader wait
+/// list is touched (the kernel console drain has no parked peer reader to wake);
+/// the only wakeable party is the writer itself, which is the caller.
+pub fn pipe_drain_console(pipe_id: u64) -> usize {
+    let mut scratch = [0u8; PIPE_BUF_SIZE];
+    let mut total = 0usize;
+    loop {
+        // Bounded by the ring capacity: at most PIPE_BUF_SIZE bytes are ever
+        // buffered, so this loop drains a full pipe in one pass and then sees
+        // a zero-length read and stops.  `pipe_read` returns None only if the
+        // pipe id has vanished (both ends closed) — treat as "nothing more".
+        let n = match pipe_read(pipe_id, &mut scratch) {
+            Some(n) => n,
+            None => break,
+        };
+        if n == 0 {
+            break;
+        }
+        // Mirror to serial so the harness still captures child diagnostics,
+        // exactly as `gui::terminal::poll_output` does for its drained chunks.
+        #[cfg(any(feature = "xeyes-test", feature = "firefox-test-core"))]
+        {
+            let text = core::str::from_utf8(&scratch[..n]).unwrap_or("\u{FFFD}");
+            crate::serial_println!("[CHILD-OUT] {}", text.trim_end_matches('\n'));
+        }
+        total += n;
+        if n < scratch.len() {
+            // Drained everything that was buffered.
+            break;
+        }
+    }
+    total
+}
+
 /// Check if a pipe has data.
 pub fn pipe_has_data(pipe_id: u64) -> bool {
     let pipes = PIPE_TABLE.lock();

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -6874,6 +6874,43 @@ fn pipe_write_blocking(pid: u64, fd: usize, pipe_id: u64, data: &[u8]) -> i64 {
             return -4; // EINTR
         }
 
+        // ── Inline console-drain (windowed-Firefox first-paint wedge) ─────────
+        //
+        // The read end of the kernel-owned console pipe (a child's stdout/stderr
+        // wired up at launch in `gui::terminal`) is drained ONLY by the
+        // cooperatively-scheduled `gui::terminal::poll_output()` on an in-kernel
+        // poll thread.  Under Firefox's ~70-thread `clone(2)` startup burst that
+        // poll thread is starved long enough for this 4 KiB pipe to fill, at
+        // which point a blocking `writev(fd=2)` would park here and — with no
+        // timely drain — never be woken, wedging the whole thread group before
+        // any frame is painted.
+        //
+        // Because this pipe has NO real peer reader (only the kernel drains it),
+        // it is always safe to discard its buffered bytes from the writer's own
+        // syscall context.  Doing so here makes forward progress independent of
+        // any poll-thread scheduling: drain inline, then re-evaluate space via
+        // `continue` instead of parking.  A normal user<->user pipe is NEVER the
+        // console drain target (`console_drain_pipe_id()` returns 0 unless THIS
+        // pipe is the running child's stdout/stderr), so this path leaves every
+        // ordinary pipe's blocking-write semantics untouched.
+        //
+        // `pipe_drain_console` reads into a kernel buffer and takes/drops
+        // `PIPE_TABLE` internally, so no pipe lock is held across it and it
+        // cannot recurse into this writer.  Refs: write(2), pipe(7).
+        if pipe_id != 0 && pipe_id == crate::gui::terminal::console_drain_pipe_id() {
+            let drained = crate::ipc::pipe::pipe_drain_console(pipe_id);
+            if drained > 0 {
+                // Freed space — retry the write without parking.
+                continue;
+            }
+            // Nothing was buffered (a transient zero-space read can race the
+            // child's own writes); fall through to the normal park so the
+            // writer is still woken by `poll_output`'s `wake_writers_all` if it
+            // does manage to run, and by the close paths on EOF/EPIPE.  This
+            // keeps the inline drain a pure progress *accelerator*, never the
+            // sole liveness mechanism.
+        }
+
         // Park atomically against the reader's `wake_writers_all`.  The lock
         // order PIPE_WRITE_WAITERS -> PIPE_TABLE is taken and released
         // entirely inside `wait_writable`; we hold no pipe lock across the

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -224,6 +224,13 @@ pub fn run() -> ! {
     total += 1;
     if test_pipe_blocking_write_semantics() { passed += 1; }
 
+    // ── Test 0a3: inline console-drain-on-park (FF first-paint wedge) ────
+    #[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
+    {
+        total += 1;
+        if test_pipe_console_drain_on_park() { passed += 1; }
+    }
+
     // ── Test 0b: eventfd wake hook (Stream A) ────────────────────────────
     total += 1;
     if test_eventfd_wake_hook() { passed += 1; }
@@ -34861,6 +34868,135 @@ fn test_pipe_blocking_write_semantics() -> bool {
     crate::syscall::dispatch_linux_kernel(3, wfd3, 0, 0, 0, 0, 0);
 
     test_pass!("pipe blocking write — EAGAIN / atomicity / EPIPE / reader-wakes-writer");
+    true
+}
+
+// ── Test: inline console-drain-on-park (windowed-Firefox first-paint wedge) ──
+//
+// The kernel-owned console pipe (a child's stdout/stderr, drained only by the
+// cooperatively-scheduled `gui::terminal::poll_output()`) can fill while the
+// drain thread is starved under Firefox's `clone(2)` startup burst.  A blocking
+// `write(2)` to the full pipe would then park forever with no timely wake.  The
+// fix drains the console pipe INLINE from the writer's own syscall context
+// before parking, so progress is independent of any poll-thread scheduling.
+//
+// This test proves (a) `pipe_drain_console` frees a full pipe, and (b) the
+// blocking-write path makes forward progress on a FULL console pipe WITHOUT a
+// concurrent reader — i.e. the writer drains it itself and the write completes
+// rather than parking.  A pipe NOT registered as the console drain must behave
+// exactly as before (no inline drain) — the negative control.
+// Refs: write(2), pipe(7), POSIX.1-2017 §write.
+#[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
+fn test_pipe_console_drain_on_park() -> bool {
+    test_header!("inline console-drain-on-park (windowed-Firefox first-paint wedge)");
+
+    let me = crate::proc::current_pid() as u64;
+
+    // ── Sub-test 1: pipe_drain_console frees a full pipe ──────────────────────
+    let mut fds = [0u32; 2];
+    let r = crate::syscall::dispatch_linux_kernel(
+        293 /*pipe2*/, fds.as_mut_ptr() as u64, 0 /*blocking*/, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("pipe_console_drain", "pipe2 returned {}", r);
+        return false;
+    }
+    let (rfd, wfd) = (fds[0] as u64, fds[1] as u64);
+    let pipe_id = crate::syscall::get_pipe_id(me, wfd as usize);
+
+    let filler = [0x5Au8; 4096];
+    let n = crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, wfd, filler.as_ptr() as u64, 4096, 0, 0, 0);
+    if n != 4096 {
+        test_fail!("pipe_console_drain", "fill write returned {} (expected 4096)", n);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+    let drained = crate::ipc::pipe::pipe_drain_console(pipe_id);
+    if drained != 4096 {
+        test_fail!("pipe_console_drain",
+            "pipe_drain_console returned {} (expected 4096)", drained);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+    if crate::ipc::pipe::pipe_space(pipe_id) != 4096 {
+        test_fail!("pipe_console_drain",
+            "after drain, space={} (expected 4096 — pipe empty)",
+            crate::ipc::pipe::pipe_space(pipe_id));
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  pipe_drain_console empties a full 4 KiB pipe (drained=4096, space=4096) ✓");
+
+    // ── Sub-test 2: blocking write to a FULL console pipe makes progress with
+    //    NO concurrent reader (the writer drains it inline and proceeds) ──────
+    // Re-fill the pipe so the next write would have to park, then register THIS
+    // pipe as the console drain.  A blocking write of a fresh 256-byte chunk
+    // must return 256 (NOT park, NOT EAGAIN) — the inline drain freed the whole
+    // ring on the first park-eligible iteration, then the loop wrote the chunk.
+    let n = crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, wfd, filler.as_ptr() as u64, 4096, 0, 0, 0);
+    if n != 4096 {
+        test_fail!("pipe_console_drain", "re-fill returned {} (expected 4096)", n);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+
+    // Negative control FIRST: a SEPARATE, non-console O_NONBLOCK pipe full to
+    // the brim must EAGAIN on a further write — proving the inline drain is
+    // gated on the console-drain registration and does NOT touch ordinary
+    // pipes.  (A blocking non-console write would genuinely park forever here
+    // with no reader thread, so the control uses O_NONBLOCK to observe the
+    // "no inline drain" decision synchronously.)
+    let chunk = [0x77u8; 256];
+    let mut ctl_fds = [0u32; 2];
+    let r = crate::syscall::dispatch_linux_kernel(
+        293 /*pipe2*/, ctl_fds.as_mut_ptr() as u64, 0x0800 /*O_NONBLOCK*/, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("pipe_console_drain", "control pipe2(O_NONBLOCK) returned {}", r);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+    let (ctl_rfd, ctl_wfd) = (ctl_fds[0] as u64, ctl_fds[1] as u64);
+    crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, ctl_wfd, filler.as_ptr() as u64, 4096, 0, 0, 0);
+    let ctrl = crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, ctl_wfd, chunk.as_ptr() as u64, 256, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, ctl_rfd, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, ctl_wfd, 0, 0, 0, 0, 0);
+    if ctrl != -11 {
+        test_fail!("pipe_console_drain",
+            "non-console full-pipe O_NONBLOCK write returned {} (expected -11 EAGAIN — no inline drain)", ctrl);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  non-console full pipe: write does NOT inline-drain (EAGAIN) ✓");
+
+    // Now register THIS pipe as the console drain and issue a BLOCKING write to
+    // the still-full pipe.  The inline drain must free space and the write must
+    // complete (256) without ever parking.
+    crate::gui::terminal::test_set_console_drain_pipe(pipe_id);
+    let n = crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, wfd, chunk.as_ptr() as u64, 256, 0, 0, 0);
+    crate::gui::terminal::test_set_console_drain_pipe(0); // clear before asserts
+    if n != 256 {
+        test_fail!("pipe_console_drain",
+            "blocking write to FULL console pipe returned {} (expected 256 — inline drain made progress)", n);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  blocking write to FULL console pipe completes inline (256, no park) ✓");
+
+    crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+
+    test_pass!("inline console-drain-on-park — frees full pipe / blocking write proceeds");
     true
 }
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -3451,6 +3451,42 @@ def cmd_start(args):
     # Fix: (1) auto-symlink from the source-of-truth if reachable, (2) emit a
     # visible banner regardless so the operator always knows the state.
     _data_img_path = Path(wt.DATA_IMG)
+
+    # --data-img OVERRIDE: point the worktree's build/data.img at an explicit
+    # prebuilt image (e.g. /home/ubuntu/gui-complete.img) by replacing the
+    # worktree symlink target.  A prebuilt complete image is authoritative — we
+    # do NOT want the staleness check to regenerate it from build/disk/, so this
+    # implies --no-regen-data-img.  Additive: when --data-img is absent the
+    # behaviour is byte-identical to before.
+    _data_img_override = getattr(args, "data_img_override", None)
+    if _data_img_override:
+        _ovr = Path(_data_img_override)
+        if not _ovr.exists():
+            print(json.dumps({"ok": False, "error": f"--data-img not found: {_ovr}"}))
+            sys.exit(2)
+        # Force no-regen for an explicit prebuilt image.
+        try:
+            setattr(args, "no_regen_data_img", True)
+        except Exception:
+            pass
+        # Replace the worktree symlink/file so all downstream machinery
+        # (build_qemu_cmd, snap topology) uses the override transparently.
+        _data_img_path.parent.mkdir(parents=True, exist_ok=True)
+        if _data_img_path.is_symlink() or _data_img_path.exists():
+            try:
+                _data_img_path.unlink()
+            except Exception:
+                pass
+        _data_img_path.symlink_to(_ovr.resolve())
+        print(
+            "╔══════════════════════════════════════════════════════════════╗\n"
+            "║  --data-img OVERRIDE (no-regen forced)                       ║\n"
+            f"║  {str(_data_img_path)[:60]:<60}  ║\n"
+            f"║  -> {str(_ovr.resolve())[:57]:<57}  ║\n"
+            "╚══════════════════════════════════════════════════════════════╝",
+            file=sys.stderr,
+        )
+
     _data_img_missing = not _data_img_path.exists()
     if _data_img_missing:
         _CANONICAL_DATA_IMG = Path("/home/ubuntu/AstryxOS/build/data.img")
@@ -12381,6 +12417,14 @@ def main():
                                "still prints to stderr so the situation is "
                                "never hidden. Use when reproducing a bug that "
                                "depends on the existing data.img contents.")
+    p_start.add_argument("--data-img", dest="data_img_override", default=None,
+                          metavar="PATH",
+                          help="Boot against an explicit prebuilt data image "
+                               "(e.g. /home/ubuntu/gui-complete.img) by "
+                               "repointing the worktree build/data.img symlink. "
+                               "Implies --no-regen-data-img (a prebuilt complete "
+                               "image is authoritative and must not be "
+                               "regenerated). Additive; absent => unchanged.")
     p_start.add_argument("--firefox-variant", dest="firefox_variant",
                           choices=("musl", "glibc"), default="musl",
                           help="Pin which Firefox userspace layout the data "


### PR DESCRIPTION
## Problem

A child's stdout/stderr is wired to an in-kernel 4 KiB pipe whose **read end is
kernel-owned** (`gui::terminal::attach_stdout_pipe` hands the child only the
*write* ends at fd 1/2; the read end is drained solely by the cooperatively
scheduled `gui::terminal::poll_output()`). Under Firefox's ~70-thread `clone(2)`
startup burst that drain thread is starved long enough for the pipe to fill, at
which point a blocking `writev(fd=2)` parks in `pipe_write_blocking` on the full
buffer (POSIX.1-2017 write(2); pipe(7)) and is never woken — wedging the whole
thread group at pid1 before any frame is painted. PR #583's extra drainers only
*delayed* the wedge (the pipe refilled at a deeper sc ~104810 / ~221309).

The golden (real Linux) drains stderr continuously and the writev never blocks,
so this is purely our scheduler/drain divergence.

## Fix — drain-on-park (option (a), lowest risk)

When a writer is about to park on a **full pipe that is the kernel-owned console
drain**, drain it **inline from the writer's own syscall context** and retry,
instead of parking. Because this pipe has no real peer reader, its buffered bytes
are always safe to discard (mirrored to serial under the FF bring-up feature,
exactly as `poll_output` does). Forward progress becomes independent of any
poll-thread scheduling.

- `ipc::pipe::pipe_drain_console(pipe_id)` — reads/discards buffered bytes into a
  kernel scratch buffer via `pipe_read` (takes+drops `PIPE_TABLE`, no SMAP
  bracket, no recursion into the writer).
- `gui::terminal::console_drain_pipe_id()` — exposes the running child's console
  pipe id (0 when none / not running) so the write path recognises it.
- `pipe_write_blocking` drains inline before parking when `pipe_id` matches. An
  ordinary user↔user pipe is **never** the console drain target, so its
  blocking-write semantics are untouched. The inline drain is a pure progress
  *accelerator* — the existing wake-on-read + close-path wakes remain the
  liveness mechanism on a transient empty read.
- `test_runner::test_pipe_console_drain_on_park` — full-pipe inline drain +
  blocking-write-proceeds path, with a non-console `O_NONBLOCK` pipe as the
  negative control. **PASS** in `test-mode`.

Also adds an additive harness flag `start --data-img PATH` (repoints the worktree
`build/data.img` symlink at a prebuilt image, forces `--no-regen`) used to
live-verify against the GUI-complete image.

## Live verification (2 boots, `firefox-test-core,kdb --ff-gui`)

**Console-writev wedge ELIMINATED.** pid1's terminal syscall is `exit_group`
(nr 231), **never** `writev` (nr 20):

- **Boot 1:** sc advanced to **286528** — past both prior re-wedge points
  (104810 / 221309). Final SC-RING shows a clean shutdown (`unlink`/`close`/
  `rt_sigaction(SIGSEGV)`/`exit_group`), not a writev park.
- **Boot 2:** pid1 sc → 49206 then exits via the same path.
- Pre-fix, pid1 froze on the console `writev` indefinitely. Now it runs its
  **full GTK/GDK windowed init** (GtkWindow / GdkFrameClockIdle signals all
  printed to the console pipe with no park) and exits cleanly.

**FF does not paint** — it now hits a *separate, pre-existing* gate: `Exiting due
to channel error` → `exit_group(11)` (SIGSEGV self-`tkill`), an **IPDL
content-process channel desync** (the IPDL crash family). The screendump at the
gate is the native AstryxOS desktop, not Firefox content, so no Discord post is
made. That gate is FF-subsystem scope, not native-kernel.

The deeper root cause (scheduler starves low-priority in-kernel poll threads
under heavy `clone` load) is noted for follow-up; drain-on-park sidesteps it for
the console path without a risky scheduler-picker rewrite.

Refs: write(2), pipe(7), POSIX.1-2017 §write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)