### PR TITLE
x11: real MIT-SHM ShmCreatePixmap shared pixmaps + windowed-FF GdkPixbuf loaders.cache provisioning

### DIFF
--- a/.ai/PROGRESS.md
+++ b/.ai/PROGRESS.md
@@ -6,6 +6,15 @@
 **GUI Tests**: 10/10 pixel checks passing (`scripts/run-gui-test.sh`)
 **Firefox**: Runs for full 15000 ticks without crashing (was: crash at 1481 syscalls at RIP=0x0)
 
+### Milestone 46 — Windowed Firefox: MIT-SHM shared pixmaps + GdkPixbuf loaders.cache (✅)
+**Completed**: 2026-06-19
+
+**What was built (combined windowed-paint branch):**
+- [x] **Real MIT-SHM `ShmCreatePixmap` + CopyArea-from-SHM-pixmap** (`kernel/src/x11/{mod,resource}.rs`): `ShmQueryVersion` now advertises `shared_pixmaps=true`; `ShmCreatePixmap` creates a real Pixmap resource whose pixel storage IS the attached SysV-SHM segment (records shmid/offset/scanline-padded stride, validates the image region fits the segment); `CopyArea(pixmap → window)` reads an SHM-backed source's LIVE pixels from the segment's physical backing at copy time. This is the second X11 present path (`gUseShmPixmaps`) — the one nsShmImage prefers when the server advertises shared pixmaps. Was a no-op stub. Headless test `test_x11_shm_create_pixmap` proves live-read (segment changed AFTER CreatePixmap; CopyArea sees the new pixels). Cites X11 MIT-SHM protocol §ShmCreatePixmap.
+- [x] **GdkPixbuf `loaders.cache` always provisioned** (`scripts/create-data-disk.sh`): the windowed (`--ff-gui`) path realizes a real toplevel, so GTK decodes its compiled-in symbolic PNG titlebar icons through GdkPixbuf. With no `loaders.cache`, GdkPixbuf comes up with an empty loader set, the first PNG decode returns NULL, and the `gdk_cairo_surface_create_from_pixbuf(NULL)`/`g_object_unref(NULL)` cascade dereferences a garbage pointer → deterministic SIGSEGV in the parent before any window is mapped. `install-firefox-musl.sh` generated the cache only on FF (re)install; the common fast path reuses an installed `build/disk` and skipped it. Now `patch-gui-caches.sh --stage-only` runs unconditionally on every data-image build. **Verified**: the parent SIGSEGV (deterministic, 5× identical-RIP) is eliminated; FF advances from "ff-launch crash" to a clean multi-thread startup park.
+- [x] **Combined branch** off `feat/mesa-gl-runtime` (GLX #598 + real ShmPutImage + Mesa injection #599) cherry-picking the mremap top-down/freed-gap fix (#596), the background-network-disable prefs seed (#597, kills the openh264 MOZ_CRASH), and `network.process.enabled=false`.
+- [x] **Residual gate (precisely localized, NOT yet painted):** post-fixes, FF reaches a healthy startup but its main thread (tid 2) + all 30 threads park before realizing the 1280×720 toplevel; the in-kernel X server is fully drained (owes no reply); FF never reaches the present path (0 ShmAttach/ShmCreatePixmap). This is the parked W101-class multi-thread event-loop/work-source stall, now in the windowed path. Screendump = empty desktop (no FF window). Reported for follow-up per the saga-exhaustion rule (do not re-open the parked futex/event-loop saga via new hypothesis flips).
+
 ### Milestone 45 — X11 server-side GLX handshake + real MIT-SHM ShmPutImage (✅, PR #598)
 **Completed**: 2026-06-19
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1300,6 +1300,79 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 Err(e) => serial_println!("[FFTEST] WARNING: could not write /tmp/hello.html: {:?}", e),
             }
 
+            // Seed the Firefox profile prefs into the VFS ramdisk.  The cmdlines
+            // launch with `--profile /tmp/ff-profile`, which Firefox creates
+            // fresh (empty) — so the prefs staged on the data image at
+            // /opt/firefox/profile never apply, leaving telemetry, safebrowsing,
+            // update, captive-portal and the GMP/OpenH264 auto-download at their
+            // network-touching defaults.  Under MOZ_DISABLE_NONLOCAL_CONNECTIONS
+            // (set for the in-process / no-network GUI run) the FIRST such
+            // background connection is FATAL — Firefox aborts with
+            //   "Non-local network connections are disabled and a connection
+            //    attempt to ciscobinary.openh264.org was made"
+            // (the OpenH264 GMP fetch) and crashes before painting.  Seed a
+            // prefs.js that disables every background-network feature so no
+            // non-local connection is ever attempted.  Ref: Firefox profile
+            // user_pref(3) prefs (media.gmp-*, app.update, toolkit.telemetry,
+            // browser.safebrowsing, network.captive-portal-service).
+            const FF_PREFS: &[u8] = br#"user_pref("browser.shell.checkDefaultBrowser", false);
+user_pref("browser.startup.page", 0);
+user_pref("browser.startup.homepage_override.mstone", "ignore");
+user_pref("startup.homepage_welcome_url", "");
+user_pref("startup.homepage_welcome_url.additional", "");
+user_pref("browser.aboutwelcome.enabled", false);
+user_pref("app.update.enabled", false);
+user_pref("app.update.auto", false);
+user_pref("app.update.service.enabled", false);
+user_pref("toolkit.telemetry.enabled", false);
+user_pref("toolkit.telemetry.unified", false);
+user_pref("toolkit.telemetry.server", "");
+user_pref("datareporting.healthreport.service.enabled", false);
+user_pref("datareporting.healthreport.uploadEnabled", false);
+user_pref("datareporting.policy.dataSubmissionEnabled", false);
+user_pref("browser.safebrowsing.malware.enabled", false);
+user_pref("browser.safebrowsing.phishing.enabled", false);
+user_pref("browser.safebrowsing.downloads.enabled", false);
+user_pref("browser.safebrowsing.update.enabled", false);
+user_pref("browser.safebrowsing.provider.google4.updateURL", "");
+user_pref("browser.safebrowsing.provider.mozilla.updateURL", "");
+user_pref("network.captive-portal-service.enabled", false);
+user_pref("network.connectivity-service.enabled", false);
+user_pref("network.prefetch-next", false);
+user_pref("network.dns.disablePrefetch", true);
+user_pref("network.dns.disablePrefetchFromHTTPS", true);
+user_pref("extensions.update.enabled", false);
+user_pref("extensions.update.autoUpdateDefault", false);
+user_pref("extensions.getAddons.cache.enabled", false);
+user_pref("extensions.systemAddon.update.enabled", false);
+user_pref("extensions.blocklist.enabled", false);
+user_pref("geo.enabled", false);
+user_pref("browser.region.network.url", "");
+user_pref("browser.region.update.enabled", false);
+user_pref("app.normandy.enabled", false);
+user_pref("app.normandy.api_url", "");
+user_pref("app.shield.optoutstudies.enabled", false);
+user_pref("services.settings.server", "");
+user_pref("browser.discovery.enabled", false);
+user_pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
+user_pref("browser.crashReports.unsubmittedCheck.enabled", false);
+user_pref("breakpad.reportURL", "");
+user_pref("media.gmp-manager.updateEnabled", false);
+user_pref("media.gmp-manager.url", "data:text/plain,");
+user_pref("media.gmp-manager.url.override", "data:text/plain,");
+user_pref("media.gmp-provider.enabled", false);
+user_pref("media.gmp-gmpopenh264.enabled", false);
+user_pref("media.gmp-gmpopenh264.autoupdate", false);
+user_pref("media.gmp.decoder.enabled", false);
+user_pref("media.peerconnection.enabled", false);
+"#;
+            let _ = crate::vfs::mkdir("/tmp/ff-profile");
+            let _ = crate::vfs::create_file("/tmp/ff-profile/prefs.js");
+            match crate::vfs::write_file("/tmp/ff-profile/prefs.js", FF_PREFS) {
+                Ok(_)  => serial_println!("[FFTEST] Wrote /tmp/ff-profile/prefs.js ({} bytes) — background network disabled", FF_PREFS.len()),
+                Err(e) => serial_println!("[FFTEST] WARNING: could not write /tmp/ff-profile/prefs.js: {:?}", e),
+            }
+
             // The Mozilla launcher (firefox-bin) reads its dependentlibs.list,
             // application.ini, omni.ja, defaults/, browser/, etc. via
             // readlink("/proc/self/exe") + dirname, then opens those files

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1365,6 +1365,8 @@ user_pref("media.gmp-gmpopenh264.enabled", false);
 user_pref("media.gmp-gmpopenh264.autoupdate", false);
 user_pref("media.gmp.decoder.enabled", false);
 user_pref("media.peerconnection.enabled", false);
+user_pref("network.process.enabled", false);
+user_pref("network.http.network_access_on_socket_process.enabled", false);
 "#;
             let _ = crate::vfs::mkdir("/tmp/ff-profile");
             let _ = crate::vfs::create_file("/tmp/ff-profile/prefs.js");

--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -1164,12 +1164,30 @@ impl VmSpace {
     pub fn find_free_range(&self, size: u64) -> Option<u64> {
         let size = page_align_up(size);
 
-        // Try the hint first
-        let mut candidate = self.mmap_hint;
+        // Top-down search for the highest free gap >= size, starting from the
+        // fixed MMAP_BASE ceiling (NOT the running `mmap_hint`).
+        //
+        // `mmap_hint` is lowered monotonically as mappings are placed below it
+        // (see insert_vma) and is never raised on munmap.  Starting the walk at
+        // `mmap_hint` therefore only ever searched the shrinking window *below*
+        // the lowest mapping ever made, so address space freed by munmap (which
+        // sits above the lowered hint) was never reused.  Under heavy
+        // mmap/munmap churn — e.g. a malloc that grows via mremap(MREMAP_MAYMOVE)
+        // (mmap a new region, copy, munmap the old) — the window below the hint
+        // eventually exhausts while plenty of freed space remains above it, so
+        // mmap(NULL,...) returns None and mremap fails with -ENOMEM in a retry
+        // storm.  Searching top-down from the fixed ceiling reuses freed gaps,
+        // matching the top-down unmapped-area search every POSIX mmap relies on
+        // (man 2 mmap / man 2 mremap MREMAP_MAYMOVE).
+        let mut candidate = MMAP_BASE;
 
-        // Simple strategy: walk down from the hint, checking each candidate
-        // against existing VMAs.
-        for _ in 0..1000 {
+        // Walk down, jumping past each overlapping VMA.  Bound the iteration by
+        // the VMA count (+slack) rather than a fixed 1000: each step skips at
+        // least one VMA, so this visits every mapping at most once and never
+        // gives up spuriously while a usable gap still exists (the old 1000 cap
+        // could ENOMEM a process holding >1000 mappings — common for a browser).
+        let max_steps = self.areas.len() + 8;
+        for _ in 0..max_steps {
             if candidate < size {
                 return None; // Ran out of address space
             }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -865,6 +865,9 @@ pub fn run() -> ! {
     total += 1;
     if test_x11_shm_put_image() { passed += 1; }
 
+    total += 1;
+    if test_x11_shm_create_pixmap() { passed += 1; }
+
     // ── Test 69: X11 RENDER extension — Pixmap + Picture + FillRectangles ────
 
     total += 1;
@@ -19043,6 +19046,172 @@ fn test_x11_shm_put_image() -> bool {
 
     crate::net::unix::close(client);
     test_pass!("X11 MIT-SHM ShmPutImage");
+    true
+}
+
+// ── X11 real MIT-SHM ShmCreatePixmap + CopyArea (Firefox gUseShmPixmaps present) ─
+//
+// The other supported MIT-SHM present path: a client backs a Pixmap directly
+// with an attached segment (ShmCreatePixmap), draws each frame into the segment,
+// and CopyAreas the pixmap to its window.  This is the path nsShmImage takes when
+// the server advertises shared_pixmaps=true.  This test verifies the full chain:
+// ShmQueryVersion reports shared_pixmaps=1, ShmCreatePixmap makes a pixmap whose
+// storage is the segment, and CopyArea(pixmap → window) reads the segment's LIVE
+// contents (we change the segment AFTER CreatePixmap to prove it is read at copy
+// time, not snapshotted at create time).  X11 MIT-SHM protocol §ShmCreatePixmap.
+fn test_x11_shm_create_pixmap() -> bool {
+    test_header!("X11 MIT-SHM ShmCreatePixmap + CopyArea (shared-pixmap present)");
+
+    let client = match x11_connect_setup("x11_shmpix") { Some(c) => c, None => return false };
+
+    // ShmQueryVersion must report shared_pixmaps=1 (so a real client takes this path).
+    {
+        let mut req = [0u8; 4];
+        req[0] = crate::x11::proto::SHM_MAJOR_OPCODE;
+        req[1] = crate::x11::proto::SHM_QUERY_VERSION;
+        req[2] = 1;
+        crate::net::unix::write(client, &req);
+        crate::x11::poll();
+        let mut rep = [0u8; 32];
+        let n = crate::net::unix::read(client, &mut rep);
+        if n < 17 || rep[1] != 1 {
+            test_fail!("x11_shmpix", "ShmQueryVersion shared_pixmaps={} (want 1, n={})", rep[1], n);
+            crate::net::unix::close(client); return false;
+        }
+    }
+
+    const W: u32 = 8; const H: u32 = 8;
+    let seg_bytes = (W * H * 4) as u64;
+    let shmid = crate::ipc::sysv_shm::shmget(
+        crate::ipc::sysv_shm::IPC_PRIVATE, seg_bytes,
+        crate::ipc::sysv_shm::IPC_CREAT | 0o600);
+    if shmid < 0 {
+        test_fail!("x11_shmpix", "shmget failed: {}", shmid);
+        crate::net::unix::close(client); return false;
+    }
+    let shmid = shmid as u32;
+    let (phys_base, _size) = match crate::ipc::sysv_shm::segment_phys(shmid) {
+        Some(v) => v,
+        None => {
+            test_fail!("x11_shmpix", "segment_phys({}) returned None", shmid);
+            crate::ipc::sysv_shm::shmctl(shmid, crate::ipc::sysv_shm::IPC_RMID, 0);
+            crate::net::unix::close(client); return false;
+        }
+    };
+    // Initial pattern (will be OVERWRITTEN after CreatePixmap to prove live read).
+    // SAFETY: phys_base is the identity-mapped base of the just-allocated segment.
+    unsafe {
+        let p = phys_base as *mut u8;
+        for i in 0..(W * H) as usize {
+            *p.add(i * 4) = 0x00; *p.add(i * 4 + 1) = 0x00;
+            *p.add(i * 4 + 2) = 0x00; *p.add(i * 4 + 3) = 0xFF;
+        }
+    }
+
+    // CreateWindow (16×16) + MapWindow.
+    const WID: u32 = 0x0081_0001;
+    {
+        let mut cw = [0u8; 40];
+        cw[0] = 1; cw[2] = 10;
+        cw[4] = 0x01; cw[5] = 0x00; cw[6] = 0x81;
+        cw[8] = 0x01;
+        cw[16] = 16; cw[18] = 16;
+        cw[22] = 1; cw[24] = 32;
+        crate::net::unix::write(client, &cw);
+        let mut mw = [0u8; 8];
+        mw[0] = 8; mw[2] = 2;
+        mw[4] = 0x01; mw[5] = 0x00; mw[6] = 0x81;
+        crate::net::unix::write(client, &mw);
+        crate::x11::poll();
+        let mut drain = [0u8; 256];
+        let _ = crate::net::unix::read(client, &mut drain);
+    }
+
+    // ShmAttach: shmseg=0x00810100.
+    const SHMSEG: u32 = 0x0081_0100;
+    {
+        let mut req = [0u8; 16];
+        req[0] = crate::x11::proto::SHM_MAJOR_OPCODE;
+        req[1] = crate::x11::proto::SHM_ATTACH;
+        req[2] = 4;
+        req[4..8].copy_from_slice(&SHMSEG.to_le_bytes());
+        req[8..12].copy_from_slice(&shmid.to_le_bytes());
+        crate::net::unix::write(client, &req);
+        crate::x11::poll();
+    }
+
+    // ShmCreatePixmap: pixmap=0x00810200, drawable=WID, 8×8 depth-24, offset 0.
+    const PIXID: u32 = 0x0081_0200;
+    {
+        let mut req = [0u8; 28];
+        req[0] = crate::x11::proto::SHM_MAJOR_OPCODE;
+        req[1] = crate::x11::proto::SHM_CREATE_PIXMAP;
+        req[2] = 7; // 7 words
+        req[4..8].copy_from_slice(&PIXID.to_le_bytes());   // pid
+        req[8..12].copy_from_slice(&WID.to_le_bytes());    // drawable
+        req[12..14].copy_from_slice(&(W as u16).to_le_bytes());
+        req[14..16].copy_from_slice(&(H as u16).to_le_bytes());
+        req[16] = 24;                                      // depth
+        req[20..24].copy_from_slice(&SHMSEG.to_le_bytes()); // shmseg
+        // offset = 0
+        crate::net::unix::write(client, &req);
+        crate::x11::poll();
+    }
+
+    // Now CHANGE the segment AFTER the pixmap exists — CopyArea must see THIS,
+    // proving the pixmap reads live segment contents (not a create-time snapshot).
+    // SAFETY: same identity-mapped segment base, still allocated.
+    unsafe {
+        let p = phys_base as *mut u8;
+        for i in 0..(W * H) as usize {
+            *p.add(i * 4) = 0x44; *p.add(i * 4 + 1) = 0x55;
+            *p.add(i * 4 + 2) = 0x66; *p.add(i * 4 + 3) = 0xFF;
+        }
+    }
+
+    // CopyArea: pixmap(0,0,8×8) → window(0,0).
+    {
+        let mut req = [0u8; 28];
+        req[0] = crate::x11::proto::OP_COPY_AREA;
+        req[2] = 7;
+        req[4..8].copy_from_slice(&PIXID.to_le_bytes());   // src = shm pixmap
+        req[8..12].copy_from_slice(&WID.to_le_bytes());    // dst = window
+        // gc at [12..16] unused
+        // src_x/src_y = 0, dst_x/dst_y = 0
+        req[24..26].copy_from_slice(&(W as u16).to_le_bytes());  // width
+        req[26..28].copy_from_slice(&(H as u16).to_le_bytes());  // height
+        crate::net::unix::write(client, &req);
+        crate::x11::poll();
+    }
+
+    // Verify the window got the POST-create segment pixels (live read).
+    let px = crate::x11::test_read_window_pixel(WID, 2, 2);
+    let ok = matches!(px, Some([0x44, 0x55, 0x66, _]));
+    if !ok {
+        test_fail!("x11_shmpix", "window pixel after CopyArea = {:?} (want [44,55,66,_] = live segment)", px);
+        crate::ipc::sysv_shm::shmctl(shmid, crate::ipc::sysv_shm::IPC_RMID, 0);
+        crate::net::unix::close(client); return false;
+    }
+    test_println!("  ShmCreatePixmap pixmap read LIVE segment via CopyArea ✓ ({:?})", px);
+
+    // FreePixmap + Detach + clean up.
+    {
+        let mut req = [0u8; 8];
+        req[0] = 54; req[2] = 2; // FreePixmap
+        req[4..8].copy_from_slice(&PIXID.to_le_bytes());
+        crate::net::unix::write(client, &req);
+        let mut det = [0u8; 8];
+        det[0] = crate::x11::proto::SHM_MAJOR_OPCODE;
+        det[1] = crate::x11::proto::SHM_DETACH;
+        det[2] = 2;
+        det[4..8].copy_from_slice(&SHMSEG.to_le_bytes());
+        crate::net::unix::write(client, &det);
+        crate::x11::poll();
+    }
+    crate::ipc::sysv_shm::shmctl(shmid, crate::ipc::sysv_shm::IPC_RMID, 0);
+
+    crate::net::unix::close(client);
+    test_pass!("X11 MIT-SHM ShmCreatePixmap");
     true
 }
 

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -2408,6 +2408,11 @@ fn op_copy_area(fd: u64, data: &[u8]) {
                             for col in 0..rw {
                                 let so = (((y0 + row as i32) * sw + x0 + col as i32) * 4) as usize;
                                 let bo = (row * rw + col) * 4;
+                                // SHM-backed sources have an empty owned `Vec`;
+                                // pixmap→pixmap from a live segment is not a path
+                                // FF uses, so leave those pixels zero rather than
+                                // index out of bounds.
+                                if so + 4 > p.pixels.len() { continue; }
                                 buf[bo..bo+4].copy_from_slice(&p.pixels[so..so+4]);
                             }
                         }
@@ -2442,8 +2447,11 @@ fn op_copy_area(fd: u64, data: &[u8]) {
             // (the compositor source of truth), NOT the transient screen
             // backbuffer.  Build a tightly packed BGRA buffer of the clipped
             // source rectangle and record the clip offset so the copy lands at
-            // the correct window-local position.
-            let (pixels, rw, rh, off_x, off_y) = {
+            // the correct window-local position.  Two source backings are
+            // supported: a server-owned pixel `Vec`, and an MIT-SHM-backed
+            // pixmap whose pixels live in an attached SysV-SHM segment (read
+            // LIVE here, so the frame the client just drew is the one copied).
+            let extracted = {
                 let srv = SERVER.lock();
                 let c = srv.clients.iter().filter_map(|s| s.as_ref()).find(|c| c.fd == fd);
                 match c.and_then(|c| c.resources.get_pixmap(src_id)) {
@@ -2456,19 +2464,70 @@ fn op_copy_area(fd: u64, data: &[u8]) {
                         let rw = (x1 - x0).max(0) as usize;
                         let rh = (y1 - y0).max(0) as usize;
                         let mut buf = alloc::vec![0u8; rw * rh * 4];
-                        for row in 0..rh {
-                            for col in 0..rw {
-                                let so = (((y0 + row as i32) * sw + x0 + col as i32) * 4) as usize;
-                                let bo = (row * rw + col) * 4;
-                                buf[bo..bo+4].copy_from_slice(&p.pixels[so..so+4]);
+                        let ok = if p.is_shm_backed() {
+                            // Resolve the segment's kernel-readable physical base
+                            // and copy the clipped rectangle from it.  Row stride
+                            // is the SHM image stride (scanline-padded), not sw*4.
+                            match crate::ipc::sysv_shm::segment_phys(p.shm_shmid) {
+                                Some((phys_base, seg_size)) => {
+                                    let stride = p.shm_stride as usize;
+                                    let base = phys_base as usize + p.shm_offset as usize;
+                                    // Last byte the loop touches must lie inside the
+                                    // segment (guards against a truncated/detached
+                                    // segment between CreatePixmap and CopyArea).
+                                    let last = (y0 + rh as i32 - 1).max(0) as usize * stride
+                                        + (x0 + rw as i32 - 1).max(0) as usize * 4 + 4;
+                                    if rw == 0 || rh == 0
+                                        || (p.shm_offset as u64 + last as u64) > seg_size {
+                                        false
+                                    } else {
+                                        // SAFETY: `phys_base` is the identity-mapped,
+                                        // kernel-readable base of a physically
+                                        // contiguous SysV segment (see
+                                        // sysv_shm::shmget); the bound check above
+                                        // keeps every read inside the segment.
+                                        for row in 0..rh {
+                                            for col in 0..rw {
+                                                let so = base
+                                                    + (y0 + row as i32) as usize * stride
+                                                    + (x0 + col as i32) as usize * 4;
+                                                let bo = (row * rw + col) * 4;
+                                                let px = unsafe {
+                                                    core::slice::from_raw_parts(so as *const u8, 4)
+                                                };
+                                                buf[bo..bo+4].copy_from_slice(px);
+                                            }
+                                        }
+                                        true
+                                    }
+                                }
+                                None => false,
                             }
-                        }
+                        } else {
+                            // Server-owned pixmap: source stride is sw*4.
+                            if rw == 0 || rh == 0 { false } else {
+                                for row in 0..rh {
+                                    for col in 0..rw {
+                                        let so = (((y0 + row as i32) * sw + x0 + col as i32) * 4) as usize;
+                                        let bo = (row * rw + col) * 4;
+                                        if so + 4 > p.pixels.len() { continue; }
+                                        buf[bo..bo+4].copy_from_slice(&p.pixels[so..so+4]);
+                                    }
+                                }
+                                true
+                            }
+                        };
                         // Window-local destination shifts by the amount the
                         // source origin was clipped (x0 - src_x, y0 - src_y).
-                        (buf, rw as i32, rh as i32, x0 - src_x, y0 - src_y)
+                        if ok { Some((buf, rw as i32, rh as i32, x0 - src_x, y0 - src_y)) }
+                        else { None }
                     }
-                    None => return,
+                    None => None,
                 }
+            };
+            let (pixels, rw, rh, off_x, off_y) = match extracted {
+                Some(v) => v,
+                None => return,
             };
             // CopyArea is a plain copy (RENDER_OP_SRC) of opaque pixels.
             window_composite_pixels(
@@ -3337,9 +3396,14 @@ fn op_shm(fd: u64, data: &[u8], seq: u16) {
     let minor = data[1];
     match minor {
         proto::SHM_QUERY_VERSION => {
-            // ShmQueryVersionReply: shared_pixmaps=0, major=1, minor=2
+            // ShmQueryVersionReply (MIT-SHM §ShmQueryVersion): shared_pixmaps=1,
+            // major=1, minor=2.  Advertising shared_pixmaps=true tells the client
+            // it may back a Pixmap directly with an attached segment via
+            // ShmCreatePixmap; clients (e.g. nsShmImage's gUseShmPixmaps path)
+            // then present with CreatePixmap → CopyArea(pixmap → window) instead
+            // of ShmPutImage.  Both present paths are now implemented server-side.
             let mut b = [0u8; 32];
-            b[0] = 1; b[1] = 0; // shared_pixmaps = false
+            b[0] = 1; b[1] = 1; // shared_pixmaps = true
             w16(&mut b, 2, seq);
             w16(&mut b, 8, 1); w16(&mut b, 10, 2); // version 1.2
             b[16] = 2; // pixmap_format = ZPixmap
@@ -3352,9 +3416,7 @@ fn op_shm(fd: u64, data: &[u8], seq: u16) {
         proto::SHM_GET_IMAGE => {
             with_client(fd, |c| c.send_error(proto::ERR_IMPLEMENTATION, 0, proto::SHM_MAJOR_OPCODE));
         }
-        // SHM_CREATE_PIXMAP: accept, treated as no-op (we route presents through
-        // ShmPutImage, not shm-backed pixmaps).
-        proto::SHM_CREATE_PIXMAP => {}
+        proto::SHM_CREATE_PIXMAP => op_shm_create_pixmap(fd, data),
         _ => {}
     }
 }
@@ -3392,6 +3454,56 @@ fn shm_lookup(fd: u64, shmseg: u32) -> Option<u32> {
     tbl.iter()
         .find(|a| a.shmseg == shmseg && a.fd == fd && a.shmseg != 0)
         .map(|a| a.shmid)
+}
+
+// ShmCreatePixmap request (MIT-SHM protocol §ShmCreatePixmap, 28 bytes):
+//   [0]      reqType        [1]  shmReqType (=5)   [2..4]  length
+//   [4..8]   pid            (new Pixmap X resource id)
+//   [8..12]  drawable       (a drawable on the target screen; only used to
+//                            pick the screen/depth — pixels come from the segment)
+//   [12..14] width          [14..16] height
+//   [16]     depth          [17..20] pad
+//   [20..24] shmseg         (the attached MIT-SHM segment id)
+//   [24..28] offset         (byte offset of the pixel origin within the segment)
+//
+// Creates a Pixmap RESOURCE whose pixel backing IS the attached SysV-SHM
+// segment: no server-owned pixel buffer is allocated.  The client draws each
+// frame directly into the segment and then `CopyArea`s the pixmap to a window;
+// `op_copy_area` reads the segment's LIVE bytes at copy time.  The row stride is
+// the scanline-padded byte width — for depth 24/32 at 32 bits-per-pixel this is
+// `width * 4` (4-byte scanline pad makes the pad a no-op at 32 bpp).
+fn op_shm_create_pixmap(fd: u64, data: &[u8]) {
+    if data.len() < 28 { return; }
+    let pid    = r32(data, 4);
+    let width  = r16(data, 12);
+    let height = r16(data, 14);
+    let depth  = data[16];
+    let shmseg = r32(data, 20);
+    let offset = r32(data, 24);
+
+    if width == 0 || height == 0 { return; }
+    // Only the 32-bpp ZPixmap depths the server composites are honoured; the
+    // CopyArea reader assumes a 4-byte BGRA pixel.
+    if depth < 24 { return; }
+
+    // The shmseg must be a live attachment owned by this client; resolve it to a
+    // SysV shmid and validate the requested image region fits in the segment
+    // before creating the resource (so a later CopyArea never reads out of range).
+    let shmid = match shm_lookup(fd, shmseg) { Some(id) => id, None => return };
+    let (_phys_base, seg_size) = match crate::ipc::sysv_shm::segment_phys(shmid) {
+        Some(v) => v, None => return,
+    };
+    let stride  = width as u64 * 4;
+    let img_len = stride * height as u64;
+    if (offset as u64).saturating_add(img_len) > seg_size { return; }
+
+    with_client(fd, |c| {
+        c.resources.insert(
+            pid,
+            ResourceBody::Pixmap(PixmapData::new_shm_backed(
+                width, height, depth, shmid, offset, stride as u32)),
+        );
+    });
 }
 
 // ShmPutImage request (MIT-SHM protocol §ShmPutImage):

--- a/kernel/src/x11/resource.rs
+++ b/kernel/src/x11/resource.rs
@@ -202,16 +202,48 @@ pub struct PixmapData {
     pub width:  u16,
     pub height: u16,
     pub depth:  u8,
-    /// Pixel data: `width * height * 4` bytes, BGRA-ordered.
+    /// Pixel data: `width * height * 4` bytes, BGRA-ordered.  Empty for an
+    /// SHM-backed pixmap (its pixels live in the attached SysV-SHM segment and
+    /// are read live at draw time — see `shm_shmid`).
     pub pixels: Vec<u8>,
+    /// MIT-SHM backing.  `0` = a normal server-owned pixmap (pixels in `pixels`).
+    /// Non-zero = the pixmap's pixel storage IS the SysV-SHM segment with this
+    /// `shmid`; the client draws each frame into the segment and the server reads
+    /// the live bytes at `phys_base + shm_offset` (row stride `shm_stride`) when
+    /// the pixmap is used as a CopyArea source.  X11 MIT-SHM `ShmCreatePixmap`.
+    pub shm_shmid:  u32,
+    /// Byte offset of the pixmap's pixel origin within the SHM segment.
+    pub shm_offset: u32,
+    /// Row stride in bytes of the SHM-backed image (scanline pad applied client
+    /// side; for depth 24/32 at 32 bpp this is `width * 4`).
+    pub shm_stride: u32,
 }
 
 impl PixmapData {
     /// Allocate a zeroed pixel buffer for `width × height`.
     pub fn new(width: u16, height: u16, depth: u8) -> Self {
         let n = (width as usize) * (height as usize) * 4;
-        PixmapData { width, height, depth, pixels: alloc::vec![0u8; n] }
+        PixmapData {
+            width, height, depth, pixels: alloc::vec![0u8; n],
+            shm_shmid: 0, shm_offset: 0, shm_stride: 0,
+        }
     }
+
+    /// Create an MIT-SHM-backed pixmap: no server-owned pixel `Vec`; the pixels
+    /// live in the SysV-SHM segment `shmid` at byte `offset`, row stride `stride`.
+    /// Used by `ShmCreatePixmap` so a later `CopyArea(pixmap → window)` reads the
+    /// segment's live contents.
+    pub fn new_shm_backed(width: u16, height: u16, depth: u8,
+                          shmid: u32, offset: u32, stride: u32) -> Self {
+        PixmapData {
+            width, height, depth, pixels: Vec::new(),
+            shm_shmid: shmid, shm_offset: offset, shm_stride: stride,
+        }
+    }
+
+    /// True if this pixmap's storage is an attached SHM segment (no owned `Vec`).
+    #[inline]
+    pub fn is_shm_backed(&self) -> bool { self.shm_shmid != 0 }
 
     /// Fill an axis-aligned rectangle with `color` (0xAARRGGBB).
     /// Clamps to pixmap bounds; silently ignores out-of-range areas.

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -788,6 +788,37 @@ printf '/lib64\n/lib/x86_64-linux-gnu\n/usr/lib/x86_64-linux-gnu\n' \
 : > "${STAGING_TREE}/etc/ld.so.cache"
 echo "[DATA-DISK] Seeded /etc/ (hostname, hosts, resolv.conf, nsswitch.conf, passwd, group, ld.so.conf)"
 
+# ── GUI runtime caches: regenerate the GdkPixbuf loaders.cache (and the glib
+# schema / mime caches) into the staging tree before mke2fs snaps it ─────────
+# The windowed Firefox (--ff-gui) path realizes a real toplevel, which makes
+# GTK decode its compiled-in symbolic titlebar icons (PNG resources) through
+# GdkPixbuf.  GdkPixbuf only registers an image loader when a matching stanza
+# exists in /usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache; with no cache it comes
+# up with an EMPTY loader set, gdk_pixbuf_new_from_*() returns NULL for the very
+# first PNG icon, and the subsequent gdk_cairo_surface_create_from_pixbuf(NULL)
+# / g_object_unref(NULL) cascade dereferences a garbage pointer — a SIGSEGV in
+# the parent process before any window is mapped.  (The PNG/JPEG decoders are
+# linked directly into libgdk_pixbuf via DT_NEEDED libpng16/libjpeg, so the
+# cache only needs the name-matched "png"/"jpeg" stanzas — no external
+# libpixbufloader-png.so is required.)  install-firefox-musl.sh generates this
+# cache when it (re)installs Firefox, but the common fast path reuses an
+# already-installed build/disk and skips that step, leaving the cache absent.
+# Regenerate it here unconditionally so every data image carries it.  Best
+# effort: cache generation never fails the image build.  Refs:
+# gdk-pixbuf-query-loaders(1), glib-compile-schemas(1).
+if [ -f "${ROOT_DIR}/scripts/patch-gui-caches.sh" ] \
+   && [ -d "${STAGING_TREE}/usr/lib/gdk-pixbuf-2.0" ]; then
+    ASTRYXOS_BUILD_DIR="${BUILD_DIR}" \
+        bash "${ROOT_DIR}/scripts/patch-gui-caches.sh" --stage-only \
+            --disk-dir "${STAGING_TREE}" 2>&1 | sed 's/^/[DATA-DISK] /' || \
+        echo "[DATA-DISK] WARNING: patch-gui-caches.sh failed — GUI caches not regenerated"
+    if [ -f "${STAGING_TREE}/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" ]; then
+        echo "[DATA-DISK] gdk-pixbuf loaders.cache present ($(grep -c '^"' "${STAGING_TREE}/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" 2>/dev/null || echo 0) stanza lines)"
+    else
+        echo "[DATA-DISK] WARNING: loaders.cache still absent after regen — windowed GTK may fault on PNG icons"
+    fi
+fi
+
 # ── Welcome/readme/docs files ────────────────────────────────────────────────
 mkdir -p "${STAGING_TREE}/home" "${STAGING_TREE}/docs" "${STAGING_TREE}/bin"
 printf 'Welcome to AstryxOS persistent storage!\n' \


### PR DESCRIPTION
## Summary

Drives the **windowed** (`--ff-gui`) Firefox paint path forward by closing two
divergences and assembling the combined windowed-paint branch. Builds on
`feat/mesa-gl-runtime` (GLX #599/#598 + real ShmPutImage) and includes the
mremap (#596) and prefs (#597) fixes via cherry-pick.

### 1. Real MIT-SHM `ShmCreatePixmap` + CopyArea-from-SHM-pixmap (kernel)
`kernel/src/x11/{mod,resource}.rs`. The X11 MIT-SHM shared-pixmap present path
(the one `nsShmImage`'s `gUseShmPixmaps` prefers) was a no-op stub, and
`ShmQueryVersion` advertised `shared_pixmaps=false`.

- `ShmQueryVersion` now advertises `shared_pixmaps=true`.
- `ShmCreatePixmap` creates a real Pixmap resource whose pixel storage **is** the
  attached SysV-SHM segment — no server-owned `Vec`. It records the resolved
  shmid, byte offset, and scanline-padded row stride after validating the image
  region fits inside the segment.
- `CopyArea(pixmap → window)` reads an SHM-backed source's **live** pixels from
  the segment's kernel-readable physical backing (`sysv_shm::segment_phys`) at
  copy time, so the frame the client just drew is the one composited. Server-owned
  pixmaps keep their existing `Vec`-read path; the pixmap→pixmap arm is
  bounds-guarded against the empty `Vec` of an SHM-backed source.

Per the X11 MIT-SHM protocol §ShmCreatePixmap.

### 2. GdkPixbuf `loaders.cache` always provisioned (build)
`scripts/create-data-disk.sh`. The windowed path realizes a real toplevel, so GTK
decodes its compiled-in symbolic PNG titlebar icons through GdkPixbuf. With no
`loaders.cache` at the env-pointed path, GdkPixbuf comes up with an **empty
loader set**, the first PNG decode returns NULL, and the
`gdk_cairo_surface_create_from_pixbuf(NULL)` / `g_object_unref(NULL)` cascade
dereferences a garbage pointer — a **deterministic SIGSEGV in the parent before
any window is mapped** (observed: `Could not load a pixbuf from
.../window-minimize-symbolic.symbolic.png ... pixbuf loaders ... could not be
found`, then a repeated identical-RIP fault, `data_phys=UNMAPPED`).

`install-firefox-musl.sh` generated this cache only on FF (re)install; the common
fast path reuses an already-installed `build/disk` and skipped it. Now
`patch-gui-caches.sh --stage-only` runs unconditionally during the data-image
build. The PNG/JPEG decoders are linked into `libgdk_pixbuf` (DT_NEEDED
libpng16/libjpeg), so the cache needs only the name-matched png/jpeg stanzas.

Refs: gdk-pixbuf-query-loaders(1), glib-compile-schemas(1).

## Verification

- `test_x11_shm_create_pixmap` (new): ShmQueryVersion(shared_pixmaps=1) →
  ShmAttach → ShmCreatePixmap → **change the segment** → CopyArea → assert the
  window shows the post-create pixels. Read back `[0x44,0x55,0x66,0xFF]` =
  proven live read. **PASS.** Full suite unregressed (213 PASS; only [FAIL]s are
  the pre-existing tcc/busybox-not-in-image env cases).
- Windowed FF boot (`--features firefox-test-core,kdb --ff-gui`) against a data
  image carrying the cache: the parent SIGSEGV (deterministic, 5× identical-RIP)
  is **eliminated**; `Could not load a pixbuf` = 0, `exit_group(11)` = 0. FF
  advances from "ff-launch crash" to a clean multi-thread startup.

## Residual gate (NOT yet painted — precisely localized)

Post-fixes, FF reaches a healthy startup but its main thread (tid 2) + all 30
threads **park before realizing the 1280×720 toplevel**. The in-kernel X server
is fully drained (owes no reply); FF never reaches the present path (0
ShmAttach/ShmCreatePixmap). Screendump = empty desktop, no FF window. This is the
parked W101-class multi-thread event-loop/work-source stall, now manifesting in
the windowed path. Reported for follow-up per the saga-exhaustion rule rather
than re-opening the parked futex/event-loop investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)