### PR TITLE
kernel/epoll: implement EPOLLET edge-triggered semantics

### DIFF
--- a/kernel/src/ipc/epoll.rs
+++ b/kernel/src/ipc/epoll.rs
@@ -35,6 +35,18 @@ pub struct EpollWatch {
     pub fd:     usize,
     pub events: u32,
     pub data:   u64,
+    /// Edge-trigger state: the ready-interest mask most recently *delivered*
+    /// to the caller for this watch.  Per `epoll(7)`, an `EPOLLET`
+    /// (edge-triggered) watch must report a readiness bit only on a
+    /// not-ready→ready transition — "events [are delivered] only when changes
+    /// occur on the monitored file descriptor".  `last_ready` records the
+    /// asserted level at the last delivery so `sys_epoll_wait` can suppress a
+    /// repeat report while the level stays high (the eventfd/socket whose
+    /// readiness never drops) and re-fire only after the level drops and rises
+    /// again.  Ignored for level-triggered watches (the default), whose
+    /// reporting is unconditional.  Reset to 0 on `EPOLL_CTL_MOD` so a MOD
+    /// re-arms the edge (Linux behaviour).
+    pub last_ready: u32,
 }
 
 /// Per-process monotonically increasing identifier for epoll instances.
@@ -125,7 +137,11 @@ impl EpollInstance {
     /// and no spurious HUP/ERR readiness leaks into the parking decision.
     pub fn add(&mut self, fd: usize, events: u32, data: u64) -> bool {
         if self.watches.iter().any(|w| w.fd == fd) { return false; }
-        self.watches.push(EpollWatch { fd, events, data });
+        // `last_ready = 0` arms a fresh edge: the first poll after ADD reports
+        // any currently-asserted readiness (a 0→ready transition), matching
+        // Linux, where a newly-added EPOLLET fd that is already ready fires
+        // once immediately.
+        self.watches.push(EpollWatch { fd, events, data, last_ready: 0 });
         true
     }
 
@@ -148,9 +164,36 @@ impl EpollInstance {
         if let Some(w) = self.watches.iter_mut().find(|w| w.fd == fd) {
             w.events = events;
             w.data   = data;
+            // `EPOLL_CTL_MOD` re-arms the edge: per `epoll(7)`, after a MOD the
+            // caller expects a currently-ready fd to be reported again (this is
+            // how EPOLLONESHOT consumers re-arm, and how an interest-mask change
+            // re-evaluates readiness).  Clear the recorded level so the next
+            // poll treats the present readiness as a fresh 0→ready transition.
+            w.last_ready = 0;
             true
         } else {
             false
+        }
+    }
+
+    /// Commit the per-watch edge state after a delivery.  `delivered` maps
+    /// `fd → asserted-interest-level` for every watch that contributed to the
+    /// returned event set; for an EPOLLET watch this becomes its new
+    /// `last_ready` so the same asserted level is not re-reported.  Level-
+    /// triggered watches are unaffected (their reporting is unconditional and
+    /// `last_ready` is never consulted for them).
+    ///
+    /// We also clear `last_ready` for any EPOLLET watch whose current asserted
+    /// level is recorded as dropping to a subset — handled by the caller
+    /// passing the freshly-computed level (including 0) so a level-drop re-arms
+    /// the edge automatically.
+    pub fn commit_edges(&mut self, delivered: &[(usize, u32)]) {
+        for &(fd, level) in delivered {
+            if let Some(w) = self.watches.iter_mut().find(|w| w.fd == fd) {
+                if w.events & EPOLLET != 0 {
+                    w.last_ready = level;
+                }
+            }
         }
     }
 }

--- a/kernel/src/ipc/epoll.rs
+++ b/kernel/src/ipc/epoll.rs
@@ -18,8 +18,8 @@ pub const EPOLLOUT:     u32 = 0x0004;
 pub const EPOLLERR:     u32 = 0x0008;
 pub const EPOLLHUP:     u32 = 0x0010;
 pub const EPOLLRDHUP:   u32 = 0x2000;
-pub const EPOLLET:      u32 = 1 << 31; // edge-triggered (accepted but not enforced)
-pub const EPOLLONESHOT: u32 = 1 << 30;
+pub const EPOLLET:      u32 = 1 << 31; // edge-triggered (enforced in sys_epoll_wait)
+pub const EPOLLONESHOT: u32 = 1 << 30; // accepted; one-shot disable not yet enforced
 
 /// Equivalent to Linux `struct epoll_event` (packed, 12 bytes).
 #[repr(C, packed)]

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -10871,7 +10871,14 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // dup'd epoll fds share the inode and thus the same instance.
     // Symmetric with sys_epoll_ctl above; see that block for the full
     // by-id rationale (PIVOT-I2 Phase D, 2026-05-23).
-    let watches_snap: alloc::vec::Vec<(usize, u32, u64)> = {
+    // Snapshot tuple: (fd, events-interest, data-cookie, last_ready-edge-state).
+    // `last_ready` is the asserted-interest level most recently DELIVERED for
+    // this watch; it is consulted only for EPOLLET watches (events & EPOLLET)
+    // to suppress repeat reports while the readiness level stays high.  The
+    // epoll_id is also captured so the freshly-computed edge levels can be
+    // committed back to the instance after delivery.
+    let epoll_id_for_commit;
+    let watches_snap: alloc::vec::Vec<(usize, u32, u64, u32)> = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = match procs.iter().find(|p| p.pid == pid) {
             Some(p) => p,
@@ -10885,51 +10892,76 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
             Some(i) => i,
             None    => return -9,
         };
-        inst.watches.iter().map(|w| (w.fd, w.events, w.data)).collect()
+        epoll_id_for_commit = epoll_id;
+        inst.watches.iter().map(|w| (w.fd, w.events, w.data, w.last_ready)).collect()
     }; // lock released here
 
+    use crate::ipc::epoll::EPOLLET;
+
+    // Compute the deliverable interest mask for one watched fd.
+    //
+    // Per `epoll(7)`: "EPOLLERR and EPOLLHUP ... it is not necessary to set
+    // [them] in events"; the kernel reports them whenever they occur,
+    // independent of the caller's interest set.  The asserted *level* is two
+    // disjoint parts:
+    //   * the caller-subscribed bits that are currently ready
+    //     (`subscribed & ready_ev`), and
+    //   * any EPOLLERR / EPOLLHUP that is ready, delivered even when
+    //     unsubscribed (`ready_ev & (EPOLLERR | EPOLLHUP)`).
+    // EPOLLRDHUP flows through the first term only (Linux reports it only when
+    // subscribed).  The stored `subscribed` mask is the caller's raw interest
+    // and is never mutated.
+    //
+    // Edge-trigger (`EPOLLET`): per `epoll(7)`, an edge-triggered watch
+    // delivers a readiness bit only on a not-ready→ready transition ("events
+    // [are delivered] only when changes occur on the monitored file
+    // descriptor").  We compute the asserted `level`, then for an EPOLLET watch
+    // deliver only the bits NEWLY asserted since the last delivery
+    // (`level & !last_ready`); a bit that stays asserted (e.g. an eventfd whose
+    // counter never drops to 0, or a socket with un-drained data) is reported
+    // exactly once and then suppressed until the level drops and rises again.
+    // Level-triggered watches (the default) deliver the full asserted `level`
+    // unconditionally, as before.  Returns `(delivered_mask, asserted_level)`.
+    let watch_events = |fd: usize, subscribed: u32, last_ready: u32| -> (u32, u32) {
+        let ready_ev = epoll_poll_events(pid, fd);
+        let level =
+            (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
+        let delivered = if subscribed & EPOLLET != 0 {
+            level & !last_ready
+        } else {
+            level
+        };
+        (delivered, level)
+    };
+
     // ── Step 2: poll without holding the lock ────────────────────────────────
+    // Fills `fired` with the edge-aware deliverable events.  The EPOLLET edge
+    // state is committed separately in Step 2b (a single recompute + write-back)
+    // after the returned set is settled, so `do_poll` itself is side-effect-free
+    // on the instance and safe to call repeatedly in the wait loop.
     let do_poll = |fired: &mut alloc::vec::Vec<EpollEvent>| {
-        for &(fd, subscribed, data) in &watches_snap {
+        fired.clear();
+        for &(fd, subscribed, data, last_ready) in &watches_snap {
             if fired.len() >= maxevents { break; }
-            let ready_ev = epoll_poll_events(pid, fd);
-            // Per `epoll(7)`: "EPOLLERR and EPOLLHUP ... it is not necessary
-            // to set [them] in events"; the kernel reports them whenever they
-            // occur, independent of the caller's interest set.  Build the
-            // delivered mask as two disjoint parts:
-            //   * the caller-subscribed bits that are currently ready
-            //     (`subscribed & ready_ev`), and
-            //   * any EPOLLERR / EPOLLHUP that is ready, delivered even when
-            //     unsubscribed (`ready_ev & (EPOLLERR | EPOLLHUP)`).
-            // EPOLLRDHUP is NOT in the always-on set — Linux only reports it
-            // when subscribed — so it flows through the first term only.
-            //
-            // The stored `subscribed` mask is the caller's raw interest and is
-            // never mutated; ERR/HUP are force-added to the *ready* side here
-            // at the single delivery site.  This keeps the readiness/wake
-            // matching wake-safe: a healthy fd reporting only EPOLLOUT against
-            // an EPOLLIN-only watch yields `(EPOLLIN & EPOLLOUT) | (EPOLLOUT &
-            // (ERR|HUP)) = 0`, so no spurious-ready perturbs the parking
-            // decision — exactly as before this ABI fix.
-            let interest =
-                (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
-            if interest != 0 {
-                fired.push(EpollEvent { events: interest, data });
+            let (delivered, _level) = watch_events(fd, subscribed, last_ready);
+            if delivered != 0 {
+                fired.push(EpollEvent { events: delivered, data });
             }
         }
     };
 
-    // Read-only readiness probe over the watch snapshot — true if any
-    // watched fd currently has a deliverable event.  Mirrors `do_poll`'s
-    // interest/ERR/HUP masking but allocates nothing and pushes nothing;
-    // used as the recheck-under-lock predicate for `wait_poll_event` so
-    // the check-and-park lost-wakeup window is closed (prepare-to-wait).
+    // Read-only readiness probe over the watch snapshot — true if any watched
+    // fd currently has a deliverable (edge-aware) event.  Mirrors `do_poll`'s
+    // edge/ERR/HUP masking but allocates nothing and pushes nothing; used as
+    // the recheck-under-lock predicate for `wait_poll_event` so the
+    // check-and-park lost-wakeup window is closed (prepare-to-wait).  Being
+    // edge-aware here is essential: an EPOLLET watch whose level stayed high
+    // after its single delivery must NOT keep the waiter awake (which would
+    // reproduce the busy-spin); `delivered == 0` for such a watch parks us.
     let probe_ready = || -> bool {
-        for &(fd, subscribed, _data) in &watches_snap {
-            let ready_ev = epoll_poll_events(pid, fd);
-            let interest =
-                (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
-            if interest != 0 { return true; }
+        for &(fd, subscribed, _data, last_ready) in &watches_snap {
+            let (delivered, _level) = watch_events(fd, subscribed, last_ready);
+            if delivered != 0 { return true; }
         }
         false
     };
@@ -11010,6 +11042,39 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
                 if signal_pending(pid) { return -4; } // EINTR
                 let now = crate::arch::x86_64::irq::get_ticks();
                 if now >= deadline_tick { break; }
+            }
+        }
+    }
+
+    // ── Step 2b: commit EPOLLET edge state ───────────────────────────────────
+    // Record, for every edge-triggered watch, the asserted readiness level as
+    // of NOW so the next `epoll_wait` reports only fresh transitions:
+    //   * a watch that stayed high keeps its level → suppressed next time
+    //     (this is what stops an edge-triggered notify-eventfd busy-spin: the
+    //     counter stays 1, level stays EPOLLIN, last_ready=EPOLLIN ⇒
+    //     delivered=0), and
+    //   * a watch whose level DROPPED (e.g. the consumer drained the fd to
+    //     not-ready) records the lower level, so the next rise is a genuine
+    //     0→ready edge and fires again.
+    // We recompute the current level for each ET watch under no lock, then
+    // write the results back into the instance under a single brief lock hold.
+    // Level-triggered watches are never touched (their `last_ready` is unused).
+    {
+        let mut et_levels: alloc::vec::Vec<(usize, u32)> = alloc::vec::Vec::new();
+        for &(fd, subscribed, _data, last_ready) in &watches_snap {
+            if subscribed & EPOLLET != 0 {
+                let (_delivered, level) = watch_events(fd, subscribed, last_ready);
+                et_levels.push((fd, level));
+            }
+        }
+        if !et_levels.is_empty() {
+            let mut procs = crate::proc::PROCESS_TABLE.lock();
+            if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {
+                if let Some(inst) = proc.epoll_sets.iter_mut()
+                    .find(|e| e.id == epoll_id_for_commit)
+                {
+                    inst.commit_edges(&et_levels);
+                }
             }
         }
     }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2825,6 +2825,14 @@ pub fn run() -> ! {
     total += 1;
     if test_293_epoll_listening_unix_has_pending() { passed += 1; }
 
+    // ── Test 305: epoll EPOLLET edge-trigger on a persistently-ready eventfd ─
+    // An EPOLLET watch must report a stays-ready fd exactly once (not on every
+    // epoll_wait); the level-only-kernel re-report was the libevent notify-
+    // eventfd busy-spin that wedged windowed Firefox before the toplevel map.
+    // Refs: epoll(7) (EPOLLET edge-triggered semantics), eventfd(2).
+    total += 1;
+    if test_305_epoll_edge_trigger() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -16494,6 +16502,138 @@ fn test_epoll_and_proc_fd() -> bool {
     if ok {
         test_pass!("epoll + /proc/self/fd (readlink+getdents) + /proc/self/status");
     }
+    ok
+}
+
+// ── Test 305: epoll EPOLLET edge-trigger semantics on an eventfd ──────────────
+//
+// Per `epoll(7)`: an `EPOLLET` (edge-triggered) watch delivers a readiness bit
+// only on a not-ready→ready transition ("events [are delivered] only when
+// changes occur on the monitored file descriptor"); a fd that STAYS ready (an
+// eventfd whose counter never returns to 0) must be reported exactly ONCE and
+// then suppressed until the level drops and rises again.  A level-triggered
+// watch (the default) is reported on EVERY `epoll_wait` while the level holds.
+//
+// This is the regression guard for the windowed-Firefox gate: libevent
+// registers its notify-eventfd EPOLLET; a level-only kernel reported it ready
+// on every `epoll_wait`, so libevent's event loop busy-spun (the eventfd
+// counter stayed 1, never drained) and the single core never ran the GTK
+// dispatch that maps+paints the toplevel.  With correct ET semantics the
+// always-ready eventfd is reported once and the loop parks.
+fn test_305_epoll_edge_trigger() -> bool {
+    test_header!("epoll EPOLLET edge-trigger on a persistently-ready eventfd (Test 305)");
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+    let pid = crate::proc::current_pid();
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = true;
+            p.subsystem = crate::win32::SubsystemType::Linux;
+        }
+    }
+
+    // 12-byte struct epoll_event: [events: u32 LE, data: u64 LE].
+    fn make_ev(events: u32, data: u64) -> [u8; 12] {
+        let mut b = [0u8; 12];
+        b[0..4].copy_from_slice(&events.to_le_bytes());
+        b[4..12].copy_from_slice(&data.to_le_bytes());
+        b
+    }
+
+    const EPOLLIN: u32 = 0x0001;
+    const EPOLLET: u32 = 1 << 31;
+    const CTL_ADD: u64 = 1;
+    const CTL_MOD: u64 = 3;
+    const EFD_NONBLOCK: u64 = 0x0800;
+
+    let mut ok = true;
+
+    // Non-blocking poll: epoll_wait(timeout_ms=0) does a single poll, no park.
+    let wait_once = |epfd: u64| -> i64 {
+        let mut buf = [[0u8; 12]; 4];
+        dispatch(232, epfd, buf[0].as_mut_ptr() as u64, 4, 0, 0, 0)
+    };
+
+    // ── Setup: eventfd (initval=0, NONBLOCK) + epoll instance ────────────────
+    let efd = dispatch(290 /*eventfd2*/, 0, EFD_NONBLOCK, 0, 0, 0, 0);
+    let epfd = dispatch(291 /*epoll_create1*/, 0, 0, 0, 0, 0, 0);
+    if efd < 0 || epfd < 0 {
+        test_fail!("ET setup", "eventfd={} epoll_create1={}", efd, epfd);
+        // fall through to teardown
+    } else {
+        let (efd, epfd) = (efd as u64, epfd as u64);
+
+        // Register the eventfd EPOLLET | EPOLLIN.
+        let ev = make_ev(EPOLLIN | EPOLLET, efd);
+        let r = dispatch(233 /*epoll_ctl*/, epfd, CTL_ADD, efd, ev.as_ptr() as u64, 0, 0);
+        if r != 0 { test_fail!("ET add", "epoll_ctl ADD = {}", r); ok = false; }
+
+        // (a) Counter is 0 → not ready → epoll_wait returns 0.
+        let r0 = wait_once(epfd);
+        if r0 != 0 { test_fail!("ET idle", "expected 0, got {}", r0); ok = false; }
+        else { test_println!("  (a) ET idle eventfd → 0 events ✓"); }
+
+        // Write 1 → counter becomes 1 (0→ready transition).
+        let one: u64 = 1;
+        let _ = dispatch(1 /*write*/, efd, &one as *const u64 as u64, 8, 0, 0, 0);
+
+        // (b) First poll after the rise → reported ONCE.
+        let r1 = wait_once(epfd);
+        if r1 != 1 { test_fail!("ET first", "expected 1 (the edge), got {}", r1); ok = false; }
+        else { test_println!("  (b) ET 0→ready: reported once ✓"); }
+
+        // (c) THE FIX: counter still 1 (never drained), level still asserted →
+        //     a second poll must report ZERO (edge already consumed).  A
+        //     level-only kernel returns 1 here forever = the busy-spin.
+        let r2 = wait_once(epfd);
+        if r2 != 0 {
+            test_fail!("ET suppress",
+                "edge-triggered watch re-reported a persistently-ready eventfd \
+                 (got {} events, expected 0) — this is the libevent busy-spin bug", r2);
+            ok = false;
+        } else { test_println!("  (c) ET stays-ready: suppressed (0 events) ✓"); }
+
+        // Drain the eventfd (read → counter back to 0), then write again
+        // (0→ready) → the edge must re-arm and fire once more.
+        let mut rbuf = [0u8; 8];
+        let _ = dispatch(0 /*read*/, efd, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+        // After a drain to 0, level dropped; a poll observes not-ready (re-arms).
+        let r3 = wait_once(epfd);
+        if r3 != 0 { test_fail!("ET drained", "expected 0 after drain, got {}", r3); ok = false; }
+        let _ = dispatch(1, efd, &one as *const u64 as u64, 8, 0, 0, 0);
+        let r4 = wait_once(epfd);
+        if r4 != 1 {
+            test_fail!("ET rearm", "edge did not re-arm after drain+rewrite (got {}, expected 1)", r4);
+            ok = false;
+        } else { test_println!("  (d) ET re-arm after drain+rewrite: fired once ✓"); }
+
+        // (e) Level-triggered control: re-register the SAME eventfd WITHOUT
+        //     EPOLLET (via MOD).  Counter is 1 (still ready).  Two successive
+        //     polls must BOTH report it — level-triggered is unconditional.
+        let evl = make_ev(EPOLLIN, efd);
+        let rm = dispatch(233, epfd, CTL_MOD, efd, evl.as_ptr() as u64, 0, 0);
+        if rm != 0 { test_fail!("LT mod", "epoll_ctl MOD = {}", rm); ok = false; }
+        let l1 = wait_once(epfd);
+        let l2 = wait_once(epfd);
+        if l1 != 1 || l2 != 1 {
+            test_fail!("LT level", "level-triggered eventfd not reported on every poll (l1={} l2={})", l1, l2);
+            ok = false;
+        } else { test_println!("  (e) level-triggered: reported on every poll ✓"); }
+
+        let _ = crate::vfs::close(pid, epfd as usize);
+        let _ = crate::vfs::close(pid, efd as usize);
+    }
+
+    // ── Tear down ────────────────────────────────────────────────────────────
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = false;
+            p.subsystem = crate::win32::SubsystemType::Aether;
+        }
+    }
+
+    if ok { test_pass!("epoll EPOLLET edge-trigger semantics (Test 305)"); }
     ok
 }
 


### PR DESCRIPTION
## Summary

The Linux-personality epoll was purely **level-triggered**: `EPOLLET` (`1<<31`)
was accepted by `epoll_ctl` but never enforced. `sys_epoll_wait` reported a
watched fd ready on **every** call as long as its readiness level stayed
asserted, regardless of whether the caller requested edge-triggered delivery.

Per **epoll(7)**, an `EPOLLET` watch must deliver a readiness bit only on a
not-ready → ready **transition** ("events are delivered only when changes occur
on the monitored file descriptor"). A fd that stays ready (an eventfd whose
counter never returns to 0, a socket with un-drained data) must be reported
**exactly once** and then suppressed until the level drops and rises again.

A consumer that registers a notify-eventfd edge-triggered and drains it once
per edge would, under level-only delivery, be handed the same ready event on
every `epoll_wait` and **busy-spin forever** instead of parking.

## Why this matters (verified end-to-end)

This was the final gate before the **first verified paint of an upstream
windowed Firefox window** on AstryxOS. A library Firefox links registers its
notify-eventfd `EPOLLIN | EPOLLRDHUP | EPOLLET` and reads it once per edge — so
its counter sits at 1 forever. The level-only kernel re-reported it ready on
every `epoll_pwait`, so that event loop spun ~2M+ times, monopolised the single
core (SMP=1), and the GTK main loop never reached the dispatch phase that maps
and paints the toplevel — the X11 request stream froze with only 1×1 helper
windows mapped.

With correct `EPOLLET` semantics: the always-ready eventfd is reported once,
the loop parks, the GTK toplevel (1280×972) maps, chrome `PutImage` paints to
it repeatedly, and the compositor composites it to screen. Verified by
screendump (Firefox chrome: tab bar, URL bar, toolbar icons, content area).

## Change

- `EpollWatch` gains `last_ready: u32` — the asserted-interest level most
  recently delivered for the watch, consulted **only** for `EPOLLET` watches.
- `sys_epoll_wait` computes the asserted level as before; for an `EPOLLET`
  watch it delivers only the newly-asserted bits (`level & !last_ready`). After
  the returned set is settled it recomputes and commits the current level for
  every edge-triggered watch, so a level that stays high is suppressed next
  call and a level that drops then rises re-arms automatically.
- The park-decision predicate (`probe_ready`) is made edge-aware too, so an
  edge-triggered watch whose level stayed high after its single delivery does
  not keep the waiter awake (which would reproduce the spin).
- `EPOLL_CTL_MOD` / `EPOLL_CTL_ADD` reset `last_ready = 0`, re-arming the edge
  so a currently-ready fd is reported again (epoll(7): MOD re-evaluates
  readiness; a freshly-added already-ready fd fires once).
- **Level-triggered watches (the default) are unchanged** — reporting stays
  unconditional and `last_ready` is never consulted for them.

## Test

**Test 305** (`test_runner.rs`): an eventfd registered `EPOLLIN | EPOLLET`
whose counter stays at 1 is reported once and then suppressed across successive
`epoll_wait` calls; it re-arms after drain-to-0 + rewrite; and the same eventfd
re-registered without `EPOLLET` (level-triggered) is reported on every call.

## Refs

epoll(7) (EPOLLET edge-triggered semantics, EPOLL_CTL_MOD re-arm), eventfd(2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
