### PR TITLE
net/dns: bound DNS name decompression to defeat compression-pointer loops (CWE-835)

### DIFF
--- a/kernel/src/net/dns.rs
+++ b/kernel/src/net/dns.rs
@@ -180,11 +180,46 @@ fn parse_response(data: &[u8], expected_id: u16) -> Option<Ipv4Address> {
     None
 }
 
+/// Maximum length of a domain name, in octets, including label-length octets
+/// (RFC 1035 §3.1: "the total length of a domain name (i.e., label octets and
+/// label length octets) is restricted to 255 octets or less").  Used to bound
+/// the bytes a single name may consume so a maliciously long or looping label
+/// run cannot run away.
+const MAX_DNS_NAME_LEN: usize = 255;
+
 /// Skip a DNS name in the packet (handles compression pointers).
 /// Returns the new offset after the name.
+///
+/// A DNS name is a sequence of length-prefixed labels terminated by a
+/// zero-length label, optionally truncated by a compression pointer
+/// (RFC 1035 §4.1.4).  A compression pointer is a two-octet field whose two
+/// high bits are set; the remaining 14 bits give an offset, from the start of
+/// the message, of a prior occurrence of the (suffix of the) name.
+///
+/// RFC 1035 §4.1.4 specifies that a pointer references a *prior* occurrence,
+/// so a well-formed pointer always targets an offset strictly less than the
+/// field that holds it.  A malformed or hostile response can encode pointer
+/// cycles (A→B→A, or a self-pointer) or a forward chain that never
+/// terminates, which would loop a naive parser forever (CWE-835).  This
+/// routine bounds the parse against that:
+///   * every followed pointer must point **strictly backward** (target offset
+///     < the offset of the pointer field), which makes the followed offsets
+///     strictly decreasing and therefore loop-free;
+///   * the number of pointer jumps is capped (belt-and-suspenders: even a
+///     non-monotonic encoding cannot exceed the message length in jumps);
+///   * the total name length walked is bounded to `MAX_DNS_NAME_LEN`.
+/// Any violation returns `None` (the response is treated as malformed) rather
+/// than looping or over-reading.
 fn skip_dns_name(data: &[u8], mut offset: usize) -> Option<usize> {
     let mut jumped = false;
     let mut result_offset = 0usize;
+    // Cap pointer follows by the message length: a message holds at most
+    // data.len()/2 distinct two-octet pointers, so no legitimate name needs
+    // more jumps than that.  Combined with the strictly-backward check below
+    // this is redundant, but it bounds even a pathological implementation slip.
+    let mut jumps_left = data.len() / 2 + 1;
+    // Bound the total name length walked across all labels (RFC 1035 §3.1).
+    let mut name_len = 0usize;
 
     loop {
         if offset >= data.len() { return None; }
@@ -196,21 +231,43 @@ fn skip_dns_name(data: &[u8], mut offset: usize) -> Option<usize> {
         }
 
         if len & 0xC0 == 0xC0 {
-            // Compression pointer (2 bytes)
+            // Compression pointer (2 bytes).  Record the position just past
+            // the pointer the *first* time we jump — that is where the name
+            // ends in the on-the-wire stream the caller is walking.
             if !jumped {
                 result_offset = offset + 2;
             }
             if offset + 1 >= data.len() { return None; }
             let ptr = ((len & 0x3F) << 8) | data[offset + 1] as usize;
+            // RFC 1035 §4.1.4: a pointer references a *prior* occurrence, so
+            // it must point strictly backward.  Reject self-pointers and
+            // forward/cyclic pointers — the followed offsets are then strictly
+            // decreasing and cannot loop.
+            if ptr >= offset { return None; }
+            // Belt-and-suspenders bound on the number of follows.
+            if jumps_left == 0 { return None; }
+            jumps_left -= 1;
             offset = ptr;
             jumped = true;
             continue;
         }
 
+        // Ordinary label: 1 length octet + `len` label octets.  Bound the
+        // accumulated name length (RFC 1035 §3.1).
+        name_len += len + 1;
+        if name_len > MAX_DNS_NAME_LEN { return None; }
         offset += 1 + len;
     }
 
     Some(if jumped { result_offset } else { offset })
+}
+
+/// Test-only re-export of [`skip_dns_name`] for the in-kernel test suite
+/// (`kernel/src/test_runner.rs` Test 520, the compression-pointer loop-guard
+/// regression).  Not exposed in any production build.
+#[cfg(feature = "test-mode")]
+pub fn test_only_skip_dns_name(data: &[u8], offset: usize) -> Option<usize> {
+    skip_dns_name(data, offset)
 }
 
 /// Resolve a hostname to an IPv6 address (AAAA record).

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2862,6 +2862,17 @@ pub fn run() -> ! {
     total += 1;
     if test_307_epoll_et_rearm_between_waits() { passed += 1; }
 
+    // ── Test 520: DNS name decompression compression-pointer loop guard ──
+    // A DNS response can encode a compression-pointer cycle (A→B→A or a
+    // self-pointer) or an unterminated forward chain.  A naive name parser
+    // follows pointers forever and hangs the kernel (CWE-835).  The skip
+    // routine must bound the parse — rejecting non-backward / cyclic pointers
+    // and capping the walked name length — while still resolving a legitimate
+    // backward compression pointer.  Refs: RFC 1035 §4.1.4 (message
+    // compression), §3.1 (255-octet name limit).
+    total += 1;
+    if test_520_dns_decompress_loop_guard() { passed += 1; }
+
     // ── Test 283: stack-prov main-stack TOP-window argv-writer capture ──
     // GATE-A blind-spot closure (2026-05-30).  Only built when the
     // `stack-prov` diagnostic feature is on (CI smoke does not enable it);
@@ -16897,6 +16908,127 @@ fn test_307_epoll_et_rearm_between_waits() -> bool {
     }
 
     if ok { test_pass!("EPOLLET re-arm across drain-then-rise between epoll_waits (Test 307)"); }
+    ok
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 520: DNS name decompression compression-pointer loop guard (CWE-835)
+//
+// `skip_dns_name` walks a DNS name, following compression pointers
+// (RFC 1035 §4.1.4: a two-octet field with the two high bits set, the low 14
+// bits an offset from the start of the message to a prior occurrence).  A
+// hostile or corrupt response can encode a pointer cycle (A→B→A, or a
+// self-pointer) or a never-terminating chain; an unguarded parser loops
+// forever and hangs the kernel.  The skip routine must bound the parse —
+// rejecting non-backward / cyclic pointers — while still resolving a
+// legitimate backward compression pointer.
+//
+// This test is self-contained (constructs raw DNS message buffers in memory,
+// no network).  The decisive property is that the malformed cases *return* at
+// all: if the guard were missing the kernel would hang here.
+// Refs: RFC 1035 §4.1.4 (message compression), §3.1 (255-octet name limit).
+// ─────────────────────────────────────────────────────────────────────────────
+fn test_520_dns_decompress_loop_guard() -> bool {
+    test_header!("DNS decompression compression-pointer loop guard (CWE-835)");
+    let mut ok = true;
+
+    // ── Case 1: self-referential pointer at the very start ───────────────
+    // A 12-byte header followed by a pointer at offset 12 that points to
+    // offset 12 (itself).  An unguarded parser loops forever; the guard must
+    // reject it (not a strictly-backward target) and return None.
+    {
+        let mut msg = [0u8; 16];
+        // offset 12,13: pointer 0xC0 0x0C → target offset 12 == self.
+        msg[12] = 0xC0;
+        msg[13] = 0x0C;
+        let r = crate::net::dns::test_only_skip_dns_name(&msg, 12);
+        if r.is_some() {
+            test_fail!("DNS decompress loop guard",
+                "self-pointer at offset 12 returned {:?}, expected None (cycle)", r);
+            ok = false;
+        } else {
+            test_println!("  self-pointer (12→12) rejected (None) ✓");
+        }
+    }
+
+    // ── Case 2: two-pointer cycle A→B→A ──────────────────────────────────
+    // Pointer at offset 12 → offset 14; pointer at offset 14 → offset 12.
+    // Each individually is a pointer; together they form a 2-cycle.  The
+    // strictly-backward rule breaks the cycle: 14→12 is backward but 12→14 is
+    // forward, so following from offset 12 hits a forward pointer and is
+    // rejected.  The decisive property is that this returns rather than
+    // looping forever.
+    {
+        let mut msg = [0u8; 16];
+        msg[12] = 0xC0; msg[13] = 0x0E; // offset 12 → 14
+        msg[14] = 0xC0; msg[15] = 0x0C; // offset 14 → 12
+        let r = crate::net::dns::test_only_skip_dns_name(&msg, 12);
+        if r.is_some() {
+            test_fail!("DNS decompress loop guard",
+                "A→B→A cycle from offset 12 returned {:?}, expected None", r);
+            ok = false;
+        } else {
+            test_println!("  2-pointer cycle (12→14→12) rejected (None) ✓");
+        }
+    }
+
+    // ── Case 3: forward pointer (must be rejected per RFC 1035 §4.1.4) ────
+    // A pointer that targets a *later* offset violates the prior-occurrence
+    // guarantee and is the building block of forward loops.
+    {
+        let mut msg = [0u8; 24];
+        msg[12] = 0xC0; msg[13] = 0x14; // offset 12 → 20 (forward)
+        let r = crate::net::dns::test_only_skip_dns_name(&msg, 12);
+        if r.is_some() {
+            test_fail!("DNS decompress loop guard",
+                "forward pointer (12→20) returned {:?}, expected None", r);
+            ok = false;
+        } else {
+            test_println!("  forward pointer (12→20) rejected (None) ✓");
+        }
+    }
+
+    // ── Case 4 (positive): a legitimate BACKWARD pointer still resolves ──
+    // Lay down a real name "ns" (label len 2, 'n','s', then root 0x00) at
+    // offset 12.  Then at offset 17 place a pointer 0xC0 0x0C → offset 12.
+    // Skipping the name *at offset 17* must follow the backward pointer,
+    // resolve the prior name, and return the offset just past the pointer
+    // (17 + 2 = 19) — the on-the-wire continuation point.
+    {
+        let mut msg = [0u8; 24];
+        // Name at 12: "ns" root.
+        msg[12] = 2; msg[13] = b'n'; msg[14] = b's'; msg[15] = 0x00;
+        // Pointer at 17 → 12.
+        msg[17] = 0xC0; msg[18] = 0x0C;
+        let r = crate::net::dns::test_only_skip_dns_name(&msg, 17);
+        if r != Some(19) {
+            test_fail!("DNS decompress loop guard",
+                "legit backward pointer at 17→12 returned {:?}, expected Some(19)", r);
+            ok = false;
+        } else {
+            test_println!("  legit backward pointer (17→12) resolved → 19 ✓");
+        }
+    }
+
+    // ── Case 5 (positive): an uncompressed name resolves to its end ──────
+    // Name "ns" root at offset 12 occupies bytes 12..16; skipping from 12 must
+    // return 16 (one past the root label).
+    {
+        let mut msg = [0u8; 24];
+        msg[12] = 2; msg[13] = b'n'; msg[14] = b's'; msg[15] = 0x00;
+        let r = crate::net::dns::test_only_skip_dns_name(&msg, 12);
+        if r != Some(16) {
+            test_fail!("DNS decompress loop guard",
+                "uncompressed name at 12 returned {:?}, expected Some(16)", r);
+            ok = false;
+        } else {
+            test_println!("  uncompressed name (12) resolved → 16 ✓");
+        }
+    }
+
+    if ok {
+        test_pass!("DNS decompression compression-pointer loop guard (Test 520)");
+    }
     ok
 }
 


### PR DESCRIPTION
## Summary

`skip_dns_name` (in `kernel/src/net/dns.rs`) followed DNS compression pointers with no termination guard. A malformed or hostile DNS response that encodes a pointer **cycle** (A→B→A, or a self-pointer) or a never-terminating **forward chain** made the parser loop forever, hanging the kernel on the DNS receive path — a live uncontrolled-resource-consumption defect (**CWE-835**).

## Fix

Per RFC 1035 §4.1.4, a compression pointer references a *prior* occurrence of the name, so a well-formed pointer always targets an offset strictly less than the field that holds it. The parse is now bounded with belt-and-suspenders guards:

- **Strictly-backward**: every followed pointer must point to an offset `<` the offset of the pointer field. The followed offsets are then strictly decreasing and cannot cycle — this alone defeats self-pointers and A→B→A cycles and rejects forward pointers.
- **Jump cap**: the number of pointer follows is capped by the message length, bounding even a pathological non-monotonic encoding.
- **Name-length bound**: the total walked name length is bounded to 255 octets (RFC 1035 §3.1).

Any violation returns `None` (the response is treated as malformed) instead of looping or over-reading. Legitimate single/multi-pointer backward compression is unaffected.

## Test

Adds **Test 520** (`test-mode`) to `kernel/src/test_runner.rs`, self-contained (no network):

- self-pointer (12→12) → rejected
- A→B→A 2-cycle (12→14→12) → rejected
- forward pointer (12→20) → rejected
- legitimate backward pointer (17→12) → resolves correctly
- uncompressed name → resolves to its end

The malformed cases' decisive property is that they *return at all*; without the guard the kernel would hang in the test. Exercised via a `#[cfg(feature = "test-mode")]` test-only re-export of the private skip routine.

## Refs

RFC 1035 §4.1.4 (message compression), §3.1 (255-octet domain name limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
