### PR TITLE
gui/firefox: declutter GUI-mode boot so the app window is the sole visible client

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1136,9 +1136,17 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 }
             }
 
-            // Create a visible X11 test window BEFORE Firefox launches
-            serial_println!("[X11-VIS] Creating X11 visual test window...");
-            {
+            // Create a visible X11 test window BEFORE Firefox launches.
+            // DECLUTTER (GUI mode): skip this synthetic cyan probe window when
+            // running windowed Firefox (astryx.ff_gui=1).  The probe is a
+            // kernel-owned 300x200 test client that would otherwise sit on the
+            // compositor root and be mistaken for — or obscure — the real
+            // Firefox toplevel.  Mirrors the xeyes-test declutter at the top of
+            // this file: in GUI mode the only visible client must be the app
+            // under observation.  Headless mode keeps the probe (it is never
+            // composited to the framebuffer there) so existing demos are intact.
+            if !boot_config::ff_gui_mode() {
+                serial_println!("[X11-VIS] Creating X11 visual test window...");
                 use crate::net::unix;
                 // Kernel-owned X11 test connection — see unix(7) SO_PEERCRED.
                 let kernel_creds = unix::PeerCreds { pid: 0, uid: 0, gid: 0 };
@@ -1188,7 +1196,15 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                     // It will persist until Firefox test ends
                 }
             }
-            gui::desktop::launch_desktop();
+            // DECLUTTER (GUI mode): in windowed Firefox mode do NOT spawn the
+            // Orbit Shell taskbar + the five demo windows (File Explorer,
+            // Terminal, Settings, Text Editor, Calculator).  They would cover
+            // the compositor root and hide the real Firefox toplevel we want to
+            // observe.  Headless mode still launches the desktop so the existing
+            // screenshot demos are unchanged.
+            if !boot_config::ff_gui_mode() {
+                gui::desktop::launch_desktop();
+            }
             hal::enable_interrupts();
 
             // Wait 30 ticks for the desktop to settle before launching Firefox.


### PR DESCRIPTION
## What
In windowed Firefox mode (`astryx.ff_gui=1`), suppress two things that clutter the compositor root and make `--ff-gui` screendumps useless:

1. The synthetic `[X11-VIS]` probe window — a kernel-owned 300×200 cyan client created *before* Firefox launches.
2. `gui::desktop::launch_desktop()` — the Orbit Shell taskbar + five demo windows (File Explorer, Terminal, Settings, Text Editor, Calculator).

Both are gated behind `!boot_config::ff_gui_mode()`, mirroring the existing xeyes-test declutter. Headless mode is unchanged (neither is composited to the framebuffer there), so existing headless screenshot demos are unaffected.

## Why
A screendump of the GUI boot showed the demo desktop + the cyan probe window, which is trivially mistaken for "Firefox painted a window" — it is not. With declutter, an `--ff-gui` screendump shows **either** the real Firefox toplevel on a clean root **or** an empty clean root (the honest signal that Firefox mapped no visible window) — never desktop chrome that can be misread as the app.

This is an observability/test change only — no behavioural change to headless boots, the scheduler, or any syscall path.

## Test
- `start --features firefox-test-core,kdb --build-only` → clean build.
- `--ff-gui` boot: confirmed no `[X11-VIS]` line and no `launch_desktop`; framebuffer is the clean compositor root. (Separately confirms the open gate: FF maps only 1×1 GTK utility windows then the content-proc crashes — no real toplevel yet.)