### PR TITLE
kernel/epoll: close the EPOLLET drain-then-rise re-arm gap (rise generation)

### DIFF
--- a/kernel/src/ipc/epoll.rs
+++ b/kernel/src/ipc/epoll.rs
@@ -47,6 +47,19 @@ pub struct EpollWatch {
     /// reporting is unconditional.  Reset to 0 on `EPOLL_CTL_MOD` so a MOD
     /// re-arms the edge (Linux behaviour).
     pub last_ready: u32,
+    /// Edge-trigger rise generation last *delivered* for this watch, for
+    /// readiness sources that expose a monotonic 0→ready rise counter (the
+    /// eventfd `rise_seq`).  The `last_ready` level-diff alone cannot detect a
+    /// drain-then-rise that happens entirely between two `epoll_wait` calls
+    /// (no call observes the intermediate level==0, so the asserted level is
+    /// identical at both observations and `level & !last_ready == 0`).  Per
+    /// `epoll(7)` each not-ready→ready transition is a fresh edge that must be
+    /// reported regardless of `epoll_wait` timing; comparing the source's live
+    /// generation against this stored value re-arms the EPOLLIN edge across
+    /// such a transition.  Sources without a generation report 0, so the
+    /// level-diff behaviour governs them unchanged.  Ignored for
+    /// level-triggered watches; reset to 0 on ADD / `EPOLL_CTL_MOD`.
+    pub et_rise: u64,
 }
 
 /// Per-process monotonically increasing identifier for epoll instances.
@@ -141,7 +154,7 @@ impl EpollInstance {
         // any currently-asserted readiness (a 0→ready transition), matching
         // Linux, where a newly-added EPOLLET fd that is already ready fires
         // once immediately.
-        self.watches.push(EpollWatch { fd, events, data, last_ready: 0 });
+        self.watches.push(EpollWatch { fd, events, data, last_ready: 0, et_rise: 0 });
         true
     }
 
@@ -170,28 +183,33 @@ impl EpollInstance {
             // re-evaluates readiness).  Clear the recorded level so the next
             // poll treats the present readiness as a fresh 0→ready transition.
             w.last_ready = 0;
+            // A MOD also re-arms the generation edge: the next poll must treat
+            // the current generation as already-consumed → 0 forces the live
+            // generation to look "newer" so a currently-ready eventfd refires.
+            w.et_rise = 0;
             true
         } else {
             false
         }
     }
 
-    /// Commit the per-watch edge state after a delivery.  `delivered` maps
-    /// `fd → asserted-interest-level` for every watch that contributed to the
-    /// returned event set; for an EPOLLET watch this becomes its new
-    /// `last_ready` so the same asserted level is not re-reported.  Level-
-    /// triggered watches are unaffected (their reporting is unconditional and
-    /// `last_ready` is never consulted for them).
-    ///
-    /// We also clear `last_ready` for any EPOLLET watch whose current asserted
-    /// level is recorded as dropping to a subset — handled by the caller
-    /// passing the freshly-computed level (including 0) so a level-drop re-arms
-    /// the edge automatically.
-    pub fn commit_edges(&mut self, delivered: &[(usize, u32)]) {
-        for &(fd, level) in delivered {
+    /// Commit the per-watch edge state after a delivery.  Each tuple is
+    /// `(fd, asserted-interest-level, rise-generation)` for an EPOLLET watch:
+    ///   * `last_ready` becomes the asserted level so the same level is not
+    ///     re-reported while it stays high (and a level-drop to a subset —
+    ///     including 0 — re-arms automatically, since the caller passes the
+    ///     freshly-computed level), and
+    ///   * `et_rise` becomes the source's current rise generation so a future
+    ///     0→ready transition (a generation bump) re-arms the EPOLLIN edge even
+    ///     if the level looked continuously high across two `epoll_wait` calls.
+    /// Level-triggered watches are unaffected (their reporting is unconditional
+    /// and neither `last_ready` nor `et_rise` is consulted for them).
+    pub fn commit_edges(&mut self, delivered: &[(usize, u32, u64)]) {
+        for &(fd, level, rise) in delivered {
             if let Some(w) = self.watches.iter_mut().find(|w| w.fd == fd) {
                 if w.events & EPOLLET != 0 {
                     w.last_ready = level;
+                    w.et_rise    = rise;
                 }
             }
         }

--- a/kernel/src/ipc/eventfd.rs
+++ b/kernel/src/ipc/eventfd.rs
@@ -209,6 +209,10 @@ pub fn write(id: u64, val: u64) -> Result<(), i64> {
     let was_zero = slot.counter == 0;
     slot.counter += val;
     if was_zero && val > 0 {
+        // `wrapping_add` is intentional and benign: only inequality with the
+        // watch's recorded `et_rise` is consulted, never an ordering, and a u64
+        // wrap requires ~2^64 rise events (centuries of edges) — a wrap would
+        // at worst alias one generation and miss a single edge, never panic.
         slot.rise_seq = slot.rise_seq.wrapping_add(1);
     }
     Ok(())

--- a/kernel/src/ipc/eventfd.rs
+++ b/kernel/src/ipc/eventfd.rs
@@ -56,11 +56,23 @@ struct EventFdEntry {
     counter: u64,
     flags:   u32,
     in_use:  bool,
+    /// Monotonic readiness-rise generation.  Bumped on every counter
+    /// `0 → non-zero` transition (a fresh not-ready→ready edge per
+    /// `eventfd(2)` + `epoll(7)`), and never on a write that only grows an
+    /// already-non-zero counter.  An edge-triggered (`EPOLLET`) epoll watch
+    /// records the generation it last delivered; `sys_epoll_wait` re-arms the
+    /// EPOLLIN edge whenever the live generation differs from the recorded
+    /// one, even when the asserted *level* looks continuously high.  This
+    /// records the 0-crossing at the moment readiness rises (the canonical
+    /// epoll ready-list / wakeup-callback contract) rather than only when an
+    /// `epoll_wait` happens to observe the drained state — closing the
+    /// drain-then-rise-between-two-waits edge-suppression gap.
+    rise_seq: u64,
 }
 
 impl EventFdEntry {
     const fn empty() -> Self {
-        Self { counter: 0, flags: 0, in_use: false }
+        Self { counter: 0, flags: 0, in_use: false, rise_seq: 0 }
     }
 }
 
@@ -134,6 +146,31 @@ pub fn read(id: u64) -> Result<u64, i64> {
     try_read(id)
 }
 
+/// Read the live counter value for an eventfd slot without mutating it.
+///
+/// Diagnostic-only (kdb introspection): returns `Some(counter)` for a live
+/// slot, `None` for a free/invalid id.  Unlike `try_read` this never resets
+/// the counter, so it is safe to call from a debugger snapshot path that must
+/// not perturb the protocol state of a live workload.
+pub fn peek_counter(id: u64) -> Option<u64> {
+    let table = TABLE.lock();
+    table.get(id as usize)
+        .filter(|s| s.in_use)
+        .map(|s| s.counter)
+}
+
+/// Read the live readiness-rise generation for an eventfd slot (see
+/// `EventFdEntry.rise_seq`).  Returns `Some(seq)` for a live slot, `None` for
+/// a free/invalid id.  `sys_epoll_wait` consults this to re-arm an EPOLLET
+/// EPOLLIN edge across a drain-then-rise that no `epoll_wait` observed at
+/// level 0.  Non-mutating; safe to call from any context.
+pub fn rise_seq(id: u64) -> Option<u64> {
+    let table = TABLE.lock();
+    table.get(id as usize)
+        .filter(|s| s.in_use)
+        .map(|s| s.rise_seq)
+}
+
 /// Was this eventfd created with `EFD_NONBLOCK`?  Per `man 2 eventfd`,
 /// EFD_NONBLOCK is shorthand for setting `O_NONBLOCK` on the resulting fd.
 /// The syscall layer combines this with the per-fd O_NONBLOCK status
@@ -163,7 +200,17 @@ pub fn write(id: u64, val: u64) -> Result<(), i64> {
     if val > u64::MAX - 1 - slot.counter {
         return Err(-27); // EFBIG
     }
+    // A write that takes the counter from 0 to non-zero is a fresh
+    // not-ready→ready edge: bump the rise generation so an edge-triggered
+    // epoll watch that already delivered the previous rise (and was drained to
+    // 0 since) re-arms.  A write that only grows an already-non-zero counter
+    // is NOT a new edge (the fd was continuously ready), so the generation is
+    // left untouched — matching `EPOLLET` "deliver only on changes" semantics.
+    let was_zero = slot.counter == 0;
     slot.counter += val;
+    if was_zero && val > 0 {
+        slot.rise_seq = slot.rise_seq.wrapping_add(1);
+    }
     Ok(())
 }
 

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -366,6 +366,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "proc-tree"      => op_proc_tree(req, out),
         "fd-table"       => op_fd_table(req, out),
         "fd-map"         => op_fd_map(req, out),
+        "epoll-watch"    => op_epoll_watch(req, out),
         "syscall-trend"  => op_syscall_trend(req, out),
         "vfs-mounts"     => op_vfs_mounts(out),
         "dmesg"          => op_dmesg(req, out),
@@ -1881,6 +1882,139 @@ fn op_fd_table(req: &str, out: &mut String) {
     if rows.len() > 256 {
         out.push_str(r#","truncated":true"#);
     }
+    out.push('}');
+}
+
+// ── epoll-watch ────────────────────────────────────────────────────────────
+//
+// Per-process epoll introspection: for every epoll instance owned by the pid,
+// dump each registered watch with its interest mask, the EPOLLET edge-trigger
+// flag, the recorded `last_ready` edge state, and the LIVE computed readiness
+// level of the target fd.  For an eventfd target the slot counter is included.
+//
+// This makes the edge-trigger contract directly observable: an EPOLLET watch
+// is "edge-suppressed" when its target currently asserts a non-zero level but
+// `level & !last_ready == 0` (no newly-asserted bit), i.e. epoll_wait will NOT
+// deliver it even though the fd is ready.  Per epoll(7) ("Level-triggered and
+// edge-triggered notification") that is correct ONLY if the level never
+// dropped-then-rose since the last delivery; if it did, the edge was lost.
+fn op_epoll_watch(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let pid = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(p) => p,
+        None => { out.push_str(r#"{"error":"missing or bad 'pid'"}"#); return; }
+    };
+
+    // One epoll watch, snapshotted under the PROCESS_TABLE lock.  The live
+    // readiness level is computed AFTER the lock is dropped, because
+    // `epoll_poll_events` itself acquires PROCESS_TABLE (would deadlock).
+    struct WatchSnap {
+        inst_id:    u64,
+        epfd:       usize,
+        watch_fd:   usize,
+        events:     u32,
+        last_ready: u32,
+        et_rise:    u64,
+        is_eventfd: bool,
+        evfd_inode: u64,
+    }
+
+    let snaps: Option<Vec<WatchSnap>> = match try_lock_brief(&PROCESS_TABLE) {
+        Some(g) => g.iter().find(|p| p.pid == pid).map(|p| {
+            let mut v: Vec<WatchSnap> = Vec::new();
+            for inst in p.epoll_sets.iter() {
+                for w in inst.watches.iter() {
+                    // Resolve whether the watched fd is an eventfd so the
+                    // caller can correlate the asserted level with a stuck
+                    // counter (the libevent notify-eventfd is the suspect).
+                    let (is_eventfd, evfd_inode) = p.file_descriptors
+                        .get(w.fd)
+                        .and_then(|f| f.as_ref())
+                        .map(|f| (matches!(f.file_type, crate::vfs::FileType::EventFd), f.inode))
+                        .unwrap_or((false, 0));
+                    v.push(WatchSnap {
+                        inst_id:    inst.id,
+                        epfd:       inst.epfd,
+                        watch_fd:   w.fd,
+                        events:     w.events,
+                        last_ready: w.last_ready,
+                        et_rise:    w.et_rise,
+                        is_eventfd,
+                        evfd_inode,
+                    });
+                }
+            }
+            v
+        }),
+        None => {
+            out.push_str(r#"{"busy":"PROCESS_TABLE held","instances":[]}"#);
+            return;
+        }
+    };
+
+    let snaps = match snaps {
+        Some(s) => s,
+        None => { let _ = write!(out, r#"{{"error":"pid {} not found"}}"#, pid); return; }
+    };
+
+    const EPOLLET: u32 = 1 << 31;
+
+    out.push('{');
+    j_kv(out, "pid", &alloc::format!("{}", pid));
+    j_kv(out, "watch_count", &alloc::format!("{}", snaps.len()));
+    j_str(out, "watches"); out.push(':'); out.push('[');
+    for (i, s) in snaps.iter().take(512).enumerate() {
+        if i > 0 { out.push(','); }
+        // Lock-free live reads (PROCESS_TABLE already dropped).
+        let live_level = crate::subsys::linux::syscall::epoll_poll_events(pid, s.watch_fd);
+        const EPOLLIN: u32 = 0x0001;
+        let is_et = s.events & EPOLLET != 0;
+        // The subscribed-and-asserted level, as sys_epoll_wait computes it.
+        let asserted = s.events & live_level;
+        // Live readiness-rise generation for an eventfd source (0 otherwise).
+        let (evfd_counter, rise_seq) = if s.is_eventfd {
+            (crate::ipc::eventfd::peek_counter(s.evfd_inode),
+             crate::ipc::eventfd::rise_seq(s.evfd_inode).unwrap_or(0))
+        } else { (None, 0) };
+        // For an EPOLLET watch, the bits epoll_wait would DELIVER right now —
+        // mirrors the kernel `watch_events`: level-diff PLUS a re-armed EPOLLIN
+        // when the source posted a fresh 0→ready rise the epoll never observed
+        // at level 0 (rise_seq != et_rise).
+        let deliverable = if is_et {
+            let mut d = asserted & !s.last_ready;
+            if s.is_eventfd && rise_seq != s.et_rise && (asserted & EPOLLIN) != 0 {
+                d |= EPOLLIN;
+            }
+            d
+        } else { asserted };
+        // "edge-suppressed" = ET watch, fd currently ready, but nothing new to
+        // deliver (the residual-gap fingerprint — should be FALSE post-fix when
+        // a genuine drain-then-rise occurred).
+        let edge_suppressed = is_et && asserted != 0 && deliverable == 0;
+
+        out.push('{');
+        j_kv(out, "inst_id",  &alloc::format!("{}", s.inst_id));
+        j_kv(out, "epfd",     &alloc::format!("{}", s.epfd));
+        j_kv(out, "fd",       &alloc::format!("{}", s.watch_fd));
+        j_str(out, "events");      out.push(':'); j_hex(out, s.events as u64); out.push(',');
+        j_kv(out, "et",       if is_et { "true" } else { "false" });
+        j_str(out, "last_ready");  out.push(':'); j_hex(out, s.last_ready as u64); out.push(',');
+        j_str(out, "live_level");  out.push(':'); j_hex(out, live_level as u64); out.push(',');
+        j_str(out, "asserted");    out.push(':'); j_hex(out, asserted as u64); out.push(',');
+        j_str(out, "deliverable"); out.push(':'); j_hex(out, deliverable as u64); out.push(',');
+        j_kv(out, "is_eventfd", if s.is_eventfd { "true" } else { "false" });
+        match evfd_counter {
+            Some(c) => j_kv(out, "evfd_counter", &alloc::format!("{}", c)),
+            None    => j_kv_str(out, "evfd_counter", "n/a"),
+        }
+        j_kv(out, "rise_seq", &alloc::format!("{}", rise_seq));
+        j_kv(out, "et_rise",  &alloc::format!("{}", s.et_rise));
+        j_kv(out, "edge_suppressed", if edge_suppressed { "true" } else { "false" });
+        j_trim_comma(out);
+        out.push('}');
+    }
+    out.push(']');
+    if snaps.len() > 512 { out.push_str(r#","truncated":true"#); }
     out.push('}');
 }
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -10909,14 +10909,21 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // dup'd epoll fds share the inode and thus the same instance.
     // Symmetric with sys_epoll_ctl above; see that block for the full
     // by-id rationale (PIVOT-I2 Phase D, 2026-05-23).
-    // Snapshot tuple: (fd, events-interest, data-cookie, last_ready-edge-state).
+    // Snapshot tuple: (fd, events-interest, data-cookie, last_ready-edge-state,
+    // et_rise-generation, eventfd-slot-id-if-any).
     // `last_ready` is the asserted-interest level most recently DELIVERED for
     // this watch; it is consulted only for EPOLLET watches (events & EPOLLET)
-    // to suppress repeat reports while the readiness level stays high.  The
-    // epoll_id is also captured so the freshly-computed edge levels can be
+    // to suppress repeat reports while the readiness level stays high.
+    // `et_rise` is the readiness-rise generation last delivered for an EPOLLET
+    // watch on a source that exposes one (the eventfd `rise_seq`); it re-arms
+    // the EPOLLIN edge across a drain-then-rise that no `epoll_wait` observed at
+    // level 0.  `evfd_slot` carries the eventfd slot id (FileDescriptor.inode)
+    // when the watched fd is an eventfd, so the live generation can be read
+    // lock-free below; `None` for every other fd type (level-diff governs).
+    // The epoll_id is also captured so the freshly-computed edge state can be
     // committed back to the instance after delivery.
     let epoll_id_for_commit;
-    let watches_snap: alloc::vec::Vec<(usize, u32, u64, u32)> = {
+    let watches_snap: alloc::vec::Vec<(usize, u32, u64, u32, u64, Option<u64>)> = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let proc = match procs.iter().find(|p| p.pid == pid) {
             Some(p) => p,
@@ -10931,10 +10938,16 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
             None    => return -9,
         };
         epoll_id_for_commit = epoll_id;
-        inst.watches.iter().map(|w| (w.fd, w.events, w.data, w.last_ready)).collect()
+        inst.watches.iter().map(|w| {
+            let evfd_slot = proc.file_descriptors.get(w.fd)
+                .and_then(|f| f.as_ref())
+                .filter(|f| matches!(f.file_type, crate::vfs::FileType::EventFd))
+                .map(|f| f.inode);
+            (w.fd, w.events, w.data, w.last_ready, w.et_rise, evfd_slot)
+        }).collect()
     }; // lock released here
 
-    use crate::ipc::epoll::EPOLLET;
+    use crate::ipc::epoll::{EPOLLET, EPOLLIN};
 
     // Compute the deliverable interest mask for one watched fd.
     //
@@ -10960,16 +10973,37 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // exactly once and then suppressed until the level drops and rises again.
     // Level-triggered watches (the default) deliver the full asserted `level`
     // unconditionally, as before.  Returns `(delivered_mask, asserted_level)`.
-    let watch_events = |fd: usize, subscribed: u32, last_ready: u32| -> (u32, u32) {
+    // Returns `(delivered_mask, asserted_level, current_rise_generation)`.
+    // `current_rise` is the eventfd `rise_seq` (0 for sources without one).
+    let watch_events = |fd: usize, subscribed: u32, last_ready: u32,
+                        et_rise: u64, evfd_slot: Option<u64>| -> (u32, u32, u64) {
         let ready_ev = epoll_poll_events(pid, fd);
         let level =
             (subscribed & ready_ev) | (ready_ev & (EPOLLERR | EPOLLHUP));
+        // Live rise generation for sources that expose one (eventfd only here).
+        let current_rise = evfd_slot
+            .and_then(crate::ipc::eventfd::rise_seq)
+            .unwrap_or(0);
         let delivered = if subscribed & EPOLLET != 0 {
-            level & !last_ready
+            // Bits newly asserted by a level change since the last delivery …
+            let mut d = level & !last_ready;
+            // … plus a re-armed EPOLLIN when the source posted a fresh
+            // 0→ready rise (a generation bump) that no `epoll_wait` observed at
+            // level 0 — the drain-then-rise-between-waits edge.  Per `epoll(7)`
+            // every not-ready→ready transition is a distinct edge, independent
+            // of whether `epoll_wait` ran while the fd was drained.  Bounded to
+            // the EPOLLIN bit and only when it is currently subscribed-asserted.
+            if evfd_slot.is_some()
+                && current_rise != et_rise
+                && (level & EPOLLIN) != 0
+            {
+                d |= EPOLLIN;
+            }
+            d
         } else {
             level
         };
-        (delivered, level)
+        (delivered, level, current_rise)
     };
 
     // ── Step 2: poll without holding the lock ────────────────────────────────
@@ -10979,9 +11013,10 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // on the instance and safe to call repeatedly in the wait loop.
     let do_poll = |fired: &mut alloc::vec::Vec<EpollEvent>| {
         fired.clear();
-        for &(fd, subscribed, data, last_ready) in &watches_snap {
+        for &(fd, subscribed, data, last_ready, et_rise, evfd_slot) in &watches_snap {
             if fired.len() >= maxevents { break; }
-            let (delivered, _level) = watch_events(fd, subscribed, last_ready);
+            let (delivered, _level, _rise) =
+                watch_events(fd, subscribed, last_ready, et_rise, evfd_slot);
             if delivered != 0 {
                 fired.push(EpollEvent { events: delivered, data });
             }
@@ -10997,8 +11032,9 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // after its single delivery must NOT keep the waiter awake (which would
     // reproduce the busy-spin); `delivered == 0` for such a watch parks us.
     let probe_ready = || -> bool {
-        for &(fd, subscribed, _data, last_ready) in &watches_snap {
-            let (delivered, _level) = watch_events(fd, subscribed, last_ready);
+        for &(fd, subscribed, _data, last_ready, et_rise, evfd_slot) in &watches_snap {
+            let (delivered, _level, _rise) =
+                watch_events(fd, subscribed, last_ready, et_rise, evfd_slot);
             if delivered != 0 { return true; }
         }
         false
@@ -11098,11 +11134,12 @@ fn sys_epoll_wait(epfd: usize, events_ptr: u64, maxevents: usize, timeout_ms: i3
     // write the results back into the instance under a single brief lock hold.
     // Level-triggered watches are never touched (their `last_ready` is unused).
     {
-        let mut et_levels: alloc::vec::Vec<(usize, u32)> = alloc::vec::Vec::new();
-        for &(fd, subscribed, _data, last_ready) in &watches_snap {
+        let mut et_levels: alloc::vec::Vec<(usize, u32, u64)> = alloc::vec::Vec::new();
+        for &(fd, subscribed, _data, last_ready, et_rise, evfd_slot) in &watches_snap {
             if subscribed & EPOLLET != 0 {
-                let (_delivered, level) = watch_events(fd, subscribed, last_ready);
-                et_levels.push((fd, level));
+                let (_delivered, level, rise) =
+                    watch_events(fd, subscribed, last_ready, et_rise, evfd_slot);
+                et_levels.push((fd, level, rise));
             }
         }
         if !et_levels.is_empty() {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2851,6 +2851,17 @@ pub fn run() -> ! {
     total += 1;
     if test_305_epoll_edge_trigger() { passed += 1; }
 
+    // ── Test 307: EPOLLET re-arm across a drain-then-rise BETWEEN epoll_waits ─
+    // The residual edge-suppression gap (a documented follow-up to the
+    // EPOLLET edge-trigger work in Test 305): if an eventfd is drained to 0
+    // and re-raised entirely between two epoll_wait calls (no call observes
+    // the intermediate level==0), a level-diff-only kernel suppresses the
+    // genuine new edge.  The eventfd rise-generation must re-arm EPOLLIN
+    // regardless of epoll_wait timing.
+    // Refs: epoll(7) ("delivers events only when changes occur"), eventfd(2).
+    total += 1;
+    if test_307_epoll_et_rearm_between_waits() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -16772,6 +16783,120 @@ fn test_305_epoll_edge_trigger() -> bool {
     }
 
     if ok { test_pass!("epoll EPOLLET edge-trigger semantics (Test 305)"); }
+    ok
+}
+
+// ── Test 307: EPOLLET re-arm across a drain-then-rise between epoll_waits ─────
+//
+// Per `epoll(7)` ("Level-triggered and edge-triggered notification"): an
+// edge-triggered watch "delivers events only when changes occur on the
+// monitored file descriptor"; each not-ready→ready transition is a distinct
+// edge that MUST be reported, independent of whether `epoll_wait` ran while the
+// fd was drained.
+//
+// Test 305 covers the case where a poll observes the drained level-0 state
+// between the drain and the re-write (the level-diff alone re-arms).  THIS test
+// covers the residual case the level-diff cannot see: the eventfd is drained to
+// 0 and re-raised entirely BETWEEN two `epoll_wait` calls, with NO intervening
+// call to observe level==0.  The asserted level is identical (EPOLLIN) at both
+// observations, so `level & !last_ready == 0`; only the readiness-rise
+// generation distinguishes the fresh edge.  A kernel without that generation
+// suppresses the edge (got 0).  Refs: epoll(7), eventfd(2).
+fn test_307_epoll_et_rearm_between_waits() -> bool {
+    test_header!("EPOLLET re-arm across drain-then-rise between epoll_waits (Test 307)");
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+    let pid = crate::proc::current_pid();
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = true;
+            p.subsystem = crate::win32::SubsystemType::Linux;
+        }
+    }
+
+    fn make_ev(events: u32, data: u64) -> [u8; 12] {
+        let mut b = [0u8; 12];
+        b[0..4].copy_from_slice(&events.to_le_bytes());
+        b[4..12].copy_from_slice(&data.to_le_bytes());
+        b
+    }
+
+    const EPOLLIN: u32 = 0x0001;
+    const EPOLLET: u32 = 1 << 31;
+    const CTL_ADD: u64 = 1;
+    const EFD_NONBLOCK: u64 = 0x0800;
+
+    let mut ok = true;
+
+    let wait_once = |epfd: u64| -> i64 {
+        let mut buf = [[0u8; 12]; 4];
+        dispatch(232, epfd, buf[0].as_mut_ptr() as u64, 4, 0, 0, 0)
+    };
+
+    let efd = dispatch(290 /*eventfd2*/, 0, EFD_NONBLOCK, 0, 0, 0, 0);
+    let epfd = dispatch(291 /*epoll_create1*/, 0, 0, 0, 0, 0, 0);
+    if efd < 0 || epfd < 0 {
+        test_fail!("307 setup", "eventfd={} epoll_create1={}", efd, epfd);
+        ok = false;
+    } else {
+        let (efd, epfd) = (efd as u64, epfd as u64);
+        let one: u64 = 1;
+
+        // Register EPOLLET | EPOLLIN.
+        let ev = make_ev(EPOLLIN | EPOLLET, efd);
+        let r = dispatch(233 /*epoll_ctl*/, epfd, CTL_ADD, efd, ev.as_ptr() as u64, 0, 0);
+        if r != 0 { test_fail!("307 add", "epoll_ctl ADD = {}", r); ok = false; }
+
+        // Rise #1: write 1 (0→ready).  First poll delivers the edge once.
+        let _ = dispatch(1 /*write*/, efd, &one as *const u64 as u64, 8, 0, 0, 0);
+        let r1 = wait_once(epfd);
+        if r1 != 1 { test_fail!("307 first", "expected 1, got {}", r1); ok = false; }
+        else { test_println!("  (a) rise #1 delivered once ✓"); }
+
+        // Persistently-ready suppression still holds (sanity vs Test 305).
+        let r2 = wait_once(epfd);
+        if r2 != 0 { test_fail!("307 suppress", "expected 0 (stays-ready), got {}", r2); ok = false; }
+        else { test_println!("  (b) stays-ready suppressed ✓"); }
+
+        // ── THE RESIDUAL GAP ── drain to 0 and re-raise with NO intervening
+        // epoll_wait observing level==0:
+        //   read(efd)  → counter 1→0 (level drops, but no poll sees it)
+        //   write(efd) → counter 0→1 (fresh 0→ready edge, generation bumps)
+        let mut rbuf = [0u8; 8];
+        let rd = dispatch(0 /*read*/, efd, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+        if rd != 8 { test_fail!("307 drain", "read returned {}", rd); ok = false; }
+        let _ = dispatch(1 /*write*/, efd, &one as *const u64 as u64, 8, 0, 0, 0);
+
+        // The next poll is the FIRST epoll_wait since rise #1.  It must report
+        // the fresh edge (rise #2).  A level-diff-only kernel returns 0 here
+        // because last_ready==EPOLLIN and the asserted level is again EPOLLIN.
+        let r3 = wait_once(epfd);
+        if r3 != 1 {
+            test_fail!("307 rearm-between-waits",
+                "drain+rise between two epoll_waits did NOT re-arm the EPOLLET edge \
+                 (got {} events, expected 1) — the suppressed-edge residual gap \
+                 (the windowed-Firefox -url busy-spin)", r3);
+            ok = false;
+        } else { test_println!("  (c) drain+rise BETWEEN waits re-armed ✓"); }
+
+        // And it is then suppressed again until the next genuine transition.
+        let r4 = wait_once(epfd);
+        if r4 != 0 { test_fail!("307 resuppress", "expected 0 after re-delivery, got {}", r4); ok = false; }
+        else { test_println!("  (d) re-suppressed after re-delivery ✓"); }
+
+        let _ = crate::vfs::close(pid, epfd as usize);
+        let _ = crate::vfs::close(pid, efd as usize);
+    }
+
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = false;
+            p.subsystem = crate::win32::SubsystemType::Aether;
+        }
+    }
+
+    if ok { test_pass!("EPOLLET re-arm across drain-then-rise between epoll_waits (Test 307)"); }
     ok
 }
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7006,6 +7006,13 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
     if op == "fd-table":
         if not rest: raise ValueError("fd-table requires <pid>")
         return {"op": "fd-table", "pid": int(rest[0], 0)}
+    if op == "epoll-watch":
+        # Per-process epoll introspection: dump each watch's interest mask,
+        # EPOLLET flag, last_ready edge state, live readiness level, and
+        # (for eventfd targets) the slot counter — plus an "edge_suppressed"
+        # fingerprint for the EPOLLET drop-then-rise residual gap.
+        if not rest: raise ValueError("epoll-watch requires <pid>")
+        return {"op": "epoll-watch", "pid": int(rest[0], 0)}
     if op == "fd-map":
         pid = int(rest[0], 0) if rest else 0  # 0 = all processes
         req: dict = {"op": "fd-map"}
@@ -12766,6 +12773,7 @@ def main():
     p_kdb.add_argument("sid")
     p_kdb.add_argument("op", choices=[
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
+        "epoll-watch",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "uread", "trace-status",
         "bell-stats", "cache-audit", "cache-aliasing", "fault-cache-keys",


### PR DESCRIPTION
## Summary

The EPOLLET edge-trigger support added in the prior epoll work (Test 305) re-armed an edge only when an `epoll_wait` observed the target fd's asserted level drop to 0 between two calls. Per **epoll(7)** ("Level-triggered and edge-triggered notification"), each not-ready → ready transition is a distinct edge that must be reported regardless of `epoll_wait` timing.

The level-diff alone cannot see a **drain-then-rise that happens entirely between two `epoll_wait` calls**: no call observes the intermediate `level==0`, so the asserted level is identical at both observations and `level & !last_ready == 0` suppresses the genuine new edge. (This is the documented residual follow-up to the EPOLLET edge-trigger work.)

## Fix

Record the `0 → non-zero` crossing at the readiness source:

- **eventfd** (`eventfd(2)`) carries a monotonic `rise_seq` generation, bumped on every counter `0 → non-zero` transition, never on a write that only grows an already-non-zero counter.
- An EPOLLET epoll watch records the generation it last delivered (`et_rise`); `sys_epoll_wait` re-arms the EPOLLIN edge whenever the live generation differs from the recorded one, even when the asserted level looks continuously high.

This is the canonical epoll ready-list / wakeup-callback contract: the 0-crossing is captured when readiness rises, not only when an `epoll_wait` happens to observe the drained state. Sources without a rise generation report 0, so the existing level-diff behaviour governs them unchanged; level-triggered watches are unaffected.

## Diagnostic tooling

Adds a kdb `epoll-watch <pid>` op (and harness wiring) that dumps, per epoll instance owned by a pid: each watch's interest mask, the EPOLLET flag, the recorded `last_ready`/`et_rise` edge state, the live computed readiness level of the target fd, and (for eventfd targets) the slot counter + `rise_seq`, plus an `edge_suppressed` fingerprint. This makes the edge-trigger contract directly observable from the harness. The live level is computed after the process-table lock is dropped (the readiness poll re-acquires it).

## Test

**Test 307** (test-mode) exercises the residual gap directly: an eventfd is drained to 0 and re-raised entirely between two `epoll_wait` calls with no intervening level-0 observation, asserting the EPOLLIN edge re-fires exactly once and is then re-suppressed while it stays ready. Test 305's persistently-ready suppression is reasserted as a sanity check.

## Scope note

This closes a documented edge-trigger correctness gap and adds reusable diagnostics; it does **not** by itself unblock any specific application gate. Level-triggered watches (the X11/pipe/socket default) are unchanged.

Refs: epoll(7), eventfd(2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
