### PR TITLE
smp: count CPU online from each AP's self-published flag (fix cpu_count==1 under -smp 2)

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -36,6 +36,18 @@ const ICR_ASSERT: u32  = 0x0000_4000;
 /// Maximum supported CPUs.
 pub const MAX_CPUS: usize = 16;
 
+/// AP online-report wait budget used by `start_aps()` after the second SIPI.
+///
+/// The loop polls the AP's self-published online flag every
+/// `AP_ONLINE_WAIT_STEP_US` microseconds for up to `AP_ONLINE_WAIT_STEPS`
+/// iterations, breaking the instant the flag appears.  The product
+/// (`500 µs × 2000 = 1 s`) is the worst-case wait for a CPU that never
+/// reports; a healthy AP exits the loop as soon as it has finished its
+/// bringup.  This is generous versus the AP's typical sub-millisecond report
+/// time under KVM, yet bounded so a genuinely-dead AP cannot stall boot.
+const AP_ONLINE_WAIT_STEPS: u32 = 2000;
+const AP_ONLINE_WAIT_STEP_US: u64 = 500;
+
 /// LAPIC base address (MMIO).
 static LAPIC_BASE: AtomicU64 = AtomicU64::new(0);
 
@@ -45,7 +57,18 @@ static IOAPIC_BASE: AtomicU64 = AtomicU64::new(0);
 /// BSP (Boot Strap Processor) APIC ID.
 static BSP_APIC_ID: AtomicU8 = AtomicU8::new(0);
 
-/// Number of active CPUs (starts at 1 for BSP).
+/// Cached number of online CPUs, published by `recount_online_cpus()`.
+///
+/// This is a *cache*, not the source of truth: the authoritative online
+/// state is the per-CPU [`AP_STARTED`] flag that each AP sets for itself
+/// once it has reached its scheduler idle loop (mirroring the way a CPU is
+/// added to the online set by the CPU itself in a standard x86 SMP bringup,
+/// rather than by the boot processor guessing from a fixed-length timeout).
+///
+/// Keeping a cache lets the hot `cpu_count()` reader avoid scanning the flag
+/// array on every call; it is refreshed by the BSP after each AP reports and
+/// can also be recomputed on demand.  It starts at 1 for the BSP, which is
+/// online from the moment this code runs.
 static CPU_COUNT: AtomicU32 = AtomicU32::new(1);
 
 /// Whether APIC is available and initialized.
@@ -63,7 +86,16 @@ static APIC_ENABLED: AtomicBool = AtomicBool::new(false);
 /// completing its own LAPIC init, so this ordering is naturally established.
 static LAPIC_TIMER_PERIOD: AtomicU32 = AtomicU32::new(0);
 
-/// AP started flags.
+/// Per-CPU online flag — the authoritative SMP online state.
+///
+/// `AP_STARTED[i]` is set to `true` by application processor `i` **itself**,
+/// from `ap_rust_entry()`, once it has enabled its local APIC, installed its
+/// per-CPU TSS/syscall MSRs, created its idle thread, and is about to enter
+/// the scheduler.  A CPU therefore counts as online exactly when it has
+/// published this flag, so the user-visible CPU count never races a fixed
+/// boot-time delay: a healthy AP that reports late is still counted.  The BSP
+/// (`AP_STARTED[BSP_APIC_ID]`) does not set this flag — it is unconditionally
+/// online and accounted for separately in [`recount_online_cpus()`].
 static AP_STARTED: [AtomicBool; MAX_CPUS] = [const { AtomicBool::new(false) }; MAX_CPUS];
 
 use crate::hal::{rdmsr, wrmsr};
@@ -400,9 +432,39 @@ pub fn is_enabled() -> bool {
     APIC_ENABLED.load(Ordering::Relaxed)
 }
 
-/// Get the number of active CPUs.
+/// Get the number of online CPUs (BSP + every AP that has reported online).
+///
+/// Reads the cached value published by [`recount_online_cpus()`].  The cache
+/// is authoritative because the count is recomputed from the per-CPU
+/// [`AP_STARTED`] online flags every time an AP reports during bringup, so a
+/// CPU is reflected here precisely when it has published itself online — never
+/// gated by a fixed boot-time timeout.  This is what feeds the user-visible
+/// `/sys/devices/system/cpu/{online,present,possible}` files and the
+/// `_SC_NPROCESSORS_ONLN` count, so it MUST equal the true number of CPUs
+/// running the scheduler.
 pub fn cpu_count() -> u32 {
     CPU_COUNT.load(Ordering::Relaxed)
+}
+
+/// Recompute the online-CPU count from the authoritative [`AP_STARTED`]
+/// online flags and republish it into the [`CPU_COUNT`] cache.
+///
+/// Online = the BSP (always online once `init()` has run) plus every AP that
+/// has set its own `AP_STARTED` flag in `ap_rust_entry()`.  Returns the fresh
+/// count.  Called by the BSP after each AP reports during `start_aps()`, and
+/// usable on demand (e.g. from diagnostics) to reconcile the cache with the
+/// real online set.  Cheap: a single pass over the fixed-size flag array.
+pub fn recount_online_cpus() -> u32 {
+    let bsp = BSP_APIC_ID.load(Ordering::Relaxed) as usize;
+    // The BSP is online and never sets its own AP_STARTED flag.
+    let mut n: u32 = 1;
+    for (i, started) in AP_STARTED.iter().enumerate() {
+        if i != bsp && started.load(Ordering::Acquire) {
+            n += 1;
+        }
+    }
+    CPU_COUNT.store(n, Ordering::Relaxed);
+    n
 }
 
 /// Get the bootstrap-processor's APIC ID.  Used by drivers to target the
@@ -646,37 +708,68 @@ pub fn start_aps() {
 
         // Check if AP started
         if AP_STARTED[ap_id as usize].load(Ordering::Acquire) {
-            CPU_COUNT.fetch_add(1, Ordering::Relaxed);
-            crate::serial_println!("[SMP] AP {} started (after SIPI #1)", ap_id);
+            let total = recount_online_cpus();
+            crate::serial_println!(
+                "[SMP] AP {} online (after SIPI #1), {} CPU(s) online", ap_id, total);
             consecutive_fails = 0;
             continue;
         }
 
-        // Send SIPI #2 (retry per Intel spec)
+        // Send SIPI #2 (the BSP issues a second Startup IPI if the AP has not
+        // reported after the first, per the Intel SDM Vol. 3A multiple-
+        // processor (MP) initialization protocol).
         lapic_write(LAPIC_ICR_HI, (ap_id as u32) << 24);
         lapic_write(LAPIC_ICR_LO, ICR_STARTUP | sipi_vector);
         for _ in 0..1000u32 {
             if lapic_read(LAPIC_ICR_LO) & (1 << 12) == 0 { break; }
         }
 
-        // Wait up to ~10 ms for the AP to start (reduced for QEMU TCG)
-        for _ in 0..10 {
-            delay_microseconds(500);
+        // Wait for the AP to publish its online flag.
+        //
+        // The AP marks itself online (`AP_STARTED[ap_id]`) from
+        // `ap_rust_entry()` only after a substantial init sequence: enabling
+        // EFER.NXE/SSE/SMEP/SMAP, reading its LAPIC ID, programming its LAPIC
+        // timer, allocating its idle thread (a heap allocation plus a
+        // `THREAD_TABLE` lock that may be contended), and configuring its
+        // per-CPU syscall MSRs.  Under KVM that work can take far longer than
+        // a handful of milliseconds — and if the host briefly deschedules the
+        // vCPU it is longer still.  The previous ~5 ms ceiling routinely
+        // expired before a perfectly healthy AP reported, so the BSP declared
+        // it absent and the online count under-reported (the AP was running
+        // its scheduler idle loop the whole time).
+        //
+        // Use a generous bounded wait so a healthy AP is always observed.  The
+        // poll is a fast relaxed-load loop that breaks the instant the flag
+        // appears, so the common case costs only as long as the AP actually
+        // needs; the ceiling only bounds the genuinely-absent case.  This
+        // mirrors the standard SMP bringup contract where the boot CPU waits
+        // for the AP's self-published "alive" state rather than guessing from
+        // a fixed delay.
+        for _ in 0..AP_ONLINE_WAIT_STEPS {
+            delay_microseconds(AP_ONLINE_WAIT_STEP_US);
             if AP_STARTED[ap_id as usize].load(Ordering::Acquire) {
                 break;
             }
         }
 
         if AP_STARTED[ap_id as usize].load(Ordering::Acquire) {
-            CPU_COUNT.fetch_add(1, Ordering::Relaxed);
-            crate::serial_println!("[SMP] AP {} started (after SIPI #2)", ap_id);
+            let total = recount_online_cpus();
+            crate::serial_println!(
+                "[SMP] AP {} online (after SIPI #2), {} CPU(s) online", ap_id, total);
             consecutive_fails = 0;
         } else {
+            crate::serial_println!(
+                "[SMP] AP {} did not report online within {} ms — treating as absent",
+                ap_id,
+                (AP_ONLINE_WAIT_STEPS as u64 * AP_ONLINE_WAIT_STEP_US) / 1000);
             consecutive_fails += 1;
         }
     }
 
-    let total = CPU_COUNT.load(Ordering::Relaxed);
+    // Final reconciliation: publish the count from the authoritative online
+    // flags so that even an AP that set its flag between our last poll and
+    // here is reflected.
+    let total = recount_online_cpus();
     crate::serial_println!(
         "[SMP] AP bootstrap complete: {} CPU(s) online (BSP={})",
         total,

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -204,6 +204,13 @@ pub fn run() -> ! {
         }
     }
 
+    // ── Test R0c: SMP online-count reflects every onlined AP ─────────────────
+    // Registered early (pure kernel state, no userspace/data.img dependency)
+    // so it always runs regardless of which userspace oracle tests are
+    // present in the data image.  Guards the SMP bringup online-count fix.
+    total += 1;
+    if test_smp_online_count_matches_started_flags() { passed += 1; }
+
     // ── Test 0-heap: Heap free-list validation + canaries — healthy churn ─
     // Runs FIRST (before any test that could itself perturb the heap) so it
     // is a clean no-false-positive assertion for the hardened allocator: the
@@ -30970,6 +30977,83 @@ fn test_pfh_install_arm_anti_alias_backout() -> bool {
     crate::proc::free_vm_space(vm);
 
     test_pass!("PFH install-arm anti-aliasing back-out");
+    true
+}
+
+/// Regression test: the online-CPU count reflects every AP that came online.
+///
+/// History: the boot processor used to poll each AP's self-published online
+/// flag (`AP_STARTED[i]`) for only a few milliseconds after SIPI and then
+/// gave up, incrementing a separate counter only if it won that race.  Under
+/// KVM a healthy AP routinely set its flag *after* that window closed, so the
+/// AP ran its scheduler idle loop while `apic::cpu_count()` stayed at 1.  That
+/// under-count cascaded into `/sys/devices/system/cpu/{present,online}` (and
+/// `_SC_NPROCESSORS_ONLN`) reporting a single CPU on a 2-CPU machine.
+///
+/// The fix makes the count derive from the authoritative per-CPU online flags
+/// (`recount_online_cpus()`), so a late-but-healthy AP is always counted.
+///
+/// This test asserts the invariants that hold regardless of how many CPUs
+/// QEMU was launched with:
+///   1. `cpu_count() == recount_online_cpus()` — the cache matches the
+///      authoritative recomputation from the online flags.
+///   2. `1 <= cpu_count() <= MAX_CPUS` — sane bounds.
+///   3. The sysfs `present`/`online` cpulist string matches the count:
+///      `"0\n"` for one CPU, else `"0-{N-1}\n"`.
+/// When launched under `-smp 2` (the harness default) AP 1 sets its online
+/// flag during boot, so the recomputed count is 2 and the present string is
+/// `"0-1\n"` — exactly the regression this guards against.
+fn test_smp_online_count_matches_started_flags() -> bool {
+    test_header!("SMP online-count reflects every onlined AP");
+
+    let cached = crate::arch::x86_64::apic::cpu_count();
+    // Recompute from the authoritative per-CPU online flags.  This both
+    // exercises the new helper and reconciles the cache, so the comparison
+    // below is meaningful even if an AP reported between boot and now.
+    let recomputed = crate::arch::x86_64::apic::recount_online_cpus();
+
+    // Invariant 1: the fast cache equals the authoritative recomputation.
+    if cached != recomputed {
+        test_fail!(
+            "SMP online-count",
+            "cpu_count() cache ({}) != recount_online_cpus() ({})",
+            cached, recomputed
+        );
+        return false;
+    }
+
+    // Invariant 2: sane bounds.
+    let n = recomputed as usize;
+    if n < 1 || n > crate::arch::x86_64::apic::MAX_CPUS {
+        test_fail!(
+            "SMP online-count",
+            "online count {} out of range [1, {}]",
+            n, crate::arch::x86_64::apic::MAX_CPUS
+        );
+        return false;
+    }
+
+    // Invariant 3: the user-visible sysfs cpulist string matches the count.
+    let present = crate::vfs::sysfs::cpu_present_string_for_test();
+    let expected = if n == 1 {
+        alloc::string::String::from("0\n")
+    } else {
+        alloc::format!("0-{}\n", n - 1)
+    };
+    if present != expected {
+        test_fail!(
+            "SMP online-count",
+            "sysfs cpu present {:?} != expected {:?} for {} online CPU(s)",
+            present, expected, n
+        );
+        return false;
+    }
+
+    test_println!(
+        "  online CPUs={} present={:?} (cache==recount, bounds OK, sysfs consistent)",
+        n, present
+    );
+    test_pass!("SMP online-count reflects every onlined AP");
     true
 }
 

--- a/kernel/src/vfs/sysfs.rs
+++ b/kernel/src/vfs/sysfs.rs
@@ -191,6 +191,15 @@ fn cpulist_range() -> String {
     if n == 1 { String::from("0\n") } else { format!("0-{}\n", n - 1) }
 }
 
+/// Test-only accessor for the cpulist string served by
+/// `/sys/devices/system/cpu/{present,online,possible}`.  Lets the in-kernel
+/// regression test assert that the user-visible CPU range stays consistent
+/// with `apic::cpu_count()` without going through the full VFS read path.
+#[cfg(feature = "test-mode")]
+pub(crate) fn cpu_present_string_for_test() -> String {
+    cpulist_range()
+}
+
 // ── SysFs filesystem ─────────────────────────────────────────────────────────
 
 pub struct SysFs;


### PR DESCRIPTION
## Problem

Under `-smp 2`, the second core comes online and runs its scheduler idle loop, but `apic::cpu_count()` returns **1**, so the second CPU never appears to userspace. The wrong count cascades into the sysfs CPU topology:

- `/sys/devices/system/cpu/present` → `"0"` (should be `"0-1"`)
- `online` and `possible` → same under-report
- `_SC_NPROCESSORS_ONLN` / `nproc` → 1 on a 2-CPU machine

All three sysfs files and the `nproc` count derive from `cpu_count()` via `vfs/sysfs.rs::cpulist_range()`, so the single root fix cascades to all of them.

## Root cause (GDB-confirmed)

`start_aps()` incremented a separate `CPU_COUNT` only if the BSP observed the AP's online flag (`AP_STARTED[i]`) within a tiny fixed window after SIPI (~200 µs, then a ~5 ms ceiling after the second SIPI). The AP marks itself online only after a substantial bringup sequence — enabling EFER.NXE/SSE/SMEP/SMAP, programming its LAPIC timer, allocating its idle thread (a heap allocation plus a possibly-contended `THREAD_TABLE` lock), and configuring its per-CPU syscall MSRs. Under KVM that routinely takes longer than the BSP's poll window, so the BSP declared a perfectly healthy AP absent and never counted it.

Live GDB on a stuck boot: `AP_STARTED[1] == 0x01` while `CPU_COUNT == 0x01` — the AP was online and running its idle loop the whole time, just never counted.

## Fix

Derive the online count from the **authoritative per-CPU online flags** instead of a counter that races a fixed delay:

- `recount_online_cpus()` computes BSP + every AP that has published its own `AP_STARTED` flag, and republishes the `CPU_COUNT` cache. The cache is refreshed after each AP reports and reconciled once more when the scan completes, so a healthy-but-late AP is always counted. This matches the standard x86 SMP model where a CPU is added to the online set by the CPU itself, not guessed by the boot processor from a timeout (Intel SDM Vol. 3A, multiple-processor initialization).
- The BSP now waits generously (bounded ~1 s, polling and breaking the instant the flag appears) for the AP to publish, rather than giving up after a few milliseconds.

The user-visible sysfs strings follow the cpulist format per `sysfs(5)` / `Documentation/admin-guide/cputopology` and become correct as a direct consequence.

## Verification (`-smp 2`, test-mode)

- Boot log: `[SMP] AP 1 online (after SIPI #2), 2 CPU(s) online`; `[SMP] AP bootstrap complete: 2 CPU(s) online`
- Live GDB: `CPU_COUNT == 2`
- New regression test **"SMP online-count reflects every onlined AP"** (registered early so it always runs): `online CPUs=2 present="0-1\n" (cache==recount, bounds OK, sysfs consistent)`
- `sched_getaffinity` reports 2 online CPUs
- **AP 1 runs real threads, not idle:** `CPU_SWITCH_GEN[0]=95`, `CPU_SWITCH_GEN[1]=114` (both cores context-switching) and per-CPU heartbeats on `cpu=1` with page-faults/syscalls advancing
- No new bugcheck / canary / #GP. Remaining test FAILs are pre-existing data-image binary-absence cases (tcc/busybox/glibc_hello), unrelated to this change

## Scope

Native SMP/APIC + sysfs-cpu only. The historical `-smp 2` Firefox SIGABRT/SIGSEGV noise is a separate userspace/IPC gate owned by another track; this change reduces smp=2 noise around it by making the topology correct but does not target it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)