### PR TITLE
sched: sleeper-fairness wake boost + wake-preemption on the Linux futex path

### DIFF
--- a/kernel/src/ke/dispatcher.rs
+++ b/kernel/src/ke/dispatcher.rs
@@ -271,15 +271,15 @@ pub fn dispatcher_header_mut(entry: &mut DispatcherEntry) -> &mut DispatcherHead
 ///
 /// Woken threads receive a priority boost to improve responsiveness.
 pub fn wake_blocked_waiters(header: &mut DispatcherHeader) {
-    use crate::proc::{THREAD_TABLE, ThreadState, PRIORITY_BOOST_WAIT, PRIORITY_MAX};
+    use crate::proc::{THREAD_TABLE, ThreadState};
 
     let mut threads = THREAD_TABLE.lock();
     for wb in header.wait_list.iter().filter(|wb| wb.satisfied) {
         if let Some(t) = threads.iter_mut().find(|t| t.tid == wb.thread_id) {
             if t.state == ThreadState::Blocked {
                 t.state = ThreadState::Ready;
-                // Apply priority boost (capped at MAX).
-                t.priority = (t.priority + PRIORITY_BOOST_WAIT).min(PRIORITY_MAX);
+                // Apply the shared wake-preemption boost (capped at MAX).
+                crate::proc::apply_wake_boost(t);
             }
         }
     }

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -309,6 +309,50 @@ impl Thread {
     pub fn is_reapable(&self) -> bool {
         self.state == ThreadState::Dead && self.tid != 0 && self.tid < 0x1000
     }
+
+    /// Construct a minimal, never-scheduled `Thread` for in-kernel unit tests.
+    ///
+    /// The row is `Blocked` and pinned to an impossible CPU so the picker and
+    /// the timer-tick wake passes never touch it; only the priority/base fields
+    /// are meaningful. Used by scheduler-invariant tests (e.g. the wake-boost
+    /// regression) that need a real `Thread` to exercise `&mut Thread` helpers
+    /// without spawning or registering anything. Test-only.
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    pub fn new_for_test(priority: u8) -> Thread {
+        Thread {
+            tid: 0xFFFF_FFFF,
+            pid: 0xFFFF_FFFF,
+            state: ThreadState::Blocked,
+            context: alloc::boxed::Box::new(CpuContext::default()),
+            kernel_stack_base: 0,
+            kernel_stack_size: 0,
+            wake_tick: u64::MAX - 2,
+            name: [0u8; 32],
+            exit_code: 0,
+            fpu_state: None,
+            user_entry_rip: 0,
+            user_entry_rsp: 0,
+            user_entry_rdx: 0,
+            user_entry_r8: 0,
+            priority,
+            base_priority: priority,
+            tls_base: 0,
+            gs_base: 0,
+            cpu_affinity: Some(0xFE),
+            last_cpu: 0,
+            first_run: false,
+            ready_since_tick: 0,
+            ctx_rsp_valid: alloc::boxed::Box::new(
+                core::sync::atomic::AtomicBool::new(true)),
+            clear_child_tid: 0,
+            fork_user_regs: ForkUserRegs::default(),
+            vfork_parent_tid: None,
+            robust_list_head: 0,
+            robust_list_len: 0,
+            vfork_isolated_stack: None,
+            vfork_isolated_tls: None,
+        }
+    }
 }
 
 // ── Priority Constants (NT-style) ────────────────────────────────────
@@ -333,6 +377,30 @@ pub const PRIORITY_MAX: u8 = 31;
 pub const PRIORITY_BOOST_WAIT: u8 = 2;
 /// Priority boost given on I/O completion.
 pub const PRIORITY_BOOST_IO: u8 = 1;
+
+/// Apply the wait-satisfied (wake) priority boost to a thread that is being
+/// transitioned out of a blocking wait.
+///
+/// A thread that has just been unblocked has not consumed any CPU while it
+/// slept, whereas any peers that were continuously runnable have. Giving the
+/// freshly-woken thread a small, self-decaying effective-priority boost lets
+/// it run ahead of those CPU-bound peers for its next scheduling decision,
+/// then decay back to `base_priority` (one point per context-switch-out, in
+/// `schedule()`). This is the run-queue-placement equivalent of POSIX
+/// SCHED_OTHER / `sched(7)` sleeper fairness: a task returning from a sleep is
+/// owed service relative to tasks that have been spending the CPU, so a
+/// wakeup is allowed to preempt the running set rather than landing at the
+/// back of an equal-priority round-robin queue.
+///
+/// The boost is one-shot and bounded (capped at `PRIORITY_MAX`, decays in the
+/// picker), so it improves wake latency without permanently re-ranking the
+/// thread. The native executive's `ke::dispatcher::wake_blocked_waiters`
+/// already applies this same boost on its Blocked→Ready edge; this helper
+/// makes the rule a single shared primitive so every wake path is consistent.
+#[inline]
+pub fn apply_wake_boost(t: &mut Thread) {
+    t.priority = (t.priority + PRIORITY_BOOST_WAIT).min(PRIORITY_MAX);
+}
 
 /// 512-byte FXSAVE area, 16-byte aligned.
 #[repr(C, align(16))]

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -551,6 +551,28 @@ fn drain_due_wakes_if_pending(threads: &mut alloc::vec::Vec<proc::Thread>) {
 }
 
 
+/// Request that the calling CPU reschedule at its next preemption point.
+///
+/// Sets the per-CPU `NEED_RESCHEDULE` flag so that the deferred-preemption
+/// check at syscall return (`check_reschedule`) — and the post-IRQ check —
+/// will invoke `schedule()` and re-select the highest-priority Ready thread.
+///
+/// This is the AstryxOS analogue of `resched_curr()`: a wakeup path that has
+/// just made a higher-priority thread runnable uses it to let that thread
+/// preempt the current (lower-priority) thread, rather than waiting out the
+/// running thread's whole time slice. Cheap and lock-free; the actual switch
+/// happens later at a safe point where no syscall lock is held.
+#[inline]
+pub fn request_reschedule() {
+    if !is_active() {
+        return;
+    }
+    let cpu = cpu_index();
+    if cpu < MAX_CPUS {
+        NEED_RESCHEDULE[cpu].store(true, Ordering::Relaxed);
+    }
+}
+
 /// Check if a reschedule is pending (called after returning from interrupt).
 ///
 /// Returns immediately if the scheduler is not yet active — this avoids

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -9606,13 +9606,37 @@ pub fn sys_futex_linux(
 
             {
                 let mut threads = crate::proc::THREAD_TABLE.lock();
+                let cur_tid = crate::proc::current_tid();
+                let cur_prio = threads
+                    .iter()
+                    .find(|th| th.tid == cur_tid)
+                    .map(|th| th.priority)
+                    .unwrap_or(0);
+                let mut max_woken_prio = 0u8;
                 for &t in &tids_to_wake {
                     if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
                         if th.state == crate::proc::ThreadState::Blocked {
                             th.state = crate::proc::ThreadState::Ready;
                             th.wake_tick = 0;
+                            // Wake-preemption: a futex waiter returning from a
+                            // sleep has not spent the CPU; boost it so it runs
+                            // ahead of continuously-runnable peers for its next
+                            // scheduling decision. See `proc::apply_wake_boost`.
+                            crate::proc::apply_wake_boost(th);
+                            max_woken_prio = max_woken_prio.max(th.priority);
                         }
                     }
+                }
+                drop(threads);
+                // resched_curr equivalent: if a woken thread now out-ranks the
+                // waker, request a reschedule so it preempts at syscall return
+                // rather than waiting out the waker's whole time slice. Without
+                // this the boost only changes *which* thread the picker prefers
+                // at the next natural switch — the waker can still run all the
+                // way to its own next block first. (POSIX sched(7): a wakeup may
+                // preempt the running task.)
+                if max_woken_prio > cur_prio {
+                    crate::sched::request_reschedule();
                 }
             }
 
@@ -9861,13 +9885,27 @@ pub fn sys_futex_linux(
 
             {
                 let mut threads = crate::proc::THREAD_TABLE.lock();
+                let cur_tid = crate::proc::current_tid();
+                let cur_prio = threads
+                    .iter()
+                    .find(|th| th.tid == cur_tid)
+                    .map(|th| th.priority)
+                    .unwrap_or(0);
+                let mut max_woken_prio = 0u8;
                 for &t in &tids_to_wake {
                     if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
                         if th.state == crate::proc::ThreadState::Blocked {
                             th.state = crate::proc::ThreadState::Ready;
                             th.wake_tick = 0;
+                            // Wake-preemption boost (see `proc::apply_wake_boost`).
+                            crate::proc::apply_wake_boost(th);
+                            max_woken_prio = max_woken_prio.max(th.priority);
                         }
                     }
+                }
+                drop(threads);
+                if max_woken_prio > cur_prio {
+                    crate::sched::request_reschedule();
                 }
             }
 
@@ -9982,13 +10020,27 @@ pub fn sys_futex_linux(
             // acquisition (same post-drain pattern as FUTEX_WAKE).
             {
                 let mut threads = crate::proc::THREAD_TABLE.lock();
+                let cur_tid = crate::proc::current_tid();
+                let cur_prio = threads
+                    .iter()
+                    .find(|th| th.tid == cur_tid)
+                    .map(|th| th.priority)
+                    .unwrap_or(0);
+                let mut max_woken_prio = 0u8;
                 for &t in &tids_to_wake {
                     if let Some(th) = threads.iter_mut().find(|th| th.tid == t) {
                         if th.state == crate::proc::ThreadState::Blocked {
                             th.state = crate::proc::ThreadState::Ready;
                             th.wake_tick = 0;
+                            // Wake-preemption boost (see `proc::apply_wake_boost`).
+                            crate::proc::apply_wake_boost(th);
+                            max_woken_prio = max_woken_prio.max(th.priority);
                         }
                     }
+                }
+                drop(threads);
+                if max_woken_prio > cur_prio {
+                    crate::sched::request_reschedule();
                 }
             }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2815,6 +2815,17 @@ pub fn run() -> ! {
         if test_285_anti_starvation_aging() { passed += 1; }
     }
 
+    // ── Test 287: wake-preemption boost lets a woken futex waiter outrank ───
+    // its waker. Regression for the Linux futex wake path not granting the
+    // sleeper-fairness boost that POSIX sched(7) requires — the root cause of
+    // the content-process worker reaching its event-target Dispatch before the
+    // just-woken main thread published the singleton. Pure scoring arithmetic.
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_287_wake_boost_preempts_runnable_peer() { passed += 1; }
+    }
+
     // ── Summary ─────────────────────────────────────────────────────────
 
     test_println!();
@@ -45038,6 +45049,81 @@ fn test_285_anti_starvation_aging() -> bool {
     test_println!("  no-contention ordering preserved (priority > affinity, affinity tie-breaks) ✓");
 
     test_pass!("anti-starvation aging frees an out-scored Ready thread");
+    true
+}
+
+// ── Test 287: wake-preemption boost lets a just-woken futex waiter outrank
+// the continuously-runnable peers that woke it ─────────────────────────────────
+//
+// Regression for the Linux-personality futex wake path failing to grant the
+// sleeper-fairness boost that POSIX SCHED_OTHER / sched(7) require: a thread
+// returning from a blocking wait has not consumed the CPU, whereas the peers
+// that stayed runnable have, so on wake it must be allowed to run ahead of
+// them rather than landing at the back of an equal-priority round-robin queue.
+//
+// Concretely: a content-process main thread that parks on a gecko init mutex
+// and is then woken by a worker must publish its one-time singleton before any
+// equal-priority worker reaches the code that consumes that singleton. Without
+// the boost the woken thread ties the workers and can lose the round-robin, so
+// a worker dereferences the still-NULL singleton and SIGSEGVs.
+//
+// This test verifies the two contractual properties of `proc::apply_wake_boost`
+// using the SAME picker score formula as `sched::schedule` (priority*4 +
+// affinity + wait_age_bonus): (1) the boost raises a freshly-woken NORMAL
+// thread's effective priority by exactly PRIORITY_BOOST_WAIT and that this
+// out-scores a continuously-runnable NORMAL peer at equal/worse affinity even
+// when the peer has the cache-warm bonus; (2) the boost is bounded at
+// PRIORITY_MAX (never overflows). Pure arithmetic on a synthesised Thread —
+// deterministic, no spawning, no scheduler races. Cite POSIX sched(7).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_287_wake_boost_preempts_runnable_peer() -> bool {
+    use crate::proc::{PRIORITY_NORMAL, PRIORITY_BOOST_WAIT, PRIORITY_MAX, apply_wake_boost};
+    use crate::sched::wait_age_bonus;
+
+    test_header!("wake-preemption boost lets a woken futex waiter outrank its waker");
+
+    // Picker score, mirrored from `sched::schedule` (affinity 0/1/2, age in ticks).
+    fn picker_score(priority: u8, affinity: u16, age: u64) -> u16 {
+        (priority as u16) * 4 + affinity + wait_age_bonus(age)
+    }
+
+    // ── Property 1: boost raises effective priority by exactly BOOST_WAIT ──
+    // Build a minimal Blocked NORMAL thread, apply the boost, check the delta.
+    let mut t = crate::proc::Thread::new_for_test(PRIORITY_NORMAL);
+    let before = t.priority;
+    apply_wake_boost(&mut t);
+    if t.priority != before + PRIORITY_BOOST_WAIT {
+        test_fail!("test287",
+            "apply_wake_boost: priority {} != base {} + BOOST_WAIT {}",
+            t.priority, before, PRIORITY_BOOST_WAIT);
+        return false;
+    }
+    test_println!("  boost raises NORMAL {} → {} (+{}) ✓", before, t.priority, PRIORITY_BOOST_WAIT);
+
+    // ── Property 2: the just-woken (boosted) thread out-scores its waker ──
+    // The woken thread just became Ready (age 0, no wait-age bonus) and, having
+    // run here last, may even be cache-cold (affinity 0). The waker stayed
+    // runnable and is cache-warm (affinity 1). The boost must still win so the
+    // woken thread is selected first.
+    let woken  = picker_score(t.priority,      0, 0); // boosted, cold
+    let waker  = picker_score(PRIORITY_NORMAL, 1, 0); // unboosted NORMAL, warm
+    if woken <= waker {
+        test_fail!("test287",
+            "woken score {} does not outrank runnable waker {} (boost ineffective)", woken, waker);
+        return false;
+    }
+    test_println!("  woken-boosted score {} > runnable-waker score {} ✓", woken, waker);
+
+    // ── Property 3: boost is bounded at PRIORITY_MAX (no overflow) ──
+    let mut hi = crate::proc::Thread::new_for_test(PRIORITY_MAX);
+    apply_wake_boost(&mut hi);
+    if hi.priority != PRIORITY_MAX {
+        test_fail!("test287", "boost at MAX overflowed: {} != {}", hi.priority, PRIORITY_MAX);
+        return false;
+    }
+    test_println!("  boost capped at PRIORITY_MAX {} ✓", PRIORITY_MAX);
+
+    test_pass!("wake-preemption boost lets a woken futex waiter outrank its waker");
     true
 }
 


### PR DESCRIPTION
## Summary

Closes a content-process worker SIGSEGV during Firefox content-process init that is a **pure scheduling/ordering race**, not memory corruption. A freshly-`clone()`'d worker thread dereferenced a process-global singleton (an event target) that the process **main thread had not yet published**, faulting at `mov rdi,[rdi+0xd0]` with `rdi==0` (CR2=0xd0).

The race reproduces **identically on `--smp 1`**, which structurally rules out cross-CPU store visibility, missing TLB shootdown, and membarrier — there is no concurrent sibling on one core, so the publishing store simply had not executed before the worker read it. The singleton lives in `.bss` (demand-zero), so `0` is its legitimate uninitialized value (not page-cache corruption).

### Root cause (trace-evidenced)

On `--smp 1` the content-process main thread:
1. parks on an early-init mutex via `futex(uaddr, FUTEX_WAIT, 2)`,
2. is woken by a worker's `futex(uaddr, FUTEX_WAKE)` (kernel returns `woken=1`),
3. but the scheduler then ran a **different, never-blocking** worker all the way to its singleton dereference before the just-woken main thread ever got the CPU.

Two Linux scheduler semantics were missing on the Linux-personality futex wake path:

1. **Sleeper fairness** (POSIX `sched(7)`, SCHED_OTHER). A thread returning from a blocking wait has not spent the CPU, whereas peers that stayed runnable have, so on wake it is owed service ahead of them. The wake path flipped the waiter to `Ready` at its **base** priority, leaving it at the back of an equal-priority round-robin queue.

2. **Wake preemption** (the `resched_curr()` contract). A wakeup that makes a higher-priority thread runnable must be able to preempt the running thread, not wait out its whole time slice. The boost alone only changes *which* thread the picker prefers at the next natural switch — the waker can still run to its own next block first.

### Fix

- `proc::apply_wake_boost(&mut Thread)` — shared primitive applying the existing self-decaying `PRIORITY_BOOST_WAIT` (capped at `PRIORITY_MAX`, decays one point per context-switch-out in the picker) on the `Blocked→Ready` edge. The native executive (`ke::dispatcher::wake_blocked_waiters`) already did this; it now calls the shared helper so both wake paths are consistent.
- `sched::request_reschedule()` — sets the per-CPU `NEED_RESCHEDULE` flag (the `resched_curr` analogue) so a higher-priority woken thread preempts at the waker's syscall-return preemption point.
- Both applied to all three Linux futex wake sites (`FUTEX_WAKE`, `FUTEX_WAKE_OP`, `FUTEX_REQUEUE`); the reschedule is requested only when a woken+boosted thread now out-ranks the waker.

This is a correctness guarantee matching Linux `wakeup_preempt`, **not** a "defer the child" priority hack — newly-created children still become runnable immediately and may preempt their creator, exactly as `wake_up_new_task` permits.

### Verification

- `--ff-gui --smp 1`, 3/3 consecutive boots: the content-process worker SIGSEGV at libxul off `0x2102190` (CR2=0xd0) **no longer occurs**. `pid=3` now reaches its own main-thread exit (`exit_group(1)`, caller = main thread) instead of `exit_group(-11)` from a worker. FF advances to mapping a real 300x200 window. The remaining `exit_group(1)` is a separate downstream gate (parent has no page content to render), out of scope here.
- Adds **test 287** asserting the boost invariants: exact `+PRIORITY_BOOST_WAIT` delta, out-scores a continuously-runnable peer in the picker score formula, and capped at `PRIORITY_MAX`. Plus a test-only `Thread::new_for_test` constructor.

### Diff

5 files, +231/-3.