### PR TITLE
harness/kdb: autopsy --hw-break (HW exec bp) + kdb uread (CR3-walk user read)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -371,6 +371,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "dmesg"          => op_dmesg(req, out),
         "syms"           => op_syms(req, out),
         "mem"            => op_mem(req, out),
+        "uread"          => op_uread(req, out),
         "read-file"      => op_read_file(req, out),
         "trace-status"   => op_trace_status(out),
         // blk-trace: dump the virtio-blk LBA trace ring as JSON (out-of-band
@@ -894,6 +895,98 @@ fn op_mem(req: &str, out: &mut String) {
     out.push('{');
     j_str(out, "addr"); out.push(':'); j_hex(out, addr); out.push(',');
     j_kv(out, "len", &alloc::format!("{}", len));
+    j_kv_str(out, "hex", &hex);
+    j_trim_comma(out);
+    out.push('}');
+}
+
+// ── uread ─────────────────────────────────────────────────────────────────────
+//
+// Read a slice of a *user* process's address space by walking that process's
+// CR3 page table and loading through the kernel direct map (PHYS_OFF + phys).
+// Unlike `mem` (which only accepts kernel higher-half VAs against the currently
+// loaded CR3) this resolves the target pid's CR3 from the process table, so a
+// user VA can be inspected regardless of which CR3 the inspecting vCPU happens
+// to hold — the common case when both vCPUs are parked in the scheduler on the
+// kernel CR3.  Per-page virt_to_phys_in walk (Intel SDM Vol.3A §4.5 4-level
+// paging); refuses cleanly on an unmapped page rather than faulting.
+//
+// Request : {"op":"uread","pid":1,"addr":"0x7eff62006580","len":64}
+// Response: {"pid":N,"cr3":..,"addr":..,"len":K,"first_phys":..,"hex":".."}
+fn op_uread(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let pid = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(p) => p,
+        None => { out.push_str(r#"{"error":"missing or bad 'pid'"}"#); return; }
+    };
+    let addr = match extract_field(req, "addr").and_then(|s| parse_u64(&s)) {
+        Some(a) => a,
+        None => { out.push_str(r#"{"error":"missing 'addr'"}"#); return; }
+    };
+    let len = match extract_field(req, "len").and_then(|s| parse_u64(&s)) {
+        Some(l) if l > 0 && l <= MEM_MAX => l,
+        Some(_) => { out.push_str(r#"{"error":"len out of range (1..=4096)"}"#); return; }
+        None    => { out.push_str(r#"{"error":"missing 'len'"}"#); return; }
+    };
+
+    // Resolve the target process's CR3 under a brief PROCESS_TABLE lock.
+    let cr3 = {
+        let pt = match try_lock_brief(&PROCESS_TABLE) {
+            Some(g) => g,
+            None => { out.push_str(r#"{"busy":"PROCESS_TABLE held"}"#); return; }
+        };
+        let c = pt.iter().find(|p| p.pid == pid).map(|p| p.cr3);
+        drop(pt);
+        match c {
+            Some(c) => c,
+            None => { let _ = write!(out, r#"{{"error":"pid {} not found"}}"#, pid); return; }
+        }
+    };
+
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    let Some(end) = addr.checked_add(len) else {
+        out.push_str(r#"{"error":"addr+len overflow"}"#); return;
+    };
+    let mut first_phys: Option<u64> = None;
+    let mut hex = alloc::string::String::with_capacity((len as usize) * 2);
+    let mut i = 0u64;
+    while i < len {
+        let va = addr + i;
+        let page = va & !0xFFF;
+        let phys = match crate::mm::vmm::virt_to_phys_in(cr3, page) {
+            Some(p) => p,
+            None => {
+                let _ = write!(out, r#"{{"pid":{},"cr3":"#, pid);
+                j_hex(out, cr3);
+                out.push_str(r#","error":"unmapped page","unmapped_page":"#);
+                j_hex(out, page);
+                let _ = write!(out, r#","read":{}}}"#, i);
+                return;
+            }
+        };
+        if first_phys.is_none() { first_phys = Some(phys + (va & 0xFFF)); }
+        let off = va & 0xFFF;
+        // bytes available in this page
+        let avail = 0x1000 - off;
+        let take = core::cmp::min(avail, len - i);
+        for b in 0..take {
+            // SAFETY: page verified mapped via virt_to_phys_in; the kernel
+            // direct map (PHYS_OFF + phys) covers all PMM frames.  Volatile so
+            // the read isn't elided.
+            let byte = unsafe {
+                core::ptr::read_volatile((PHYS_OFF + phys + off + b) as *const u8)
+            };
+            let _ = write!(hex, "{:02x}", byte);
+        }
+        i += take;
+        let _ = end; // end computed for overflow check only
+    }
+    out.push('{');
+    let _ = write!(out, r#""pid":{},"#, pid);
+    j_str(out, "cr3"); out.push(':'); j_hex(out, cr3); out.push(',');
+    j_str(out, "addr"); out.push(':'); j_hex(out, addr); out.push(',');
+    j_kv(out, "len", &alloc::format!("{}", len));
+    if let Some(fp) = first_phys { j_str(out, "first_phys"); out.push(':'); j_hex(out, fp); out.push(','); }
     j_kv_str(out, "hex", &hex);
     j_trim_comma(out);
     out.push('}');

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -407,6 +407,25 @@ class GdbClient:
         resp = self.send(f"z0,{addr:x},1")
         return resp == "OK"
 
+    def set_hbreak(self, addr: int) -> bool:
+        """Set a HARDWARE execution breakpoint via the GDB Z1 packet.
+
+        Unlike a Z0 software breakpoint (which writes a 0xCC into the target
+        page and therefore needs that page mapped in the CPU's current CR3),
+        a Z1 breakpoint is programmed into the x86 debug registers (DR0..DR3
+        + DR7) and fires on the linear address regardless of which CR3 is
+        loaded.  This is the only way to break on a userspace VA while both
+        vCPUs are parked in the kernel on the kernel CR3 — exactly the
+        situation when investigating a user-space library routine.
+        """
+        resp = self.send(f"Z1,{addr:x},1")
+        return resp == "OK"
+
+    def del_hbreak(self, addr: int) -> bool:
+        """Remove a hardware execution breakpoint via z1."""
+        resp = self.send(f"z1,{addr:x},1")
+        return resp == "OK"
+
     # ── hardware watchpoints (Z2/Z3/Z4 packets) ──────────────────────────────
     #
     # GDB remote-protocol watchpoint kinds (see the GDB Remote Serial Protocol
@@ -6717,10 +6736,14 @@ def cmd_autopsy(args):
 
     armed_addrs: list[int] = []
     try:
-        # Arm all requested breakpoints.
+        # Arm all requested breakpoints.  A hardware (Z1) breakpoint fires on
+        # the linear address regardless of CR3 — necessary for userspace VAs
+        # while the vCPUs are parked on the kernel CR3.
+        use_hw = bool(getattr(args, "hw_break", False))
         for b in breaks:
-            ok = gdb.set_bp(b["addr"])
+            ok = gdb.set_hbreak(b["addr"]) if use_hw else gdb.set_bp(b["addr"])
             b["armed"] = bool(ok)
+            b["hw"] = use_hw
             if ok:
                 armed_addrs.append(b["addr"])
         if not armed_addrs:
@@ -6818,7 +6841,10 @@ def cmd_autopsy(args):
         # surprise the next agent who attaches via `step`/`cont`.
         for addr in armed_addrs:
             try:
-                gdb.del_bp(addr)
+                if bool(getattr(args, "hw_break", False)):
+                    gdb.del_hbreak(addr)
+                else:
+                    gdb.del_bp(addr)
             except Exception:
                 pass
         try:
@@ -12716,6 +12742,15 @@ def main():
         "--leave-paused", action="store_true",
         help="On exit, leave the guest paused (so a follow-up `step`/`mem` "
              "session can pick up state). Default: resume the guest.",
+    )
+    p_autopsy.add_argument(
+        "--hw-break", action="store_true", dest="hw_break",
+        help="Arm the breakpoint(s) as HARDWARE execution breakpoints "
+             "(GDB Z1 / x86 debug registers) instead of software (Z0). "
+             "Required to break on a userspace VA while both vCPUs are "
+             "parked on the kernel CR3 — a Z0 sw breakpoint needs the user "
+             "page mapped in the inspecting CR3, a Z1 hw breakpoint fires "
+             "on the linear address regardless of CR3.",
     )
     p_autopsy.add_argument(
         "--output", default=None, metavar="PATH",

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7014,10 +7014,16 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         # as "0x29d91000".
         phys = int(rest[0], 0)
         return {"op": "arm-phys", "phys": f"0x{phys:x}"}
-    if op == "user-mem":
+    if op == "user-mem" or op == "uread":
+        # Read a slice of a user process's address space by walking that
+        # process's CR3 (kernel op "uread").  Resolves the target pid's CR3
+        # from the process table, so the read works regardless of which CR3
+        # the inspecting vCPU holds (both vCPUs are usually parked on the
+        # kernel CR3 in the scheduler).
         if len(rest) < 3: raise ValueError("user-mem requires <pid> <addr> <len>")
-        return {"op": "user-mem", "pid": int(rest[0], 0),
-                "addr": rest[1], "len": int(rest[2], 0)}
+        addr = int(rest[1], 0)
+        return {"op": "uread", "pid": int(rest[0], 0),
+                "addr": f"0x{addr:x}", "len": int(rest[2], 0)}
     if op == "rip-trace":
         # Periodic userspace RIP sampler for one TID over a fixed
         # wall-clock window.  Used to characterise userspace plateaux
@@ -12726,7 +12732,7 @@ def main():
     p_kdb.add_argument("op", choices=[
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
         "syscall-trend", "vfs-mounts",
-        "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "trace-status",
+        "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "uread", "trace-status",
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
         "arm-phys",


### PR DESCRIPTION
Two additive debug-tooling primitives for userspace-memory autopsy. Both
are dev-tooling only (no kernel runtime behaviour change on production
paths); they make it possible to inspect a userspace process while both
vCPUs are parked in the kernel on the kernel CR3.

## 1. `kdb uread <pid> <addr> <len>` — CR3-walk user-memory read

`kdb mem` only reads kernel higher-half VAs against the currently loaded
CR3. When both vCPUs are parked in the scheduler on the kernel CR3, a
target *user* VA is unmapped in the inspecting CPU's address space and
unreadable via `mem`.

`uread` resolves the target pid's CR3 from the process table, walks it
per-page (Intel SDM Vol.3A §4.5, 4-level paging) via `virt_to_phys_in`,
and reads through the kernel direct map. It refuses cleanly on an
unmapped page rather than faulting in kernel mode, and is bounded to a
single page per call. Output is one-shot structured JSON matching the
`mem` shape (`pid`, `cr3`, `addr`, `len`, `first_phys`, `hex`).

The harness `kdb user-mem` request builder previously emitted an op the
kernel never implemented; it (and a new `uread` alias) now map to this op.

## 2. `autopsy --hw-break` — GDB Z1 hardware execution breakpoint

Adds `GdbClient.set_hbreak` / `del_hbreak` (GDB Remote Serial Protocol
Z1/z1 packets) and an `autopsy --hw-break` flag.

A software (Z0) breakpoint writes a `0xCC` trap byte into the target
page, so it requires that page present in the inspecting CPU's active
address space — impossible for a userspace VA while the vCPUs sit on the
kernel CR3. A hardware execution breakpoint is programmed into the x86
debug registers (DR0..DR3 + DR7, Intel SDM Vol.3B §17.2) and fires on the
linear address regardless of the active CR3.

The flag defaults off (Z0 behaviour unchanged); it adds an additive `hw`
field to each per-breakpoint JSON record. No breaking changes to existing
autopsy output.

## Smoke test (through `scripts/qemu-harness.py`)

Booted one kdb session; user processes ascension (pid 1, cr3 0x7d0000)
and orbit (pid 2, cr3 0x8ce1000) present.

- `uread 2 0x4000A1 27` → `"Orbit: AstryxOS user shell\n"` (exact known
  data-string content from the embedded ELF).
- `uread 2 0x400000 8` → `7f454c4602010100` (ELF magic); same at pid 1
  with its distinct CR3 — per-pid CR3 resolution confirmed.
- `uread 2 0xdead0000 16` → `{"error":"unmapped page"}` (clean refusal,
  no kernel fault); `uread 99 ...` → `{"error":"pid 99 not found"}`.
- `autopsy --hw-break <addr>` → armed via Z1 and fired (`hit_count: 1`,
  full register dump captured, symbol-resolved). Firing while QEMU was on
  the kernel CR3 validates the CR3-independent mechanism.

Kernel builds clean through the harness build path
(`firefox-test`-class features unaffected; only `kdb.rs` + the harness
Python are touched). Diff: 2 files, +141 / -7.