### PR TITLE
x11: reassemble client requests across socket reads (over-length PutImage)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -865,6 +865,10 @@ pub fn run() -> ! {
     total += 1;
     if test_x11_query_extension_event_bases() { passed += 1; }
 
+    // ── X11 request reassembly across socket reads (over-length PutImage) ─────
+    total += 1;
+    if test_x11_request_reassembly() { passed += 1; }
+
     // ── Test 69: X11 RENDER extension — Pixmap + Picture + FillRectangles ────
 
     total += 1;
@@ -18998,6 +19002,167 @@ fn test_x11_query_extension_event_bases() -> bool {
 }
 
 // ── Test 69: X11 RENDER — Pixmap + Picture + FillRectangles + Composite ──────
+
+// ── X11 request reassembly across socket reads (over-length PutImage) ─────────
+//
+// Regression for an X11-protocol correctness bug that blanks windowed clients:
+// a single X request larger than one socket read returns (the AF_UNIX recv ring
+// is bounded, and a BIG-REQUESTS PutImage can carry a whole window's chrome)
+// must be reassembled across reads and dispatched intact — never partially read
+// and dropped, which would desynchronise the client's request stream.  (X11
+// Protocol Encoding §Requests; BIG-REQUESTS extension.)
+//
+// This test sends a PutImage whose pixel payload alone exceeds 4 KiB, SPLIT
+// across two separate writes with a poll() in between, so the server first
+// reads an incomplete request (must retain it) and only on the second poll has
+// the whole request buffered (must dispatch it).  It does this for both a core
+// (16-bit length) PutImage and a BIG-REQUESTS (32-bit length) PutImage, then
+// reads back the painted window pixels to prove the request was dispatched and
+// applied — not silently dropped.
+#[cfg(feature = "test-mode")]
+fn test_x11_request_reassembly() -> bool {
+    test_header!("X11 request reassembly across reads (over-length PutImage)");
+
+    // ── Connect + setup ──────────────────────────────────────────────────────
+    let client = crate::net::unix::create(crate::net::unix::SockKind::Stream,
+        crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 });
+    if client == u64::MAX { test_fail!("x11_reasm", "unix::create() failed"); return false; }
+    if crate::net::unix::connect(client, b"/tmp/.X11-unix/X0\0",
+        crate::net::unix::PeerCreds { pid: 0, uid: 0, gid: 0 }) < 0 {
+        test_fail!("x11_reasm", "connect failed");
+        crate::net::unix::close(client); return false;
+    }
+    let hello: [u8; 12] = [0x6C, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    crate::net::unix::write(client, &hello);
+    crate::x11::poll();
+    let mut setup_buf = [0u8; 128];
+    let n = crate::net::unix::read(client, &mut setup_buf);
+    if n < 8 || setup_buf[0] != 1 {
+        test_fail!("x11_reasm", "setup failed (n={})", n);
+        crate::net::unix::close(client); return false;
+    }
+
+    // ── Create + map a 64×64 window so PutImage has a pixel surface ───────────
+    const WID: u32 = 0x0071_0501;
+    let mut cw = [0u8; 40];
+    cw[0] = 1; cw[2] = 10;
+    cw[4..8].copy_from_slice(&WID.to_le_bytes());
+    cw[8] = 1;                                  // parent = ROOT
+    cw[12] = 5; cw[14] = 5;                      // x=5 y=5
+    cw[16] = 64; cw[18] = 64;                    // w=64 h=64
+    cw[22] = 1;                                  // class = InputOutput
+    cw[24] = 32;                                 // visual = ROOT_VISUAL
+    cw[28] = 0x02;                               // vmask = CW_BACK_PIXEL
+    let mut mw = [0u8; 8];
+    mw[0] = 8; mw[2] = 2; mw[4..8].copy_from_slice(&WID.to_le_bytes());
+    crate::net::unix::write(client, &cw);
+    crate::net::unix::write(client, &mw);
+    crate::x11::poll();
+    let mut ev = [0u8; 64];
+    let _ = crate::net::unix::read(client, &mut ev);
+    test_println!("  created + mapped 64×64 window ✓");
+
+    const W: u32 = 64; const H: u32 = 64;
+    // Helper: build a ZPixmap PutImage (opcode 72) filled with `bgra`, standard
+    // (16-bit-length) wire form.
+    let build_core_put_image = |bgra: [u8; 4]| -> alloc::vec::Vec<u8> {
+        let px_len = (W * H * 4) as usize;            // 16384 bytes
+        let total  = 24 + px_len;                      // 16408 bytes
+        let units  = (total / 4) as u16;               // fits in 16 bits
+        let mut r = alloc::vec![0u8; total];
+        r[0] = 72;
+        r[1] = crate::x11::proto::IMAGE_FORMAT_ZPIXMAP;
+        r[2] = units as u8; r[3] = (units >> 8) as u8;
+        r[4..8].copy_from_slice(&WID.to_le_bytes());
+        r[12] = W as u8; r[13] = (W >> 8) as u8;
+        r[14] = H as u8; r[15] = (H >> 8) as u8;
+        r[20] = 0;                                      // left-pad
+        r[21] = 24;                                     // depth = 24
+        for px in r[24..].chunks_exact_mut(4) { px.copy_from_slice(&bgra); }
+        r
+    };
+    // Helper: same image in BIG-REQUESTS form — 16-bit length = 0, a 32-bit
+    // extended length word inserted between the 4-byte header and the body,
+    // length counted in 4-byte units of the WHOLE request incl. the inserted
+    // word.  (BIG-REQUESTS extension.)
+    let build_big_put_image = |bgra: [u8; 4]| -> alloc::vec::Vec<u8> {
+        let px_len = (W * H * 4) as usize;
+        let total  = 28 + px_len;
+        let units  = (total / 4) as u32;
+        let mut r = alloc::vec![0u8; total];
+        r[0] = 72;
+        r[1] = crate::x11::proto::IMAGE_FORMAT_ZPIXMAP;
+        r[2] = 0; r[3] = 0;                            // 16-bit length = 0 → big
+        r[4..8].copy_from_slice(&units.to_le_bytes()); // 32-bit length (units)
+        r[8..12].copy_from_slice(&WID.to_le_bytes());  // drawable (body+0)
+        r[16] = W as u8; r[17] = (W >> 8) as u8;       // width  (body+8)
+        r[18] = H as u8; r[19] = (H >> 8) as u8;       // height (body+10)
+        r[24] = 0;                                      // left-pad (body+16)
+        r[25] = 24;                                     // depth (body+17)
+        for px in r[28..].chunks_exact_mut(4) { px.copy_from_slice(&bgra); }
+        r
+    };
+
+    // Split a request across two writes with a poll() in between, forcing the
+    // server to read an incomplete request first (retain) then complete it.
+    let send_split_and_check = |req: &[u8], bgra: [u8; 4], label: &str| -> bool {
+        let cut = 4000usize.min(req.len() / 2);
+        let n1 = crate::net::unix::write(client, &req[..cut]);
+        if n1 != cut as i64 {
+            test_fail!("x11_reasm", "{}: first write {} != {}", label, n1, cut);
+            return false;
+        }
+        crate::x11::poll();
+        let before = crate::x11::test_read_window_pixel(WID, 1, 1);
+        if before == Some(bgra) {
+            test_fail!("x11_reasm", "{}: pixel applied from PARTIAL request (drop/desync bug)", label);
+            return false;
+        }
+        let n2 = crate::net::unix::write(client, &req[cut..]);
+        if n2 != (req.len() - cut) as i64 {
+            test_fail!("x11_reasm", "{}: second write {} != {}", label, n2, req.len() - cut);
+            return false;
+        }
+        crate::x11::poll();
+        let after = crate::x11::test_read_window_pixel(WID, 1, 1);
+        if after != Some(bgra) {
+            test_fail!("x11_reasm", "{}: window pixel = {:?} (want {:?}) — request not reassembled",
+                label, after, bgra);
+            return false;
+        }
+        let corner = crate::x11::test_read_window_pixel(WID, (W - 1) as u32, (H - 1) as u32);
+        if corner != Some(bgra) {
+            test_fail!("x11_reasm", "{}: corner pixel = {:?} (want {:?}) — tail of payload lost",
+                label, corner, bgra);
+            return false;
+        }
+        test_println!("  {}: {}-byte PutImage reassembled across 2 reads + applied ✓",
+            label, req.len());
+        true
+    };
+
+    let req_a = build_core_put_image([0x11, 0x22, 0x33, 0xFF]);
+    if !send_split_and_check(&req_a, [0x11, 0x22, 0x33, 0xFF], "core") {
+        crate::net::unix::close(client); return false;
+    }
+    let req_b = build_big_put_image([0x44, 0x55, 0x66, 0xFF]);
+    if !send_split_and_check(&req_b, [0x44, 0x55, 0x66, 0xFF], "big-requests") {
+        crate::net::unix::close(client); return false;
+    }
+
+    if crate::net::unix::has_data(client) {
+        let mut extra = [0u8; 32];
+        let n = crate::net::unix::read(client, &mut extra);
+        if n > 0 && extra[0] == 0 {
+            test_fail!("x11_reasm", "unexpected X error after reassembly (code={})", extra[1]);
+            crate::net::unix::close(client); return false;
+        }
+    }
+
+    crate::net::unix::close(client);
+    test_pass!("X11 request reassembly across reads");
+    true
+}
 
 fn test_x11_render_draw() -> bool {
     test_header!("X11 RENDER extension — CreatePixmap + Picture + FillRectangles");

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -44,6 +44,15 @@ static X11_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 // ─────────────────────────────────────────────────────────────────────────────
 const MAX_CLIENTS:      usize = 32;
+/// Largest single request the server will buffer for reassembly, in bytes.
+/// This matches the maximum request length advertised to clients after they
+/// enable the BIG-REQUESTS extension (BIGREQ_MAX_REQUEST_LEN is in 4-byte
+/// units; ×4 gives bytes).  A client whose pending request exceeds this cap is
+/// disconnected rather than allowed to grow the per-client receive buffer
+/// without bound (DoS guard — `panic=abort` makes an OOM/over-large alloc
+/// fatal to the whole kernel, so hostile input must be rejected gracefully).
+/// See the X11 BIG-REQUESTS extension specification.
+const MAX_REQUEST_BYTES: usize = (proto::BIGREQ_MAX_REQUEST_LEN as usize) * 4;
 const SOCKET_PATH:      &[u8] = b"/tmp/.X11-unix/X0\0";
 const RESOURCE_ID_BASE: u32   = 0x0040_0000;
 const RESOURCE_ID_MASK: u32   = 0x001F_FFFF;
@@ -58,6 +67,17 @@ struct Client {
     /// Per-client event mask selected on the root window (updated by
     /// ChangeWindowAttributes when the target is ROOT_WINDOW_ID).
     root_event_mask: u32,
+    /// Persistent receive-reassembly buffer.  A single X request can be larger
+    /// than one socket read returns (the AF_UNIX recv ring is bounded, and a
+    /// BIG-REQUESTS PutImage can be up to MAX_REQUEST_BYTES), so request bytes
+    /// are accumulated here across reads and a request is only dispatched once
+    /// fully buffered.  Bytes consumed by complete requests are drained from
+    /// the front; an incomplete tail is retained for the next read.  See the
+    /// X11 Protocol Encoding §Requests and the BIG-REQUESTS extension.
+    recv:            alloc::vec::Vec<u8>,
+    /// Guards against two concurrent `service_fd` calls (poll() can run on more
+    /// than one CPU) draining the same client's `recv` buffer simultaneously.
+    servicing:       bool,
     resources:       Box<ResourceTable>,
 }
 
@@ -65,6 +85,8 @@ impl Client {
     fn new(fd: u64) -> Self {
         Client { fd, seq: 0, setup_done: false,
                  root_event_mask: 0,
+                 recv: alloc::vec::Vec::new(),
+                 servicing: false,
                  resources: Box::new(ResourceTable::new()) }
     }
     fn next_seq(&mut self) -> u16 { self.seq = self.seq.wrapping_add(1); self.seq }
@@ -530,63 +552,205 @@ pub fn poll() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn service_fd(fd: u64) {
-    let mut buf = [0u8; 4096];
-    let n = unix::read(fd, &mut buf);
-    if n <= 0 { return; }
-    let data = &buf[..n as usize];
-    #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
-    crate::serial_println!("[X11SVC] fd={} read {} bytes", fd, n);
+    // Take ownership of this client's reassembly buffer for the duration of the
+    // call.  `poll()` can run concurrently on more than one CPU, so guard with a
+    // `servicing` flag: if another CPU is already draining this client, bail —
+    // the in-progress call will pick up the freshly-arrived bytes on its next
+    // read loop.  Moving `recv` out (rather than holding SERVER across the parse
+    // loop) is mandatory: per-op handlers re-take SERVER via `with_client`, so
+    // holding it across dispatch would deadlock.
+    let mut recv = {
+        let mut srv = SERVER.lock();
+        match srv.clients.iter_mut().filter_map(|s| s.as_mut()).find(|c| c.fd == fd) {
+            Some(c) if !c.servicing => {
+                c.servicing = true;
+                core::mem::take(&mut c.recv)
+            }
+            _ => return,
+        }
+    };
+
+    // Drain every byte currently queued on the socket and append it to the
+    // reassembly buffer.  Draining fully (rather than a single ≤4096 read) frees
+    // the peer's bounded AF_UNIX send ring promptly, so a client streaming a
+    // request larger than the ring (e.g. a 128 KiB BIG-REQUESTS PutImage) can
+    // push the remainder — without this, a request bigger than the recv ring
+    // could never be fully delivered.
+    let mut chunk = [0u8; 4096];
+    let mut overflow = false;
+    loop {
+        let n = unix::read(fd, &mut chunk);
+        if n <= 0 { break; } // -EAGAIN (empty) / EOF / error → stop draining
+        let n = n as usize;
+        // DoS guard: never let the per-client buffer exceed the advertised
+        // maximum request length.  A pending request larger than the cap is a
+        // protocol violation (or hostile input); disconnect the client rather
+        // than grow the buffer unbounded (panic=abort makes OOM fatal).
+        if recv.len() + n > MAX_REQUEST_BYTES {
+            overflow = true;
+            break;
+        }
+        recv.extend_from_slice(&chunk[..n]);
+        #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+        crate::serial_println!("[X11SVC] fd={} read {} bytes (buffered={})", fd, n, recv.len());
+    }
+
+    if overflow {
+        #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+        crate::serial_println!("[X11SVC] fd={} pending request exceeds max ({} bytes) — disconnecting",
+            fd, MAX_REQUEST_BYTES);
+        let mut srv = SERVER.lock();
+        for slot in srv.clients.iter_mut() {
+            if let Some(c) = slot { if c.fd == fd { *slot = None; break; } }
+        }
+        unix::close(fd);
+        return; // `recv` (the local Vec) is dropped — client state is gone.
+    }
+
+    // Is the connection-setup handshake complete?  (Re-read under the lock; it
+    // may have been set by a prior `service_fd` for the same fd.)
     let setup = {
         let s = SERVER.lock();
         s.clients.iter().filter_map(|s| s.as_ref()).find(|c| c.fd == fd)
          .map(|c| c.setup_done).unwrap_or(false)
     };
-    if !setup { handle_setup(fd, data); return; }
+
     let mut off = 0usize;
-    while off + 4 <= data.len() {
-        // X11 core request length is a 16-bit count of 4-byte units (§Requests).
-        // Under the BIG-REQUESTS extension a length field of 0 means the real
-        // length is the following 32-bit word (in 4-byte units), inserted
-        // between the 4-byte request header and the body — so the body that
-        // would normally start at offset 4 starts at offset 8.  Treating length
-        // 0 as "stop parsing" would silently drop this request AND every request
-        // batched after it in the same read — desynchronising the client's
-        // reply/sequence expectations.  (X11 BIG-REQUESTS extension spec.)
-        let short_len = r16(data, off + 2) as usize;
-        let req_len_units = if short_len == 0 {
-            if off + 8 > data.len() { break; }
-            // A big request always spans >= 2 units: the 4-byte request header
-            // plus the inserted 4-byte extended-length word.  A reported length
-            // of 0 or 1 is malformed; accepting it makes the body splice
-            // [off+8..end] have start > end (end <= off+4) → slice-index panic
-            // (and panic=abort would take the whole kernel down on hostile
-            // client input).  Reject malformed big requests instead.
-            let big = r32(data, off + 4) as usize;
-            if big < 2 { break; }
-            big
-        } else {
-            short_len
-        };
-        if req_len_units == 0 { break; } // malformed: zero even in big form
-        let end = off + req_len_units * 4;
-        if end > data.len() || end <= off { break; }
-        if short_len == 0 {
-            // Big request: normalise to standard layout before dispatch so the
-            // per-op handlers (which read fields at fixed standard offsets) see
-            // a conventional request.  Splice out the inserted 4-byte
-            // extended-length word: keep the 4-byte header [off..off+4], then
-            // the body [off+8..end].  The reconstructed 16-bit length field is
-            // left as the request's true length truncated into 16 bits (the
-            // handlers key off the slice length, not this field).
-            let mut norm = alloc::vec::Vec::with_capacity(4 + (end - (off + 8)));
-            norm.extend_from_slice(&data[off..off + 4]);
-            norm.extend_from_slice(&data[off + 8..end]);
-            handle_request(fd, &norm);
-        } else {
-            handle_request(fd, &data[off..end]);
+    if !setup {
+        // The first message (ClientHello) may itself span reads.  Only consume
+        // it once fully buffered; otherwise retain everything for the next read.
+        match try_parse_setup(&recv) {
+            SetupParse::NeedMore => off = 0,
+            SetupParse::Consumed(used) => { handle_setup(fd, &recv[..used]); off = used; }
+            SetupParse::Failed(reason) => {
+                send_fail(fd, reason);
+                // Drop all buffered bytes for a failed setup; the client is
+                // expected to close after a failure reply.
+                off = recv.len();
+            }
         }
-        off = end;
     }
+
+    if setup {
+        // Request-stream parse loop over the persistent buffer.  Dispatch every
+        // COMPLETE request and advance `off`; stop (retaining the tail) at the
+        // first request that is not yet fully buffered.
+        while off + 4 <= recv.len() {
+            let data = &recv[..];
+            // X11 core request length is a 16-bit count of 4-byte units
+            // (§Requests).  Under the BIG-REQUESTS extension a length field of 0
+            // means the real length is the following 32-bit word (in 4-byte
+            // units), inserted between the 4-byte request header and the body —
+            // so the body that would normally start at offset 4 starts at
+            // offset 8.  Treating length 0 as "stop parsing" would silently drop
+            // this request and every request batched after it, desynchronising
+            // the client's reply/sequence stream.  (X11 BIG-REQUESTS extension.)
+            let short_len = r16(data, off + 2) as usize;
+            let req_len_units = if short_len == 0 {
+                // Need the inserted 32-bit length word to know the real size.
+                if off + 8 > data.len() { break; } // not yet buffered → wait
+                // A big request always spans ≥ 2 units (header + inserted word).
+                // A reported length of 0 or 1 is malformed; accepting it makes
+                // the body splice [off+8..end] have start > end → slice panic
+                // (panic=abort would take the kernel down on hostile input).
+                let big = r32(data, off + 4) as usize;
+                if big < 2 {
+                    // Malformed big request — cannot resync; drop the client.
+                    drop_servicing_client(fd);
+                    unix::close(fd);
+                    return;
+                }
+                big
+            } else {
+                short_len
+            };
+            let end = off + req_len_units * 4;
+            // Sanity: a non-overflowing end that is still past what we have
+            // buffered means the request is incomplete → retain and wait.
+            if end <= off { // overflow / malformed length
+                drop_servicing_client(fd);
+                unix::close(fd);
+                return;
+            }
+            if end > recv.len() { break; } // not fully buffered yet → wait
+
+            if short_len == 0 {
+                // Big request: normalise to standard layout before dispatch so
+                // the per-op handlers (which read fields at fixed standard
+                // offsets) see a conventional request.  Splice out the inserted
+                // 4-byte extended-length word: keep the 4-byte header
+                // [off..off+4], then the body [off+8..end].
+                let mut norm = alloc::vec::Vec::with_capacity(4 + (end - (off + 8)));
+                norm.extend_from_slice(&recv[off..off + 4]);
+                norm.extend_from_slice(&recv[off + 8..end]);
+                handle_request(fd, &norm);
+            } else {
+                // Dispatch the complete request in place.  `handle_request` may
+                // re-enter the X11 server (event delivery) but never touches this
+                // client's `recv` — it was moved out and is protected by the
+                // `servicing` guard — so borrowing a slice of the local buffer
+                // across the call is sound and avoids a per-request copy.
+                handle_request(fd, &recv[off..end]);
+            }
+            off = end;
+        }
+    }
+
+    // Drain the consumed prefix; retain the partial tail for the next read.
+    // Then return the buffer to the client and clear the servicing guard.
+    if off > 0 { recv.drain(..off); }
+    // Reclaim capacity once the buffer empties so a one-off large request does
+    // not pin MAX_REQUEST_BYTES of heap for the client's lifetime.
+    if recv.is_empty() && recv.capacity() > 8192 {
+        recv = alloc::vec::Vec::new();
+    }
+    let mut srv = SERVER.lock();
+    if let Some(c) = srv.clients.iter_mut().filter_map(|s| s.as_mut()).find(|c| c.fd == fd) {
+        // The client still exists (it was not disconnected mid-parse).  Restore
+        // its reassembly buffer and clear the guard.
+        c.recv = recv;
+        c.servicing = false;
+    }
+    // If the client vanished (closed concurrently), `recv` is simply dropped.
+}
+
+/// Clear the `servicing` guard for a client that is about to be force-closed
+/// from inside the parse loop, so the slot is consistent before removal.
+fn drop_servicing_client(fd: u64) {
+    let mut srv = SERVER.lock();
+    for slot in srv.clients.iter_mut() {
+        if let Some(c) = slot { if c.fd == fd { *slot = None; return; } }
+    }
+}
+
+/// Result of attempting to parse the connection-setup request from a buffer
+/// that may not yet hold the whole message.
+enum SetupParse<'a> {
+    /// The full setup request is not yet buffered — read more and retry.
+    NeedMore,
+    /// The setup request occupies `usize` bytes at the front of the buffer.
+    Consumed(usize),
+    /// The setup request is malformed; reply with the given failure reason.
+    Failed(&'a [u8]),
+}
+
+/// Determine whether a complete X11 connection-setup request is buffered.
+///
+/// Layout (X11 Protocol Encoding §Connection Setup): a 12-byte fixed header
+/// (byte-order, protocol major/minor, auth-name length `n`, auth-data length
+/// `d`), followed by the auth name padded to a 4-byte boundary and the auth
+/// data padded to a 4-byte boundary.  The total length is therefore
+/// `12 + pad4(n) + pad4(d)`; the request must not be dispatched until that
+/// many bytes are present.
+fn try_parse_setup(data: &[u8]) -> SetupParse<'static> {
+    if data.len() < 12 { return SetupParse::NeedMore; }
+    if data[0] != 0x6C { return SetupParse::Failed(b"big-endian not supported"); }
+    if r16(data, 2) != 11 { return SetupParse::Failed(b"unsupported protocol"); }
+    let n_auth = r16(data, 6) as usize;
+    let d_auth = r16(data, 8) as usize;
+    let total = 12 + ((n_auth + 3) & !3) + ((d_auth + 3) & !3);
+    if data.len() < total { return SetupParse::NeedMore; }
+    SetupParse::Consumed(total)
 }
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
@@ -3306,9 +3470,11 @@ fn op_shm(fd: u64, data: &[u8], seq: u16) {
 //
 // After this exchange the client may send requests whose 16-bit length field
 // is 0; in that case the next four bytes carry the real (32-bit) length.
-// We acknowledge the negotiation and advertise 4 MiB, but we do not yet
-// handle 32-bit lengths in the dispatcher — requests that large aren't needed
-// for GTK/Firefox init.
+// We acknowledge the negotiation and advertise 4 MiB.  `service_fd` reads the
+// 32-bit extended length, reassembles the request across socket reads (the
+// AF_UNIX recv ring is smaller than a large PutImage), and normalises it to the
+// standard layout before dispatch — so GTK/Firefox BIG-REQUESTS PutImage
+// (e.g. window chrome) is delivered intact rather than dropped.
 // ═════════════════════════════════════════════════════════════════════════════
 
 fn op_bigreq(fd: u64, data: &[u8], seq: u16) {


### PR DESCRIPTION
## Problem

The in-kernel X11 server's per-client input path (`service_fd`) read a single
≤4096-byte chunk per service call and parsed requests directly out of that one
buffer. Any single X request larger than what one read returned was silently
dropped at the parse loop's `break`, together with the bytes already pulled out
of the socket — desynchronising the client's request stream.

Two cases trigger this:

1. A **BIG-REQUESTS PutImage** (opcode 72) carrying a full window's image. GTK
   toolkits enable BIG-REQUESTS and send a ~128 KB PutImage with the window
   chrome; it was dropped, so the mapped toplevel never painted.
2. Any **core request larger than the bounded AF_UNIX recv ring** — the server
   could only ever read a ring's worth at a time, so a request bigger than the
   ring could never be fully delivered.

This is a pure X11-protocol correctness bug, independent of any compositor or
rendering work.

## Fix

Give each client a persistent receive-reassembly buffer:

- `service_fd` drains all queued socket bytes into the buffer (draining fully
  frees the peer's bounded send ring so a client can stream a request larger
  than the ring), parses every **complete** request out of it, and **retains an
  incomplete tail** for the next read instead of dropping it.
- The connection-setup handshake is parsed the same way, so it too may span
  reads.
- BIG-REQUESTS requests (16-bit length `0` → 32-bit extended length word) are
  reassembled, then normalised to the standard request layout before dispatch.
- **DoS guard:** a pending request is capped at the advertised maximum request
  length (`BIGREQ_MAX_REQUEST_LEN × 4` = 4 MiB); a client exceeding it is
  disconnected gracefully rather than growing the buffer without bound
  (`panic=abort` makes an over-large allocation fatal to the kernel).
- A `servicing` guard prevents two concurrent `poll()` callers on different
  CPUs from draining the same client's buffer at once.

## Verification

- **Protocol level:** with the fix, a windowed upstream client streaming a
  128024-byte core PutImage to a mapped 1280×972 toplevel now has every PutImage
  **dispatched** (38 observed in one run), with the receive buffer accumulating
  ~99 KB of a single request across reads before completing it — proving
  cross-read reassembly. Before the fix every one of those requests was dropped.
- **Regression test:** `test_x11_request_reassembly` (in `test_runner.rs`) sends
  both a core and a BIG-REQUESTS PutImage larger than 4 KiB, each **split across
  two writes with a poll() in between**, and asserts the painted window pixels —
  proving the request is reassembled and dispatched, not dropped on the partial
  read. Full kernel test suite: 213 passed, the only 2 failures are pre-existing
  test-data-disk staging gaps (TCC/busybox binaries absent), unrelated to this
  change. All 15 X11 tests pass.

## Specs

- X11 Protocol Encoding §Requests (16-bit length in 4-byte units)
- X11 BIG-REQUESTS extension (32-bit extended length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
