### PR TITLE
vfs/x11: fix two Firefox paint gates (deadvertise MIT-SHM + reopen /proc/self/fd memfd by inode)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1316,6 +1316,22 @@ pub fn run() -> ! {
     total += 1;
     if test_mprotect_split_inode_pin_balance() { passed += 1; }
 
+    // ── Test 295: /proc/self/fd/N reopen of an UNLINKED memfd ─────────────
+    // procfs magic-symlink contract (proc(5)): opening /proc/<pid>/fd/<N>
+    // must DUP the underlying open file by its backing inode, not re-resolve
+    // the link target's pathname.  An unlinked memfd (memfd_create(2)) has no
+    // resolvable name, so re-resolving the (removed) path ENOENT'd and broke
+    // Firefox's shared-memory read-only reopen.  Verifies: (a) the reopen
+    // succeeds, (b) the new fd reads the memfd contents from a fresh offset,
+    // (c) a read-only reopen honours O_RDONLY on the new fd.  Placed beside the
+    // inode-pin tests (119b/119c) — same VFS anonymous-inode surface — and
+    // ahead of the heavy Firefox-launch oracle so it runs on every build.
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_295_proc_fd_memfd_reopen() { passed += 1; }
+    }
+
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
     // Cross-subsystem: drivers::log_ring (the PMM-backed guest-RAM ring) +
     // drivers::serial (the fast-path routing + COM1 fallback).  One test
@@ -27421,9 +27437,15 @@ fn test_x11_big_requests_enable() -> bool {
 // ── Test 134: X11 MIT-SHM — QueryExtension present + ShmQueryVersion ─────────
 
 fn test_x11_query_extension_mit_shm() -> bool {
-    test_header!("X11 MIT-SHM — QueryExtension present + ShmQueryVersion");
+    test_header!("X11 MIT-SHM — QueryExtension NOT present + absent from ListExtensions");
 
-    use crate::x11::proto;
+    // Regression for the SHM-deadvertise paint fix (equivalent to the
+    // purge-lost Test 75b): the server does NOT implement the MIT-SHM image
+    // transport, so it must report the extension as ABSENT.  Per the MIT-SHM
+    // protocol spec, a client that gets present=0 from QueryExtension falls
+    // back to core XPutImage(72), which `op_put_image` composites correctly.
+    // Advertising present=1 would make Firefox route paints through the
+    // unsupported SHM CopyArea arm and silently drop the window contents.
 
     let fd = x11_connect_and_setup("mitshm");
     if fd == u64::MAX {
@@ -27431,7 +27453,7 @@ fn test_x11_query_extension_mit_shm() -> bool {
         return false;
     }
 
-    // ── QueryExtension("MIT-SHM") ─────────────────────────────────────────────
+    // ── QueryExtension("MIT-SHM") → must reply present=0 ─────────────────────
     // Name = 7 bytes → padded to 8; header=8 → total=16 = 4 words.
     let name = b"MIT-SHM"; // 7 bytes
     let nlen = name.len() as u16;
@@ -27450,40 +27472,48 @@ fn test_x11_query_extension_mit_shm() -> bool {
         crate::net::unix::close(fd);
         return false;
     }
-    if rep[8] != 1 {
-        test_fail!("x11_mitshm", "MIT-SHM not present (present={})", rep[8]);
+    if rep[8] != 0 {
+        test_fail!("x11_mitshm", "MIT-SHM advertised as present (present={}), expected 0", rep[8]);
         crate::net::unix::close(fd);
         return false;
     }
-    let major = rep[9];
-    if major == 0 {
-        test_fail!("x11_mitshm", "MIT-SHM major opcode is 0");
-        crate::net::unix::close(fd);
-        return false;
-    }
-    test_println!("  QueryExtension(MIT-SHM): present=1 major={} ✓", major);
+    test_println!("  QueryExtension(MIT-SHM): present=0 ✓");
 
-    // ── ShmQueryVersion (minor 0) ────────────────────────────────────────────
-    let req: [u8; 4] = [proto::SHM_MAJOR_OPCODE, proto::SHM_QUERY_VERSION, 1, 0];
-    crate::net::unix::write(fd, &req);
+    // ── ListExtensions(99) → MIT-SHM must NOT appear ─────────────────────────
+    let le = [99u8, 0, 1, 0]; // OP_LIST_EXTENSIONS, 1 word
+    crate::net::unix::write(fd, &le);
     crate::x11::poll();
-    let mut vrep = [0u8; 32];
-    let n = crate::net::unix::read(fd, &mut vrep);
-    if n < 12 || vrep[0] != 1 {
-        test_fail!("x11_mitshm", "ShmQueryVersion no reply n={}", n);
+    let mut lrep = [0u8; 256];
+    let n = crate::net::unix::read(fd, &mut lrep);
+    if n < 32 || lrep[0] != 1 {
+        test_fail!("x11_mitshm", "ListExtensions no reply n={}", n);
         crate::net::unix::close(fd);
         return false;
     }
-    let shm_major = u16::from_le_bytes([vrep[8], vrep[9]]);
-    if shm_major != 1 {
-        test_fail!("x11_mitshm", "SHM major={} (expected 1)", shm_major);
+    // Reply body is a sequence of length-prefixed names starting at byte 32.
+    // Scan for the literal "MIT-SHM" name; it must be absent.
+    let nbytes = n as usize;
+    let mut p = 32usize;
+    let mut found_mit_shm = false;
+    while p < nbytes {
+        let len = lrep[p] as usize;
+        p += 1;
+        if p + len > nbytes { break; }
+        if &lrep[p..p + len] == &b"MIT-SHM"[..] {
+            found_mit_shm = true;
+            break;
+        }
+        p += len;
+    }
+    if found_mit_shm {
+        test_fail!("x11_mitshm", "MIT-SHM still present in ListExtensions");
         crate::net::unix::close(fd);
         return false;
     }
-    test_println!("  ShmQueryVersion: {}.{} ✓", shm_major, u16::from_le_bytes([vrep[10], vrep[11]]));
+    test_println!("  ListExtensions: MIT-SHM absent ✓");
 
     crate::net::unix::close(fd);
-    test_pass!("X11 MIT-SHM extension");
+    test_pass!("X11 MIT-SHM deadvertised (forces core XPutImage fallback)");
     true
 }
 
@@ -43260,6 +43290,106 @@ fn test_294_kstack_switch_gen_gate() -> bool {
     test_println!("  E: too-recent push → tick gate withholds (ok)");
 
     test_pass!("switch-generation gate: withhold-until-advanced + escape valve correct");
+    true
+}
+
+// ── Test 295: /proc/self/fd/N reopen of an UNLINKED memfd ────────────────────
+//
+// memfd_create(2) returns an anonymous (unlinked) inode whose only name —
+// the synthesised /tmp/.memfd_NNNN — is removed at creation time.  Firefox's
+// shared-memory layer re-opens that fd read-only via /proc/self/fd/<N> to get
+// an independently-flagged handle on the same backing.  Per proc(5), each
+// /proc/<pid>/fd/<N> entry is a magic symlink to the *open file* — opening it
+// must DUP the underlying inode, not re-resolve the (now non-existent) path.
+//
+// Before the fix, vfs::open followed the procfs symlink to the fd's stored
+// open_path string and re-resolved it; the unlinked memfd's path NotFound'd →
+// ENOENT, breaking the content-process sandbox channel.  This test asserts the
+// reopen succeeds, reads back the memfd's bytes from a fresh offset, and that
+// a read-only reopen records O_RDONLY on the new fd.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_295_proc_fd_memfd_reopen() -> bool {
+    test_header!("/proc/self/fd/N reopen of an unlinked memfd (proc(5) magic symlink)");
+
+    let pid = crate::proc::current_pid_lockless();
+
+    // ── Create an anonymous memfd (O_RDWR, unlinked by sys_memfd_create) ──
+    let memfd = crate::subsys::linux::syscall::sys_memfd_create_test(0, 0);
+    if memfd < 0 {
+        test_fail!("proc_fd_reopen", "memfd_create returned {} (expected fd >= 0)", memfd);
+        return false;
+    }
+    let memfd = memfd as usize;
+
+    // Write a known payload through the RDWR fd; offset advances to len.
+    let payload: &[u8] = b"PAINT-OK-0123456789";
+    let w = crate::vfs::fd_write(pid, memfd, payload.as_ptr(), payload.len());
+    match w {
+        Ok(n) if n == payload.len() => {}
+        other => {
+            test_fail!("proc_fd_reopen", "fd_write returned {:?} (expected {})", other, payload.len());
+            crate::subsys::linux::syscall::sys_close_test(memfd as u64);
+            return false;
+        }
+    }
+
+    // ── Reopen via /proc/self/fd/<N> READ-ONLY — this is the gate ─────────
+    let mut path = alloc::string::String::from("/proc/self/fd/");
+    path.push_str(&alloc::format!("{}", memfd));
+    let reopened = match crate::vfs::open(pid, path.as_str(), crate::vfs::flags::O_RDONLY) {
+        Ok(fd) => fd,
+        Err(e) => {
+            test_fail!("proc_fd_reopen",
+                "open({}) of unlinked memfd FAILED ({:?}) — magic-symlink reopen regressed",
+                path, e);
+            crate::subsys::linux::syscall::sys_close_test(memfd as u64);
+            return false;
+        }
+    };
+    test_println!("  open(/proc/self/fd/{}) → fd {} ✓ (no ENOENT)", memfd, reopened);
+
+    // ── The new fd must alias the SAME inode and read the payload from 0 ──
+    let mut rbuf = [0u8; 32];
+    let r = crate::vfs::fd_read(pid, reopened, rbuf.as_mut_ptr(), rbuf.len());
+    let got = match r {
+        Ok(n) => n,
+        Err(e) => {
+            test_fail!("proc_fd_reopen", "fd_read on reopened fd failed ({:?})", e);
+            crate::subsys::linux::syscall::sys_close_test(memfd as u64);
+            crate::subsys::linux::syscall::sys_close_test(reopened as u64);
+            return false;
+        }
+    };
+    if got != payload.len() || &rbuf[..got] != payload {
+        test_fail!("proc_fd_reopen",
+            "reopened fd read {} bytes {:?} (expected {} bytes {:?})",
+            got, &rbuf[..got], payload.len(), payload);
+        crate::subsys::linux::syscall::sys_close_test(memfd as u64);
+        crate::subsys::linux::syscall::sys_close_test(reopened as u64);
+        return false;
+    }
+    test_println!("  reopened fd reads memfd payload from fresh offset ✓");
+
+    // ── The read-only reopen must record O_RDONLY (access mode honoured) ──
+    let accmode_ok = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == pid)
+            .and_then(|p| p.file_descriptors.get(reopened))
+            .and_then(|f| f.as_ref())
+            .map(|f| (f.flags & 0b11) == crate::vfs::flags::O_RDONLY)
+            .unwrap_or(false)
+    };
+    if !accmode_ok {
+        test_fail!("proc_fd_reopen", "reopened fd did not record O_RDONLY access mode");
+        crate::subsys::linux::syscall::sys_close_test(memfd as u64);
+        crate::subsys::linux::syscall::sys_close_test(reopened as u64);
+        return false;
+    }
+    test_println!("  read-only reopen recorded O_RDONLY ✓");
+
+    crate::subsys::linux::syscall::sys_close_test(reopened as u64);
+    crate::subsys::linux::syscall::sys_close_test(memfd as u64);
+    test_pass!("/proc/self/fd/N reopen of an unlinked memfd succeeds + reads contents");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1332,6 +1332,22 @@ pub fn run() -> ! {
         if test_295_proc_fd_memfd_reopen() { passed += 1; }
     }
 
+    // ── Test 295b: /proc/self/fd/N reopen of a SENTINEL fd must not UAF ────
+    // Sibling of Test 295.  An eventfd (and every other non-inode-backed
+    // "sentinel" fd: pipe / socket / epoll / timerfd / signalfd / inotify /
+    // PTY) carries a type-specific refcount that the magic-symlink clone path
+    // does not balance.  Cloning one and then closing the clone would free /
+    // underflow the shared backing object under the original fd (eventfd →
+    // outright slot free = UAF).  The reopen must instead decline (the
+    // pre-interception /proc/self/fd → /dev/fd re-resolution yields a benign
+    // ENOENT for a nameless fd, per proc(5)) and leave the original fd fully
+    // usable.  Locks in that the sentinel-fd reopen no longer corrupts state.
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_295b_proc_fd_sentinel_reopen_no_uaf() { passed += 1; }
+    }
+
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
     // Cross-subsystem: drivers::log_ring (the PMM-backed guest-RAM ring) +
     // drivers::serial (the fast-path routing + COM1 fallback).  One test
@@ -43390,6 +43406,94 @@ fn test_295_proc_fd_memfd_reopen() -> bool {
     crate::subsys::linux::syscall::sys_close_test(reopened as u64);
     crate::subsys::linux::syscall::sys_close_test(memfd as u64);
     test_pass!("/proc/self/fd/N reopen of an unlinked memfd succeeds + reads contents");
+    true
+}
+
+/// Test 295b — reopening /proc/self/fd/<N> for a SENTINEL fd (eventfd) must
+/// NOT clone the slot (that would underflow the eventfd's type-specific
+/// refcount and free it under the original fd = UAF).  The reopen must decline
+/// cleanly and leave the original eventfd fully functional.  Uses the real
+/// syscall dispatch so the eventfd-aware close path (sys_close → eventfd::close)
+/// is exercised exactly as Firefox's AudioIPC/IPC fds hit it.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_295b_proc_fd_sentinel_reopen_no_uaf() -> bool {
+    test_header!("/proc/self/fd/N reopen of a sentinel (eventfd) declines, no UAF (proc(5))");
+
+    let pid = crate::proc::current_pid_lockless();
+    const EFD_NONBLOCK: u64 = 0x0800;
+
+    // ── Create an eventfd (sentinel fd: mount_idx == usize::MAX, EventFd) ──
+    let efd = crate::syscall::dispatch_linux_kernel(290 /*eventfd2*/, 7, EFD_NONBLOCK, 0, 0, 0, 0);
+    if efd < 0 {
+        test_fail!("sentinel_reopen", "eventfd2(7) failed ({})", efd);
+        return false;
+    }
+    let efd = efd as usize;
+    test_println!("  eventfd2(7, EFD_NONBLOCK) → fd {} ✓", efd);
+
+    // ── Reopen via /proc/self/fd/<N> — must DECLINE (not clone the slot) ──
+    // With the sentinel-fd gate, reopen_proc_fd returns NotFound and open()
+    // falls through to the /proc/self/fd → /dev/fd re-resolution, which has no
+    // name to resolve → a benign error (ENOENT).  A SUCCESS here would mean the
+    // dangerous clone path ran and the eventfd refcount is now unbalanced.
+    let mut path = alloc::string::String::from("/proc/self/fd/");
+    path.push_str(&alloc::format!("{}", efd));
+    match crate::vfs::open(pid, path.as_str(), crate::vfs::flags::O_RDONLY) {
+        Err(_) => {
+            test_println!("  open({}) declined cleanly (no sentinel clone) ✓", path);
+        }
+        Ok(clone_fd) => {
+            // Regression: the clone path ran.  Closing it via the real syscall
+            // would free the shared eventfd slot under `efd` (UAF).  Do NOT
+            // close it through that path; just fail loudly.
+            test_fail!("sentinel_reopen",
+                "open({}) of an eventfd SUCCEEDED (fd {}) — sentinel clone path ran (UAF risk)",
+                path, clone_fd);
+            crate::syscall::dispatch_linux_kernel(3 /*close*/, efd as u64, 0, 0, 0, 0, 0);
+            return false;
+        }
+    }
+
+    // ── The ORIGINAL eventfd must still be fully functional ───────────────
+    // read → 7 (initval), counter clears → EAGAIN, write 5 → read 5.
+    let mut rbuf = [0u8; 8];
+    let n = crate::syscall::dispatch_linux_kernel(0 /*read*/, efd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+    if n != 8 || u64::from_le_bytes(rbuf) != 7 {
+        test_fail!("sentinel_reopen",
+            "original eventfd read after reopen returned n={} val={} (expected 8 / 7) — slot corrupted",
+            n, u64::from_le_bytes(rbuf));
+        crate::syscall::dispatch_linux_kernel(3 /*close*/, efd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  original eventfd read → 7 (initval intact) ✓");
+
+    let n = crate::syscall::dispatch_linux_kernel(0 /*read*/, efd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+    if n != -11 {
+        test_fail!("sentinel_reopen",
+            "original eventfd re-read returned {} (expected -11 EAGAIN) — slot corrupted", n);
+        crate::syscall::dispatch_linux_kernel(3 /*close*/, efd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+
+    let wbuf = 5u64.to_le_bytes();
+    let n = crate::syscall::dispatch_linux_kernel(1 /*write*/, efd as u64, wbuf.as_ptr() as u64, 8, 0, 0, 0);
+    let n2 = crate::syscall::dispatch_linux_kernel(0 /*read*/, efd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+    if n != 8 || n2 != 8 || u64::from_le_bytes(rbuf) != 5 {
+        test_fail!("sentinel_reopen",
+            "original eventfd write/read roundtrip failed (w={} r={} val={}) — slot corrupted",
+            n, n2, u64::from_le_bytes(rbuf));
+        crate::syscall::dispatch_linux_kernel(3 /*close*/, efd as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  original eventfd write 5 → read 5 (fully functional) ✓");
+
+    // ── Close the original via the real eventfd-aware close path ──────────
+    let r = crate::syscall::dispatch_linux_kernel(3 /*close*/, efd as u64, 0, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("sentinel_reopen", "close(eventfd) failed ({})", r);
+        return false;
+    }
+    test_pass!("/proc/self/fd/N reopen of a sentinel fd declines + original stays usable (no UAF)");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2239,6 +2239,29 @@ fn reopen_proc_fd(
     };
     let (inode, mount_idx, file_type, is_console, open_path) = backing;
 
+    // Only inode-backed files reopen safely by cloning the (mount_idx, inode)
+    // slot — their liveness is the fd-table scan for (mount_idx, inode), so the
+    // freshly-installed slot is self-counting.  Sentinel fds (pipe / socket /
+    // eventfd / epoll / timerfd / signalfd / inotify / PTY / a console fd)
+    // carry a type-specific refcount this clone path does not balance; copying
+    // their backing into a new slot would underflow that count when the clone
+    // is closed (eventfd → outright slot free = UAF; socket → ref_count
+    // underflow tripping its close-path debug_assert; pipe → reader/writer
+    // undercount → phantom EOF/EPIPE).  Until this path replicates sys_dup's
+    // per-type inc_ref, return NotFound for them so open() falls back to the
+    // normal /proc/self/fd → /dev/fd re-resolution (which yields a benign
+    // ENOENT for a nameless sentinel fd — the exact pre-PR semantics, per
+    // proc(5)).
+    if mount_idx == usize::MAX
+        || is_console
+        || !matches!(
+            file_type,
+            FileType::RegularFile | FileType::Directory | FileType::SymLink
+        )
+    {
+        return Err(VfsError::NotFound);
+    }
+
     // Build the new fd: same backing inode, fresh offset, caller's access mode.
     // O_CLOEXEC (0x80000) is honoured per the requested flags; O_CREAT/O_TRUNC
     // are stripped (they do not apply to an existing open file).
@@ -2307,7 +2330,16 @@ pub fn open(pid: crate::proc::Pid, path: &str, open_flags: u32) -> VfsResult<usi
     // layer re-opens an O_RDWR memfd read-only this way; re-resolving the
     // (removed) name was breaking the content-process sandbox channel.
     if let Some((target_pid, fd_num)) = parse_proc_fd_path(path, pid) {
-        return reopen_proc_fd(pid, target_pid, fd_num, open_flags);
+        match reopen_proc_fd(pid, target_pid, fd_num, open_flags) {
+            // NotFound means either the target fd is gone or it is a sentinel fd
+            // this clone path declines to dup (see reopen_proc_fd).  Fall through
+            // to normal /proc/self/fd → /dev/fd re-resolution so the outcome
+            // matches the pre-interception behaviour (a benign ENOENT for a
+            // nameless sentinel fd).  Any other result (success or a hard error)
+            // is returned directly.
+            Err(VfsError::NotFound) => {}
+            other => return other,
+        }
     }
 
     // C4: redirect /proc/<N>/... to /proc/self/... for inode resolution,

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2168,6 +2168,117 @@ fn proc_target_pid(open_path: &str) -> Option<u64> {
     pid_str.parse::<u64>().ok()
 }
 
+/// If `path` is exactly `/proc/{self|<pid>}/fd/<N>` (no trailing components),
+/// return `(target_pid, fd_num)` where `target_pid` is `caller_pid` for the
+/// `self` form and the parsed numeric pid otherwise.  Returns `None` for any
+/// other path (including `/proc/self/fd` directory listing or
+/// `/proc/self/fd/<N>/something`).
+///
+/// Used by `open()` to honour the procfs magic-symlink contract: opening
+/// `/proc/<pid>/fd/<N>` must DUP the underlying open file by its backing inode
+/// (per proc(5) — each entry is a symbolic link "to the actual file"), NOT
+/// re-resolve the link target's pathname.  An unlinked memfd / O_TMPFILE inode
+/// has no resolvable name, so re-resolving the pathname would ENOENT even
+/// though the file is fully alive (held open by the target fd).
+fn parse_proc_fd_path(path: &str, caller_pid: crate::proc::Pid) -> Option<(crate::proc::Pid, usize)> {
+    let rest = path.strip_prefix("/proc/")?;
+    let (pid_part, after_pid) = rest.split_once('/')?;
+    let target_pid: crate::proc::Pid = if pid_part == "self" {
+        caller_pid
+    } else if !pid_part.is_empty() && pid_part.bytes().all(|b| b.is_ascii_digit()) {
+        pid_part.parse::<crate::proc::Pid>().ok()?
+    } else {
+        return None;
+    };
+    let fd_part = after_pid.strip_prefix("fd/")?;
+    // Reject nested components: the fd number must be the final path element.
+    if fd_part.is_empty() || fd_part.contains('/') {
+        return None;
+    }
+    let fd_num = fd_part.parse::<usize>().ok()?;
+    Some((target_pid, fd_num))
+}
+
+/// Honour the procfs `/proc/<pid>/fd/<N>` magic-symlink open by DUPing the
+/// underlying open file: clone the target fd's backing inode handle into a
+/// fresh fd in `caller_pid`'s table, with a new (zeroed) offset and the
+/// caller's requested access mode (`open_flags`).  This is the flat-fd-model
+/// equivalent of a real kernel sharing the target file's `f_path` via
+/// `nd_jump_link()` — it never re-resolves the link target's pathname, so it
+/// works for unlinked memfd / anonymous tmpfs inodes that have no name.
+///
+/// Returns `Err(NotFound)` (→ ENOENT) if the target process or fd does not
+/// exist, matching `open(/proc/<pid>/fd/<N>)` for a closed fd.
+///
+/// `O_CREAT`/`O_TRUNC` are meaningless against an existing open file and are
+/// ignored here (a real kernel applies neither when jumping the link to an
+/// already-open file).  The access mode (O_RDONLY/O_WRONLY/O_RDWR) is taken
+/// from `open_flags`; widening beyond the original fd's mode is permitted here
+/// (we do not yet enforce per-fd mode narrowing on read/write), but the common
+/// case is Mozilla re-opening an `O_RDWR` memfd as `O_RDONLY`, which is honoured.
+fn reopen_proc_fd(
+    caller_pid: crate::proc::Pid,
+    target_pid: crate::proc::Pid,
+    fd_num: usize,
+    open_flags: u32,
+) -> VfsResult<usize> {
+    // Snapshot the backing fields of the target fd and install the new fd in a
+    // single PROCESS_TABLE acquisition so the clone is atomic w.r.t. a
+    // concurrent close()/dup() of the target.
+    let mut procs = crate::proc::PROCESS_TABLE.lock();
+
+    // Read the target fd's backing.  The borrow ends before we mutate the
+    // caller's table below.
+    let backing = {
+        let tproc = procs.iter().find(|p| p.pid == target_pid)
+            .ok_or(VfsError::NotFound)?;
+        let f = tproc.file_descriptors.get(fd_num)
+            .and_then(|slot| slot.as_ref())
+            .ok_or(VfsError::NotFound)?;
+        (f.inode, f.mount_idx, f.file_type, f.is_console, f.open_path.clone())
+    };
+    let (inode, mount_idx, file_type, is_console, open_path) = backing;
+
+    // Build the new fd: same backing inode, fresh offset, caller's access mode.
+    // O_CLOEXEC (0x80000) is honoured per the requested flags; O_CREAT/O_TRUNC
+    // are stripped (they do not apply to an existing open file).
+    let cloexec = (open_flags & 0x0008_0000) != 0;
+    let new_flags = open_flags & !(flags::O_CREAT | flags::O_TRUNC);
+    let new_fd = FileDescriptor {
+        inode,
+        mount_idx,
+        offset: 0,
+        flags: new_flags,
+        file_type,
+        is_console,
+        cloexec,
+        // Preserve the TARGET's open_path (the real backing path, e.g. an
+        // unlinked memfd's synthesized name or empty for anon fds) — NOT the
+        // /proc/self/fd/N magic path — so /proc introspection and the
+        // unlink-on-last-close bookkeeping stay consistent with the original fd.
+        open_path,
+    };
+
+    let cproc = procs.iter_mut().find(|p| p.pid == caller_pid)
+        .ok_or(VfsError::InvalidArg)?;
+    let free_idx = cproc.file_descriptors.iter().position(|f| f.is_none());
+    let fd_idx = if let Some(i) = free_idx {
+        cproc.file_descriptors[i] = Some(new_fd);
+        i
+    } else {
+        let nofile_limit = cproc.rlimits_soft[7]
+            .min(MAX_FDS_PER_PROCESS as u64) as usize;
+        if cproc.file_descriptors.len() < nofile_limit {
+            let idx = cproc.file_descriptors.len();
+            cproc.file_descriptors.push(Some(new_fd));
+            idx
+        } else {
+            return Err(VfsError::TooManyOpenFiles);
+        }
+    };
+    Ok(fd_idx)
+}
+
 /// If `open_path` matches `/proc/{pid-or-self}/task/<tid>/stat`, return the TID.
 /// Returns `None` for all other paths.
 fn proc_task_tid_from_stat_path(open_path: &str) -> Option<u64> {
@@ -2188,6 +2299,17 @@ fn proc_task_tid_from_stat_path(open_path: &str) -> Option<u64> {
 
 /// Open a file for a process, returning the fd number.
 pub fn open(pid: crate::proc::Pid, path: &str, open_flags: u32) -> VfsResult<usize> {
+    // procfs magic-symlink open: `/proc/{self|<pid>}/fd/<N>` must DUP the
+    // underlying open file by its backing inode, NOT re-resolve the link
+    // target's pathname (per proc(5)).  Intercept BEFORE path resolution so an
+    // unlinked memfd / anonymous tmpfs inode — which has no resolvable name —
+    // reopens correctly instead of returning ENOENT.  Mozilla's shared-memory
+    // layer re-opens an O_RDWR memfd read-only this way; re-resolving the
+    // (removed) name was breaking the content-process sandbox channel.
+    if let Some((target_pid, fd_num)) = parse_proc_fd_path(path, pid) {
+        return reopen_proc_fd(pid, target_pid, fd_num, open_flags);
+    }
+
     // C4: redirect /proc/<N>/... to /proc/self/... for inode resolution,
     // while preserving the original path in the fd for target-PID detection.
     //

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -2791,7 +2791,14 @@ fn op_query_extension(fd: u64, data: &[u8], seq: u16) {
     // the extension defines no events/errors); see proto.rs for the rationale —
     // clients key their event-dispatch maps on first_event.
     match name {
-        "MIT-SHM"        => { b[8]=1; b[9]=proto::SHM_MAJOR_OPCODE;       b[10]=proto::SHM_FIRST_EVENT;       b[11]=proto::SHM_FIRST_ERROR; }
+        // MIT-SHM is deliberately NOT advertised.  We do not implement the
+        // shared-memory image transport (Attach → CreatePixmap(shmseg) →
+        // CopyArea(shm-pixmap → window)); advertising it would make clients
+        // believe SHM works and route paints through an unsupported arm,
+        // silently dropping them.  Per the MIT-SHM protocol spec, a client that
+        // gets present=0 from QueryExtension falls back to core XPutImage(72),
+        // which `op_put_image` composites correctly.  Falling into the `_` arm
+        // below yields the canonical not-present reply (present=0).
         "BIG-REQUESTS"   => { b[8]=1; b[9]=proto::BIGREQ_MAJOR_OPCODE;    b[10]=0;                            b[11]=0; }
         "XKEYBOARD"      => { b[8]=1; b[9]=proto::XKEYBOARD_MAJOR_OPCODE; b[10]=proto::XKEYBOARD_FIRST_EVENT; b[11]=proto::XKEYBOARD_FIRST_ERROR; }
         "SHAPE"     => { b[8]=1; b[9]=proto::SHAPE_MAJOR_OPCODE;   b[10]=proto::SHAPE_FIRST_EVENT;  b[11]=proto::SHAPE_FIRST_ERROR; }
@@ -2814,8 +2821,13 @@ fn op_query_extension(fd: u64, data: &[u8], seq: u16) {
 // ── ListExtensions (99) ──────────────────────────────────────────────────────
 
 fn op_list_extensions(fd: u64, seq: u16) {
+    // MIT-SHM is intentionally absent: we do not implement the SHM image
+    // transport, and advertising it would make clients route paints through an
+    // unsupported arm.  Omitting it forces the core XPutImage(72) fallback
+    // (per the MIT-SHM protocol spec), which we composite correctly.  Keep this
+    // list in sync with `op_query_extension`.
     let names: &[&[u8]] = &[
-        b"MIT-SHM", b"BIG-REQUESTS", b"XKEYBOARD", b"SHAPE", b"RENDER",
+        b"BIG-REQUESTS", b"XKEYBOARD", b"SHAPE", b"RENDER",
         b"XFIXES", b"DAMAGE", b"XTEST", b"XInputExtension",
         b"DPMS", b"SYNC", b"COMPOSITE", b"RANDR",
     ];


### PR DESCRIPTION
## Summary

Firefox now maps a real toplevel window but paints 0 ops because of two kernel-side divergences on the paint path. This PR fixes both, named by a golden-diff against an upstream paint sequence.

### Gate 1 — stop advertising MIT-SHM (`kernel/src/x11/mod.rs`)
Our X server advertises the MIT-SHM extension via `QueryExtension`/`ListExtensions` but stubs the shared-memory image transport. A client that believes SHM works routes its paint through `CreatePixmap(shmseg) → CopyArea(shm-pixmap → window)`, which hits the unsupported arm and is silently dropped. Per the **MIT-SHM protocol spec**, a client that gets `present=0` from `QueryExtension` falls back to core `XPutImage(72)`, which `op_put_image` composites correctly.

- `op_query_extension`: `"MIT-SHM"` now falls into the not-present arm (`present=0`).
- `op_list_extensions`: `"MIT-SHM"` removed from the advertised set.
- `op_shm` left in place (harmless — a conforming client never reaches it after `present=0`).

### Gate 2 — `/proc/self/fd/N` reopen of an unlinked memfd no longer ENOENTs (`kernel/src/vfs/mod.rs`)
`memfd_create(2)` returns an anonymous (unlinked) inode whose synthesised name is removed at creation. Mozilla's shared-memory layer re-opens that fd **read-only** via `/proc/self/fd/<N>` to obtain an independently-flagged handle on the same backing. Our `open()` followed the procfs magic symlink to the fd's stored path string and **re-resolved** it; the unlinked memfd has no resolvable name, so the re-resolve returned **ENOENT** → the content-process sandbox channel broke.

Per **proc(5)**, each `/proc/<pid>/fd/<N>` entry is a magic symlink to the *open file* — opening it must **DUP the underlying open file by its backing inode**, not re-resolve a pathname. `vfs::open` now intercepts `/proc/{self|<pid>}/fd/<N>` **before** path resolution and clones the target fd's backing `(inode, mount, type)` into a fresh fd with a new offset and the caller's requested access mode (so a read-only reopen of an `O_RDWR` memfd is honoured). General to any fd type; the unlinked-memfd case is the one that must stop ENOENT'ing. Independent of the #591 MAP_SHARED inode-pin **lifetime** fix — this is a separate **reopen-by-path** bug.

## Tests (`kernel/src/test_runner.rs`)
- **Test 134** rewritten: `QueryExtension(MIT-SHM) → present=0` **and** MIT-SHM absent from `ListExtensions` (regression for the deadvertise).
- **Test 295** (new): `open(/proc/self/fd/N)` of an unlinked memfd succeeds, the new fd reads the memfd contents from a fresh offset, and a read-only reopen records `O_RDONLY`. Placed beside the inode-pin tests (119b/119c) so it runs ahead of the heavy Firefox-launch oracle.

Both pass in `test-mode`:
```
QueryExtension(MIT-SHM): present=0 ✓   ListExtensions: MIT-SHM absent ✓
open(/proc/self/fd/0) → fd 1 ✓ (no ENOENT)   reads payload from fresh offset ✓   recorded O_RDONLY ✓
```

## `--ff-gui` verification (honest)
Booted `--features firefox-test-core,kdb --ff-gui` on the GUI data image:
- ✅ **Gate 2 confirmed fixed**: 0 occurrences of "read-only dup failed / not using memfd". FF advances far past the old gate — libxul loads, content processes spawn, GTK initialises.
- ✅ **Gate 1 confirmed**: MIT-SHM no longer advertised; Test 134 green.
- ⚠️ **FF does NOT paint yet** — a **separate, deeper gate** remains. The content process (pid 3) takes a userspace **SIGSEGV** during libxul early init (`#PF: CR2=0xd0`, NULL+0xd0 read, faulting RIP in libxul's file-backed mapping, with a poisoned pointer `0x9ff49ad74a5a0015` threaded through registers + stack). This is the W215-family CLONE_VM store-visibility / aliasing crash, **outside filesystem scope** (kernel mm). The toplevel (1280×972) never maps; no `PutImage`/`CopyArea` fires. Screendump shows the desktop background only — **not claiming paint**.

This PR removes two genuine paint blockers and moves the failure point from a path-resolution ENOENT to a deeper mm/aliasing SIGSEGV; the remaining gate is for the kernel-mm owner.

Refs: MIT-SHM protocol spec; proc(5); memfd_create(2); POSIX.1-2017 open(2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)