### PR TITLE
linux/sockets: honor writev/sendmsg contiguous-prefix invariant on short stream writes

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2381,21 +2381,46 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     unsafe { core::slice::from_raw_parts(base, slen) }.to_vec()
                 };
                 let data: &[u8] = &data_owned;
+                // POSIX sendmsg(2): bytes sent are a CONTIGUOUS PREFIX of the
+                // gathered iovec sequence.  When a single buffer is short-written
+                // (the AF_UNIX byte-stream recv ring or the AF_INET send buffer
+                // filled mid-buffer), we MUST stop and return the prefix; pushing
+                // the next iovec's bytes while the tail of this one is unwritten
+                // would reorder the stream, because the caller retries from `total`
+                // and would re-send the skipped tail AFTER the later buffer.
+                // (Mozilla's IPC channel — ipc_channel_posix.cc
+                // ProcessOutgoingMessages — sends a multi-iovec header+payload
+                // frame and advances its write iterator by the returned byte
+                // count, so a non-prefix return corrupts the message stream and
+                // the reader parses payload as a garbage header.)
+                let short_write;
                 if crate::syscall::is_unix_socket_fd(pid, fd) {
                     let unix_id = crate::syscall::get_unix_socket_id(pid, fd);
                     match crate::net::unix::write(unix_id, data) {
-                        n if n >= 0 => total += n as usize,
-                        e => return e,
+                        n if n >= 0 => {
+                            total += n as usize;
+                            short_write = (n as usize) < data.len();
+                        }
+                        e => {
+                            // A surfaced error after a partial success is reported
+                            // as the prefix; an error before any bytes is the error.
+                            if total > 0 { return total as i64; }
+                            return e;
+                        }
                     }
                 } else {
                     if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
                     let socket_id = crate::syscall::get_socket_id(pid, fd);
                     match crate::net::socket::socket_send(socket_id, data) {
-                        Ok(n) => total += n,
-                        Err("EPIPE") => return -32,
-                        Err(_) => return -104,
+                        Ok(n) => {
+                            total += n;
+                            short_write = n < data.len();
+                        }
+                        Err("EPIPE") => { if total > 0 { return total as i64; } return -32; }
+                        Err(_)       => { if total > 0 { return total as i64; } return -104; }
                     }
                 }
+                if short_write { break; } // contiguous-prefix contract — stop
             }
             total as i64
         }
@@ -7892,8 +7917,21 @@ pub fn sys_writev(fd: u64, iov_ptr: u64, iovcnt: u64) -> i64 {
         let len = iov[1] as usize;
         if len == 0 { continue; }
         let result = sys_write_linux(fd, base, len as u64);
-        if result < 0 { return result; }
+        // POSIX writev(2): the return value is the number of bytes written,
+        // which is always a CONTIGUOUS PREFIX of the gathered iovec sequence.
+        // If a single buffer is short-written (e.g. a byte-stream socket whose
+        // send buffer filled mid-buffer), we MUST stop here and report the
+        // prefix; continuing to the next iovec would push its bytes into the
+        // stream ahead of the unwritten tail of this one, and the caller —
+        // which retries from `total` per the contiguous-prefix contract —
+        // would then re-send those skipped bytes after the later buffer,
+        // permanently reordering the stream.  A surfaced error after a partial
+        // success is reported as the prefix (matching writev(2): a partial
+        // write is success, not failure); an error before any bytes is the
+        // error itself.  Mirrors sys_readv's short-read handling below.
+        if result < 0 { return if total > 0 { total } else { result }; }
         total += result;
+        if (result as usize) < len { break; } // short write — stop (prefix contract)
     }
     total
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -749,6 +749,13 @@ pub fn run() -> ! {
     total += 1;
     if test_unix_socketpair() { passed += 1; }
 
+    // ── Test 306: writev contiguous-prefix invariant on AF_UNIX short write ─
+    // Regression for the content-render gate: a multi-iovec writev whose first
+    // buffer short-writes (recv ring fills mid-buffer) must return a contiguous
+    // prefix and must NOT push later buffers' bytes ahead of the unwritten tail.
+    total += 1;
+    if test_writev_contiguous_prefix_on_short_write() { passed += 1; }
+
     // ── Test 294: proc_metrics net_r_bytes via recvmsg(2) ─────────────────
     // Regression for the omission where nr-47 on AF_UNIX called read_msg()
     // directly and skipped bump_net_read(); the counter appeared to freeze
@@ -14860,6 +14867,126 @@ fn test_unix_socketpair() -> bool {
     crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
 
     test_pass!("AF_UNIX socketpair round-trip");
+    true
+}
+
+// ── Test 306: writev(2) contiguous-prefix invariant on a short stream write ────
+//
+// POSIX writev(2)/sendmsg(2): the byte count returned is always a CONTIGUOUS
+// PREFIX of the gathered iovec sequence.  When a single buffer short-writes —
+// here the 32 KiB AF_UNIX recv ring fills partway through the first iovec —
+// the kernel must stop and report the prefix; it must NOT proceed to push the
+// next iovec's bytes (which would land in the stream ahead of the first iovec's
+// unwritten tail).  A non-prefix return reorders the byte stream: a caller that
+// retries from the returned count re-sends the skipped tail AFTER the later
+// buffer, corrupting any framed protocol on top (the exact failure mode that
+// desynced Mozilla's IPC channel and aborted the content process).
+//
+// This is the writev mirror of sys_readv's short-read `break`.
+fn test_writev_contiguous_prefix_on_short_write() -> bool {
+    test_header!("writev contiguous-prefix on AF_UNIX short write");
+
+    // AF_UNIX recv ring capacity (net/unix.rs RECV_BUF_CAP).  recv_space() is
+    // CAP-1 (one slot reserved to disambiguate full/empty), so the most a
+    // peer can hold before writes start short-writing is CAP-1 bytes.
+    const RING_CAP: usize = 32768;
+    const RING_USABLE: usize = RING_CAP - 1;
+
+    let mut fds = [0i32; 2];
+    let r = crate::syscall::dispatch_linux_kernel(
+        53, 1, 1, 0, fds.as_mut_ptr() as u64, 0, 0,
+    );
+    if r != 0 {
+        test_fail!("writev_prefix", "socketpair() returned {}", r);
+        return false;
+    }
+
+    // Pre-fill the peer ring (fd[1]) to leave exactly `room` free bytes so the
+    // first iovec of the writev below short-writes after `room` bytes.
+    let room: usize = 100;
+    let prefill = alloc::vec![0xAAu8; RING_USABLE - room];
+    let pn = crate::syscall::dispatch_linux_kernel(
+        1, fds[0] as u64, prefill.as_ptr() as u64, prefill.len() as u64, 0, 0, 0,
+    );
+    if pn != prefill.len() as i64 {
+        test_fail!("writev_prefix", "prefill write returned {} (expected {})",
+                   pn, prefill.len());
+        return false;
+    }
+
+    // writev with two iovecs.  iov[0] is larger than `room`, so it short-writes
+    // after `room` bytes; iov[1] must NOT be pushed (would reorder the stream).
+    //   iov[0] = 0xB1 * 200   (only first `room`=100 should land)
+    //   iov[1] = 0xC2 * 200   (must NOT land at all)
+    let buf0 = alloc::vec![0xB1u8; 200];
+    let buf1 = alloc::vec![0xC2u8; 200];
+    let iov: [[u64; 2]; 2] = [
+        [buf0.as_ptr() as u64, buf0.len() as u64],
+        [buf1.as_ptr() as u64, buf1.len() as u64],
+    ];
+    let wn = crate::syscall::dispatch_linux_kernel(
+        20, fds[0] as u64, iov.as_ptr() as u64, 2, 0, 0, 0, // writev
+    );
+
+    // Expect exactly `room` bytes (contiguous prefix), NOT room + 200 (iov[1]).
+    if wn != room as i64 {
+        test_fail!("writev_prefix",
+            "writev returned {} — expected contiguous prefix {} (a value of {} \
+             means iov[1] was pushed past iov[0]'s unwritten tail = stream reorder)",
+            wn, room, room + buf1.len());
+        crate::syscall::dispatch_linux_kernel(3, fds[0] as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  writev short-write returned {} (contiguous prefix) ✓", wn);
+
+    // Drain the whole ring and verify byte ORDER: prefill 0xAA bytes, then
+    // exactly `room` 0xB1 bytes, then NOTHING (no 0xC2 from iov[1]).  Any 0xC2
+    // appearing before the trailing 0xB1 tail would prove a reorder.
+    let total_expected = (RING_USABLE - room) + room; // prefill + iov[0] prefix
+    let mut drained = alloc::vec![0u8; RING_CAP];
+    let mut got = 0usize;
+    // Read in chunks until the ring is empty (read returns -EAGAIN=-11).
+    loop {
+        let rn = crate::syscall::dispatch_linux_kernel(
+            0, fds[1] as u64, drained[got..].as_mut_ptr() as u64,
+            (drained.len() - got) as u64, 0, 0, 0,
+        );
+        if rn <= 0 { break; }
+        got += rn as usize;
+        if got >= drained.len() { break; }
+    }
+    if got != total_expected {
+        test_fail!("writev_prefix",
+            "drained {} bytes, expected {} (prefill {} + prefix {})",
+            got, total_expected, RING_USABLE - room, room);
+        crate::syscall::dispatch_linux_kernel(3, fds[0] as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    // No 0xC2 byte (iov[1]) may appear anywhere in the stream.
+    if drained[..got].iter().any(|&b| b == 0xC2) {
+        test_fail!("writev_prefix",
+            "found a 0xC2 byte (iov[1]) in the stream — iov[1] was pushed \
+             despite iov[0] short-writing = byte-stream reorder/corruption");
+        crate::syscall::dispatch_linux_kernel(3, fds[0] as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    // The last `room` bytes must be 0xB1 (iov[0] prefix), preceded by 0xAA.
+    if drained[got - room..got].iter().any(|&b| b != 0xB1)
+        || drained[got - room - 1] != 0xAA
+    {
+        test_fail!("writev_prefix", "byte ordering at the prefill/prefix seam is wrong");
+        crate::syscall::dispatch_linux_kernel(3, fds[0] as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  drained {} bytes in order, zero iov[1] bytes leaked ✓", got);
+
+    crate::syscall::dispatch_linux_kernel(3, fds[0] as u64, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
+    test_pass!("writev contiguous-prefix on AF_UNIX short write");
     true
 }
 


### PR DESCRIPTION
## Summary

Fixes the **windowed-Firefox content-render gate** — the reason real web content never rendered (content processes died in a respawn loop and no page loaded).

POSIX `writev(2)` / `sendmsg(2)` guarantee the returned byte count is always a **contiguous prefix** of the gathered iovec sequence. The AF_UNIX / AF_INET gather loops in `sys_writev` and the `sendmsg` (nr 46) handler accumulated the per-iovec byte count but **did not stop when a single buffer was short-written** (the AF_UNIX 32 KiB recv ring, or the AF_INET send buffer, filling mid-buffer). They proceeded to push the *next* iovec's bytes into the stream ahead of the unwritten tail of the short buffer.

A caller that retries from the returned count (the contiguous-prefix contract) then re-sends the skipped tail **after** the later buffer, permanently **reordering the byte stream**. Any length-framed protocol layered on the socket desyncs: the reader parses payload bytes as a message header.

## The observed failure

On a windowed-Firefox boot browsing `https://example.com`, this corrupted the IPC channel between the parent and a content process. The parent's IPC reader saw a garbage message header (an absurd `num_handles`, e.g. `0x26000000`), rejected the message with **"Message requires an excessive number of descriptors"** (`ipc_channel_posix.cc:489`), aborted the channel, and the content process exited (**"Exiting due to channel error"**) into a respawn loop — so no page ever loaded (0 TLS connections).

## The fix

Stop the gather loop on the first short per-iovec write and return the accumulated prefix, mirroring `sys_readv`'s existing short-read `break`. A surfaced error *after* a partial success is reported as the prefix (a partial write is success, not failure, per `writev(2)`); an error before any byte is the error itself. Both the AF_UNIX and AF_INET arms are covered in the `sendmsg` handler.

## Test

Adds **Test 306**: a multi-iovec `writev` whose first buffer short-writes (recv ring pre-filled to leave 100 free bytes) must return the contiguous prefix (100, not 300) and leave the stream byte-ordered with **zero** bytes from the later iovec leaked into the stream.

```
writev short-write returned 100 (contiguous prefix) ✓
drained 32767 bytes in order, zero iov[1] bytes leaked ✓
[PASS] writev contiguous-prefix on AF_UNIX short write
```

Full test-mode suite: **216 pass / 0 regressions** (the only 2 failures are pre-existing data-image staging gaps — `tcc` / `busybox` binaries absent from the image — unrelated to this change).

## Live verification

Windowed Firefox on `https://example.com` (SMP=1): content processes now **survive** past the IPC channel (0 channel errors, 0 "excessive descriptors", 0 content-process deaths) where previously they entered the respawn loop.

## Refs

POSIX.1-2017 `writev(2)`, `send(2)` / `sendmsg(2)` (return value is bytes transmitted, a prefix of the gather buffers); `unix(7)` SOCK_STREAM byte-stream ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
