### PR TITLE
build/ff: provision Mesa software-GL (llvmpipe) runtime for the windowed GLX path

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -1073,6 +1073,23 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
         "MOZ_X11_EGL=0",
         "MOZ_ACCELERATED=0",
         "LIBGL_ALWAYS_SOFTWARE=1",
+        // Mesa software-GL (Gallium llvmpipe) selection.  There is no GPU and no
+        // DRM render node on this target, so we pin Mesa to the CPU rasteriser
+        // and skip hardware-driver probing:
+        //   GALLIUM_DRIVER / MESA_LOADER_DRIVER_OVERRIDE=llvmpipe force the
+        //     Gallium frontend to load the llvmpipe pipe driver directly
+        //     instead of enumerating DRM devices (which would fail with no
+        //     /dev/dri), so glxtest's GLX context-create succeeds and reports
+        //     a "llvmpipe" GL_RENDERER.
+        //   LIBGL_DRIVERS_PATH lists both the historical /usr/lib/dri and the
+        //     compiled-in default /usr/lib/xorg/modules/dri so libGL finds
+        //     libgallium_dri.so (= swrast_dri.so) regardless of which staging
+        //     path the image carries it at.
+        // Refs: Mesa 3D environment-variables docs (LIBGL_*, GALLIUM_DRIVER,
+        // MESA_LOADER_DRIVER_OVERRIDE); OpenGL/GLX 1.4 spec.
+        "GALLIUM_DRIVER=llvmpipe",
+        "MESA_LOADER_DRIVER_OVERRIDE=llvmpipe",
+        "LIBGL_DRIVERS_PATH=/usr/lib/dri:/usr/lib/xorg/modules/dri",
         // LD_LIBRARY_PATH (the variant-aware search scope selected from the
         // binary's PT_INTERP) is already in the base environment above; it
         // covers the firefox-esr / opt / in-tree tail for both libcs.

--- a/scripts/install-firefox-musl.sh
+++ b/scripts/install-firefox-musl.sh
@@ -147,6 +147,33 @@ case "${FIREFOX_PKG}" in
         ;;
 esac
 
+# ── Software-OpenGL (Mesa) runtime ───────────────────────────────────────────
+# Firefox's GPU-feature probe (glxtest) dlopen()s libGL.so.1 and runs a GLX
+# context-create + glGetString(GL_RENDERER) handshake in a forked child before
+# the compositor starts.  Without a GL client runtime the probe fails at
+# dlopen("libGL.so.1") ("libGL.so.1 missing"), GL is marked unavailable, and on
+# a headless/no-DRM target WebRender has no GL path for the windowed (--ff-gui)
+# compositor.  We therefore stage the Mesa software-GL stack (Gallium llvmpipe)
+# so the GLX handshake reaches the X server and WebRender can initialise a
+# software OpenGL context.  These are pure userland libraries from the same
+# pinned Alpine repo as the rest of the FF stack (no DRM / no kernel driver
+# dependency); llvmpipe renders entirely on the CPU.
+#
+# Package -> SONAME map (Alpine v3.20, mesa 24.0.9 / llvm17 17.0.6):
+#   mesa-gl           -> libGL.so.1            (GLX/OpenGL client + dispatch)
+#   mesa-egl          -> libEGL.so.1           (EGL client; FF probes it too)
+#   mesa-dri-gallium  -> /usr/lib/xorg/modules/dri/libgallium_dri.so
+#                        (+ swrast_dri.so symlink) = llvmpipe pipe driver
+#   mesa-gbm          -> libgbm.so.1           (DT_NEEDED of libEGL)
+# apk pulls the transitive runtime deps automatically: mesa + mesa-glapi
+# (libglapi.so.0), llvm17-libs (libLLVM-17.so), libelf, libxshmfence,
+# libxxf86vm, wayland-libs-server.  All land under ${ROOTFS}/usr/lib (the DRI
+# driver at .../usr/lib/xorg/modules/dri, which is libGL's compiled-in default
+# LIBGL_DRIVERS_PATH) and flow through the existing `cp -aL ${ROOTFS}/usr/lib/.`
+# staging step unchanged.  Refs: Mesa 3D docs (gallium/llvmpipe), OpenGL/GLX
+# 1.4 spec, EGL 1.5 spec.
+FIREFOX_GL_PACKAGES="mesa-gl mesa-egl mesa-dri-gallium mesa-gbm"
+
 # Mozilla artefacts ship with DT_RUNPATH=/usr/lib/<package> baked into the
 # ELF .dynamic section (where <package> is either "firefox-esr" or "firefox"
 # depending on the build).  Per the ELF gABI (System V ABI §5.4 "Dynamic
@@ -179,8 +206,10 @@ if [ "${FORCE}" = false ] && [ -f "${FIREFOX_BIN}" ] && \
    file "${FIREFOX_BIN}" 2>/dev/null | grep -q 'ld-musl' && \
    [ -e "${DISK_LIB}/libz.so.1" ] && \
    [ -e "${DISK_FF_TREE}/libxul.so" ] && \
+   [ -e "${DISK_USR_LIB}/libGL.so.1" ] && \
+   [ -e "${DISK_USR_LIB}/dri/libgallium_dri.so" ] && \
    [ "${EXISTING_PKG}" = "${FIREFOX_PKG}" ]; then
-    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base + runpath staged for ${FIREFOX_PKG} — skipping (use --force to reinstall)"
+    echo "[FF-MUSL] ${FIREFOX_BIN} present and musl-linked, base + runpath + Mesa-GL staged for ${FIREFOX_PKG} — skipping (use --force to reinstall)"
     exit 0
 fi
 
@@ -243,13 +272,37 @@ EOF
         --arch=x86_64 \
         --no-cache \
         --initdb \
-        add "${FIREFOX_PKG}" 2>&1 \
+        add "${FIREFOX_PKG}" ${FIREFOX_GL_PACKAGES} 2>&1 \
         | sed 's/^/[FF-MUSL apk] /' \
         | tail -40 || true
 
     if [ ! -f "${ROOTFS_FF_SENTINEL}" ]; then
         echo "[FF-MUSL] ERROR: ${FIREFOX_PKG} not present in rootfs after apk add"
         echo "[FF-MUSL]        Expected file: ${ROOTFS_FF_SENTINEL}"
+        exit 1
+    fi
+fi
+
+# ── Ensure the Mesa software-GL stack is present in the rootfs ───────────────
+# The bootstrap block above only runs when the FF sentinel is absent, so a
+# rootfs cached from a pre-Mesa build of this script would otherwise never gain
+# libGL.  Detect the GL runtime by its canonical SONAME and `apk add` the Mesa
+# package set into the existing rootfs when missing — idempotent, and a no-op
+# once present.  The sentinel is libGL.so.1 (owned by mesa-gl).
+ROOTFS_GL_SENTINEL="${ROOTFS}/usr/lib/libGL.so.1"
+if [ ! -e "${ROOTFS_GL_SENTINEL}" ]; then
+    echo "[FF-MUSL] Adding Mesa software-GL stack to rootfs (${FIREFOX_GL_PACKAGES})"
+    "${APK_BIN}" \
+        --root="${ROOTFS}" \
+        --arch=x86_64 \
+        --no-cache \
+        add ${FIREFOX_GL_PACKAGES} 2>&1 \
+        | sed 's/^/[FF-MUSL apk-gl] /' \
+        | tail -30 || true
+    if [ ! -e "${ROOTFS_GL_SENTINEL}" ]; then
+        echo "[FF-MUSL] ERROR: libGL.so.1 not present in rootfs after Mesa apk add"
+        echo "[FF-MUSL]        Expected file: ${ROOTFS_GL_SENTINEL}"
+        echo "[FF-MUSL]        The windowed (--ff-gui) GLX/WebRender path needs it."
         exit 1
     fi
 fi
@@ -694,6 +747,35 @@ if [ -n "${MISSING_BASE_LIBS}" ]; then
     echo "[FF-MUSL]        — check ${ROOTFS}/usr/lib/ and extend stage step (a)."
     exit 1
 fi
+
+# Verify the Mesa software-GL stack (FIREFOX_GL_PACKAGES) landed in the staging
+# tree.  The windowed (--ff-gui) Firefox path needs libGL.so.1 for the glxtest
+# GLX handshake and the Gallium llvmpipe DRI driver
+# (xorg/modules/dri/libgallium_dri.so = swrast_dri.so) for the software OpenGL
+# context WebRender initialises.  These flow through the bulk
+# `cp -aL ${ROOTFS}/usr/lib/.` stage; this check fails loud (greppable
+# "[FF-MUSL][GL]") if a stale rootfs or a copy error dropped them, so a GUI
+# image cannot ship GL-less and silently fall back to "libGL.so.1 missing".
+DISK_DRI_DRIVER="${DISK_USR_LIB}/xorg/modules/dri/libgallium_dri.so"
+MISSING_GL_LIBS=""
+for gl_lib in \
+    "${DISK_USR_LIB}/libGL.so.1" \
+    "${DISK_USR_LIB}/libEGL.so.1" \
+    "${DISK_USR_LIB}/libglapi.so.0" \
+    "${DISK_USR_LIB}/libLLVM-17.so" \
+    "${DISK_DRI_DRIVER}" \
+    "${DISK_USR_LIB}/libgbm.so.1" \
+    "${DISK_USR_LIB}/libxshmfence.so.1" \
+    "${DISK_USR_LIB}/libXxf86vm.so.1"; do
+    [ -e "${gl_lib}" ] || MISSING_GL_LIBS="${MISSING_GL_LIBS} ${gl_lib#${DISK_DIR}}"
+done
+if [ -n "${MISSING_GL_LIBS}" ]; then
+    echo "[FF-MUSL][GL] ERROR: Mesa software-GL libs missing from staging:${MISSING_GL_LIBS}"
+    echo "[FF-MUSL][GL]        ${FIREFOX_GL_PACKAGES} may have failed to install into"
+    echo "[FF-MUSL][GL]        ${ROOTFS}/usr/lib — re-run with --force to rebuild the rootfs."
+    exit 1
+fi
+echo "[FF-MUSL][GL] ok: Mesa software-GL stack staged (libGL.so.1, libEGL.so.1, xorg/modules/dri/libgallium_dri.so = llvmpipe)"
 
 # Verify the GUI runtime caches (c1/c3) actually landed in the staging tree.
 # These three BINARY index files are produced here (Alpine ships them only as


### PR DESCRIPTION
## What

Provisions the **Mesa software-GL stack (Gallium llvmpipe)** into the musl
Firefox test image so the windowed (`--ff-gui`) GPU-feature probe (glxtest)
can `dlopen("libGL.so.1")` and run a GLX handshake against the in-kernel X11
GLX server. Stacks on top of the server-side GLX handshake + real MIT-SHM
`ShmPutImage` work on this branch.

Before this change glxtest failed at `dlopen("libGL.so.1")` (`libGL.so.1
missing`) and never reached the GLX server.

## Changes

1. **`scripts/install-firefox-musl.sh`** — the permanent fix. Appends a Mesa
   package set (`mesa-gl mesa-egl mesa-dri-gallium mesa-gbm`) to the rootfs
   `apk add`, pinned to the same Alpine v3.20 repo as the rest of the FF stack
   (mesa 24.0.9 / llvm17 17.0.6). apk pulls the transitive deps (mesa-glapi,
   llvm17-libs, libelf, libxshmfence, libxxf86vm, wayland-libs-server). The
   libraries land under the rootfs `/usr/lib` tree (the llvmpipe DRI driver at
   `/usr/lib/xorg/modules/dri/libgallium_dri.so`, libGL's compiled-in default
   `LIBGL_DRIVERS_PATH`) and flow through the existing
   `cp -aL ${ROOTFS}/usr/lib/.` staging step unchanged, so a regenerated image
   always carries Mesa. Three durability hooks: the rootfs-add, an idempotent
   "ensure libGL in rootfs" backfill (sentinel `libGL.so.1`), and the
   up-to-date skip-gate + a loud `[FF-MUSL][GL]` staging check both gate on
   `libGL.so.1` + the llvmpipe DRI driver.

2. **`kernel/src/gui/terminal.rs`** — points the staged Mesa loader at the CPU
   rasteriser on a no-GPU/no-DRM target: `GALLIUM_DRIVER=llvmpipe`,
   `MESA_LOADER_DRIVER_OVERRIDE=llvmpipe`,
   `LIBGL_DRIVERS_PATH=/usr/lib/dri:/usr/lib/xorg/modules/dri`, alongside the
   existing `LIBGL_ALWAYS_SOFTWARE=1`.

## Verification (live, harness `--ff-gui` against the Mesa image)

- glxtest **no longer** reports `libGL.so.1 missing`; it `dlopen`s libGL and
  issues real GLX protocol to the server.
- **GLX requests reach the X server**: `op=146` (GLX major opcode) confirmed —
  `minor=7` QueryVersion, `minor=14` GetVisualConfigs, `minor=19`
  QueryServerString, `minor=21` GetFBConfigs, `minor=20` ClientInfo
  (reproducible across two boots).
- FF maps the **1280x972 toplevel** (`[X11] MapWindow 0x400016 1280x972`) and
  begins MIT-SHM setup (`op=139` QueryVersion/Attach).

## Known follow-up gate (NOT this PR's scope — kernel/X11)

glxtest's `glXChooseVisual` returns NULL after consuming the GetVisualConfigs
reply, so it never reaches `CreateContext`/`MakeCurrent` and writes no
renderer (`No GPUs detected`). GL is then marked unavailable, and the FF
GPU/compositor process **NULL-derefs a GL context** (`CR2=0x00000000000000d0`,
content pid SIGSEGV, `CompositorBridgeChild ... AbnormalShutdown`). The
toplevel maps but never receives a `ShmPutImage`, so the framebuffer shows the
desktop background only — no paint yet.

The remaining gate is therefore either (a) the GLX `GetVisualConfigs` /
`GetFBConfigs` reply encoding in `kernel/src/x11/mod.rs` (so
`glXChooseVisual` matches an RGBA visual) or (b) seeding software-WebRender
prefs so FF skips the GL path. Both are kernel-side and tracked separately.

Refs: Mesa 3D docs (gallium/llvmpipe), OpenGL/GLX 1.4 spec, EGL 1.5 spec,
ELF gABI (System V ABI §5.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)