### PR TITLE
net/udp: bound per-port receive queue + VecDeque for O(1) dequeue (rx-flood DoS)

### DIFF
--- a/kernel/src/net/udp.rs
+++ b/kernel/src/net/udp.rs
@@ -4,6 +4,7 @@
 
 extern crate alloc;
 
+use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::Mutex;
@@ -21,6 +22,33 @@ static UDP_RX_BAD_CSUM: AtomicU64 = AtomicU64::new(0);
 /// Read the running count of UDP RX checksum drops.
 pub fn rx_bad_csum_count() -> u64 {
     UDP_RX_BAD_CSUM.load(Ordering::Relaxed)
+}
+
+/// Maximum number of datagrams a single bound UDP port will buffer before
+/// the receive queue is considered full.  A connectionless socket has no
+/// flow control on the wire (RFC 768) — a peer can transmit faster than
+/// the application drains, and a flood (e.g. a UDP/QUIC reflection storm
+/// aimed at a bound port) would otherwise grow this queue without bound
+/// until the kernel exhausts memory.  POSIX permits a datagram socket to
+/// silently drop received datagrams once its receive buffer is full
+/// (`SO_RCVBUF` semantics); UDP's unreliable contract means the sender
+/// must already tolerate loss.  We therefore cap the per-port depth and
+/// drop the *incoming* datagram on overflow, never evicting a datagram the
+/// application has not yet read.  Sized to absorb a normal request/reply
+/// burst (a DNS resolver's parallel A/AAAA queries, a DHCP exchange)
+/// without spilling.
+const UDP_PORT_QUEUE_CAP: usize = 256;
+
+/// Count of UDP datagrams discarded on receive because the destination
+/// port's receive queue was already at [`UDP_PORT_QUEUE_CAP`].  Exposed
+/// for tests and the stats surface; Relaxed because the counter carries
+/// no synchronisation duty.
+static UDP_RX_QUEUE_FULL: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of UDP RX drops caused by a full per-port
+/// receive queue.
+pub fn rx_queue_full_count() -> u64 {
+    UDP_RX_QUEUE_FULL.load(Ordering::Relaxed)
 }
 
 /// A UDP header (parsed).
@@ -51,9 +79,13 @@ pub struct UdpDatagram {
 }
 
 /// Per-port receive buffer.
+///
+/// `queue` is a `VecDeque` so the common receive path can dequeue from the
+/// front in O(1) (`pop_front`) instead of the O(n) shift a `Vec` incurs on
+/// `remove(0)`, and the enqueue path appends at the back (`push_back`).
 struct UdpBinding {
     port: u16,
-    queue: Vec<UdpDatagram>,
+    queue: VecDeque<UdpDatagram>,
 }
 
 /// Bound UDP ports.
@@ -99,12 +131,25 @@ pub fn handle_udp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
     // Deliver to bound port.
     let mut bindings = UDP_BINDINGS.lock();
     let delivered = if let Some(binding) = bindings.iter_mut().find(|b| b.port == header.dst_port) {
-        binding.queue.push(UdpDatagram {
-            src_ip,
-            src_port: header.src_port,
-            data: Vec::from(payload),
-        });
-        true
+        // Bound but full: the application has not drained the receive
+        // queue and we are already holding `UDP_PORT_QUEUE_CAP` datagrams.
+        // Per POSIX `SO_RCVBUF` semantics a datagram socket may silently
+        // drop the newly-arrived datagram once its buffer is full; UDP's
+        // unreliable contract (RFC 768) means the sender already tolerates
+        // loss.  Dropping the *incoming* datagram (rather than evicting a
+        // queued one) preserves the data the application has yet to read
+        // and bounds memory under a receive flood.
+        if binding.queue.len() >= UDP_PORT_QUEUE_CAP {
+            UDP_RX_QUEUE_FULL.fetch_add(1, Ordering::Relaxed);
+            false
+        } else {
+            binding.queue.push_back(UdpDatagram {
+                src_ip,
+                src_port: header.src_port,
+                data: Vec::from(payload),
+            });
+            true
+        }
     } else {
         false
     };
@@ -146,7 +191,7 @@ pub fn bind(port: u16) -> Result<(), &'static str> {
     }
     bindings.push(UdpBinding {
         port,
-        queue: Vec::new(),
+        queue: VecDeque::new(),
     });
     Ok(())
 }
@@ -156,7 +201,7 @@ pub fn recv(port: u16) -> Option<UdpDatagram> {
     let mut bindings = UDP_BINDINGS.lock();
     if let Some(binding) = bindings.iter_mut().find(|b| b.port == port) {
         if !binding.queue.is_empty() {
-            return Some(binding.queue.remove(0));
+            return binding.queue.pop_front();
         }
     }
     None

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2704,6 +2704,17 @@ pub fn run() -> ! {
         if test_274_udp_connect_auto_bind() { passed += 1; }
     }
 
+    // ── Test 521: UDP per-port receive-queue cap (rx-flood DoS) ───────────
+    // Regression test for the unbounded per-port UDP receive queue: a flood
+    // of datagrams to a bound port grew the queue without limit (memory
+    // exhaustion).  Verifies the per-port depth never exceeds
+    // UDP_PORT_QUEUE_CAP and that overflow drops the *incoming* datagram
+    // (the cap-many earliest survivors are retained, FIFO).
+    // Refs: RFC 768 (UDP, unreliable datagram delivery); POSIX SO_RCVBUF
+    // (datagram socket may drop on a full receive buffer).
+    total += 1;
+    if test_521_udp_queue_cap() { passed += 1; }
+
     // ── Test 277: PT_TLS page refcount initialisation (process-teardown) ──
     // Verifies that each physical frame backing a PT_TLS segment receives
     // refcount = 1 immediately after map_page_in, mirroring the PT_LOAD
@@ -48904,6 +48915,122 @@ fn test_275_pty_syscall_smoke() -> bool {
 
     if ok { test_pass!("PTY syscall smoke — open/ioctl/read/write end-to-end (Test 275)"); }
     ok
+}
+
+// ── Test 521: UDP per-port receive-queue cap (rx-flood DoS) ─────────────────
+//
+// Regression test for the unbounded per-port UDP receive queue.  Incoming
+// datagrams to a bound port were pushed onto a per-port queue with no upper
+// limit, so a UDP/QUIC flood aimed at the port grew the queue without bound
+// until the kernel exhausted memory (a denial-of-service).
+//
+// A connectionless datagram socket has no on-the-wire flow control (RFC 768),
+// so the kernel must bound its own receive buffer and drop excess datagrams.
+// POSIX SO_RCVBUF semantics permit a datagram socket to silently discard a
+// newly-arrived datagram once its receive buffer is full; UDP's unreliable
+// contract means the sender already tolerates loss.  The fix caps the per-port
+// depth at UDP_PORT_QUEUE_CAP and drops the *incoming* datagram on overflow,
+// never evicting an already-queued datagram the application has not yet read.
+//
+// Strategy (self-contained — no real network, no sockets):
+//   1. bind() a fresh port and drain any residue.
+//   2. Build a single cksum-0 (sender opt-out, RFC 768 / RFC 1122 §4.1.3.4)
+//      datagram template whose payload encodes a 1-byte sequence number, so
+//      no per-datagram checksum recompute is needed.
+//   3. Feed (cap + overflow) datagrams through handle_udp() with ascending
+//      sequence numbers.
+//   4. Assert: exactly `overflow` datagrams were counted as queue-full drops,
+//      and recv() yields exactly `cap` datagrams whose sequence numbers are
+//      the first `cap` (0..cap) in FIFO order — i.e. the earliest survivors
+//      are retained and the newest are dropped.
+//
+// Refs: RFC 768 (UDP); RFC 1122 §4.1.3.4 (UDP checksum opt-out);
+// POSIX (IEEE 1003.1) SO_RCVBUF.
+fn test_521_udp_queue_cap() -> bool {
+    test_header!("net: UDP per-port receive-queue cap (RFC 768, SO_RCVBUF)");
+
+    use crate::net::udp;
+    const PORT: u16 = 17521;
+    // Local mirror of the kernel cap; the kernel's UDP_PORT_QUEUE_CAP is
+    // private to net/udp.rs.  Keep these in sync.
+    const CAP: usize = 256;
+    const OVERFLOW: usize = 64;
+
+    if let Err(e) = udp::bind(PORT) {
+        test_fail!("test521", "bind({}) failed: {}", PORT, e);
+        return false;
+    }
+
+    // Drain any pre-existing datagrams on the port.
+    while udp::recv(PORT).is_some() {}
+
+    // Build a cksum-0 datagram template: header (8 bytes) + 1-byte payload.
+    // payload[0] is the sequence number, overwritten per send.
+    let udp_len: u16 = 8 + 1;
+    let mut pkt = alloc::vec::Vec::with_capacity(udp_len as usize);
+    pkt.extend_from_slice(&12345u16.to_be_bytes()); // src port
+    pkt.extend_from_slice(&PORT.to_be_bytes());      // dst port
+    pkt.extend_from_slice(&udp_len.to_be_bytes());   // length
+    pkt.push(0); pkt.push(0);                        // checksum = 0 (opt-out)
+    pkt.push(0);                                     // payload[0] = seq
+
+    let src = [127, 0, 0, 1];
+    let dst = [127, 0, 0, 1];
+
+    // Feed CAP + OVERFLOW datagrams.  Sequence numbers wrap into a u8 but
+    // the first CAP are 0..CAP-1 mod 256 (CAP == 256 → 0..255), which is
+    // exactly the survivor set we assert below.
+    let total_sent = CAP + OVERFLOW;
+    let before_full = udp::rx_queue_full_count();
+    for i in 0..total_sent {
+        pkt[8] = (i & 0xFF) as u8;
+        udp::handle_udp(src, dst, &pkt);
+    }
+    let after_full = udp::rx_queue_full_count();
+
+    // Exactly OVERFLOW datagrams must have been dropped as queue-full.
+    let drops = after_full.wrapping_sub(before_full);
+    test_println!("  sent {} datagrams (cap {}); queue-full drops: {}",
+                  total_sent, CAP, drops);
+    if drops != OVERFLOW as u64 {
+        udp::unbind(PORT);
+        test_fail!("test521",
+            "expected {} queue-full drops, got {}", OVERFLOW, drops);
+        return false;
+    }
+
+    // recv() must yield exactly CAP datagrams — the earliest CAP sent — in
+    // FIFO order.  The queue depth never exceeded the cap.
+    let mut received = 0usize;
+    let mut order_ok = true;
+    while let Some(dg) = udp::recv(PORT) {
+        let expected = (received & 0xFF) as u8;
+        if dg.data.len() != 1 || dg.data[0] != expected {
+            order_ok = false;
+        }
+        received += 1;
+        // Defensive: a broken cap would let this run past CAP forever.
+        if received > CAP + OVERFLOW + 1 {
+            break;
+        }
+    }
+    test_println!("  received {} datagrams; FIFO order ok: {}", received, order_ok);
+
+    udp::unbind(PORT);
+
+    if received != CAP {
+        test_fail!("test521",
+            "queue held {} datagrams, expected exactly cap={}", received, CAP);
+        return false;
+    }
+    if !order_ok {
+        test_fail!("test521",
+            "survivors were not the earliest CAP datagrams in FIFO order");
+        return false;
+    }
+
+    test_pass!("UDP per-port receive-queue cap (RFC 768, SO_RCVBUF)");
+    true
 }
 
 // ── Test 277: PT_TLS page refcount initialisation ───────────────────────────


### PR DESCRIPTION
## Problem

Incoming UDP datagrams were appended to a per-port receive queue (`UdpBinding.queue`) with **no upper bound**. A connectionless datagram socket has no on-the-wire flow control (RFC 768) — a peer can transmit faster than the application drains. A UDP/QUIC flood aimed at a bound port therefore grows the queue without limit until the kernel exhausts memory: a denial-of-service.

This is the same unbounded-receive class as the prior UDP/QUIC flood hardening; this PR closes the per-port-queue instance.

## Fix

- **Cap the per-port depth** at `UDP_PORT_QUEUE_CAP` (256). When the queue is full, drop the *incoming* datagram. POSIX `SO_RCVBUF` semantics permit a datagram socket to silently discard a newly-arrived datagram once its receive buffer is full, and UDP's unreliable contract (RFC 768) means the sender already tolerates loss. Dropping the incoming datagram rather than evicting a queued one preserves the data the application has not yet read.
- **Overflow accounting**: drops are counted in a `Relaxed` atomic exposed via `rx_queue_full_count()` for the stats surface and tests, mirroring the existing `rx_bad_csum_count()`.
- **`Vec` → `VecDeque`**: the receive path now dequeues from the front in O(1) (`pop_front`) instead of the O(n) shift `Vec::remove(0)` incurred; the enqueue path appends at the back (`push_back`). All call sites (struct field, `bind`, `handle_udp`, `recv`) updated consistently.

## Test

**Test 521** (`test_runner.rs`, self-contained — no real network): bind a port, feed `cap + overflow` checksum-0 datagrams through `handle_udp()`, and assert exactly `overflow` queue-full drops occurred and `recv()` yields exactly `cap` datagrams — the earliest `cap` in FIFO order. Uses the loopback-address checksum opt-out (RFC 1122 §4.1.3.4).

## Verification

- `cargo +nightly check --features test-mode` (kernel target): clean, no errors.

## Refs

- RFC 768 — User Datagram Protocol (unreliable datagram delivery)
- RFC 1122 §4.1.3.4 — UDP checksum opt-out
- POSIX (IEEE 1003.1) — `SO_RCVBUF` (datagram socket may drop on a full receive buffer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
