### PR TITLE
debug: runtime-armable per-PID [SC] syscall trace + content-proc auto-arm

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -373,6 +373,13 @@ pub fn dispatch(req: &str, out: &mut String) {
         "mem"            => op_mem(req, out),
         "read-file"      => op_read_file(req, out),
         "trace-status"   => op_trace_status(out),
+        // Runtime per-PID [SC]/[SC-RET] trace arming (no recompile).  `trace-pid`
+        // sets/clears the live target PID; `trace-contentproc` arms auto-capture
+        // of the first `-contentproc` child.  Both are query-only when their arg
+        // is absent.  Effective only under a `firefox-test-core` build without
+        // the global `syscall-trace` firehose.
+        "trace-pid"        => op_trace_pid(req, out),
+        "trace-contentproc" => op_trace_contentproc(req, out),
         // blk-trace: dump the virtio-blk LBA trace ring as JSON (out-of-band
         // drain replacing the old per-op COM1 write). `blk-trace-flush` re-emits
         // the classic `[BLK]` serial lines for the legacy heatmap ingestion.
@@ -999,8 +1006,66 @@ fn op_read_file(req: &str, out: &mut String) {
 
 fn op_trace_status(out: &mut String) {
     use core::fmt::Write;
-    let _ = write!(out, r#"{{"syscall_trace":{},"pf_trace":{},"build":"kdb"}}"#,
-                   cfg!(feature = "syscall-trace"), cfg!(feature = "pf-trace"));
+    // `trace_pid_effective` is true when the runtime per-PID `[SC]` emit block
+    // is actually compiled in (firefox-test-core present, syscall-trace global
+    // firehose absent).  When `syscall_trace` is true the global firehose
+    // already traces every PID, so the per-PID block is intentionally compiled
+    // out and `trace-pid` arming is a no-op (the firehose covers it).
+    let trace_pid_effective =
+        cfg!(feature = "firefox-test-core") && !cfg!(feature = "syscall-trace");
+    let target = crate::syscall::TRACE_PID
+        .load(core::sync::atomic::Ordering::Relaxed);
+    let contentproc = crate::syscall::TRACE_CONTENTPROC
+        .load(core::sync::atomic::Ordering::Relaxed);
+    let _ = write!(out,
+        r#"{{"syscall_trace":{},"pf_trace":{},"trace_pid":{},"trace_contentproc":{},"trace_pid_effective":{},"build":"kdb"}}"#,
+        cfg!(feature = "syscall-trace"), cfg!(feature = "pf-trace"),
+        target, contentproc, trace_pid_effective);
+}
+
+// trace-pid: set / clear / query the runtime per-PID `[SC]`/`[SC-RET]` trace
+// target.  Request shape: {"op":"trace-pid","pid":N}.  pid=0 clears.  When the
+// `pid` field is absent the op is query-only (reports the current target).
+// Cheap one relaxed atomic load on the syscall hot path when unset.
+fn op_trace_pid(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    use core::sync::atomic::Ordering;
+    let prev = crate::syscall::TRACE_PID.load(Ordering::Relaxed);
+    let new = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(p) => { crate::syscall::TRACE_PID.store(p, Ordering::Relaxed); p }
+        None => prev, // query-only
+    };
+    let effective =
+        cfg!(feature = "firefox-test-core") && !cfg!(feature = "syscall-trace");
+    let _ = write!(out,
+        r#"{{"ok":true,"prev":{},"trace_pid":{},"effective":{}}}"#,
+        prev, new, effective);
+}
+
+// trace-contentproc: arm/disarm/query auto-capture of the first `-contentproc`
+// child.  Request shape: {"op":"trace-contentproc","on":"on"|"off"}.  When armed,
+// the exec path stores the content-proc PID into TRACE_PID the moment it execs,
+// so the trace starts at the content-proc's first post-exec syscall (no race).
+fn op_trace_contentproc(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    use core::sync::atomic::Ordering;
+    let prev = crate::syscall::TRACE_CONTENTPROC.load(Ordering::Relaxed);
+    let now = match extract_field(req, "on").unwrap_or_default().as_str() {
+        "on" | "1" | "true" => {
+            crate::syscall::TRACE_CONTENTPROC.store(true, Ordering::Relaxed);
+            true
+        }
+        "off" | "0" | "false" => {
+            crate::syscall::TRACE_CONTENTPROC.store(false, Ordering::Relaxed);
+            false
+        }
+        _ => prev, // query-only
+    };
+    let effective =
+        cfg!(feature = "firefox-test-core") && !cfg!(feature = "syscall-trace");
+    let _ = write!(out,
+        r#"{{"ok":true,"prev":{},"armed":{},"effective":{}}}"#,
+        prev, now, effective);
 }
 
 // ── blk-trace ────────────────────────────────────────────────────────────────

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -967,6 +967,51 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         );
     }
 
+    // ── Runtime per-PID [SC] trace (firefox-test-core, runtime-armable) ──────
+    // The `syscall-trace` block above is the always-on firehose for *every*
+    // PID and is a compile-time feature.  This block is the runtime-armable
+    // per-PID equivalent: it emits the identical `[SC]` line shape but only for
+    // the single PID stored in `crate::syscall::TRACE_PID` (armed at runtime via
+    // the kdb `trace-pid` / `trace-contentproc` ops).  It exists so an agent can
+    // capture the full syscall stream of a late-spawned process (a Firefox
+    // `-contentproc` child that does not exist at boot) without recompiling.
+    //
+    // Compiled only under `firefox-test-core` (the Firefox bring-up profile that
+    // the live demo boots) AND only when `syscall-trace` is NOT already pulling
+    // in the global firehose — so there is never a double emit, and builds
+    // without `firefox-test-core` pay nothing at all.  When `TRACE_PID == 0`
+    // (the default) the cost is a single relaxed atomic load.
+    #[cfg(all(feature = "firefox-test-core", not(feature = "syscall-trace")))]
+    {
+        let trace_pid = crate::syscall::TRACE_PID
+            .load(core::sync::atomic::Ordering::Relaxed);
+        if trace_pid != 0 && crate::proc::current_pid_lockless() == trace_pid {
+            let user_rip = unsafe { crate::syscall::get_user_rip() };
+            let caller_rip = crate::syscall::get_user_caller_rip();
+            let tid_now = crate::proc::current_tid();
+            let rsp_live = crate::proc::current_kernel_rsp_live();
+            let (kstack_base, kstack_size) = {
+                let threads = crate::proc::THREAD_TABLE.lock();
+                threads.iter().find(|t| t.tid == tid_now)
+                    .map(|t| (t.kernel_stack_base, t.kernel_stack_size))
+                    .unwrap_or((0, 0))
+            };
+            let kdepth = if kstack_base > 0 {
+                kstack_base.wrapping_add(kstack_size).wrapping_sub(rsp_live)
+            } else { 0 };
+            crate::serial_fast_println!(
+                "[SC] pid={} tid={} nr={} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x} ksp={:#x} kdepth={:#x}",
+                trace_pid,
+                tid_now,
+                num,
+                user_rip,
+                caller_rip,
+                arg1, arg2, arg3, arg4, arg5, arg6,
+                rsp_live, kdepth,
+            );
+        }
+    }
+
     // ── Phase 3B: periodic user-stack snapshot on hot syscalls ──────────────
     // Triggered every Nth `clock_gettime` / `gettimeofday` / `futex` call from
     // any user pid (>= 12 to skip kernel init / shell processes).  Emits an
@@ -1184,6 +1229,25 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         num,
         ret as u64,
     );
+
+    // Runtime per-PID return-side counterpart to the global firehose above —
+    // same gating rationale as the `[SC]` entry block: only the single armed
+    // `TRACE_PID`, only under `firefox-test-core` without the global
+    // `syscall-trace` firehose (no double emit).
+    #[cfg(all(feature = "firefox-test-core", not(feature = "syscall-trace")))]
+    {
+        let trace_pid = crate::syscall::TRACE_PID
+            .load(core::sync::atomic::Ordering::Relaxed);
+        if trace_pid != 0 && crate::proc::current_pid_lockless() == trace_pid {
+            crate::serial_fast_println!(
+                "[SC-RET] pid={} tid={} nr={} ret={:#x}",
+                trace_pid,
+                crate::proc::current_tid(),
+                num,
+                ret as u64,
+            );
+        }
+    }
 
     // ── Dead-thread drain (exit_group SMP coherence) ──────────────────────
     //

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -875,6 +875,32 @@ pub fn set_per_cpu_id(cpu_id: u8) {
 pub static DEBUG_TRACE_PID: core::sync::atomic::AtomicU64 =
     core::sync::atomic::AtomicU64::new(0);
 
+/// Runtime per-PID `[SC]`/`[SC-RET]` trace target, armable at *runtime* via the
+/// kdb `trace-pid` op (no recompile, no boot-time-only `DEBUG_TRACE_PID` edit).
+///
+/// 0 (default) = disabled.  When non-zero, the syscall entry/return path emits
+/// the full firehose `[SC]`/`[SC-RET]` pair for *only* that PID — identical line
+/// format to the `syscall-trace` global firehose, so the existing host-side
+/// post-processors (`qemu-harness.py`, the golden-diff scanners) parse it
+/// unchanged.  Cost when disabled is a single relaxed atomic load on the entry
+/// path; the emit block is compiled only under `firefox-test-core` (the
+/// functional Firefox bring-up profile) and only when the always-on
+/// `syscall-trace` firehose is NOT already compiled in, so there is never a
+/// double emit and production builds pay nothing.
+///
+/// This exists because a Firefox `-contentproc` child forks late in the run
+/// (~tick 5000) and does not exist at boot, so a boot-time-static target is
+/// useless for capturing its complete init syscall trace.
+pub static TRACE_PID: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+
+/// When true, the first process that `execve`s with `-contentproc` in its argv
+/// auto-arms [`TRACE_PID`] to its own PID — capturing the content process from
+/// its very first post-exec syscall with no host-side timing race.  Set at
+/// runtime via the kdb `trace-contentproc` op; off by default.
+pub static TRACE_CONTENTPROC: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
 /// Global Linux syscall counter for the Firefox oracle test.
 /// Incremented on every Linux syscall dispatch from any user-mode PID.
 /// Reset to zero by the test before spawning Firefox, then read after
@@ -1486,6 +1512,23 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
                 || argv_owned.iter().any(|a| a == "-contentproc");
             if is_content && !CONTENTPROC_GATE_SEEN.swap(true, Ordering::Relaxed) {
                 crate::serial_println!("[GATE] content-procs");
+            }
+
+            // Auto-arm the runtime per-PID syscall trace to the FIRST
+            // `-contentproc` child, when opted in at runtime via the kdb
+            // `trace-contentproc` op.  Captures the content process from its
+            // first post-exec syscall with no host-side timing race.  `pid` is
+            // the PID that will run this new image (execve(2) preserves the PID
+            // per POSIX), so this is the content-proc's own PID.  Fires once;
+            // off (and zero-cost) unless `TRACE_CONTENTPROC` was set.
+            if argv_owned.iter().any(|a| a == "-contentproc")
+                && crate::syscall::TRACE_CONTENTPROC.load(Ordering::Relaxed)
+                && crate::syscall::TRACE_PID.load(Ordering::Relaxed) == 0
+            {
+                let cp_pid = crate::proc::current_pid_lockless();
+                crate::syscall::TRACE_PID.store(cp_pid, Ordering::Relaxed);
+                crate::serial_println!(
+                    "[TRACE-PID] auto-armed contentproc pid={}", cp_pid);
             }
         }
     }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -6966,6 +6966,34 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
                 "(expected on|off|true|false|1|0)"
             )
         return {"op": "futex-set-cluster-wake", "on": val}
+    if op == "trace-pid":
+        # Runtime per-PID [SC]/[SC-RET] trace arming (no recompile).
+        #   kdb <sid> trace-pid            → query current target
+        #   kdb <sid> trace-pid 3          → trace pid 3
+        #   kdb <sid> trace-pid 0          → clear
+        # Carried as {"pid": N} to match the kernel extract_field("pid") parse.
+        # Effective only on a firefox-test-core build WITHOUT the global
+        # syscall-trace firehose (response carries "effective": bool).
+        if not rest:
+            return {"op": "trace-pid"}
+        return {"op": "trace-pid", "pid": int(rest[0], 0)}
+    if op == "trace-contentproc":
+        # Arm/disarm/query auto-capture of the first -contentproc child.
+        #   kdb <sid> trace-contentproc        → query
+        #   kdb <sid> trace-contentproc on     → arm
+        #   kdb <sid> trace-contentproc off    → disarm
+        # When armed, the exec path stores the content-proc PID into the trace
+        # target at exec time, so the trace begins at its first post-exec
+        # syscall with no host-side timing race.
+        if not rest:
+            return {"op": "trace-contentproc"}
+        val = rest[0].strip().lower()
+        if val not in ("on", "off", "true", "false", "1", "0"):
+            raise ValueError(
+                f"trace-contentproc: unrecognised value '{rest[0]}' "
+                "(expected on|off)"
+            )
+        return {"op": "trace-contentproc", "on": val}
     if op == "proc":
         if not rest: raise ValueError("proc requires <pid>")
         return {"op": "proc", "pid": int(rest[0], 0)}
@@ -12727,6 +12755,11 @@ def main():
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "trace-status",
+        # Runtime-armable per-PID [SC]/[SC-RET] trace (no recompile).
+        # `trace-pid <pid>` sets/clears/queries the live target; `trace-contentproc
+        # on|off` auto-arms capture of the first -contentproc child at exec time.
+        # Effective on a firefox-test-core build without the syscall-trace firehose.
+        "trace-pid", "trace-contentproc",
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
         "arm-phys",


### PR DESCRIPTION
## What

Add a way to arm per-PID `[SC]`/`[SC-RET]` syscall tracing **at runtime** (no recompile, no boot-time-only edit), so an agent can capture the complete init syscall stream of a process that does not exist at boot — specifically a Firefox `-contentproc` child, which forks late (~tick 5000).

### Why the existing mechanism is insufficient

- The full `[SC]`/`[SC-RET]` firehose is gated behind the `syscall-trace` cargo feature and traces **every** PID.
- The only per-PID filter, `DEBUG_TRACE_PID`, is settable solely at boot from `test_runner.rs`. A static boot-time target is useless for a PID that only comes into existence mid-run.

## How

- **`TRACE_PID` (AtomicU64) + `TRACE_CONTENTPROC` (AtomicBool)** in `syscall/mod.rs`. When `TRACE_PID` is non-zero, the syscall entry/return path emits the **identical** `[SC]`/`[SC-RET]` line shape for **only** that PID, so existing host-side post-processors (`qemu-harness.py`, the golden-diff scanners) parse it unchanged.
- The emit block is compiled **only under `firefox-test-core`** and **only when `syscall-trace` is NOT compiled in** (no double emit; non-Firefox/production builds pay nothing). Cost when unset is **one relaxed atomic load** on the entry path — no syscall-semantics or hot-path change.
- **Auto-arm**: when opted in via kdb, the first process that `execve`s with `-contentproc` in its argv stores its own PID into `TRACE_PID` at exec time, so the trace begins at the content-proc's **first post-exec syscall** with no host-side timing race.
- **kdb ops** (request/response JSON, non-interactive): `trace-pid <pid>` (set/clear/query) and `trace-contentproc on|off` (arm auto-capture). `trace-status` extended **additively** with `trace_pid`, `trace_contentproc`, `trace_pid_effective`. Matching `qemu-harness.py kdb` passthrough branches added.

All additions are additive (new JSON keys only). Test/debug infra: non-interactive, one-shot, structured JSON; zero hot-path cost when unset; gated out of production builds.

## Usage

```
# arm auto-capture of the first -contentproc child (no race)
python3 scripts/qemu-harness.py kdb <sid> trace-contentproc on

# or arm a specific live PID
python3 scripts/qemu-harness.py kdb <sid> trace-pid 3

# query / clear
python3 scripts/qemu-harness.py kdb <sid> trace-status
python3 scripts/qemu-harness.py kdb <sid> trace-pid 0
```

## Live verification

Boot `--features firefox-test-core,kdb` against the FF image, armed `trace-contentproc on` before content procs spawned:

- `trace-contentproc on` -> `{"ok": true, "prev": false, "armed": true, "effective": true}`
- auto-arm fired: `[TRACE-PID] auto-armed contentproc pid=3`; `trace-status` -> `trace_pid: 3`
- **1596 `[SC] pid=3`** + **1594 `[SC-RET] pid=3`** lines captured (the content-proc init stream: mmap/mremap/open/mprotect/fstat/gettid/getrandom — classic musl/libxul startup)
- **0 `[SC]` lines for any other PID** — per-PID filter holds exactly.

Default-feature build and `firefox-test-core,kdb` build both green; `qemu-harness-smoke.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)