### PR TITLE
mm/vfs: pin backing inode for live MAP_SHARED file mappings (fixes FF main-proc realize/map SIGSEGV)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1237,7 +1237,7 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
 /// - Bit 1: Write (1 = write, 0 = read)
 /// - Bit 2: User (1 = user mode, 0 = kernel mode)
 /// - Bit 4: Instruction fetch
-fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut InterruptFrame) -> bool {
+fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptFrame) -> bool {
     PAGE_FAULT_TOTAL.fetch_add(1, Ordering::Relaxed);
     // Per-process PF counter.  Lockless: takes neither THREAD_TABLE nor
     // PROCESS_TABLE; one bounds-check + one Acquire load + one Relaxed
@@ -1878,7 +1878,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                     cached_phys,
                                     c_mount, c_inode, c_off,
                                     mount_idx, inode, file_page_offset,
-                                    _frame.rip,
+                                    frame.rip,
                                 );
                             }
                         }
@@ -1960,6 +1960,59 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                     }
                 }
                 return true;
+            }
+
+            // ── Defensive: dead / truncated backing inode → SIGBUS ───────────
+            //
+            // The page was not in the cache, so its contents (if any) must come
+            // from the backing inode.  If `stat` on that inode fails the inode
+            // no longer exists in the filesystem — e.g. a still-live MAP_SHARED
+            // mapping whose backing tmpfs/shm inode was freed.  POSIX mmap(2)
+            // specifies SIGBUS for "a reference to a portion of [a file] mapping
+            // that does not correspond to the file" (a truncated / removed
+            // backing).  Without this guard the readahead path below would see
+            // `file_size == 0`, map no page, and return an *unserviced* fault
+            // that the caller converts to a silent SIGSEGV (or, worse, a
+            // zero-filled page) — making any residual inode-lifetime bug a
+            // mystery crash instead of a loud, spec-correct SIGBUS.
+            //
+            // Only the faulting page matters here (pure readahead is best-
+            // effort and simply retries), and only Ring-3 faults are eligible
+            // for signal delivery; a kernel-mode fault on a dead inode falls
+            // through to the existing unresolved-fault path.
+            {
+                let inode_alive = {
+                    let fs_for_stat: Option<Arc<dyn crate::vfs::FileSystemOps>> =
+                        crate::vfs::MOUNTS.try_lock()
+                            .and_then(|m| m.get(mount_idx).map(|mt| mt.fs.clone()));
+                    match fs_for_stat {
+                        // Contended MOUNTS: cannot prove the inode is dead, so
+                        // do NOT synthesise SIGBUS — fall through and let the
+                        // normal path (which re-tries the lock) decide.
+                        None => true,
+                        Some(fs) => fs.stat(inode).is_ok(),
+                    }
+                };
+                if !inode_alive {
+                    crate::serial_println!(
+                        "[PF/SIGBUS] dead file-backing inode={} mount={} foff={:#x} cr2={:#x} shared={}",
+                        inode, mount_idx, file_page_offset, faulting_addr, is_shared);
+                    if error_code & 4 != 0 {
+                        // BUS_ADRERR = 3 (physical address valid but no object).
+                        let delivered = unsafe {
+                            crate::signal::deliver_fault_signal_from_isr(
+                                crate::signal::SIGBUS, 3,
+                                faulting_addr, error_code,
+                                frame as *mut InterruptFrame,
+                            )
+                        };
+                        // Delivered → IRET runs the handler (handled).  No
+                        // handler → return false so the caller default-kills
+                        // the process (the correct default action for SIGBUS).
+                        return delivered;
+                    }
+                    return false;
+                }
             }
 
             // 2. Not cached — allocate pages and read from the filesystem.
@@ -2501,7 +2554,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                     phys,
                                     c_mount, c_inode, c_off,
                                     mount_idx, inode, foff,
-                                    _frame.rip,
+                                    frame.rip,
                                 );
                             }
                         }
@@ -2619,7 +2672,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                             "[PF] MOUNTS spin exceeded bound at faulting_addr={:#x} \
                              rip={:#x} — leaving page unread (likely same-thread \
                              MOUNTS recursion outside vfs::*; see #82 follow-up)",
-                            faulting_addr, _frame.rip,
+                            faulting_addr, frame.rip,
                         );
                         break None;
                     }
@@ -2878,7 +2931,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, _frame: &mut Interrupt
                                     phys,
                                     c_mount, c_inode, c_off,
                                     mount_idx, inode, file_page_offset,
-                                    _frame.rip,
+                                    frame.rip,
                                 );
                             }
                         }

--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -882,6 +882,14 @@ impl VmSpace {
         // Copy VMA list to child.
         let mut child_areas = Vec::with_capacity(self.areas.len());
         for vma in &self.areas {
+            // The child independently maps every VMA the parent had, so a
+            // MAP_SHARED file-backed mapping inherited by the child holds its
+            // OWN inode pin.  This balances the unpin the child's teardown
+            // (free_process_memory / free_vm_space) will perform over its
+            // areas; without it the child's exit would underflow the parent's
+            // pin and free a still-mapped shm inode.  This direct push bypasses
+            // insert_vma, so pin here.  See vfs::vma_pin_if_shared_file.
+            crate::vfs::vma_pin_if_shared_file(vma.flags, &vma.backing);
             child_areas.push(vma.clone());
         }
 
@@ -960,6 +968,13 @@ impl VmSpace {
         // Find insertion point (sorted by base)
         let pos = self.areas.iter().position(|v| v.base > vma.base)
             .unwrap_or(self.areas.len());
+        // A MAP_SHARED file-backed VMA entering the address space holds one
+        // kernel pin on its inode for the duration of its membership in this
+        // list (POSIX mmap(2)'s independent open-file reference).  Pin before
+        // moving `vma` into the Vec so we can read its flags/backing.  See
+        // vfs::vma_pin_if_shared_file.  Balanced in remove_range / on whole-
+        // VmSpace teardown (proc::free_process_memory).
+        crate::vfs::vma_pin_if_shared_file(vma.flags, &vma.backing);
         self.areas.insert(pos, vma);
         // W216 H_5j-B: notify the PFH install loop that the VMA list changed.
         self.generation.fetch_add(1, Ordering::Release);
@@ -995,8 +1010,13 @@ impl VmSpace {
             }
 
             if vma.base >= base && vma.end() <= end {
-                // Completely contained — remove
-                self.areas.remove(i);
+                // Completely contained — remove.  This VMA leaves the address
+                // space entirely, so drop the MAP_SHARED-file pin it held (if
+                // any).  This is the munmap / MAP_FIXED-replacement path that
+                // tears down a shm mapping; when it is the last reference the
+                // pinned, deferred-deleted inode is freed here.
+                let removed = self.areas.remove(i);
+                crate::vfs::vma_unpin_if_shared_file(removed.flags, &removed.backing);
                 continue;
             }
 
@@ -1034,7 +1054,14 @@ impl VmSpace {
                     backing: right_backing,
                     name: vma.name,
                 };
-                self.areas.remove(i);
+                // One MAP_SHARED-file VMA becomes two: drop the original's pin
+                // and place one pin per surviving piece so the inode stays
+                // pinned exactly once per live mapping.  The inserts below
+                // bypass insert_vma, so pin them directly here.
+                let removed = self.areas.remove(i);
+                crate::vfs::vma_unpin_if_shared_file(removed.flags, &removed.backing);
+                crate::vfs::vma_pin_if_shared_file(right.flags, &right.backing);
+                crate::vfs::vma_pin_if_shared_file(left.flags, &left.backing);
                 self.areas.insert(i, right);
                 self.areas.insert(i, left);
                 i += 2;

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1776,6 +1776,18 @@ pub fn free_process_memory(pid: Pid) {
     const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
     const PAGE_PRESENT: u64 = 1;
 
+    // Whole-address-space teardown bypasses VmSpace::remove_range, so drop the
+    // MAP_SHARED-file inode pins this process held directly.  This is the path
+    // an exiting process takes when it still has shm mappings live (the common
+    // case for the POSIX shm idiom: the file was unlinked while mapped, so the
+    // last unpin here frees the deferred-deleted inode).  See
+    // vfs::vma_pin_if_shared_file.  The unpin queues the orphan-check/free; the
+    // reap below runs it (PROCESS_TABLE is not held on this path).
+    for vma in &vm_space.areas {
+        crate::vfs::vma_unpin_if_shared_file(vma.flags, &vma.backing);
+    }
+    crate::vfs::reap_pending_inodes();
+
     for vma in &vm_space.areas {
         // Skip MMIO device VMAs — their "physical addresses" are I/O registers,
         // not PMM-tracked frames; decrementing their refcount would corrupt the
@@ -1868,6 +1880,16 @@ pub fn free_vm_space(vm_space: crate::mm::vma::VmSpace) {
     // Firefox bringup (W216 audit teardown-leak finding).
     const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
     const PAGE_PRESENT: u64 = 1;
+
+    // Drop MAP_SHARED-file inode pins held by this (consumed) VmSpace — the
+    // execve teardown counterpart of the unpin loop in free_process_memory.
+    // See vfs::vma_pin_if_shared_file.  free_vm_space is, by its caller's
+    // contract (sys_exec), invoked with PROCESS_TABLE released, so the reap
+    // (which takes PROCESS_TABLE) is safe here.
+    for vma in &vm_space.areas {
+        crate::vfs::vma_unpin_if_shared_file(vma.flags, &vma.backing);
+    }
+    crate::vfs::reap_pending_inodes();
 
     for vma in &vm_space.areas {
         if let VmBacking::Device { .. } = &vma.backing { continue; }

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1001,6 +1001,30 @@ pub unsafe fn deliver_sigsegv_from_isr(
     error_code: u64,
     frame: *mut crate::arch::x86_64::idt::InterruptFrame,
 ) -> bool {
+    // SEGV_MAPERR (1, not-present) / SEGV_ACCERR (2, protection) per
+    // POSIX.1-2017 §2.4.2; chosen here from the #PF error-code present bit.
+    let si_code: i32 = if error_code & 1 != 0 { 2 } else { 1 };
+    deliver_fault_signal_from_isr(SIGSEGV, si_code, cr2, error_code, frame)
+}
+
+/// Deliver a synchronous fault signal (SIGSEGV or SIGBUS) to the faulting
+/// Ring-3 thread from the page-fault ISR by synthesising a signal frame on the
+/// user stack and redirecting IRET to the installed handler.  Returns `false`
+/// (and makes no change) if the process has no user handler installed for
+/// `signo` (Default/Ignore) — the caller then kills the process.
+///
+/// `signo` is the signal number (`SIGSEGV` for an unmapped/protection fault,
+/// `SIGBUS` per POSIX `mmap(2)` for a reference to a portion of a file mapping
+/// that has no backing — e.g. a still-live `MAP_SHARED` mapping whose backing
+/// inode was truncated/removed).  `si_code` is the `siginfo_t.si_code` (e.g.
+/// `SEGV_MAPERR`/`SEGV_ACCERR` for SIGSEGV, `BUS_ADRERR`=3 for SIGBUS).
+pub unsafe fn deliver_fault_signal_from_isr(
+    signo: u8,
+    si_code: i32,
+    cr2: u64,
+    error_code: u64,
+    frame: *mut crate::arch::x86_64::idt::InterruptFrame,
+) -> bool {
     let pid = crate::proc::current_pid();
     let mut procs = crate::proc::PROCESS_TABLE.lock();
     let proc_entry = match procs.iter_mut().find(|p| p.pid == pid) {
@@ -1026,7 +1050,7 @@ pub unsafe fn deliver_sigsegv_from_isr(
         None => return false,
     };
 
-    let action = sig_state.actions[SIGSEGV as usize];
+    let action = sig_state.actions[signo as usize];
     let (handler_addr, restorer) = match action {
         SigAction::Handler { addr, restorer } => (addr, restorer),
         _ => return false, // Default or Ignore — caller kills the process
@@ -1044,7 +1068,7 @@ pub unsafe fn deliver_sigsegv_from_isr(
         TRAMPOLINE_VADDR
     };
 
-    let action_flags = sig_state.action_flags[SIGSEGV as usize];
+    let action_flags = sig_state.action_flags[signo as usize];
     let want_siginfo = (action_flags & SA_SIGINFO) != 0;
 
     // ── User stack layout (growing downward) ─────────────────────────────────
@@ -1149,7 +1173,7 @@ pub unsafe fn deliver_sigsegv_from_isr(
     // range-validated via `virt_to_phys_in(cr3, new_rsp)` above.
     let _smap_g = UserGuard::new();
     (*sig_frame_ptr).restorer    = restorer_addr;
-    (*sig_frame_ptr).sig_num     = SIGSEGV as u64;
+    (*sig_frame_ptr).sig_num     = signo as u64;
     (*sig_frame_ptr).saved_mask  = saved_mask;
     (*sig_frame_ptr).saved_rsp   = user_rsp;
     (*sig_frame_ptr).saved_r15   = isr_r15;
@@ -1205,13 +1229,12 @@ pub unsafe fn deliver_sigsegv_from_isr(
     }
 
     // ── Write siginfo_t (Linux x86_64 layout, POSIX.1-2017 §2.4.2) ──────────
-    // offset  0: si_signo (i32) = SIGSEGV
+    // offset  0: si_signo (i32) = signo (SIGSEGV / SIGBUS)
     // offset  4: si_errno (i32) = 0
-    // offset  8: si_code  (i32) = SEGV_MAPERR (1) or SEGV_ACCERR (2)
+    // offset  8: si_code  (i32) = SEGV_MAPERR/ACCERR (SIGSEGV) or BUS_ADRERR (SIGBUS)
     // offset 16: si_addr  (u64) = cr2 (faulting virtual address)
     core::ptr::write_bytes(siginfo_ptr, 0, 128);
-    let si_code: i32 = if error_code & 1 != 0 { 2 } else { 1 }; // present=ACCERR, not-present=MAPERR
-    core::ptr::write(siginfo_ptr.add(0)  as *mut i32, SIGSEGV as i32);
+    core::ptr::write(siginfo_ptr.add(0)  as *mut i32, signo as i32);
     core::ptr::write(siginfo_ptr.add(4)  as *mut i32, 0i32);
     core::ptr::write(siginfo_ptr.add(8)  as *mut i32, si_code);
     core::ptr::write(siginfo_ptr.add(16) as *mut u64, cr2);
@@ -1229,23 +1252,23 @@ pub unsafe fn deliver_sigsegv_from_isr(
     //   RDX at frame[-4] = frame_u64 - 32
     let p_rdi = (frame_u64 - 48) as *mut u64;
     let p_rsi = (frame_u64 - 40) as *mut u64;
-    *p_rdi = SIGSEGV as u64;            // RDI = signo (arg1, always set)
+    *p_rdi = signo as u64;              // RDI = signo (arg1, always set)
     *p_rsi = siginfo_ptr as u64;        // RSI = &siginfo_t (arg2, always set)
     if want_siginfo {
         let p_rdx = (frame_u64 - 32) as *mut u64;
         *p_rdx = ucontext_ptr as u64;   // RDX = &ucontext_t (arg3, SA_SIGINFO only)
     }
 
-    // Block SIGSEGV during handler execution (re-enabled by sigreturn).
-    sig_state.blocked |= 1u64 << SIGSEGV;
+    // Block this signal during handler execution (re-enabled by sigreturn).
+    sig_state.blocked |= 1u64 << signo;
     sig_state.blocked &= !((1u64 << SIGKILL) | (1u64 << SIGSTOP));
 
     // Drop PROCESS_TABLE before the serial writes — COM1 is slow and should
     // never block other CPUs from looking up their own process entry.
     drop(procs);
     crate::serial_println!(
-        "[SIGNAL] SIGSEGV ISR delivery: PID={} CR2={:#x} user_rip={:#x} handler={:#x} new_rsp={:#x} siginfo={} r14={:#x} rbp={:#x} rbx={:#x} rsi={:#x}",
-        pid, cr2, user_rip, handler_addr, new_rsp,
+        "[SIGNAL] sig={} ISR delivery: PID={} CR2={:#x} user_rip={:#x} handler={:#x} new_rsp={:#x} siginfo={} r14={:#x} rbp={:#x} rbx={:#x} rsi={:#x}",
+        signo, pid, cr2, user_rip, handler_addr, new_rsp,
         if want_siginfo { "SA_SIGINFO" } else { "classic" },
         isr_r14, isr_rbp, isr_rbx, isr_rsi
     );

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -7713,7 +7713,25 @@ fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
         // CRITICAL: for file-backed VMAs, each split piece must have its
         // file offset adjusted by (piece.base - original_vma_base) so that
         // demand-paging reads from the correct file position.
-        space.areas.remove(i);
+        //
+        // INODE-PIN BALANCE: one MAP_SHARED file-backed VMA is being replaced
+        // by 2-3 surviving pieces, each a new VMA-list membership carrying the
+        // same backing inode.  The invariant is exactly one kernel inode pin
+        // per MAP_SHARED file VMA-list membership (see vfs::vma_pin_if_shared_file
+        // / vma_unpin_if_shared_file).  So drop the removed original's pin and
+        // place one pin per surviving piece.  Without this the pin count stays 1
+        // while 2-3 pieces map the inode, and the first piece's teardown would
+        // free the inode out from under the others (a demand-fault on a dead
+        // inode).  The inserts below bypass insert_vma, so the pins are placed
+        // directly here, mirroring VmSpace::remove_range's hole-punch split.
+        //
+        // The unpin uses vma_unpin_if_shared_file, which never takes
+        // PROCESS_TABLE (we hold it here) — it queues the orphan free to the
+        // reaper drained after the lock is released (see reap_pending_inodes
+        // below).  vma_pin_if_shared_file only touches PINNED_INODES, so it is
+        // safe under the lock.
+        let removed = space.areas.remove(i);
+        crate::vfs::vma_unpin_if_shared_file(removed.flags, &removed.backing);
         let overlap_start = vma_base.max(base);
         let overlap_end   = vma_end.min(end);
 
@@ -7752,10 +7770,26 @@ fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
         }
         let n = pieces.len();
         for piece in pieces.into_iter().rev() {
+            // One pin per surviving MAP_SHARED-file piece (balances the
+            // removed original's unpin above; no-op for non-shared/anon/device).
+            crate::vfs::vma_pin_if_shared_file(piece.flags, &piece.backing);
             space.areas.insert(i, piece);
         }
         i += n;
     }
+
+    // Release PROCESS_TABLE before the (lock-free) PTE retag below: the PTE
+    // walk and TLB shootdown use only the copied `cr3`, not the address-space
+    // record, so the lock is no longer needed here.  Dropping it now also lets
+    // the inode reaper run outside the critical section.
+    drop(procs);
+
+    // A partial-overlap split above may have dropped the last pin of an
+    // already-unlinked shm inode (vma_unpin_if_shared_file queues the orphan
+    // free under the lock).  Free it now that PROCESS_TABLE is released — same
+    // wiring as sys_munmap's post-Phase-1 reap.  No-op when nothing was
+    // unpinned.  See vfs::reap_pending_inodes.
+    crate::vfs::reap_pending_inodes();
 
     // Walk every page and retag PTEs.  TLB invalidation is coalesced
     // into a single shootdown over [base, end) after the loop so that
@@ -10344,6 +10378,14 @@ fn sys_memfd_create(_name: u64, flags: u64) -> i64 {
 #[cfg(feature = "test-mode")]
 pub fn sys_memfd_create_test(_name: u64, flags: u64) -> i64 {
     sys_memfd_create(_name, flags)
+}
+
+/// Test shim: call sys_mprotect from in-kernel tests.  Exercises the real
+/// VMA-split + inode-pin-rebalance path against the current process's address
+/// space (Test 119c).  See mprotect(2).
+#[cfg(feature = "test-mode")]
+pub fn sys_mprotect_test(addr: u64, len: u64, prot: u64) -> i64 {
+    sys_mprotect(addr, len, prot)
 }
 
 /// Test shim: call sys_fcntl from in-kernel tests.

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -3400,46 +3400,57 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
             pid, base, length, r, w, x, fd as i64, offset, name);
     }
 
-    // Phase 3 — install the new VMA under PROCESS_TABLE.
-    let mut procs = crate::proc::PROCESS_TABLE.lock();
-    let proc = match procs.iter_mut().find(|p| p.pid == pid) {
-        Some(p) => p,
-        None => return -3, // ESRCH (process exited between phases)
-    };
-    let space = match proc.vm_space.as_mut() {
-        Some(s) => s,
-        None => return -3,
-    };
+    // Phase 3 — install the new VMA under PROCESS_TABLE.  The block yields the
+    // syscall result rather than returning directly so the reap below always
+    // runs (Phase 2a above may have queued an inode free even on the rare
+    // process-exited-between-phases path).
+    let result = 'phase3: {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        let proc = match procs.iter_mut().find(|p| p.pid == pid) {
+            Some(p) => p,
+            None => break 'phase3 -3, // ESRCH (process exited between phases)
+        };
+        let space = match proc.vm_space.as_mut() {
+            Some(s) => s,
+            None => break 'phase3 -3,
+        };
 
-    match space.insert_vma(vma) {
-        Ok(()) => {
-            // Lower `mmap_hint` only when this allocation participates in the
-            // NULL-hint downward-walk regime — i.e. neither MAP_FIXED nor a
-            // MAP_STACK kernel-chosen allocation.  See
-            // `VmSpace::note_mmap_placement` for the full rationale; the
-            // critical case is MAP_FIXED at a PIE-biased shared-library load
-            // base, which would otherwise destroy the per-process entropy
-            // seeded by `randomised_mmap_hint()` before any NULL-hint
-            // allocation is ever issued (POSIX mmap(2), CWE-330).
-            let hint_before = space.mmap_hint;
-            space.note_mmap_placement(base, is_fixed, is_stack_alloc);
-            let hint_after = space.mmap_hint;
-            #[cfg(all(feature = "firefox-test-core", feature = "firefox-trace-verbose"))]
-            crate::serial_println!(
-                "[MMAP-HINT] pid={} base={:#x} hint_before={:#x} hint_after={:#x} is_fixed={} is_stack_alloc={}",
-                pid, base, hint_before, hint_after, is_fixed as u8, is_stack_alloc as u8
-            );
-            let _ = (hint_before, hint_after);
-            base as i64
+        match space.insert_vma(vma) {
+            Ok(()) => {
+                // Lower `mmap_hint` only when this allocation participates in the
+                // NULL-hint downward-walk regime — i.e. neither MAP_FIXED nor a
+                // MAP_STACK kernel-chosen allocation.  See
+                // `VmSpace::note_mmap_placement` for the full rationale; the
+                // critical case is MAP_FIXED at a PIE-biased shared-library load
+                // base, which would otherwise destroy the per-process entropy
+                // seeded by `randomised_mmap_hint()` before any NULL-hint
+                // allocation is ever issued (POSIX mmap(2), CWE-330).
+                let hint_before = space.mmap_hint;
+                space.note_mmap_placement(base, is_fixed, is_stack_alloc);
+                let hint_after = space.mmap_hint;
+                #[cfg(all(feature = "firefox-test-core", feature = "firefox-trace-verbose"))]
+                crate::serial_println!(
+                    "[MMAP-HINT] pid={} base={:#x} hint_before={:#x} hint_after={:#x} is_fixed={} is_stack_alloc={}",
+                    pid, base, hint_before, hint_after, is_fixed as u8, is_stack_alloc as u8
+                );
+                let _ = (hint_before, hint_after);
+                base as i64
+            }
+            Err(_) => {
+                crate::serial_println!(
+                    "[MMAP-ERR] pid={} insert_vma failed: base={:#x} len={:#x} flags={:#x} fd={}",
+                    pid, base, length, flags, fd as i64
+                );
+                -12 // ENOMEM
+            }
         }
-        Err(_) => {
-            crate::serial_println!(
-                "[MMAP-ERR] pid={} insert_vma failed: base={:#x} len={:#x} flags={:#x} fd={}",
-                pid, base, length, flags, fd as i64
-            );
-            -12 // ENOMEM
-        }
-    }
+    }; // PROCESS_TABLE released here
+
+    // A MAP_FIXED replacement (Phase 2a above) may have dropped the last pin of
+    // an unlinked shm inode under PROCESS_TABLE; free it now that the lock is
+    // released.  No-op when nothing was unpinned.  See vfs::reap_pending_inodes.
+    crate::vfs::reap_pending_inodes();
+    result
 }
 
 /// munmap — Unmap a region of the current process's address space.
@@ -3484,6 +3495,13 @@ pub(crate) fn sys_munmap(addr: u64, length: u64) -> i64 {
         let _ = space.remove_range(addr, length);
         cr3
     }; // PROCESS_TABLE released here
+
+    // remove_range above (run under PROCESS_TABLE) may have dropped the last pin
+    // of an unlinked shm inode; free it now that the lock is released.  No-op
+    // when nothing was unpinned.  See vfs::reap_pending_inodes.  This is the
+    // POSIX shm teardown moment: munmap of the final mapping of an already
+    // shm_unlink'd region frees the inode here.
+    crate::vfs::reap_pending_inodes();
 
     // ── Phase 2 (lock-free) — clear PTEs and release backing frames. ──────
     crate::mm::vmm::unmap_and_free_range_in(cr3, addr, length);

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1299,6 +1299,14 @@ pub fn run() -> ! {
     total += 1;
     if test_umount_removes_mount() { passed += 1; }
 
+    // ── Test 119b: MAP_SHARED-file inode pin survives unlink + last close ──
+    // Cross-subsystem: mm::vma (VMA pin/unpin at insert/teardown) + vfs
+    // (unlink-on-last-close + PINNED_INODES).  Reproduces the POSIX shm idiom
+    // a content/IPC layer uses (shm_open → mmap(MAP_SHARED) → close → unlink)
+    // and asserts the inode's data survives until the mapping is torn down.
+    total += 1;
+    if test_shm_mmap_pin_survives_unlink_close() { passed += 1; }
+
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
     // Cross-subsystem: drivers::log_ring (the PMM-backed guest-RAM ring) +
     // drivers::serial (the fast-path routing + COM1 fallback).  One test
@@ -48255,6 +48263,143 @@ fn test_288_scm_memfd_inode_lifecycle() -> bool {
     // Final close of the last reference frees the (unlinked) inode.
     crate::subsys::linux::syscall::sys_close_test(recv_fd as u64);
     test_pass!("SCM-passed memfd inode survives sender close (Test 288)");
+    true
+}
+
+// ── Test 119b: MAP_SHARED-file inode pin survives unlink + last close ────────
+//
+// POSIX mmap(2) makes a mapping an independent reference on the backing file:
+// the inode (and its data) must survive a close(2) of the mapping fd, and an
+// unlink(2)/shm_unlink, until the mapping itself is torn down.  This is the
+// POSIX shared-memory idiom an IPC layer uses — memfd_create/shm_open →
+// mmap(MAP_SHARED) → close(fd) — and the exact path that crashed Firefox's
+// main process: it mapped a /dev/shm IPC region MAP_SHARED then close()'d the
+// fd, the inode was freed under it, and the next demand fault on the still-live
+// mapping found a dead inode and SIGSEGV'd.
+//
+// This exercises the kernel invariant directly (no user process needed): a live
+// MAP_SHARED file VMA holds one inode pin (the pin `insert_vma` takes), so the
+// last close must NOT free the inode; once the mapping's pin is dropped (the
+// unpin `remove_range`/teardown takes) and nothing else references it, the
+// inode is freed by the deferred reaper.
+//
+// Cross-subsystem: mm::vma (VMA pin/unpin balance) + vfs (unlink-on-last-close
+// C5 + PINNED_INODES authority + PENDING_INODE_REAP).
+// Refs: mmap(2), munmap(2), memfd_create(2), shm_open(3).
+fn test_shm_mmap_pin_survives_unlink_close() -> bool {
+    use crate::mm::vma::{VmBacking, MAP_SHARED, MAP_PRIVATE};
+    test_header!("MAP_SHARED-file inode pin survives unlink + last close (Test 119b)");
+    const MFD_CLOEXEC: u64 = 0x0001;
+
+    // memfd_create gives an already-unlinked (anonymous) inode — exactly the
+    // post-shm_unlink lifetime the bug is about.
+    let fd = crate::subsys::linux::syscall::sys_memfd_create_test(0, MFD_CLOEXEC);
+    if fd < 0 {
+        test_fail!("shm_mmap_pin", "memfd_create returned {}", fd);
+        return false;
+    }
+    let surf = [0xDEu8, 0xAD, 0xBE, 0xEF];
+    let wn = crate::syscall::sys_write_test(fd as usize, surf.as_ptr(), surf.len());
+    if wn != surf.len() as i64 {
+        test_fail!("shm_mmap_pin", "write to memfd = {} (want {})", wn, surf.len());
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+
+    // Snapshot (mount_idx, inode).
+    let pid = crate::proc::current_pid_lockless();
+    let (mnt, ino) = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter().find(|p| p.pid == pid)
+            .and_then(|p| p.file_descriptors.get(fd as usize))
+            .and_then(|f| f.as_ref())
+            .map(|f| (f.mount_idx, f.inode))
+        {
+            Some(v) => v,
+            None => {
+                test_fail!("shm_mmap_pin", "could not resolve memfd inode");
+                crate::subsys::linux::syscall::sys_close_test(fd as u64);
+                return false;
+            }
+        }
+    };
+    if mnt == usize::MAX {
+        test_fail!("shm_mmap_pin", "memfd has sentinel mount_idx (not a real inode)");
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+    let shared_backing = VmBacking::File { mount_idx: mnt, inode: ino, offset: 0, elf_load_delta: 0 };
+    test_println!("  memfd inode {} on mount {} ✓", ino, mnt);
+
+    // A MAP_PRIVATE mapping must NOT pin (it copies file pages into anon frames
+    // and does not need the inode to outlive close) — assert the gate first.
+    crate::vfs::vma_pin_if_shared_file(MAP_PRIVATE, &shared_backing);
+    if crate::vfs::inode_is_pinned_pub(mnt, ino) {
+        test_fail!("shm_mmap_pin", "MAP_PRIVATE wrongly pinned the inode");
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+    test_println!("  MAP_PRIVATE does not pin ✓");
+
+    // Now the live MAP_SHARED mapping takes its inode pin (as insert_vma does).
+    crate::vfs::vma_pin_if_shared_file(MAP_SHARED, &shared_backing);
+    if !crate::vfs::inode_is_pinned_pub(mnt, ino) {
+        test_fail!("shm_mmap_pin", "MAP_SHARED did not pin the inode");
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+
+    // close(2) the only fd.  This is unlink-on-last-close (C5): WITHOUT the pin
+    // the inode would be freed here.  WITH the pin it must survive — this is the
+    // exact moment Firefox crashed.
+    crate::subsys::linux::syscall::sys_close_test(fd as u64);
+
+    // The inode's data must still be readable directly from the filesystem — it
+    // was not freed under the still-live mapping.
+    if let Some((fs, _)) = crate::vfs::fs_at(mnt) {
+        let mut rbuf = [0u8; 4];
+        match fs.read(ino, 0, &mut rbuf) {
+            Ok(n) if n == 4 && rbuf == surf => {
+                test_println!("  inode data survives last close while MAP_SHARED-pinned ✓");
+            }
+            other => {
+                test_fail!("shm_mmap_pin",
+                    "inode read after close = {:?} buf={:?} (want Ok(4) {:?}) — freed early",
+                    other, rbuf, surf);
+                crate::vfs::vma_unpin_if_shared_file(MAP_SHARED, &shared_backing);
+                crate::vfs::reap_pending_inodes();
+                return false;
+            }
+        }
+    } else {
+        test_fail!("shm_mmap_pin", "mount {} vanished", mnt);
+        return false;
+    }
+
+    // Tear down the mapping (the unpin remove_range / address-space teardown
+    // performs).  This drops the last pin; the deferred reaper then frees the
+    // now-orphaned (unlinked, no open fd, no pin) inode.
+    crate::vfs::vma_unpin_if_shared_file(MAP_SHARED, &shared_backing);
+    if crate::vfs::inode_is_pinned_pub(mnt, ino) {
+        test_fail!("shm_mmap_pin", "inode still pinned after the only mapping's unpin");
+        crate::vfs::reap_pending_inodes();
+        return false;
+    }
+    crate::vfs::reap_pending_inodes();
+
+    // The inode must now be gone: a fresh fs read fails (inode freed) and the
+    // deferred-delete record is drained.
+    if let Some((fs, _)) = crate::vfs::fs_at(mnt) {
+        let mut rbuf = [0u8; 4];
+        if fs.read(ino, 0, &mut rbuf).is_ok() {
+            test_fail!("shm_mmap_pin",
+                "inode {} still readable after mapping teardown — leaked", ino);
+            return false;
+        }
+    }
+    test_println!("  inode freed once the last MAP_SHARED mapping is torn down ✓");
+
+    test_pass!("MAP_SHARED-file inode pin survives unlink + last close (Test 119b)");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1307,6 +1307,15 @@ pub fn run() -> ! {
     total += 1;
     if test_shm_mmap_pin_survives_unlink_close() { passed += 1; }
 
+    // ── Test 119c: mprotect partial-overlap split keeps the inode-pin balance ─
+    // Cross-subsystem: subsys::linux::syscall (sys_mprotect VMA split) + mm::vma
+    // (per-membership pin) + vfs (PINNED_INODES + deferred reaper).  Forces a
+    // 3-way mprotect split of a MAP_SHARED file mapping and asserts the pin
+    // count tracks the surviving-piece count, then frees the address space and
+    // asserts the inode is reclaimed exactly once (no double-free, no leak).
+    total += 1;
+    if test_mprotect_split_inode_pin_balance() { passed += 1; }
+
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
     // Cross-subsystem: drivers::log_ring (the PMM-backed guest-RAM ring) +
     // drivers::serial (the fast-path routing + COM1 fallback).  One test
@@ -48400,6 +48409,275 @@ fn test_shm_mmap_pin_survives_unlink_close() -> bool {
     test_println!("  inode freed once the last MAP_SHARED mapping is torn down ✓");
 
     test_pass!("MAP_SHARED-file inode pin survives unlink + last close (Test 119b)");
+    true
+}
+
+// ── Test 119c: mprotect partial-overlap split keeps the inode-pin balance ────
+//
+// POSIX mprotect(2) changes the protection of an *interior* sub-range of a
+// mapping by splitting the containing VMA into up to three pieces (a left
+// remnant at the old prot, the middle at the new prot, a right remnant at the
+// old prot).  Each surviving piece is an independent VMA-list membership that
+// still maps the same backing inode, so the kernel's one-pin-per-MAP_SHARED-
+// file-VMA-membership invariant (see vfs::vma_pin_if_shared_file) requires the
+// split to drop the original's single pin and place one pin per piece.
+//
+// Before the fix, sys_mprotect's partial-overlap arm removed the original VMA
+// WITHOUT unpinning and inserted the pieces WITHOUT pinning, so the pin count
+// stayed 1 while 2-3 pieces mapped the inode.  At address-space teardown the
+// first piece's unpin then freed the inode out from under the still-mapped
+// remnants — a demand-fault on a dead inode (the exact UAF Test 119b guards,
+// resurfacing through the split path).  This test forces a 3-way split via the
+// real sys_mprotect and asserts the pin count tracks the membership count, then
+// tears the address space down and asserts the inode is freed exactly once
+// (no double-free, no leak).
+//
+// Cross-subsystem: subsys::linux::syscall (sys_mprotect split) + mm::vma (VMA
+// membership) + vfs (PINNED_INODES authority + deferred reaper).
+// Refs: mprotect(2), mmap(2), munmap(2), memfd_create(2).
+fn test_mprotect_split_inode_pin_balance() -> bool {
+    use crate::mm::vma::{VmArea, VmBacking, VmProt, MAP_SHARED, PROT_READ, PROT_WRITE, PROT_NONE};
+    test_header!("mprotect partial-overlap split keeps MAP_SHARED inode-pin balance (Test 119c)");
+    const MFD_CLOEXEC: u64 = 0x0001;
+
+    // 1. An already-unlinked (memfd) inode — the post-shm_unlink lifetime where
+    //    a stale free is fatal.
+    let fd = crate::subsys::linux::syscall::sys_memfd_create_test(0, MFD_CLOEXEC);
+    if fd < 0 {
+        test_fail!("mprotect_split_pin", "memfd_create returned {}", fd);
+        return false;
+    }
+    let surf = [0x11u8, 0x22, 0x33, 0x44];
+    let wn = crate::syscall::sys_write_test(fd as usize, surf.as_ptr(), surf.len());
+    if wn != surf.len() as i64 {
+        test_fail!("mprotect_split_pin", "write to memfd = {} (want {})", wn, surf.len());
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+    let pid_now = crate::proc::current_pid_lockless();
+    let (mnt, ino) = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        match procs.iter().find(|p| p.pid == pid_now)
+            .and_then(|p| p.file_descriptors.get(fd as usize))
+            .and_then(|f| f.as_ref())
+            .map(|f| (f.mount_idx, f.inode))
+        {
+            Some(v) => v,
+            None => {
+                test_fail!("mprotect_split_pin", "could not resolve memfd inode");
+                crate::subsys::linux::syscall::sys_close_test(fd as u64);
+                return false;
+            }
+        }
+    };
+    if mnt == usize::MAX {
+        test_fail!("mprotect_split_pin", "memfd has sentinel mount_idx (not a real inode)");
+        crate::subsys::linux::syscall::sys_close_test(fd as u64);
+        return false;
+    }
+
+    // 2. A synthetic process with its own user address space, carrying ONE
+    //    MAP_SHARED file VMA spanning 4 pages.  insert_vma takes exactly one
+    //    inode pin (as the real mmap path does).
+    let test_pid: u64 = 9973;
+    let mut vm = match crate::mm::vma::VmSpace::new_user() {
+        Some(vs) => vs,
+        None => {
+            test_fail!("mprotect_split_pin", "VmSpace::new_user() OOM");
+            crate::subsys::linux::syscall::sys_close_test(fd as u64);
+            return false;
+        }
+    };
+    let cr3 = vm.cr3;
+    let vma_base: u64 = 0x5000_0000;
+    let vma_len:  u64 = 0x4000; // 4 pages
+    {
+        let vma = VmArea {
+            base: vma_base,
+            length: vma_len,
+            prot: PROT_READ | PROT_WRITE,
+            flags: MAP_SHARED,
+            backing: VmBacking::File { mount_idx: mnt, inode: ino, offset: 0, elf_load_delta: 0 },
+            name: "[shm-split-test]",
+        };
+        if vm.insert_vma(vma).is_err() {
+            test_fail!("mprotect_split_pin", "insert_vma failed");
+            crate::subsys::linux::syscall::sys_close_test(fd as u64);
+            crate::proc::free_vm_space(vm);
+            return false;
+        }
+    }
+    // The mapping now holds the inode pin.  Close the fd: this is the POSIX shm
+    // idiom (mmap then close) and exactly the lifetime the bug is about — the
+    // inode must outlive the fd because the mapping references it.  Closing
+    // AFTER insert_vma is essential: closing first would run unlink-on-last-
+    // close with no pin and free the inode before the mapping ever pins it.
+    crate::subsys::linux::syscall::sys_close_test(fd as u64);
+    if crate::vfs::inode_pin_count_pub(mnt, ino) != 1 {
+        test_fail!("mprotect_split_pin",
+            "after insert_vma pin count = {} (want 1)", crate::vfs::inode_pin_count_pub(mnt, ino));
+        crate::proc::free_vm_space(vm);
+        return false;
+    }
+    test_println!("  single MAP_SHARED VMA → pin count 1 ✓");
+
+    // 3. Register the synthetic process holding this VmSpace.
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        procs.push(crate::proc::Process {
+            pid: test_pid,
+            parent_pid: 0,
+            name: { let mut n = [0u8; 64]; n[..9].copy_from_slice(b"mpsplit!\0"); n },
+            state: crate::proc::ProcessState::Active,
+            cr3,
+            threads: alloc::vec::Vec::new(),
+            exit_code: 0,
+            file_descriptors: alloc::vec::Vec::new(),
+            cwd: alloc::string::String::from("/"),
+            uid: 0, gid: 0, euid: 0, egid: 0,
+            pgid: test_pid as u32, sid: test_pid as u32,
+            no_new_privs: false,
+            cap_permitted: !0u64, cap_effective: !0u64,
+            rlimits_soft: [u64::MAX; 16],
+            supplementary_groups: alloc::vec::Vec::new(),
+            umask: 0o022,
+            vm_space: Some(vm),
+            signal_state: Some(crate::signal::SignalState::new()),
+            linux_abi: true,
+            handle_table: None,
+            subsystem: crate::win32::SubsystemType::Linux,
+            token_id: None,
+            exe_path: None,
+            epoll_sets: alloc::vec::Vec::new(),
+            auxv: alloc::vec::Vec::new(),
+            envp: alloc::vec::Vec::new(),
+            alarm_deadline_ticks: 0,
+            alarm_interval_ticks: 0,
+            pdeath_signal: 0,
+        });
+    }
+
+    // Synchronous teardown helper: take the VmSpace out and free it (the
+    // address-space teardown path that unpins every surviving piece + reaps).
+    let teardown = || -> Option<crate::mm::vma::VmSpace> {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        let old = procs.iter_mut().find(|p| p.pid == test_pid)
+            .and_then(|p| p.vm_space.take());
+        procs.retain(|p| p.pid != test_pid);
+        old
+    };
+
+    // 4. mprotect the MIDDLE two pages to PROT_NONE.  Interior sub-range →
+    //    3-way partial-overlap split (left RW remnant, middle NONE, right RW
+    //    remnant).  Drive the REAL syscall: make the synthetic process current
+    //    so sys_mprotect (keyed on current_pid_lockless) operates on it.
+    let split_base = vma_base + 0x1000;   // page 1
+    let split_len:  u64 = 0x2000;          // pages 1..3
+    let prev_pid = crate::proc::current_pid_lockless();
+    crate::proc::set_current_pid(test_pid);
+    let mp = crate::subsys::linux::syscall::sys_mprotect_test(split_base, split_len, PROT_NONE as u64);
+    crate::proc::set_current_pid(prev_pid);
+    if mp != 0 {
+        test_fail!("mprotect_split_pin", "sys_mprotect returned {} (want 0)", mp);
+        if let Some(s) = teardown() { crate::proc::free_vm_space(s); }
+        return false;
+    }
+
+    // 5. The split must have produced 3 pieces, all still mapping the inode,
+    //    and the pin count must now equal that membership count (one pin per
+    //    piece).  Pre-fix this is the failing assertion: count stayed 1.
+    let (n_areas, n_shared_file_pieces) = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        let p = procs.iter().find(|p| p.pid == test_pid);
+        let space = p.and_then(|p| p.vm_space.as_ref());
+        match space {
+            Some(s) => {
+                let total = s.areas.len();
+                let pieces = s.areas.iter().filter(|a|
+                    a.flags & MAP_SHARED != 0
+                        && matches!(a.backing,
+                            VmBacking::File { mount_idx, inode, .. } if mount_idx == mnt && inode == ino)
+                ).count();
+                (total, pieces)
+            }
+            None => (0, 0),
+        }
+    };
+    if n_shared_file_pieces != 3 {
+        test_fail!("mprotect_split_pin",
+            "split produced {} MAP_SHARED-file pieces of the inode (want 3); total areas {}",
+            n_shared_file_pieces, n_areas);
+        if let Some(s) = teardown() { crate::proc::free_vm_space(s); }
+        return false;
+    }
+    let pin_after = crate::vfs::inode_pin_count_pub(mnt, ino);
+    if pin_after != 3 {
+        test_fail!("mprotect_split_pin",
+            "after 3-way split pin count = {} (want 3 — one per surviving piece)", pin_after);
+        if let Some(s) = teardown() { crate::proc::free_vm_space(s); }
+        return false;
+    }
+    // The inode is still alive: its data reads correctly.
+    if let Some((fs, _)) = crate::vfs::fs_at(mnt) {
+        let mut rbuf = [0u8; 4];
+        match fs.read(ino, 0, &mut rbuf) {
+            Ok(n) if n == 4 && rbuf == surf => {}
+            other => {
+                test_fail!("mprotect_split_pin",
+                    "inode read after split = {:?} buf={:?} (want Ok(4) {:?}) — freed early",
+                    other, rbuf, surf);
+                if let Some(s) = teardown() { crate::proc::free_vm_space(s); }
+                return false;
+            }
+        }
+    }
+    test_println!("  3-way split → 3 pieces, pin count 3, inode alive ✓");
+
+    // Belt-and-braces: the middle piece is now PROT_NONE, the remnants RW.
+    {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(s) = procs.iter().find(|p| p.pid == test_pid).and_then(|p| p.vm_space.as_ref()) {
+            let mid = s.areas.iter().find(|a| a.base == split_base);
+            let none_prot: VmProt = PROT_NONE;
+            if mid.map(|a| a.prot != none_prot).unwrap_or(true) {
+                test_fail!("mprotect_split_pin", "middle piece prot not PROT_NONE after split");
+                if let Some(s) = teardown() { crate::proc::free_vm_space(s); }
+                return false;
+            }
+        }
+    }
+
+    // 6. Tear the address space down — the real exit/exec path that unpins each
+    //    surviving piece exactly once and reaps the now-orphaned inode.  With
+    //    the fix this drops 3 pins (1 per piece) to 0 and frees the inode once.
+    //    Pre-fix it would drop the count-1 pin to 0 on the first piece (freeing
+    //    the inode), then unpin twice more against an absent entry.
+    if let Some(space) = teardown() {
+        crate::proc::free_vm_space(space);
+    } else {
+        test_fail!("mprotect_split_pin", "synthetic process vanished before teardown");
+        return false;
+    }
+    if crate::vfs::inode_pin_count_pub(mnt, ino) != 0 {
+        test_fail!("mprotect_split_pin",
+            "inode still pinned (count {}) after teardown of all pieces",
+            crate::vfs::inode_pin_count_pub(mnt, ino));
+        return false;
+    }
+    crate::vfs::reap_pending_inodes(); // free_vm_space already reaps; harmless re-drain.
+
+    // 7. The inode must now be freed exactly once: a fresh fs read fails.
+    if let Some((fs, _)) = crate::vfs::fs_at(mnt) {
+        let mut rbuf = [0u8; 4];
+        if fs.read(ino, 0, &mut rbuf).is_ok() {
+            test_fail!("mprotect_split_pin",
+                "inode {} still readable after all pieces torn down — leaked", ino);
+            return false;
+        }
+    }
+    test_println!("  all pieces torn down → inode freed exactly once (no double-free, no leak) ✓");
+
+    test_pass!("mprotect partial-overlap split keeps MAP_SHARED inode-pin balance (Test 119c)");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -180,29 +180,47 @@ pub fn pin_inode(mount_idx: usize, inode: u64) {
     }
 }
 
-/// Drop one kernel pin on `(mount_idx, inode)`.  When the pin count reaches
-/// zero AND the inode was deferred-deleted with no remaining open fd, the inode
-/// is freed here (the pin was the last thing keeping it alive).  Returns true
-/// if the inode was actually freed by this call.
-pub fn unpin_inode(mount_idx: usize, inode: u64) -> bool {
-    if mount_idx == usize::MAX { return false; }
-    let now_unpinned = {
-        let mut p = PINNED_INODES.lock();
-        if let Some(idx) = p.iter().position(|(m, n, _)| *m == mount_idx && *n == inode) {
-            if p[idx].2 > 1 {
-                p[idx].2 -= 1;
-                false
-            } else {
-                p.remove(idx);
-                true
-            }
-        } else {
+/// Inodes whose last kernel pin was dropped by an *under-lock* caller (one that
+/// already holds [`crate::proc::PROCESS_TABLE`]) and which therefore could not
+/// run the orphan check / free inline.  Drained by [`reap_pending_inodes`] after
+/// the caller releases PROCESS_TABLE.  Entries: `(mount_idx, inode_number)`.
+///
+/// This mirrors the fd-close machinery's split between a lock-free fast path and
+/// a deferred free: the VMA-list edit that drops a `MAP_SHARED` mapping's pin
+/// (munmap, `MAP_FIXED` replacement, a hole-punch split) runs inside the
+/// `mmap`/`munmap` PROCESS_TABLE critical section, so the actual inode-free —
+/// which itself must scan PROCESS_TABLE for surviving fd references — is queued
+/// here and reaped once the lock is dropped.  Calling a PROCESS_TABLE-taking
+/// helper while PROCESS_TABLE is held would self-deadlock the non-reentrant
+/// spin lock.
+static PENDING_INODE_REAP: Mutex<Vec<(usize, u64)>> = Mutex::new(Vec::new());
+
+/// Decrement the pin count on `(mount_idx, inode)`.  Returns `true` iff this call
+/// dropped the *last* pin (count reached zero and the entry was removed).  Does
+/// NOT take any lock other than `PINNED_INODES`, so it is safe to call with
+/// `PROCESS_TABLE` held.
+fn dec_pin(mount_idx: usize, inode: u64) -> bool {
+    let mut p = PINNED_INODES.lock();
+    if let Some(idx) = p.iter().position(|(m, n, _)| *m == mount_idx && *n == inode) {
+        if p[idx].2 > 1 {
+            p[idx].2 -= 1;
             false
+        } else {
+            p.remove(idx);
+            true
         }
-    };
-    if !now_unpinned { return false; }
-    // Last pin gone — free the inode iff it was deferred-deleted and no process
-    // fd table still references it.  Mirrors the close()-time last-close test.
+    } else {
+        false
+    }
+}
+
+/// Free `(mount_idx, inode)` iff it was deferred-deleted (unlinked while open or
+/// mapped) and no process fd table still references it.  Returns `true` if the
+/// inode was actually freed.  Takes `PROCESS_TABLE`, so callers MUST NOT already
+/// hold it (use [`unpin_inode_deferred`] + [`reap_pending_inodes`] instead).
+///
+/// Mirrors the close()-time last-close test in [`close`] (its C5 path).
+fn try_free_orphan_inode(mount_idx: usize, inode: u64) -> bool {
     let still_open = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         procs.iter().any(|p| p.file_descriptors.iter().any(|fdo| {
@@ -210,7 +228,9 @@ pub fn unpin_inode(mount_idx: usize, inode: u64) -> bool {
                 .unwrap_or(false)
         }))
     };
-    if still_open { return false; }
+    // Another live kernel pin (e.g. an in-flight SCM_RIGHTS descriptor) keeps the
+    // inode alive even after this one was dropped.
+    if still_open || inode_is_pinned(mount_idx, inode) { return false; }
     let was_deleted = {
         let mut dl = DELETED_INODES.lock();
         let before = dl.len();
@@ -226,10 +246,125 @@ pub fn unpin_inode(mount_idx: usize, inode: u64) -> bool {
     false
 }
 
+/// Drop one kernel pin on `(mount_idx, inode)`.  When the pin count reaches
+/// zero AND the inode was deferred-deleted with no remaining open fd, the inode
+/// is freed here (the pin was the last thing keeping it alive).  Returns true
+/// if the inode was actually freed by this call.
+///
+/// Takes `PROCESS_TABLE`; callers MUST NOT hold it.  The in-flight SCM_RIGHTS
+/// drop path and the no-lock address-space teardown paths use this directly.
+/// Under-lock VMA edits (munmap/mmap-replace/split) must use
+/// [`unpin_inode_deferred`] instead.
+pub fn unpin_inode(mount_idx: usize, inode: u64) -> bool {
+    if mount_idx == usize::MAX { return false; }
+    if !dec_pin(mount_idx, inode) { return false; }
+    try_free_orphan_inode(mount_idx, inode)
+}
+
+/// Drop one kernel pin on `(mount_idx, inode)` from a context that may already
+/// hold `PROCESS_TABLE` (e.g. `VmSpace::remove_range` running inside the
+/// `mmap`/`munmap` critical section).  This NEVER takes `PROCESS_TABLE`: if the
+/// last pin is dropped, the orphan check + free is queued for
+/// [`reap_pending_inodes`], which the syscall layer runs after releasing the
+/// lock.  See [`PENDING_INODE_REAP`].
+pub fn unpin_inode_deferred(mount_idx: usize, inode: u64) {
+    if mount_idx == usize::MAX { return; }
+    if dec_pin(mount_idx, inode) {
+        PENDING_INODE_REAP.lock().push((mount_idx, inode));
+    }
+}
+
+/// Drain [`PENDING_INODE_REAP`] and free any inode whose last `MAP_SHARED`
+/// mapping pin was dropped under `PROCESS_TABLE` and which is now orphaned
+/// (deferred-deleted, no open fd, no other pin).  MUST be called with
+/// `PROCESS_TABLE` *not* held; the syscall layer invokes it after every
+/// `mmap`/`munmap` that may have unpinned an inode, so a still-mapped shm
+/// inode is freed the moment its last mapping is torn down (the POSIX shm
+/// `shm_open`→`mmap`→`close`→`shm_unlink` idiom).
+pub fn reap_pending_inodes() {
+    // Move the queue out under its own lock so we are not iterating while the
+    // (possibly slow) free path runs, and so a re-entrant push cannot deadlock.
+    let pending: Vec<(usize, u64)> = {
+        let mut q = PENDING_INODE_REAP.lock();
+        if q.is_empty() { return; }
+        core::mem::take(&mut *q)
+    };
+    for (mount_idx, inode) in pending {
+        try_free_orphan_inode(mount_idx, inode);
+    }
+}
+
 /// True if `(mount_idx, inode)` currently has at least one kernel pin
 /// (see [`pin_inode`]).
 fn inode_is_pinned(mount_idx: usize, inode: u64) -> bool {
     PINNED_INODES.lock().iter().any(|(m, n, c)| *m == mount_idx && *n == inode && *c > 0)
+}
+
+/// Public view of [`inode_is_pinned`] for regression tests that assert the
+/// MAP_SHARED-file pin balance (see test_runner Test 119b).  Test-mode only.
+#[cfg(feature = "test-mode")]
+pub fn inode_is_pinned_pub(mount_idx: usize, inode: u64) -> bool {
+    inode_is_pinned(mount_idx, inode)
+}
+
+/// Place one kernel pin on the inode backing a `MAP_SHARED` file-backed VMA.
+///
+/// POSIX `mmap(2)` makes a mapping an independent reference on the underlying
+/// open file description: "The mmap() function adds an extra reference to the
+/// file associated with the file descriptor fildes which is not removed by a
+/// subsequent close() on that file descriptor."  Combined with `unlink(2)`
+/// ("if [the link count] was the last link ... but [a] process has the file
+/// open, the file shall remain in existence until ... the file is no longer
+/// open"), a live `MAP_SHARED` mapping must keep an unlinked file's inode (and
+/// its data) alive until the mapping is torn down.
+///
+/// This is exactly the POSIX shared-memory idiom — `shm_open` → `ftruncate` →
+/// `mmap(MAP_SHARED)` → `close(fd)` → `shm_unlink` — used by, among others,
+/// the cross-process IPC shared buffers of large desktop applications.  Without
+/// this pin the `close(fd)` after `mmap` triggers unlink-on-last-close (see
+/// [`close`]'s C5 path), `remove_inode` frees the ramfs/tmpfs inode, and the
+/// next demand-fault on the still-live mapping reads a now-absent inode →
+/// SIGSEGV.
+///
+/// `MAP_PRIVATE` file mappings (e.g. ELF `PT_LOAD` segments) do NOT pin: a
+/// private mapping copies file pages into anonymous frames and does not require
+/// the inode to survive past `close`.  Anonymous and device mappings have no
+/// inode and are ignored.
+///
+/// Balanced by [`vma_unpin_if_shared_file`]; one pin per VMA-list membership.
+pub fn vma_pin_if_shared_file(
+    flags: crate::mm::vma::VmFlags,
+    backing: &crate::mm::vma::VmBacking,
+) {
+    if flags & crate::mm::vma::MAP_SHARED == 0 {
+        return;
+    }
+    if let crate::mm::vma::VmBacking::File { mount_idx, inode, .. } = backing {
+        pin_inode(*mount_idx, *inode);
+    }
+}
+
+/// Drop the kernel pin placed by [`vma_pin_if_shared_file`] when a `MAP_SHARED`
+/// file-backed VMA leaves a process's address space (munmap, `MAP_FIXED`
+/// replacement, a hole-punch split, or whole-address-space teardown at
+/// exit/exec).
+///
+/// This uses [`unpin_inode_deferred`], which NEVER takes `PROCESS_TABLE`, so it
+/// is safe to call from inside `VmSpace::remove_range` (run under PROCESS_TABLE
+/// by `mmap`/`munmap`) and from the address-space teardown VMA walks.  When this
+/// drops the last pin of an already-unlinked shm inode, the actual free is
+/// queued; the caller frees it by calling [`reap_pending_inodes`] after it
+/// releases PROCESS_TABLE.
+pub fn vma_unpin_if_shared_file(
+    flags: crate::mm::vma::VmFlags,
+    backing: &crate::mm::vma::VmBacking,
+) {
+    if flags & crate::mm::vma::MAP_SHARED == 0 {
+        return;
+    }
+    if let crate::mm::vma::VmBacking::File { mount_idx, inode, .. } = backing {
+        unpin_inode_deferred(*mount_idx, *inode);
+    }
 }
 
 // ───── firefox-test screenshot-write gate ───────────────────────────────────

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -307,6 +307,18 @@ pub fn inode_is_pinned_pub(mount_idx: usize, inode: u64) -> bool {
     inode_is_pinned(mount_idx, inode)
 }
 
+/// Exact kernel pin count on `(mount_idx, inode)` (0 when unpinned).  Lets
+/// regression tests assert the one-pin-per-VMA-membership invariant precisely
+/// after an `mprotect` split (Test 119c), not just "pinned vs not".  Test-mode
+/// only.
+#[cfg(feature = "test-mode")]
+pub fn inode_pin_count_pub(mount_idx: usize, inode: u64) -> u32 {
+    PINNED_INODES.lock().iter()
+        .find(|(m, n, _)| *m == mount_idx && *n == inode)
+        .map(|(_, _, c)| *c)
+        .unwrap_or(0)
+}
+
 /// Place one kernel pin on the inode backing a `MAP_SHARED` file-backed VMA.
 ///
 /// POSIX `mmap(2)` makes a mapping an independent reference on the underlying


### PR DESCRIPTION
## Summary

Fixes the deterministic SIGSEGV that killed Firefox's main process at the GTK realize/map transition, before it could paint. With this fix the main process no longer crashes there and advances to map a real 1280x972 toplevel (it could not before).

## The bug

A `MAP_SHARED` file mapping is an independent reference on its backing inode (POSIX `mmap(2)`: the mapping adds a reference not removed by a later `close(2)`; `unlink(2)`/`shm_unlink` keep an unlinked file alive while any reference remains). AstryxOS pinned **nothing** for live `MAP_SHARED` file VMAs, so the POSIX shared-memory idiom — `memfd_create`/`shm_open` -> `ftruncate` -> `mmap(MAP_SHARED)` -> `close(fd)` (-> `shm_unlink`) — freed the inode at the `close` while the mapping was still live. The next demand fault then stat'd a dead inode (size 0), populated no page, and returned an unserviced fault that became a silent SIGSEGV.

This is the deterministic crash a cross-process IPC layer that maps a `/dev/shm` region `MAP_SHARED` then `close()`s the fd hits.

## The fix

**1. Pin balance (one pin per `MAP_SHARED` file VMA-list membership):**
- `insert_vma` (+1, the mmap install)
- `clone_for_fork` (+1, the child inherits each VMA)
- `remove_range` fully-contained (-1, munmap / `MAP_FIXED` replacement)
- `remove_range` hole-punch split (-1 original, +1 each surviving half)
- `free_process_memory` / `free_vm_space` (-1 each, address-space teardown)

`PINNED_INODES` is authoritative: `close(2)`'s unlink-on-last-close (C5) and the unpin orphan-check both decline to free an inode that still has a live `MAP_SHARED` mapping.

**2. Deadlock fix:** `unpin_inode` takes `PROCESS_TABLE`, but the unpin sites (`remove_range`) run inside the `mmap`/`munmap` `PROCESS_TABLE` critical section. Split unpin into a lock-free `PINNED_INODES` decrement (`unpin_inode_deferred`) that queues the orphan-check/free, and a reaper (`reap_pending_inodes`) the syscall layer runs after dropping the lock — mirroring the fd-close path's deferred inode free.

**3. Defensive SIGBUS:** a demand fault on a file-backed VMA whose backing inode no longer stats (dead/truncated mapping) now delivers SIGBUS (`BUS_ADRERR`) to a Ring-3 faulter instead of a silent zero page or an unserviced fault — making any residual lifetime bug loud and spec-correct per POSIX `mmap(2)`. `deliver_sigsegv_from_isr` is generalised into `deliver_fault_signal_from_isr`.

## Test

New regression **Test 119b**: `memfd` -> `MAP_SHARED` pin -> `close(fd)` -> the inode data must still read; tear down the mapping -> the orphaned inode is then freed. Also asserts `MAP_PRIVATE` does **not** pin. Passes.

Full test-mode suite: **205 pass**, 3 pre-existing environmental fails (missing `tcc`/`busybox` on the GUI test image; the known KVM HLT-idle timer-rate quirk) — none related to mm/vfs/mmap. No deadlock, no DEC-UNDERFLOW.

## Verification (GUI FF boot, `--ff-gui` against the prebuilt image)

- The PID 1 `/dev/shm` mmap SIGSEGV / `exit_group(11)` is **gone** — PID 1 stays alive and advances (sc 15k -> 3.3M).
- FF maps a **real toplevel** `MapWindow 0x400016 1280x972` (cross-checked against the X11 window list), not the 1x1 synthetic windows.
- No spurious SIGBUS from the defensive change during normal operation.

**Honesty note:** FF does **not** yet paint. A screendump shows the desktop background (30 distinct dark-blue gradient colors), not painted FF chrome. The window maps but issues no present ops — that is the separate, **parked downstream gate** (AstryxOS-specific GObject signal-registration failure killing the GTK frame-clock paint cycle), independent of and downstream from the SIGSEGV fixed here.

## Notes

- Based on `ff/gui-declutter-desktop` (PR #589) for a clean single-client screendump; merge after/with that.
- Refs: POSIX.1-2017 `mmap(2)`, `munmap(2)`, `unlink(2)`; `memfd_create(2)`, `shm_open(3)`; SIGBUS-on-truncated-mapping semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)