### PR TITLE
net/tcp: ring InetRx poll-bell on RX readiness edges + bell-park recv/accept

### DIFF
--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -673,6 +673,68 @@ pub fn socket_has_data(id: u64) -> bool {
     }
 }
 
+/// True if a `recv(2)` on this socket would return *without blocking* — i.e.
+/// a message/bytes are queued, OR the read side is at end-of-stream (an
+/// orderly EOF, which `recv` reports as a 0-length return).  This is the
+/// readability gate a `poll(2)` caller observes for `POLLIN` per IEEE Std
+/// 1003.1-2017 §poll: "data other than high-priority data may be read", and
+/// a connection on which the peer has performed an orderly shutdown is
+/// reported as readable so the read returns the EOF.
+///
+/// Strictly **non-destructive** — it inspects state only and never dequeues
+/// a datagram or drains the stream buffer, so it is safe to call repeatedly
+/// from a blocking-recv park predicate (unlike [`socket_recv_status`] /
+/// [`socket_recvfrom`], which consume).  It is the data-OR-EOF superset of
+/// [`socket_has_data`] (which reports buffered bytes only): a TCP connection
+/// whose peer FINned with an empty buffer is *not* `has_data` but *is*
+/// `read_ready`, because the next recv returns 0 (RFC 9293 §3.5 / RFC 793
+/// §3.5 orderly close).
+pub fn socket_read_ready(id: u64) -> bool {
+    let sockets = SOCKETS.lock();
+    let sock = match sockets.iter().find(|s| s.id == id) {
+        Some(s) => s,
+        None => return false,
+    };
+    // shutdown(SHUT_RD): every subsequent recv returns 0 (EOF) — always
+    // readable per IEEE 1003.1 §shutdown.
+    if sock.shut_rd { return true; }
+    if !sock.bound { return false; }
+    match sock.socket_type {
+        // UDP is connectionless: an empty queue is never EOF, only
+        // "no datagram yet" (would-block).  Readable iff queued.
+        SocketType::Udp => super::udp::has_data(sock.local_port),
+        SocketType::Tcp => {
+            if sock.connected && sock.remote_port != 0 {
+                // Per-connection: buffered bytes for this 4-tuple, OR the
+                // peer has half-closed (an empty read here returns EOF).
+                if super::tcp::has_data_for(sock.local_port,
+                                            sock.remote_ip,
+                                            sock.remote_port) {
+                    return true;
+                }
+                // Mirror `socket_recv_status`'s peer-FIN EOF classification:
+                // a connection that received the peer's FIN sits in
+                // CloseWait (or has progressed past it); with no buffered
+                // data that is an orderly EOF.  A vanished TCB is also EOF
+                // (the flow is gone — a reader must drain to completion
+                // rather than spin).
+                match super::tcp::get_state(sock.local_port) {
+                    Some(st) => matches!(st,
+                        super::tcp::TcpState::CloseWait
+                        | super::tcp::TcpState::LastAck
+                        | super::tcp::TcpState::TimeWait
+                        | super::tcp::TcpState::Closed),
+                    None => true,
+                }
+            } else {
+                // Listener: readable iff accept(2) would not block.
+                super::tcp::has_data(sock.local_port)
+                    || super::tcp::has_pending_accept(sock.local_port)
+            }
+        }
+    }
+}
+
 /// Close a socket.
 ///
 /// For TCP, the underlying close path depends on whether this socket

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -445,8 +445,22 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
         // on SMP would stall a peer core spinning on the lock across the
         // unbounded transmit.  See `OutSeg`.
         let mut out: Vec<OutSeg> = Vec::new();
-        process_segment(&mut conns[i], &hdr, payload, &mut out);
+        let readiness_edge = process_segment(&mut conns[i], &hdr, payload, &mut out);
         drop(conns);
+        // Ring the poll bell AFTER dropping `TCP_CONNECTIONS` (lock-free,
+        // exactly like the UDP receive path) so a thread parked in
+        // `poll(2)` / `epoll_wait(2)` / `select(2)` / a blocking `recv(2)`
+        // on this socket re-evaluates immediately rather than only on the
+        // 1 s resync floor.  IEEE Std 1003.1-2017 §poll requires a socket
+        // with newly-arrived data — or a peer-FIN that makes a read return
+        // EOF, or a completed handshake that makes `accept(2)` not block —
+        // to report readiness; the bell delivers that edge with sub-second
+        // latency.  Rung before the transmit below so the wake is not
+        // delayed by the (unbounded, I/O-bearing) `send_ipv4` calls.
+        if readiness_edge {
+            crate::ipc::waitlist::ring_poll_bell_for(
+                crate::ipc::waitlist::PollBellSource::InetRx);
+        }
         for o in out {
             super::ipv4::send_ipv4(o.remote_ip, super::ipv4::PROTO_TCP, &o.seg);
         }
@@ -526,9 +540,31 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
 /// Process one segment on an existing connection (lock already held by
 /// caller).  Any reply segments are pushed into `out` for the caller to
 /// transmit *after* releasing the `TCP_CONNECTIONS` lock — see `OutSeg`.
+///
+/// Returns `true` if this segment advanced the connection across a
+/// readiness edge a `poll(2)` / `epoll_wait(2)` / `select(2)` caller cares
+/// about, so the caller can ring the poll bell *after* dropping the
+/// `TCP_CONNECTIONS` lock (the bell is rung lock-free, exactly like the
+/// UDP receive path).  The edges are, per IEEE Std 1003.1-2017 §poll:
+///   * new in-order data delivered into `recv_buffer` → `POLLIN`;
+///   * a state transition the poller observes as readable/writable —
+///     `SynReceived`→`Established` (a listener child completed the
+///     handshake → `accept(2)` will not block), `SynSent`→`Established`
+///     (an active `connect(2)` completed → `POLLOUT`), or any move into a
+///     read-closed state (`CloseWait`/`FinWait2`/`TimeWait`/`Closed`,
+///     peer-FIN → an empty stream read returns 0/EOF → `POLLIN`).
+/// A spurious ring is harmless: the woken poller re-scans its fd set and
+/// re-parks if nothing it watches is ready.
+#[must_use]
 fn process_segment(conn: &mut TcpConnection, hdr: &TcpHeader, payload: &[u8],
-                   out: &mut Vec<OutSeg>) {
+                   out: &mut Vec<OutSeg>) -> bool {
     conn.peer_window = hdr.window as u32;
+
+    // Snapshot the poll-relevant fields before processing so we can detect
+    // a readiness edge by comparison afterwards, rather than threading a
+    // flag through every `match` arm (which is brittle to future edits).
+    let state_before = conn.state;
+    let recv_len_before = conn.recv_buffer.len();
 
     let lp = conn.local_port;
     let rp = conn.remote_port;
@@ -657,6 +693,22 @@ fn process_segment(conn: &mut TcpConnection, hdr: &TcpHeader, payload: &[u8],
 
         _ => {}
     }
+
+    // A readiness edge fired if new data landed in the receive buffer, or
+    // the connection moved into a state a poller observes as readable
+    // (read-closed / accept-pending) or writable (connect completed).
+    // Mirrors the "wake socket sleepers on data ready" discipline: ring on
+    // the data-arrival and read-shutdown edges, not on every segment.
+    let data_arrived = conn.recv_buffer.len() > recv_len_before;
+    let edge_state = state_before != conn.state
+        && matches!(conn.state,
+            TcpState::Established      // 3WHS done: accept(2)/connect(2) ready
+            | TcpState::CloseWait      // peer FIN: empty read → EOF (POLLIN)
+            | TcpState::FinWait2       // our FIN ACKed (no read-closed edge,
+                                       //   but a poller may watch the change)
+            | TcpState::TimeWait       // peer FIN: read-closed
+            | TcpState::Closed);       // connection done: read-closed
+    data_arrived || edge_state
 }
 
 // ── Send path ─────────────────────────────────────────────────────────────────
@@ -1127,7 +1179,9 @@ pub fn test_feed_segment(local_port: u16, remote_ip: Ipv4Address,
         checksum:    0,
     };
     let mut out: Vec<OutSeg> = Vec::new();
-    process_segment(conn, &hdr, payload, &mut out);
+    // The readiness-edge return is irrelevant to this state-inspection
+    // helper (no poller is parked in the in-kernel test path); discard it.
+    let _ = process_segment(conn, &hdr, payload, &mut out);
     Some((conn.state, conn.recv_buffer.len()))
 }
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1863,14 +1863,28 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
 
             // Dequeue one accept-pending child TCB on this listener's
             // local port.  When the pending queue is empty either
-            // block (BLOCKing socket) by yielding until the NIC RX
-            // path drives a fresh child past 3WHS (RFC 793 §3.4), or
+            // block (BLOCKing socket) until the NIC RX path drives a
+            // fresh child past the 3-way handshake (RFC 793 §3.4), or
             // return EAGAIN under SOCK_NONBLOCK / O_NONBLOCK.
             //
-            // The TCP RX advances connection state directly from the
-            // NIC IRQ, so a simple yield+poll loop is sufficient.
-            // `net::poll()` also drains other pending events so we
-            // don't starve sibling sockets.
+            // Blocking accept parks on the global IPC poll bell rather
+            // than spin-yielding at 100 Hz: the TCP receive path rings
+            // `PollBellSource::InetRx` when a listener child completes
+            // the handshake (`SynReceived`→`Established`), waking us
+            // immediately to re-check `has_pending_accept`.  Per IEEE
+            // Std 1003.1-2017 §accept the call blocks until a connection
+            // is present, so the caller deadline is infinite; the bell's
+            // resync floor bounds any (harmless) missed ring.
+            //
+            // Lost-wakeup safety: the `ready_now` predicate
+            // (`has_pending_accept`, side-effect free) re-checks the
+            // *only* condition the InetRx ring covers for this loop — a
+            // child reaching `Established`.  `wait_poll_event` runs that
+            // re-check under the POLL_BELL lock before committing to the
+            // park, so a ring that races the re-check is serialized
+            // behind the bell and cannot be lost.  `take_pending_accept`
+            // (which mutates `accepted`) is only called *after* a
+            // positive observation, never inside the wait predicate.
             let blocking = !(nonblock || fd_nonblock);
             let (peer_ip, peer_port) = loop {
                 if let Some(p) = crate::net::tcp::take_pending_accept(listener_port) {
@@ -1878,8 +1892,17 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 }
                 if !blocking { return -11; } // EAGAIN
                 if signal_pending(pid)       { return -4;  } // EINTR
+                // Pump the NIC RX ring + TCP demux so a freshly-arrived
+                // ACK completing a child's handshake becomes visible,
+                // then park on the bell until InetRx rings (or the
+                // resync floor fires) and re-check.
                 crate::net::poll();
-                crate::sched::yield_cpu();
+                if crate::net::tcp::has_pending_accept(listener_port) {
+                    continue;
+                }
+                crate::ipc::waitlist::wait_poll_event(
+                    u64::MAX,
+                    || crate::net::tcp::has_pending_accept(listener_port));
             };
 
             // Materialise the accept-side socket bound to this 4-tuple.
@@ -2062,21 +2085,53 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                         .unwrap_or(false)
                 };
                 let blocking = !(msg_dontwait || fd_nonblock);
-                // For blocking sockets, yield until the socket has data
+                // For blocking sockets, park until the socket is readable
+                // (data queued OR an orderly EOF the peer's FIN produced)
                 // or the receive deadline fires.  3000 ticks (≈30 s) is
                 // the upper bound — matches SO_RCVTIMEO's POSIX default
                 // (zero = no timeout) cap of "very long" without leaving
                 // a zombie syscall pinning the runner forever.  Most
                 // DNS resolvers retry within 5 s anyway (RFC 1035 §4.2.1).
+                //
+                // Park on the global IPC poll bell rather than spin-
+                // yielding at 100 Hz: the TCP/UDP receive path rings
+                // `PollBellSource::InetRx` on data arrival and on the
+                // peer-FIN read-closed edge, waking us immediately to
+                // re-check.  IEEE Std 1003.1-2017 §recvfrom: a blocking
+                // receive returns when a message is available or the
+                // connection is shut down for reading.
+                //
+                // Lost-wakeup safety: the `ready_now` predicate
+                // `socket_read_ready` re-checks *both* conditions the
+                // InetRx ring covers — buffered bytes AND a stream
+                // peer-FIN/read-closed edge (so a recv that will return 0
+                // wakes promptly instead of stalling to the 30 s floor).
+                // It is strictly NON-DESTRUCTIVE (it does not dequeue a
+                // datagram or drain the stream buffer): the destructive
+                // drain happens only in `socket_recvfrom` below, after a
+                // positive observation — using the consuming
+                // `socket_recv_status` in the predicate would silently
+                // drop a UDP datagram or stream bytes the recv must return.
+                // `wait_poll_event` runs the re-check under the POLL_BELL
+                // lock before parking, so a ring that races the re-check is
+                // serialized behind the bell and cannot be lost.  (The old
+                // `socket_has_data` predicate checked data only and relied
+                // on the 30 s deadline to escape a peer-FIN-with-empty-
+                // buffer EOF; `socket_read_ready` is strictly more
+                // responsive while remaining non-destructive.)
                 if blocking {
                     let deadline = crate::arch::x86_64::irq::get_ticks() + 3000;
-                    while !crate::net::socket::socket_has_data(socket_id) {
+                    loop {
+                        if crate::net::socket::socket_read_ready(socket_id) { break; }
                         if signal_pending(pid) { return -4; } // EINTR
                         crate::net::poll();
+                        if crate::net::socket::socket_read_ready(socket_id) { break; }
                         if crate::arch::x86_64::irq::get_ticks() >= deadline {
                             return -11; // EAGAIN — surfaces as "timed out"
                         }
-                        crate::sched::yield_cpu();
+                        crate::ipc::waitlist::wait_poll_event(
+                            deadline,
+                            || crate::net::socket::socket_read_ready(socket_id));
                     }
                 }
                 match crate::net::socket::socket_recvfrom(socket_id) {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2697,6 +2697,13 @@ pub fn run() -> ! {
         if test_523_tcp_graceful_close_fin_defer() { passed += 1; }
     }
 
+    // ── Test 522: TCP RX rings the InetRx poll-bell on readiness edges ──
+    // Asserts the TCP receive path wakes pollers (and blocking recv/accept)
+    // on the accept-complete and data-arrival edges, matching the UDP path,
+    // so poll/epoll readiness has sub-second latency (IEEE 1003.1 §poll).
+    total += 1;
+    if test_522_tcp_rx_poll_bell() { passed += 1; }
+
     // ── Test 274: UDP connect/sendto auto-bind (DNS unblocker) ──────────
     // Exercises the three socket-layer fixes that unblock outbound DNS
     // for any glibc/musl-linked Linux client:
@@ -33895,6 +33902,137 @@ fn test_276_tcp_send_buffer_drain() -> bool {
 /// have been segmentized, then form a FIN segment and send it"), RFC 9293
 /// §3.7 (data transfer), RFC 5681 §3.1 (slow start), IEEE Std 1003.1-2017
 /// §close / §shutdown.
+// ── Test 522: TCP RX rings the InetRx poll-bell on readiness edges ──────────
+//
+// The TCP receive path must wake `poll(2)` / `epoll_wait(2)` / `select(2)`
+// and blocking `recv(2)` callers the moment a watched socket becomes
+// readable, exactly as the UDP path does — otherwise a poller observes the
+// new data only on the bell's ~1 s resync floor (a latency tail userspace
+// reactors and DNS resolvers cannot absorb, IEEE Std 1003.1-2017 §poll).
+//
+// This test drives `handle_tcp` with synthetic segments over an in-kernel
+// listener (no wire, no NIC) and asserts that the two readiness edges a
+// poller cares about each bump the `BELL_RINGS_BY_SOURCE[InetRx]` counter:
+//   1. the listener child completing the 3-way handshake
+//      (SynReceived → Established → `accept(2)` will not block); and
+//   2. in-order data arriving on the Established connection (POLLIN).
+//
+// Counting the per-source ring (not a wake) makes the assertion hermetic —
+// no thread need be parked.  A regression that drops the ring (e.g. reverts
+// `handle_tcp` to the pre-fix "deliver data, never ring" path) makes the
+// observed delta zero and fails the test.
+fn test_522_tcp_rx_poll_bell() -> bool {
+    test_header!("TCP RX rings InetRx poll-bell on accept + data readiness edges");
+
+    use core::sync::atomic::Ordering;
+    use crate::net::tcp;
+    use crate::ipc::waitlist::{BELL_RINGS_BY_SOURCE, PollBellSource};
+
+    const LOCAL_PORT: u16 = 47018; // distinct from the 3WHS test's 47017
+    let client_ip: [u8; 4] = [10, 0, 2, 9];
+    let client_port: u16   = 54399;
+    let our_ip = crate::net::our_ip();
+    let inet_rx = PollBellSource::InetRx as usize;
+
+    // Build a data-bearing segment inline so the test compiles in every
+    // lane (the shared payload helper is kdb-gated).  Layout matches
+    // `make_tcp_seg`: 20-byte header (data-offset 5) then the payload.
+    fn data_seg(src: u16, dst: u16, seq: u32, ack: u32, flags: u8,
+                payload: &[u8]) -> alloc::vec::Vec<u8> {
+        let mut s = alloc::vec::Vec::with_capacity(20 + payload.len());
+        s.extend_from_slice(&src.to_be_bytes());
+        s.extend_from_slice(&dst.to_be_bytes());
+        s.extend_from_slice(&seq.to_be_bytes());
+        s.extend_from_slice(&ack.to_be_bytes());
+        s.push(5 << 4);          // data offset = 5 words (20 bytes), no options
+        s.push(flags);
+        s.extend_from_slice(&65535u16.to_be_bytes()); // window
+        s.push(0); s.push(0);    // checksum (unchecked on this synthetic path)
+        s.push(0); s.push(0);    // urgent pointer
+        s.extend_from_slice(payload);
+        s
+    }
+
+    if let Err(e) = tcp::listen(LOCAL_PORT) {
+        test_fail!("test_522_tcp_rx_poll_bell", "listen({}) failed: {}", LOCAL_PORT, e);
+        return false;
+    }
+
+    // ── Edge 1: SYN → SynReceived (no readiness edge yet — a half-open
+    // child is not accept-ready, so the bell must NOT advance here). ──
+    let before_syn = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
+    let client_isn: u32 = 0x5EED_0001;
+    let syn = make_tcp_seg(client_port, LOCAL_PORT, client_isn, 0, tcp::SYN);
+    tcp::handle_tcp(client_ip, our_ip, &syn);
+    let after_syn = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
+    if after_syn != before_syn {
+        test_fail!("test_522_tcp_rx_poll_bell",
+            "SYN (half-open child) rang InetRx (delta {}) — not an accept edge",
+            after_syn - before_syn);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    test_println!("  SYN → SynReceived: no spurious ring ✓");
+
+    // ── Edge 2: ACK completes the handshake (SynReceived → Established).
+    // accept(2) will not block → InetRx must ring. ──
+    let before_ack = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
+    let ack = make_tcp_seg(client_port, LOCAL_PORT,
+                           client_isn.wrapping_add(1), 0, tcp::ACK);
+    tcp::handle_tcp(client_ip, our_ip, &ack);
+    let after_ack = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
+    // Confirm the child actually reached Established (guards against the
+    // ring firing for an unrelated reason).
+    let established = tcp::snapshot_connections().iter().any(|c|
+        c.local_port == LOCAL_PORT && c.remote_ip == client_ip
+        && c.remote_port == client_port && c.state == tcp::TcpState::Established);
+    if !established {
+        test_fail!("test_522_tcp_rx_poll_bell", "child not Established after ACK");
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    if after_ack <= before_ack {
+        test_fail!("test_522_tcp_rx_poll_bell",
+            "handshake-complete edge did not ring InetRx (delta {})",
+            after_ack - before_ack);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    test_println!("  ACK → Established: accept edge rang InetRx (Δ{}) ✓",
+        after_ack - before_ack);
+
+    // ── Edge 3: in-order data arrival on the Established connection. ──
+    let before_data = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
+    const PAYLOAD: &[u8] = b"GET / HTTP/1.0\r\n\r\n";
+    let seg = data_seg(client_port, LOCAL_PORT, client_isn.wrapping_add(1),
+                       0, tcp::PSH | tcp::ACK, PAYLOAD);
+    tcp::handle_tcp(client_ip, our_ip, &seg);
+    let after_data = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
+    let got = tcp::read_from(LOCAL_PORT, client_ip, client_port);
+    if got != PAYLOAD {
+        test_fail!("test_522_tcp_rx_poll_bell",
+            "data not buffered: read {} bytes, expected {}", got.len(), PAYLOAD.len());
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    if after_data <= before_data {
+        test_fail!("test_522_tcp_rx_poll_bell",
+            "data-arrival edge did not ring InetRx (delta {})",
+            after_data - before_data);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    test_println!("  in-order data arrival: POLLIN edge rang InetRx (Δ{}) ✓",
+        after_data - before_data);
+
+    // Hermetic teardown — drop the synthetic child and the listener so
+    // sibling tests on neighbouring ports are unaffected.
+    let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+
+    test_pass!("TCP RX rings InetRx poll-bell on accept + data readiness edges");
+    true
+}
+
 #[cfg(any(feature = "test-mode", feature = "firefox-test-core",
           feature = "oracle-test", feature = "oracle-daemon-test"))]
 fn test_523_tcp_graceful_close_fin_defer() -> bool {


### PR DESCRIPTION
## Summary

The TCP receive path delivered data into a connection's `recv_buffer` and advanced the connection state machine but **never rang the global poll bell**. The UDP path rings `PollBellSource::InetRx` on datagram arrival; TCP did not. As a result a thread parked in `poll(2)` / `epoll_wait(2)` / `select(2)` — or a blocking `recv(2)` / `accept(2)` — on an AF_INET stream socket only re-evaluated readiness on the bell's ~1 s resync floor, giving stream sockets a ~1 s readiness latency tail that polled userspace reactors cannot absorb. The in-kernel `accept(2)` and `recvfrom(45)` blocking paths also `yield_cpu`-spun at 100 Hz instead of parking.

## What changed

**Ring the bell on RX readiness edges** (`net/tcp.rs`). `handle_tcp` rings `PollBellSource::InetRx` *after dropping the `TCP_CONNECTIONS` lock* (lock-free, mirroring the UDP receive path) whenever `process_segment` reports a readiness edge a poller cares about, per IEEE Std 1003.1-2017 §poll:
- new in-order data delivered into `recv_buffer` (`POLLIN`);
- `SynReceived → Established`: a listener child completed the 3-way handshake → `accept(2)` will not block;
- `SynSent → Established`: an active `connect(2)` completed (`POLLOUT`);
- a move into a read-closed state (`CloseWait` / `FinWait2` / `TimeWait` / `Closed`) from a peer FIN, so an empty stream read returns 0/EOF (RFC 9293 §3.5, RFC 793 §3.5 orderly close).

`process_segment` returns the edge to its single caller; a spurious ring is harmless (the woken poller re-scans and re-parks).

**Convert the two AF_INET blocking busy-loops to poll-bell parks** (`subsys/linux/syscall.rs`):
- `accept(2)`: parks on the side-effect-free `has_pending_accept` predicate (the destructive `take_pending_accept`, which sets `accepted`, runs only after a positive observation).
- `recvfrom(45)`: parks on a new non-destructive `socket_read_ready` predicate (`net/socket.rs`) — data queued **OR** stream peer-FIN/EOF. The old `socket_has_data` predicate checked data only and leaned on the 30 s deadline to escape a peer-FIN-with-empty-buffer EOF; `socket_read_ready` is strictly more responsive and stays non-destructive. (Using the consuming `socket_recv_status` / `socket_recvfrom` as a poll predicate would have silently dropped a UDP datagram or stream bytes — `socket_read_ready` inspects state only.)

**Lost-wakeup safety.** Each park's `ready_now` predicate re-checks every condition the InetRx ring covers, and `wait_poll_event` runs it under the `POLL_BELL` lock before committing to the park, so a ring racing the recheck is serialized behind the bell and cannot be lost; the resync floor bounds any future un-wired source.

The `recvmsg(47)` AF_INET-TCP path is already non-blocking (returns EAGAIN immediately) and benefits from the bell ring via the caller's poll loop, so it needs no loop conversion.

## Test

`test_522_tcp_rx_poll_bell` drives `handle_tcp` with synthetic segments over an in-kernel listener (no NIC, no wire) and asserts `BELL_RINGS_BY_SOURCE[InetRx]` advances on the handshake-complete and data-arrival edges, and does **not** advance for a half-open SYN child. Self-contained, always-compiled, registered in `run()`.

## Spec references

IEEE Std 1003.1-2017 §poll / §accept / §recvfrom / §shutdown; RFC 9293 §3.5 / §3.7; RFC 793 §3.4 / §3.5; RFC 1035 §4.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
