### PR TITLE
build/ff: provision the software-GL closure into the windowed-Firefox image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,19 @@ jobs:
       # one that corrupts the ext2 image while patching it.
       - name: patch-gui-caches smoke (image cache provisioning + ext2 integrity)
         run: python3 scripts/patch-gui-caches-smoke.py
+      # Boot-free smoke for the software-GL (Mesa llvmpipe) image-provisioning
+      # tool (patch-gui-gl.sh).  Exercises arg validation, --verify on a GL-less
+      # image (must report the closure incomplete + exit non-zero), and — the
+      # load-bearing path — the debugfs injection of the libGL/libEGL closure
+      # (incl. the llvmpipe DRI driver under xorg/modules/dri/) into a scratch
+      # ext2 image, asserting byte-identical readback, that e2fsck still reports
+      # the image clean, and that a follow-up --verify then passes.
+      # Failure mode this prevents: a --ff-gui data image that ships GL-less
+      # (glxtest "libGL.so.1 missing" → content compositor child cannot bring up
+      # a software OpenGL context → CompositorBridgeChild AbnormalShutdown → no
+      # render), or an injection path that corrupts the ext2 image.
+      - name: patch-gui-gl smoke (software-GL image provisioning + ext2 integrity)
+        run: python3 scripts/patch-gui-gl-smoke.py
 
   kernel-build:
     name: bootloader + kernel builds

--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -961,3 +961,28 @@ else
 fi
 
 echo "[DATA-DISK] Created: ${DATA_IMG} (${SIZE_MB} MiB, ext2)"
+
+# ── Verify the software-GL closure landed in the produced image ──────────────
+# The windowed (--ff-gui) Firefox path's GPU-feature probe (glxtest) and the
+# content-process compositor dlopen() libGL.so.1 / libEGL.so.1 by SONAME; if
+# those (or the Gallium llvmpipe DRI driver) are absent from the IMAGE, glxtest
+# reports "libGL.so.1 missing" and the content compositor child cannot bring up
+# a software OpenGL context (CompositorBridgeChild AbnormalShutdown → no render).
+# install-firefox-musl.sh already fails loud if the GL stack is missing from the
+# STAGING tree; this check closes the remaining gap — an image whose CONTENT is
+# GL-incomplete even though it was freshly written (e.g. a path that dropped the
+# xorg/modules/dri driver dir).  Only runs when the staging tree actually
+# carries the GL stack, so a deliberately GL-less build is unaffected.  Warn
+# (don't fail): headless Firefox boots and non-FF images do not need GL.
+# Ref: ld.so(8), dlopen(3), Mesa 3D docs (Gallium/llvmpipe).
+if [ -e "${STAGING_TREE}/usr/lib/libGL.so.1" ] \
+   && [ -f "${ROOT_DIR}/scripts/patch-gui-gl.sh" ] \
+   && command -v debugfs >/dev/null 2>&1; then
+    if bash "${ROOT_DIR}/scripts/patch-gui-gl.sh" --verify "${DATA_IMG}" >/dev/null 2>&1; then
+        echo "[DATA-DISK][GL] ok: image carries the complete software-GL closure (libGL/libEGL + llvmpipe DRI driver)"
+    else
+        echo "[DATA-DISK][GL] WARNING: image is GL-incomplete despite a GL-staged tree — the --ff-gui windowed path will fall back to 'libGL.so.1 missing'."
+        echo "[DATA-DISK][GL]          repair without a rebuild: scripts/patch-gui-gl.sh --image ${DATA_IMG} --in-place"
+        bash "${ROOT_DIR}/scripts/patch-gui-gl.sh" --verify "${DATA_IMG}" 2>&1 | grep -E 'MISSING|present' || true
+    fi
+fi

--- a/scripts/patch-gui-gl-smoke.py
+++ b/scripts/patch-gui-gl-smoke.py
@@ -71,6 +71,7 @@ GL_MEMBERS = [
     ("usr/lib/libdrm_amdgpu.so.1",              "/usr/lib/libdrm_amdgpu.so.1"),
     ("usr/lib/libdrm_nouveau.so.2",             "/usr/lib/libdrm_nouveau.so.2"),
     ("usr/lib/libdrm_intel.so.1",               "/usr/lib/libdrm_intel.so.1"),
+    ("usr/lib/libpciaccess.so.0",               "/usr/lib/libpciaccess.so.0"),
 ]
 # Versioned/extra aliases the tool also injects (so the staging tree has them
 # present and the inject loop finds them).
@@ -93,6 +94,7 @@ GL_ALIASES = [
     "usr/lib/libxcb-randr.so.0.1.0",
     "usr/lib/libxcb-sync.so.1.0.0",
     "usr/lib/libxcb-xfixes.so.0.0.0",
+    "usr/lib/libpciaccess.so.0.11.1",
 ]
 
 

--- a/scripts/patch-gui-gl-smoke.py
+++ b/scripts/patch-gui-gl-smoke.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+patch-gui-gl-smoke.py — Host-side smoke test for patch-gui-gl.sh
+
+Exercises the software-GL (Mesa llvmpipe) image-provisioning tool end-to-end
+WITHOUT needing qemu-x86_64, a kernel build, or a real Firefox/Mesa tree:
+
+  - bash -n               syntax check
+  - --help                prints usage, exits 0
+  - unknown arg           exits non-zero (arg validation)
+  - --verify (GL-less)    reports the closure MISSING and exits non-zero
+  - --image injection     synthetic GL libs are injected into a scratch ext2
+                          image via debugfs; each reads back byte-identical;
+                          e2fsck still reports the image clean; and a follow-up
+                          --verify now passes (closure complete)
+
+The GL libraries are fabricated as small deterministic blobs (the tool copies
+file CONTENT, it does not parse ELF), so the test is hermetic.  The DRI driver
+is staged under usr/lib/xorg/modules/dri/ exactly as install-firefox-musl.sh
+lays it out.
+
+Run directly:
+
+    python3 scripts/patch-gui-gl-smoke.py
+
+Exit codes:
+    0  — all checks passed
+    1  — one or more checks failed
+    2  — environment prerequisite missing (mke2fs/debugfs) — treated as skip
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "patch-gui-gl.sh"
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+INFO = "\033[36mINFO\033[0m"
+SKIP = "\033[33mSKIP\033[0m"
+
+failures = 0
+
+# The required GL closure members the verify gate checks (must match
+# GL_REQUIRED in patch-gui-gl.sh), as (staging-relative-path, image-abs-path).
+# Versioned aliases are also injected by the tool but the verify gate keys off
+# the SONAMEs + the software DRI driver, so the smoke stages exactly those.
+GL_MEMBERS = [
+    ("usr/lib/libGL.so.1",                      "/usr/lib/libGL.so.1"),
+    ("usr/lib/libEGL.so.1",                     "/usr/lib/libEGL.so.1"),
+    ("usr/lib/libgbm.so.1",                     "/usr/lib/libgbm.so.1"),
+    ("usr/lib/libglapi.so.0",                   "/usr/lib/libglapi.so.0"),
+    ("usr/lib/libLLVM-17.so",                   "/usr/lib/libLLVM-17.so"),
+    ("usr/lib/libelf.so.1",                     "/usr/lib/libelf.so.1"),
+    ("usr/lib/libwayland-server.so.0",          "/usr/lib/libwayland-server.so.0"),
+    ("usr/lib/libxshmfence.so.1",               "/usr/lib/libxshmfence.so.1"),
+    ("usr/lib/libXxf86vm.so.1",                 "/usr/lib/libXxf86vm.so.1"),
+    ("usr/lib/xorg/modules/dri/swrast_dri.so",  "/usr/lib/xorg/modules/dri/swrast_dri.so"),
+]
+# Versioned/extra aliases the tool also injects (so the staging tree has them
+# present and the inject loop finds them).
+GL_ALIASES = [
+    "usr/lib/libGL.so.1.2.0",
+    "usr/lib/libEGL.so.1.0.0",
+    "usr/lib/libgbm.so.1.0.0",
+    "usr/lib/libglapi.so.0.0.0",
+    "usr/lib/libLLVM-17.0.6.so",
+    "usr/lib/libelf-0.191.so",
+    "usr/lib/libz.so.1",
+    "usr/lib/xorg/modules/dri/libgallium_dri.so",
+]
+
+
+def check(label: str, ok: bool, detail: str = "") -> bool:
+    global failures
+    tag = PASS if ok else FAIL
+    if not ok:
+        failures += 1
+    line = f"{tag}  {label}"
+    if detail:
+        line += f"\n      {detail}"
+    print(line)
+    return ok
+
+
+def run(args, **kw):
+    return subprocess.run(
+        ["bash", str(SCRIPT)] + args,
+        capture_output=True, text=True, timeout=180, **kw,
+    )
+
+
+def have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+def stage_gl_tree(stage: Path) -> dict:
+    """Write deterministic blobs for the full GL closure; return path->bytes."""
+    contents = {}
+    n = 1
+    for rel, _abs in GL_MEMBERS:
+        p = stage / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        # Distinct, non-trivial body per member so readback comparison is real.
+        body = (f"GL-STUB:{rel}\n".encode() + bytes((n * 7) % 256 for _ in range(64)))
+        p.write_bytes(body)
+        contents[rel] = body
+        n += 1
+    for rel in GL_ALIASES:
+        p = stage / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        body = (f"GL-ALIAS:{rel}\n".encode() + bytes((n * 11) % 256 for _ in range(32)))
+        p.write_bytes(body)
+        contents[rel] = body
+        n += 1
+    return contents
+
+
+def make_glless_image(td: Path) -> Path:
+    """Create a scratch ext2 image WITHOUT any GL libs (just a stub /usr/lib)."""
+    empty = td / "glless-stage"
+    (empty / "usr/lib").mkdir(parents=True)
+    (empty / "usr/lib/placeholder").write_text("not gl\n")
+    img = td / "glless.img"
+    mk = subprocess.run(
+        ["mke2fs", "-q", "-F", "-t", "ext2", "-d", str(empty), str(img), "16m"],
+        capture_output=True, text=True)
+    if mk.returncode != 0:
+        raise RuntimeError(mk.stderr)
+    return img
+
+
+def main() -> int:
+    print(f"{INFO}  patch-gui-gl smoke — using {SCRIPT}")
+    if not SCRIPT.exists():
+        print(f"{FAIL}  script not found")
+        return 1
+
+    # 1. bash -n syntax
+    syn = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
+    check("bash -n (syntax)", syn.returncode == 0, syn.stderr.strip())
+
+    # 2. --help
+    r = run(["--help"])
+    check("--help exits 0 + prints usage", r.returncode == 0 and "Usage:" in r.stdout)
+
+    # 3. unknown arg rejected
+    r = run(["--bogus-flag"])
+    check("unknown arg rejected (rc!=0)", r.returncode != 0)
+
+    if not (have("mke2fs") and have("debugfs") and have("e2fsck")):
+        print(f"{SKIP}  image checks (mke2fs/debugfs/e2fsck absent)")
+        print()
+        if failures:
+            print(f"{FAIL}  {failures} check(s) failed")
+            return 1
+        print(f"{PASS}  syntax/arg checks passed (image checks skipped)")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="gui-gl-smoke-", dir=os.environ.get("TMPDIR")) as td:
+        tdp = Path(td)
+
+        # 4. --verify on a GL-less image: reports MISSING, exits non-zero.
+        try:
+            glless = make_glless_image(tdp)
+        except RuntimeError as e:
+            check("mke2fs GL-less scratch image", False, str(e)[:300])
+            glless = None
+        if glless is not None:
+            r = run(["--verify", str(glless)])
+            check("--verify on GL-less image reports incomplete (rc!=0)",
+                  r.returncode != 0 and "MISSING" in r.stdout, r.stdout[-300:])
+
+        # 5. --image injection roundtrip into a scratch ext2 image.
+        stage = tdp / "disk"
+        stage.mkdir()
+        staged = stage_gl_tree(stage)
+
+        img = tdp / "data.img"
+        emptydir = tdp / "emptyimg"
+        emptydir.mkdir()
+        # Pre-populate a /usr/lib so the image has the base dir (mirrors a real
+        # FF image that already ships non-GL libs).
+        (emptydir / "usr/lib").mkdir(parents=True)
+        (emptydir / "usr/lib/libc.musl-x86_64.so.1").write_text("musl stub\n")
+        mk = subprocess.run(
+            ["mke2fs", "-q", "-F", "-t", "ext2", "-d", str(emptydir), str(img), "64m"],
+            capture_output=True, text=True)
+        if mk.returncode != 0:
+            check("mke2fs scratch image", False, mk.stderr.strip()[:300])
+        else:
+            r = run(["--disk-dir", str(stage), "--image", str(img), "--in-place"])
+            check("--image injection rc=0", r.returncode == 0, r.stdout[-500:])
+
+            # Each injected member reads back byte-identical.
+            ok_all = True
+            mism = ""
+            for rel, contents in staged.items():
+                absn = "/" + rel
+                cat = subprocess.run(["debugfs", "-R", f"cat {absn}", str(img)],
+                                     capture_output=True)
+                if cat.stdout != contents:
+                    ok_all = False
+                    mism = f"mismatch at {absn} ({len(cat.stdout)} vs {len(contents)} bytes)"
+            check("injected GL libs read back byte-identical", ok_all, mism)
+
+            # e2fsck still clean.
+            fsck = subprocess.run(["e2fsck", "-fn", str(img)],
+                                  capture_output=True, text=True)
+            check("e2fsck clean after injection (rc 0)", fsck.returncode == 0,
+                  fsck.stdout[-300:])
+
+            # Follow-up --verify now passes (closure complete).
+            r = run(["--verify", str(img)])
+            check("--verify on patched image now passes (rc 0)",
+                  r.returncode == 0 and "[ok]" in r.stdout, r.stdout[-300:])
+
+    print()
+    if failures:
+        print(f"{FAIL}  {failures} check(s) failed")
+        return 1
+    print(f"{PASS}  all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/patch-gui-gl-smoke.py
+++ b/scripts/patch-gui-gl-smoke.py
@@ -60,6 +60,17 @@ GL_MEMBERS = [
     ("usr/lib/libxshmfence.so.1",               "/usr/lib/libxshmfence.so.1"),
     ("usr/lib/libXxf86vm.so.1",                 "/usr/lib/libXxf86vm.so.1"),
     ("usr/lib/xorg/modules/dri/swrast_dri.so",  "/usr/lib/xorg/modules/dri/swrast_dri.so"),
+    # GL-only second-order DT_NEEDED (must match GL_REQUIRED in patch-gui-gl.sh).
+    ("usr/lib/libxcb-glx.so.0",                 "/usr/lib/libxcb-glx.so.0"),
+    ("usr/lib/libxcb-dri2.so.0",                "/usr/lib/libxcb-dri2.so.0"),
+    ("usr/lib/libxcb-present.so.0",             "/usr/lib/libxcb-present.so.0"),
+    ("usr/lib/libxcb-randr.so.0",               "/usr/lib/libxcb-randr.so.0"),
+    ("usr/lib/libxcb-sync.so.1",                "/usr/lib/libxcb-sync.so.1"),
+    ("usr/lib/libxcb-xfixes.so.0",              "/usr/lib/libxcb-xfixes.so.0"),
+    ("usr/lib/libdrm_radeon.so.1",              "/usr/lib/libdrm_radeon.so.1"),
+    ("usr/lib/libdrm_amdgpu.so.1",              "/usr/lib/libdrm_amdgpu.so.1"),
+    ("usr/lib/libdrm_nouveau.so.2",             "/usr/lib/libdrm_nouveau.so.2"),
+    ("usr/lib/libdrm_intel.so.1",               "/usr/lib/libdrm_intel.so.1"),
 ]
 # Versioned/extra aliases the tool also injects (so the staging tree has them
 # present and the inject loop finds them).
@@ -72,6 +83,16 @@ GL_ALIASES = [
     "usr/lib/libelf-0.191.so",
     "usr/lib/libz.so.1",
     "usr/lib/xorg/modules/dri/libgallium_dri.so",
+    "usr/lib/libdrm_radeon.so.1.0.1",
+    "usr/lib/libdrm_amdgpu.so.1.0.0",
+    "usr/lib/libdrm_nouveau.so.2.0.0",
+    "usr/lib/libdrm_intel.so.1.0.0",
+    "usr/lib/libxcb-glx.so.0.0.0",
+    "usr/lib/libxcb-dri2.so.0.0.0",
+    "usr/lib/libxcb-present.so.0.0.0",
+    "usr/lib/libxcb-randr.so.0.1.0",
+    "usr/lib/libxcb-sync.so.1.0.0",
+    "usr/lib/libxcb-xfixes.so.0.0.0",
 ]
 
 

--- a/scripts/patch-gui-gl.sh
+++ b/scripts/patch-gui-gl.sh
@@ -111,6 +111,17 @@ DRI_REL="usr/lib/xorg/modules/dri"
 # xorg/modules/dri/ — libGL's compiled-in default LIBGL_DRIVERS_PATH — as a
 # single 34 MiB object hardlinked under three names; swrast_dri.so is the name
 # the loader opens for software rendering.
+#
+# The GL-only second-order deps below (the DT_NEEDED of libGL/libEGL/libgbm and
+# of the Gallium driver that NO base-image library needs) must be injected and
+# verified too: ld.so resolves a DT_NEEDED chain eagerly at dlopen(3) time
+# (ld.so(8)), so if any of them is absent the dlopen("libGL.so.1") /
+# dlopen("swrast_dri.so") still fails even when the anchor itself is present.
+#   libdrm_{radeon,amdgpu,nouveau,intel}         DT_NEEDED of the Gallium driver
+#   libxcb-{glx,dri2,present,randr,sync,xfixes}   DT_NEEDED of libGL/libEGL/libgbm
+# (Their own DT_NEEDED in turn — libdrm.so.2, libxcb.so.1, libX11*, libz,
+# libzstd, libxcb-shm/dri3 — is base-shared and already in every FF/X11 image,
+# so it is NOT injected here.)
 GL_LIBS=(
     libGL.so.1            libGL.so.1.2.0
     libEGL.so.1           libEGL.so.1.0.0
@@ -122,6 +133,16 @@ GL_LIBS=(
     libLLVM-17.so         libLLVM-17.0.6.so
     libelf.so.1           libelf-0.191.so
     libz.so.1
+    libdrm_radeon.so.1    libdrm_radeon.so.1.0.1
+    libdrm_amdgpu.so.1    libdrm_amdgpu.so.1.0.0
+    libdrm_nouveau.so.2   libdrm_nouveau.so.2.0.0
+    libdrm_intel.so.1     libdrm_intel.so.1.0.0
+    libxcb-glx.so.0       libxcb-glx.so.0.0.0
+    libxcb-dri2.so.0      libxcb-dri2.so.0.0.0
+    libxcb-present.so.0   libxcb-present.so.0.0.0
+    libxcb-randr.so.0     libxcb-randr.so.0.1.0
+    libxcb-sync.so.1      libxcb-sync.so.1.0.0
+    libxcb-xfixes.so.0    libxcb-xfixes.so.0.0.0
 )
 # DRI driver objects (under usr/lib/xorg/modules/dri/).  swrast_dri.so is the
 # load target for software rendering; libgallium_dri.so is the canonical object.
@@ -143,11 +164,29 @@ GL_REQUIRED=(
     "/usr/lib/libxshmfence.so.1"
     "/usr/lib/libXxf86vm.so.1"
     "/usr/lib/xorg/modules/dri/swrast_dri.so"
+    # GL-only DT_NEEDED of libGL/libEGL/libgbm + the Gallium driver (ld.so
+    # resolves these eagerly at dlopen time — a closure missing any of them
+    # still fails to load libGL/swrast even with the anchors present).
+    "/usr/lib/libxcb-glx.so.0"
+    "/usr/lib/libxcb-dri2.so.0"
+    "/usr/lib/libxcb-present.so.0"
+    "/usr/lib/libxcb-randr.so.0"
+    "/usr/lib/libxcb-sync.so.1"
+    "/usr/lib/libxcb-xfixes.so.0"
+    "/usr/lib/libdrm_radeon.so.1"
+    "/usr/lib/libdrm_amdgpu.so.1"
+    "/usr/lib/libdrm_nouveau.so.2"
+    "/usr/lib/libdrm_intel.so.1"
 )
 
 # ── image present-check ──────────────────────────────────────────────────────
-img_has() {  # img_has <image> <abs-path>  -> 0 if a regular file inode exists
-    debugfs -R "stat $2" "$1" 2>/dev/null | grep -q 'Inode:'
+# True only when the path is a REGULAR FILE in the image.  `debugfs stat` prints
+# "Inode:" for directories and symlinks too, so we additionally require
+# "Type: regular" — a GL closure member must be a real file the loader can mmap,
+# never a stray dir/symlink left by a partial write.
+img_has() {  # img_has <image> <abs-path>  -> 0 if a regular-file inode exists
+    debugfs -R "stat $2" "$1" 2>/dev/null \
+        | grep -qE 'Type: *regular'
 }
 
 # ── inject a staged regular file into the image at its absolute disk path ─────

--- a/scripts/patch-gui-gl.sh
+++ b/scripts/patch-gui-gl.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# patch-gui-gl.sh — inject the software-OpenGL (Mesa llvmpipe) runtime closure
+# the windowed (--ff-gui) Firefox path needs into an existing ext2 data image,
+# WITHOUT a full create-data-disk.sh rebuild.
+#
+# Why this exists
+# ---------------
+# Firefox's GPU-feature probe (the `glxtest` child) and the content-process
+# compositor/WebRender bring-up dlopen() the OpenGL client libraries by SONAME:
+#
+#     dlopen("libGL.so.1")      glxtest GLX path
+#     dlopen("libEGL.so.1")     EGL path (also NEEDs libgbm.so.1)
+#
+# If those libraries are absent from the running image, the loader returns
+# ENOENT, glxtest reports "libGL.so.1 missing" / "libEGL missing", GL is marked
+# unavailable, and the content compositor child cannot initialise the software
+# OpenGL context → CompositorBridgeChild AbnormalShutdown → the page never
+# renders.  (Ref: ld.so(8) library search; dlopen(3); Mesa 3D docs for the
+# Gallium llvmpipe software rasteriser.)
+#
+# scripts/install-firefox-musl.sh stages the full Mesa software-GL stack into
+# build/disk/usr/lib (+ the Gallium DRI driver at
+# build/disk/usr/lib/xorg/modules/dri/), and create-data-disk.sh snaps build/disk
+# into the ext2 data.img with mke2fs -d.  A data image built BEFORE that staging
+# existed (or that was assembled by a path which dropped the DRI driver dirs)
+# ships GL-less.  Because the staleness is by CONTENT, not mtime, a freshly
+# *written* image can still be GL-incomplete — exactly the failure this tool
+# repairs.  It mirrors scripts/patch-gui-caches.sh: a one-shot, non-interactive
+# debugfs -w injection (unprivileged, no mount, no 2 GiB rebuild).
+#
+# Usage
+# -----
+#   patch-gui-gl.sh --image <data.img> [--in-place] [--disk-dir <dir>]
+#   patch-gui-gl.sh --verify <data.img>     (report-only; exit 0 iff complete)
+#
+# All output is structured "[GUI-GL] ..." lines.  Operates on a COPY
+# ("<image>.gl-patched") unless --in-place is given.
+#
+# Refs: ld.so(8), dlopen(3), the ELF/dynamic-linking (gABI) standard,
+# Mesa 3D documentation (Gallium / llvmpipe software rasteriser),
+# debugfs(8), mke2fs(8) -d.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
+DISK_DIR="${BUILD_DIR}/disk"
+IMAGE=""
+IN_PLACE=0
+VERIFY_ONLY=0
+
+usage() {
+    cat <<EOF
+Usage: patch-gui-gl.sh [options]
+
+  --image <data.img>     Inject the staged Mesa software-GL closure into this
+                         ext2 image.
+  --in-place             With --image: modify the image in place (default: a
+                         "<image>.gl-patched" copy is produced and patched).
+  --verify <data.img>    Report-only: list which GL closure members are present
+                         / missing in the image.  Exit 0 iff the closure is
+                         complete; non-zero otherwise.  No modification.
+  --disk-dir <dir>       Staging tree the libs are copied FROM
+                         (default: ${DISK_DIR}).
+  -h, --help             This help.
+
+Exit status: 0 on success; non-zero if a required member could not be injected
+or (with --verify) the image is GL-incomplete.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image) IMAGE="${2:?--image needs a path}"; shift 2 ;;
+        --in-place) IN_PLACE=1; shift ;;
+        --verify) IMAGE="${2:?--verify needs a path}"; VERIFY_ONLY=1; shift 2 ;;
+        --disk-dir) DISK_DIR="${2:?--disk-dir needs a path}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "[GUI-GL] ERROR: unknown arg '$1'" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+DISK_USR_LIB="${DISK_DIR}/usr/lib"
+DRI_REL="usr/lib/xorg/modules/dri"
+
+# ── The software-GL injection closure ────────────────────────────────────────
+# Each entry is a path RELATIVE to the staging /usr/lib (or the staging root for
+# the DRI driver).  This is the transitive dlopen closure of libGL.so.1 +
+# libEGL.so.1 that is NOT already part of the base FF/X11 image, computed from
+# their DT_NEEDED entries (readelf -d) minus the libraries every FF image
+# already ships (libexpat, libxcb*, libX11*, libdrm.so.2, libwayland-client,
+# libstdc++, libgcc_s, libz already-present, etc.).  The members listed here are
+# the ones the Mesa staging step (install-firefox-musl.sh) adds on top of the
+# base image.  Both the SONAME and its versioned real name are written because
+# the staging tree carries them as independent (hardlinked) regular files, which
+# is how mke2fs -d would lay them out; the loader resolves the SONAME form.
+#
+#   libGL.so.1        OpenGL/GLX dispatch (glxtest dlopen target)
+#   libEGL.so.1       EGL client (FF probes it; NEEDs libgbm + libwayland-server)
+#   libgbm.so.1       Generic Buffer Management (DT_NEEDED of libEGL)
+#   libglapi.so.0     GL API dispatch (DT_NEEDED of libGL + libEGL + driver)
+#   libwayland-server.so.0  DT_NEEDED of libEGL + libgbm
+#   libxshmfence.so.1 DT_NEEDED of libGL + libEGL
+#   libXxf86vm.so.1   DT_NEEDED of libGL
+#   libLLVM-17.so     llvmpipe JIT backend (DT_NEEDED of the Gallium driver)
+#   libelf.so.1       DT_NEEDED of the Gallium driver
+#   libz.so.1         DT_NEEDED of the Gallium driver (often base, injected if absent)
+#
+# The Gallium DRI driver itself (the llvmpipe pipe driver) lives under
+# xorg/modules/dri/ — libGL's compiled-in default LIBGL_DRIVERS_PATH — as a
+# single 34 MiB object hardlinked under three names; swrast_dri.so is the name
+# the loader opens for software rendering.
+GL_LIBS=(
+    libGL.so.1            libGL.so.1.2.0
+    libEGL.so.1           libEGL.so.1.0.0
+    libgbm.so.1           libgbm.so.1.0.0
+    libglapi.so.0         libglapi.so.0.0.0
+    libwayland-server.so.0
+    libxshmfence.so.1
+    libXxf86vm.so.1
+    libLLVM-17.so         libLLVM-17.0.6.so
+    libelf.so.1           libelf-0.191.so
+    libz.so.1
+)
+# DRI driver objects (under usr/lib/xorg/modules/dri/).  swrast_dri.so is the
+# load target for software rendering; libgallium_dri.so is the canonical object.
+DRI_DRIVERS=(
+    swrast_dri.so
+    libgallium_dri.so
+)
+
+# Members that MUST be present for the GL pipeline to come up (the verify gate).
+# These are the SONAMEs the loader resolves + the software DRI driver.
+GL_REQUIRED=(
+    "/usr/lib/libGL.so.1"
+    "/usr/lib/libEGL.so.1"
+    "/usr/lib/libgbm.so.1"
+    "/usr/lib/libglapi.so.0"
+    "/usr/lib/libLLVM-17.so"
+    "/usr/lib/libelf.so.1"
+    "/usr/lib/libwayland-server.so.0"
+    "/usr/lib/libxshmfence.so.1"
+    "/usr/lib/libXxf86vm.so.1"
+    "/usr/lib/xorg/modules/dri/swrast_dri.so"
+)
+
+# ── image present-check ──────────────────────────────────────────────────────
+img_has() {  # img_has <image> <abs-path>  -> 0 if a regular file inode exists
+    debugfs -R "stat $2" "$1" 2>/dev/null | grep -q 'Inode:'
+}
+
+# ── inject a staged regular file into the image at its absolute disk path ─────
+# Mirrors patch-gui-caches.sh inject_into_image: ensure parent dirs, idempotent
+# rm then write, then stat-verify it landed.
+inject_file() {
+    local img="$1" staged="$2" abs="$3"
+    [ -f "${staged}" ] || { echo "[GUI-GL] inject skip ${abs}: not staged (${staged})"; return 0; }
+    local dir; dir="$(dirname "${abs}")"
+    local p="" seg _segs
+    IFS='/' read -ra _segs <<< "${dir#/}"
+    for seg in "${_segs[@]}"; do
+        p="${p}/${seg}"
+        debugfs -w -R "mkdir ${p}" "${img}" >/dev/null 2>&1 || true
+    done
+    debugfs -w -R "rm ${abs}" "${img}" >/dev/null 2>&1 || true
+    if debugfs -w -R "write ${staged} ${abs}" "${img}" 2>&1 | grep -qiE 'error|not found|no such'; then
+        echo "[GUI-GL] ERROR: debugfs write failed for ${abs}"
+        return 1
+    fi
+    if img_has "${img}" "${abs}"; then
+        echo "[GUI-GL] injected ${abs} ($(stat -c%s "${staged}") bytes)"
+    else
+        echo "[GUI-GL] ERROR: ${abs} not present after debugfs write"
+        return 1
+    fi
+}
+
+# ── verify mode ──────────────────────────────────────────────────────────────
+do_verify() {  # do_verify <image>
+    local img="$1" missing=0 present=0
+    echo "[GUI-GL] verify image: ${img}"
+    local m
+    for m in "${GL_REQUIRED[@]}"; do
+        if img_has "${img}" "${m}"; then
+            echo "[GUI-GL]   PRESENT ${m}"
+            present=$((present + 1))
+        else
+            echo "[GUI-GL]   MISSING ${m}"
+            missing=$((missing + 1))
+        fi
+    done
+    echo "[GUI-GL] verify: ${present}/${#GL_REQUIRED[@]} required GL members present"
+    if [ "${missing}" -eq 0 ]; then
+        echo "[GUI-GL][ok] image carries the complete software-GL closure"
+        return 0
+    fi
+    echo "[GUI-GL][MISSING] image is GL-incomplete (${missing} member(s) absent) — run patch-gui-gl.sh --image ${img} --in-place"
+    return 1
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+command -v debugfs >/dev/null 2>&1 || { echo "[GUI-GL] ERROR: debugfs not found (apt-get install e2fsprogs)"; exit 1; }
+[ -n "${IMAGE}" ] || { echo "[GUI-GL] ERROR: --image or --verify is required" >&2; usage >&2; exit 2; }
+[ -f "${IMAGE}" ] || { echo "[GUI-GL] ERROR: image not found: ${IMAGE}"; exit 1; }
+
+if [ "${VERIFY_ONLY}" -eq 1 ]; then
+    do_verify "${IMAGE}"
+    exit $?
+fi
+
+echo "[GUI-GL] staging tree: ${DISK_DIR}"
+echo "[GUI-GL] image:        ${IMAGE}"
+
+TARGET="${IMAGE}"
+if [ "${IN_PLACE}" -eq 0 ]; then
+    TARGET="${IMAGE}.gl-patched"
+    echo "[GUI-GL] copying ${IMAGE} -> ${TARGET} (use --in-place to patch the original)"
+    cp -f --reflink=auto "${IMAGE}" "${TARGET}"
+fi
+
+rc=0
+for lib in "${GL_LIBS[@]}"; do
+    inject_file "${TARGET}" "${DISK_USR_LIB}/${lib}" "/usr/lib/${lib}" || rc=1
+done
+for drv in "${DRI_DRIVERS[@]}"; do
+    inject_file "${TARGET}" "${DISK_DIR}/${DRI_REL}/${drv}" "/usr/lib/xorg/modules/dri/${drv}" || rc=1
+done
+
+echo "[GUI-GL] image patched: ${TARGET} (rc=${rc})"
+if [ "${rc}" -eq 0 ]; then
+    do_verify "${TARGET}" || rc=1
+fi
+exit "${rc}"

--- a/scripts/patch-gui-gl.sh
+++ b/scripts/patch-gui-gl.sh
@@ -118,6 +118,7 @@ DRI_REL="usr/lib/xorg/modules/dri"
 # (ld.so(8)), so if any of them is absent the dlopen("libGL.so.1") /
 # dlopen("swrast_dri.so") still fails even when the anchor itself is present.
 #   libdrm_{radeon,amdgpu,nouveau,intel}         DT_NEEDED of the Gallium driver
+#   libpciaccess.so.0                            DT_NEEDED of libdrm_intel (3rd-order)
 #   libxcb-{glx,dri2,present,randr,sync,xfixes}   DT_NEEDED of libGL/libEGL/libgbm
 # (Their own DT_NEEDED in turn — libdrm.so.2, libxcb.so.1, libX11*, libz,
 # libzstd, libxcb-shm/dri3 — is base-shared and already in every FF/X11 image,
@@ -137,6 +138,7 @@ GL_LIBS=(
     libdrm_amdgpu.so.1    libdrm_amdgpu.so.1.0.0
     libdrm_nouveau.so.2   libdrm_nouveau.so.2.0.0
     libdrm_intel.so.1     libdrm_intel.so.1.0.0
+    libpciaccess.so.0     libpciaccess.so.0.11.1
     libxcb-glx.so.0       libxcb-glx.so.0.0.0
     libxcb-dri2.so.0      libxcb-dri2.so.0.0.0
     libxcb-present.so.0   libxcb-present.so.0.0.0
@@ -177,6 +179,7 @@ GL_REQUIRED=(
     "/usr/lib/libdrm_amdgpu.so.1"
     "/usr/lib/libdrm_nouveau.so.2"
     "/usr/lib/libdrm_intel.so.1"
+    "/usr/lib/libpciaccess.so.0"
 )
 
 # ── image present-check ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The windowed (`--ff-gui`) Firefox path's GPU-feature probe (the `glxtest` child) and the content-process compositor `dlopen()` the OpenGL client libraries by SONAME (`libGL.so.1`, `libEGL.so.1`). When those — or the Gallium llvmpipe software DRI driver they load — are absent from the running data image, the loader returns `ENOENT`, `glxtest` reports `libGL.so.1 missing` / `libEGL missing`, GL is marked unavailable, and the content compositor child cannot initialise a software OpenGL context → `CompositorBridgeChild` closes with `AbnormalShutdown` → the page never renders.

`install-firefox-musl.sh` stages the full Mesa software-GL stack into `build/disk/usr/lib` (+ the Gallium DRI driver under `usr/lib/xorg/modules/dri/`), and `create-data-disk.sh` snaps that tree into the ext2 image with `mke2fs -d`. But an image written from a staging tree predating the Mesa staging — or assembled by a path that dropped the DRI driver directory — ships GL-less **even though it is newer by mtime** than the staging tree, so an mtime-based freshness check does not catch it. This is a by-CONTENT staleness.

## Diagnosis (trace-validated, not assumed)

Booting the windowed browsing config at `https://example.com` against the as-shipped image:

```
[CHILD-OUT] glxtest: cannot access /sys/bus/pci   (benign — also in the host reference)
[CHILD-OUT] glxtest: libEGL missing               ← OUR DIVERGENCE
[CHILD-OUT] glxtest: libGL.so.1 missing           ← OUR DIVERGENCE
[CHILD-OUT] No GPUs detected via PCI
[PROC] PID 2 exit_group(0)                         (glxtest bails; GL unavailable)
```

First failing dlopen: `libEGL.so.1` → `ENOENT` (the library file is genuinely not present in the image's `/usr/lib`). `debugfs --verify` of the image confirmed 0/10 required GL members present despite the staging tree carrying all of them.

## Fix (build/image only — no kernel change)

- **`scripts/patch-gui-gl.sh`** — one-shot, non-interactive tool that injects the transitive `dlopen` closure of `libGL.so.1` + `libEGL.so.1` (the members the Mesa staging step adds on top of the base FF/X11 image: libGL, libEGL, libgbm, libglapi, libwayland-server, libxshmfence, libXxf86vm, libLLVM-17, libelf, libz) plus the llvmpipe DRI driver (`swrast_dri.so` / `libgallium_dri.so`) into an existing ext2 image via `debugfs -w` — unprivileged, no mount, no 2 GiB rebuild. `--verify` reports present/missing and gates on a complete closure. Mirrors the established `patch-gui-caches.sh` injection pattern.
- **`create-data-disk.sh`** — after `mke2fs -d`, when the staging tree carries the GL stack, verify the produced image carries the complete closure and warn (with the exact one-line repair command) if not. Warn, not fail: headless boots and non-FF images do not need GL.
- **`scripts/patch-gui-gl-smoke.py` + a `tooling-smoke` CI step** — boot-free, qemu-free hermetic exercise of arg validation, `--verify` on a GL-less image (must report incomplete + exit non-zero), and the load-bearing debugfs injection into a scratch ext2 image (byte-identical readback, e2fsck-clean, follow-up `--verify` passes).

**Failure mode the CI step prevents:** a `--ff-gui` data image that silently ships GL-less (regressing the content compositor to `libGL.so.1 missing`), or an injection path that corrupts the ext2 image while patching it.

## Verification (live)

Rebooting the windowed browsing config at `https://example.com` against the patched image:

- `glxtest` **no longer reports `libEGL`/`libGL` missing** — only the benign `cannot access /sys/bus/pci`, matching a working host reference.
- The content (pid3) and GPU/compositor (pid4) children **survive the GL probe** (previously the GL child bailed immediately).
- The full-size FF chrome **paints** (`MapWindow 0x400016 1280×972`); screendump shows the complete Firefox chrome rendered via llvmpipe software GL.
- **DNS for `example.com` resolves** to real IPs (`172.66.147.243`, `104.20.23.154`).

The run now advances to a **separate downstream gate** — the content-process `CompositorBridgeChild AbnormalShutdown` (a wake-fairness / content-proc-init gate tracked on `realweb/compositorbridge-gate`), at which point the page content does not yet paint and no port-443 TLS is established. That gate is out of scope for this build-tooling change. **The GL-provisioning gate is closed.**

## Scope note

This PR is purely additive image provisioning (2 modified files, +38 lines; 2 new scripts). It contains **no kernel changes** and does **not** touch the GUI launch env, so it cannot regress the New-Tab in-process paint config on master (which still sets `MOZ_FORCE_DISABLE_E10S` / `MOZ_DISABLE_NONLOCAL_CONNECTIONS`). The browsing-env change (enabling E10S + non-local connections for real-web browsing) is a separate kernel-source concern tracked on `realweb/compositorbridge-gate` and should land behind a flag/mode so the paint-only config keeps working.

## Refs

ld.so(8) library search; dlopen(3); the ELF/dynamic-linking (gABI) standard; Mesa 3D documentation (Gallium / llvmpipe software rasteriser); debugfs(8); mke2fs(8) -d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
