### PR TITLE
net/unix: gate AF_UNIX SEQPACKET POLLOUT on the message-slot ring (NDE-8)

### DIFF
--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -780,6 +780,7 @@ pub fn writable(id: u64) -> bool {
     if s.state == UnixState::Free { return true; }     // closed: write → EPIPE, no block
     if s.state != UnixState::Connected { return true; } // not connected: never blocks
     if s.shut_wr { return true; }                       // SHUT_WR: write → EPIPE, no block
+    let kind = s.kind;
     let peer = s.peer_id;
     if peer == u64::MAX || (peer as usize) >= MAX_UNIX_SOCKETS { return true; }
     let peer = &t.0[peer as usize];
@@ -787,6 +788,21 @@ pub fn writable(id: u64) -> bool {
     // Genuinely connected, write side open, peer alive: writable iff the peer's
     // recv ring has room for at least one byte — the exact condition under
     // which our STREAM/SEQPACKET `write()` returns >0 rather than -EAGAIN.
+    //
+    // SEQPACKET additionally enforces a per-message slot ring (`seq_lens`,
+    // `SEQ_QUEUE_CAP` slots): `write()` returns -EAGAIN once that ring is full
+    // *even when the byte ring has room*.  The POLLOUT / EPOLLOUT predicate
+    // must mirror BOTH halves of the send-side EAGAIN condition, otherwise a
+    // producer whose peer has drained the byte ring but not the slot ring is
+    // told the socket is writable, retries `sendmsg(2)`, gets -EAGAIN, and
+    // busy-spins poll→sendmsg→EAGAIN — the stuck-producer pattern `poll(2)` /
+    // `epoll(7)` exist to avoid.  A non-full slot ring is freed as the peer
+    // `recvmsg(2)`s each message, at which point the recv-drain write-space
+    // wake re-checks this predicate (`man 7 unix`).
+    if kind == SockKind::SeqPacket {
+        let queued = (peer.seq_tail + SEQ_QUEUE_CAP - peer.seq_head) % SEQ_QUEUE_CAP;
+        if queued >= SEQ_QUEUE_CAP - 1 { return false; }
+    }
     peer.recv_space() > 0
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -14871,6 +14871,101 @@ fn test_unix_pollout_writable_gate() -> bool {
 
     unix::close(a);
     unix::close(b);
+
+    // ── gap #3: SEQPACKET message-slot ring back-pressure ─────────────────────
+    //
+    // A SOCK_SEQPACKET `write()` returns -EAGAIN once the peer's per-message
+    // slot ring is full *even when the byte ring still has room* — a SEQPACKET
+    // socket preserves message boundaries, so each outstanding datagram costs
+    // one slot regardless of size.  Firefox's IPDL channels (socketpair
+    // SOCK_SEQPACKET) burst many tiny messages; if `writable()` only checked
+    // the byte ring, a producer whose peer drained the bytes but not the
+    // messages would be told the socket is POLLOUT-ready, retry `sendmsg(2)`,
+    // get -EAGAIN, and busy-spin (or tear the channel down).  The POLLOUT /
+    // EPOLLOUT predicate must mirror BOTH halves of the send-side EAGAIN
+    // condition (`man 7 unix` SOCK_SEQPACKET, `man 2 poll`).
+    let (sa, sb) = unix::socketpair(unix::SockKind::SeqPacket,
+        unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if sa == u64::MAX || sb == u64::MAX {
+        test_fail!("unix_pollout_gate", "SEQPACKET socketpair returned MAX");
+        return false;
+    }
+
+    // Fresh SEQPACKET pair → writable.
+    if !unix::writable(sa) {
+        test_fail!("unix_pollout_gate", "fresh SEQPACKET socket sa not writable");
+        unix::close(sa); unix::close(sb);
+        return false;
+    }
+
+    // Fill `sb`'s SEQPACKET slot ring with tiny (1-byte) messages.  Each costs
+    // one slot but ~nothing of the 32 KiB byte ring, so the slot ring fills
+    // (write→EAGAIN) long before the byte ring does — the exact state that
+    // exposes gap #3.
+    let one = [0x5au8; 1];
+    let mut msgs: i64 = 0;
+    loop {
+        let n = unix::write(sa, &one);
+        if n == -11 { break; }            // EAGAIN — slot ring full
+        if n <= 0 {
+            test_fail!("unix_pollout_gate", "unexpected SEQPACKET write ret {}", n);
+            unix::close(sa); unix::close(sb);
+            return false;
+        }
+        msgs += 1;
+        if msgs > 4096 {                  // slot ring is SEQ_QUEUE_CAP (64) — must
+            test_fail!("unix_pollout_gate",  // EAGAIN well before this
+                "SEQPACKET slot ring never filled ({} msgs, byte ring not the gate)",
+                msgs);
+            unix::close(sa); unix::close(sb);
+            return false;
+        }
+    }
+    test_println!("  SEQPACKET: filled slot ring with {} 1-byte msgs (write→EAGAIN) ✓",
+        msgs);
+
+    // Slot ring full but byte ring nearly empty → `sa` must NOT be writable.
+    // Before the gap-#3 fix `writable()` only checked `recv_space() > 0` (true
+    // here, since msgs tiny bytes « 32 KiB) and wrongly reported POLLOUT-ready.
+    if unix::writable(sa) {
+        test_fail!("unix_pollout_gate",
+            "SEQPACKET sa still writable with full slot ring but empty byte ring \
+             (POLLOUT/EAGAIN divergence — gap #3)");
+        unix::close(sa); unix::close(sb);
+        return false;
+    }
+    test_println!("  SEQPACKET slot ring full: writable(sa)=false ✓ (gap #3)");
+
+    // Drain one message from `sb` → frees a slot → `sa` writable again, and the
+    // recv-drain rings the write-space bell (gap #2 for SEQPACKET).
+    let before_seq = BELL_RINGS_BY_SOURCE[PollBellSource::UnixRead as usize]
+        .load(core::sync::atomic::Ordering::Relaxed);
+    let mut one_sink = [0u8; 1];
+    let r = unix::read(sb, &mut one_sink);
+    if r != 1 {
+        test_fail!("unix_pollout_gate", "SEQPACKET drain-one returned {}", r);
+        unix::close(sa); unix::close(sb);
+        return false;
+    }
+    let after_seq = BELL_RINGS_BY_SOURCE[PollBellSource::UnixRead as usize]
+        .load(core::sync::atomic::Ordering::Relaxed);
+    if after_seq <= before_seq {
+        test_fail!("unix_pollout_gate",
+            "SEQPACKET recv drain did not ring UnixRead bell ({}→{})",
+            before_seq, after_seq);
+        unix::close(sa); unix::close(sb);
+        return false;
+    }
+    if !unix::writable(sa) {
+        test_fail!("unix_pollout_gate",
+            "SEQPACKET sa not writable after freeing a slot");
+        unix::close(sa); unix::close(sb);
+        return false;
+    }
+    test_println!("  SEQPACKET: drain-one freed a slot, rang bell, writable(sa)=true ✓");
+
+    unix::close(sa);
+    unix::close(sb);
     test_pass!("AF_UNIX POLLOUT writable-gate + recv-drain wake");
     true
 }


### PR DESCRIPTION
## Summary

Closes a POLLOUT/EAGAIN divergence on AF_UNIX `SOCK_SEQPACKET` sockets: the
`POLLOUT`/`EPOLLOUT` writable predicate did not enforce the per-message slot
ring that `write(2)` enforces, so the kernel could report a SEQPACKET socket
writable while a `sendmsg(2)`/`sendto(2)` on it returned `-EAGAIN`.

## Root cause

`net::unix::writable()` is the single source of truth for `POLLOUT` across
`poll(2)`, `select(2)` and `epoll_wait(2)`. For SEQPACKET it only checked the
byte ring (`recv_space() > 0`).

But a SEQPACKET `write()` returns `-EAGAIN` on **two** conditions (per `man 7
unix`, `SOCK_SEQPACKET` preserves message boundaries — each outstanding
datagram costs one slot regardless of size):

1. the peer's byte ring is full, **or**
2. the peer's per-message slot ring is full (`SEQ_QUEUE_CAP` slots).

When a peer drained the bytes but not the messages — the common case for a
channel that bursts many tiny messages — `writable()` returned `true` while
`write()` returned `-EAGAIN`.

For a non-blocking, epoll-driven producer (the canonical pattern: `send` →
`EAGAIN` → arm `EPOLLOUT` → `epoll_wait` → retry, per `epoll(7)`/`poll(2)`),
this means the reactor is told the socket is writable, retries the send, gets
`-EAGAIN` again, and busy-spins `poll→send→EAGAIN` — the stuck-producer
pattern `poll(2)` exists to avoid.

## Fix

Mirror **both** halves of the send-side `-EAGAIN` condition in `writable()`:
for a SEQPACKET socket, also require a free slot in the peer's message-length
ring. Freed space is already signalled by the recv-drain write-space wake
(`read_msg` rings the write-side poll bell on drain), so a producer parked on
`EPOLLOUT` re-checks the moment the peer `recvmsg(2)`s a message — matching the
`man 7 unix` recv-side write-space wake.

`has_data()` was already SEQPACKET-aware on the `EPOLLIN` side; this makes the
`EPOLLOUT` side symmetric. The send path is unchanged: `sendmsg(46)` /
`sendto(44)` correctly return `-EAGAIN` on a full queue (non-blocking +
epoll-driven is the correct mode here, confirmed against the reference
behaviour of an epoll-driven IPC reactor).

This continues the AF_UNIX POLLOUT lineage from #484 (which added the byte-ring
gate `#1` and the recv-drain wake `#2`); this is gap `#3` (the slot ring).

## Test

Extends `test_unix_pollout_writable_gate` with a SEQPACKET slot-ring case
(gap `#3`): fill the slot ring with 1-byte messages (byte ring stays
near-empty), assert `writable()==false`, drain one message, assert the
write-space bell rings and `writable()==true`. Full suite: **208 pass / 3
pre-existing env fails** (TCC binary absent, `monotonic-rate` timer artifact,
`dynamic_elf` state) — none socket-related.

## Scope note (honest)

This is a real, spec-grounded ABI-fidelity fix and passes its regression. It is
**not** verified to produce a Firefox paint on its own: in the windowed FF boot
(`firefox-test-core --ff-gui`, smp=1, on master incl. #594), FF currently
plateaus at an **earlier** gate — the gecko socket process exits during pre-IPC
init (an `mremap`→`-ENOMEM` retry storm near the top of the stack +
`/sys/devices/system/cpu/present` probing), **before any AF_UNIX IPDL channel
traffic occurs** (zero `sendmsg`/`recvmsg` in the run). That earlier gate is
outside the NDE socket scope (mm `mremap` semantics / sysfs `cpu/present`) and
is reported for follow-up. This PR removes a genuine POLLOUT divergence that
would otherwise bite once FF reaches the channel-heavy phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)