### PR TITLE
net/tcp: bound stream recv drain to requested length (no truncation loss)

### DIFF
--- a/kernel/src/httpd_demo.rs
+++ b/kernel/src/httpd_demo.rs
@@ -213,7 +213,10 @@ pub fn pump() {
 
     // ── Step 2: drain RX into per-session buffers ─────────────────────
     for (rip, rp) in &live_peers {
-        let bytes = tcp::read_from(HTTPD_PORT, *rip, *rp);
+        // Drain everything currently queued for this 4-tuple into the
+        // per-session accumulator (usize::MAX = no caller-buffer bound;
+        // the MAX_REQ_BYTES guard below caps the session buffer).
+        let bytes = tcp::read_from(HTTPD_PORT, *rip, *rp, usize::MAX);
         if bytes.is_empty() { continue; }
         let mut ss = HTTP_SESSIONS.lock();
         if let Some(s) = ss.iter_mut()

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -218,7 +218,10 @@ pub fn pump() {
     // than one harness shell is talking to kdb at the same time.  See
     // tcp::read_from for the per-connection variant.
     for (rip, rp) in &new_peers {
-        let bytes = tcp::read_from(KDB_PORT, *rip, *rp);
+        // Drain everything queued for this 4-tuple into the per-session
+        // accumulator (usize::MAX = no caller-buffer bound; MAX_REQ_BYTES
+        // below caps the session buffer).
+        let bytes = tcp::read_from(KDB_PORT, *rip, *rp, usize::MAX);
         if bytes.is_empty() { continue; }
         let mut ss = KDB_SESSIONS.lock();
         if let Some(s) = ss.iter_mut()

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -452,7 +452,14 @@ pub enum RecvOutcome {
 /// `recv(2)` on a non-blocking socket with no data pending must return
 /// `EAGAIN` per IEEE 1003.1; returning 0 there is an EOF lie that drives a
 /// polled reactor into a tight re-read loop.
-pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
+///
+/// `max_len` bounds a *stream* (TCP) drain to the caller's buffer
+/// capacity: a byte-stream read returns at most that many octets and the
+/// remainder stays queued for the next read (IEEE Std 1003.1-2017 §read,
+/// RFC 9293 §3.10.3). It is ignored for datagram (UDP) sockets, where a
+/// whole datagram is dequeued and any portion exceeding the buffer is
+/// truncated and discarded with MSG_TRUNC semantics (recvmsg(2)).
+pub fn socket_recv_status(id: u64, max_len: usize) -> Result<RecvOutcome, &'static str> {
     let sockets = SOCKETS.lock();
     let sock = sockets.iter().find(|s| s.id == id)
         .ok_or("socket not found")?;
@@ -484,9 +491,10 @@ pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
                 return Err("not bound");
             }
             let data = if sock.connected && sock.remote_port != 0 {
-                super::tcp::read_from(sock.local_port, sock.remote_ip, sock.remote_port)
+                super::tcp::read_from(sock.local_port, sock.remote_ip,
+                                      sock.remote_port, max_len)
             } else {
-                super::tcp::read(sock.local_port)
+                super::tcp::read(sock.local_port, max_len)
             };
             if !data.is_empty() {
                 crate::proc::proc_metrics::bump_net_read(
@@ -515,7 +523,11 @@ pub fn socket_recv_status(id: u64) -> Result<RecvOutcome, &'static str> {
 }
 
 /// Receive data from a socket (non-blocking).
-pub fn socket_recv(id: u64) -> Result<Vec<u8>, &'static str> {
+///
+/// `max_len` bounds a *stream* (TCP) drain to the caller's buffer
+/// capacity; surplus stream octets stay queued for the next read (IEEE
+/// Std 1003.1-2017 §read). Ignored for datagram (UDP) sockets.
+pub fn socket_recv(id: u64, max_len: usize) -> Result<Vec<u8>, &'static str> {
     let sockets = SOCKETS.lock();
     let sock = sockets.iter().find(|s| s.id == id)
         .ok_or("socket not found")?;
@@ -548,9 +560,10 @@ pub fn socket_recv(id: u64) -> Result<Vec<u8>, &'static str> {
             if sock.connected && sock.remote_port != 0 {
                 Ok(super::tcp::read_from(sock.local_port,
                                          sock.remote_ip,
-                                         sock.remote_port))
+                                         sock.remote_port,
+                                         max_len))
             } else {
-                Ok(super::tcp::read(sock.local_port))
+                Ok(super::tcp::read(sock.local_port, max_len))
             }
         }
     };
@@ -575,7 +588,13 @@ pub fn socket_recv(id: u64) -> Result<Vec<u8>, &'static str> {
 /// the payload is empty and the address is the zero 4-tuple — callers
 /// must check the byte count before consulting the address (matches the
 /// existing non-blocking semantics of [`socket_recv`]).
-pub fn socket_recvfrom(id: u64) -> Result<(Vec<u8>, Ipv4Address, u16), &'static str> {
+///
+/// `max_len` bounds a *stream* (TCP) drain to the caller's buffer
+/// capacity; surplus stream octets stay queued for the next read (IEEE
+/// Std 1003.1-2017 §read, RFC 9293 §3.10.3). Ignored for datagram (UDP)
+/// sockets, where the whole datagram is dequeued (recvfrom(2) truncation
+/// discards the excess).
+pub fn socket_recvfrom(id: u64, max_len: usize) -> Result<(Vec<u8>, Ipv4Address, u16), &'static str> {
     let sockets = SOCKETS.lock();
     let sock = sockets.iter().find(|s| s.id == id)
         .ok_or("socket not found")?;
@@ -613,7 +632,7 @@ pub fn socket_recvfrom(id: u64) -> Result<(Vec<u8>, Ipv4Address, u16), &'static 
             let peer_port = sock.remote_port;
             let local_port = sock.local_port;
             drop(sockets);
-            let data = super::tcp::read(local_port);
+            let data = super::tcp::read(local_port, max_len);
             Ok((data, peer_ip, peer_port))
         }
     };

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -1072,17 +1072,45 @@ pub fn has_data_for(local_port: u16,
                  && !c.recv_buffer.is_empty())
 }
 
-pub fn read(port: u16) -> Vec<u8> {
+/// Dequeue up to `max_len` bytes from the receive buffer of the
+/// Established TCB on `port`, leaving any surplus queued for the next
+/// read.
+///
+/// A byte-stream read must return *at most* the number of bytes the
+/// caller asked for, and the bytes it does not return must remain
+/// available for a subsequent read (IEEE Std 1003.1-2017 §read; the
+/// receive side of RFC 9293 §3.10.3 — the receive buffer advances by
+/// exactly the consumed octet count). The previous behaviour cloned the
+/// whole buffer and cleared it unconditionally, so when the caller's
+/// buffer was smaller than the queued bytes the syscall layer copied
+/// `min(data, cap)` and dropped the rest on the floor — silently losing
+/// stream octets.
+///
+/// `max_len == 0` consumes nothing and returns an empty vector.
+pub fn read(port: u16, max_len: usize) -> Vec<u8> {
     let mut conns = TCP_CONNECTIONS.lock();
     if let Some(conn) = conns.iter_mut()
         .find(|c| c.local_port == port && c.state == TcpState::Established)
     {
-        let d = conn.recv_buffer.clone();
-        conn.recv_buffer.clear();
-        d
+        drain_recv(conn, max_len)
     } else {
         Vec::new()
     }
+}
+
+/// Drain at most `max_len` leading octets from `conn.recv_buffer`,
+/// shifting the remainder down to the front so it is returned by the
+/// next read. Shared by [`read`] and [`read_from`] so the bounded-drain
+/// invariant is enforced in exactly one place.
+fn drain_recv(conn: &mut TcpConnection, max_len: usize) -> Vec<u8> {
+    let take = max_len.min(conn.recv_buffer.len());
+    if take == 0 {
+        return Vec::new();
+    }
+    // `Vec::drain(..take)` removes the first `take` octets and shifts the
+    // tail down, so `recv_buffer` keeps exactly the bytes not yet
+    // delivered to user space.
+    conn.recv_buffer.drain(..take).collect()
 }
 
 /// Test-only: synthesise an Established TCB with the given 4-tuple and a
@@ -1208,7 +1236,12 @@ pub fn test_recv_next(local_port: u16, remote_ip: Ipv4Address,
 /// matches strictly so per-connection drains stay isolated.
 ///
 /// Mirrors the shape of [`send_data_to`] / [`close_connection`].
-pub fn read_from(local_port: u16, remote_ip: Ipv4Address, remote_port: u16) -> Vec<u8> {
+///
+/// Dequeues up to `max_len` bytes and leaves any surplus queued for the
+/// next read (see [`read`] for the byte-stream bounding contract — IEEE
+/// Std 1003.1-2017 §read, RFC 9293 §3.10.3).
+pub fn read_from(local_port: u16, remote_ip: Ipv4Address, remote_port: u16,
+                 max_len: usize) -> Vec<u8> {
     let mut conns = TCP_CONNECTIONS.lock();
     if let Some(conn) = conns.iter_mut().find(|c| {
         c.local_port  == local_port
@@ -1216,9 +1249,7 @@ pub fn read_from(local_port: u16, remote_ip: Ipv4Address, remote_port: u16) -> V
             && c.remote_port == remote_port
             && c.state       == TcpState::Established
     }) {
-        let d = conn.recv_buffer.clone();
-        conn.recv_buffer.clear();
-        d
+        drain_recv(conn, max_len)
     } else {
         Vec::new()
     }

--- a/kernel/src/subsys/aether/syscall.rs
+++ b/kernel/src/subsys/aether/syscall.rs
@@ -427,7 +427,12 @@ pub fn dispatch(
             // same way the Linux personality does — an empty receive on a
             // live socket must not read as a 0-byte EOF, or a polled reader
             // busy-loops.  See recv(2) / IEEE 1003.1 §recv.
-            match crate::net::socket::socket_recv_status(socket_id) {
+            // Pass the user buffer size `buf_len` so a TCP stream drain
+            // returns at most `buf_len` octets and leaves the surplus
+            // queued for the next recvfrom (IEEE Std 1003.1-2017 §read;
+            // RFC 9293 §3.10.3) rather than draining the whole buffer and
+            // dropping the bytes past `buf_len`.
+            match crate::net::socket::socket_recv_status(socket_id, buf_len) {
                 Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                     let copy_len = data.len().min(buf_len);
                     if copy_len > 0 {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2134,7 +2134,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                             || crate::net::socket::socket_read_ready(socket_id));
                     }
                 }
-                match crate::net::socket::socket_recvfrom(socket_id) {
+                // Pass the user buffer capacity `len` so a TCP stream
+                // drain returns at most `len` octets and leaves the
+                // remainder queued for the next recvfrom (IEEE Std
+                // 1003.1-2017 §read; RFC 9293 §3.10.3). A datagram (UDP)
+                // recv ignores it and dequeues the whole datagram, then
+                // truncates the copy below (recvfrom(2) discards the
+                // excess of an oversized datagram).
+                match crate::net::socket::socket_recvfrom(socket_id, len) {
                     Ok((data, src_ip, src_port)) => {
                         // Empty result on a non-blocking socket = EAGAIN
                         // per IEEE 1003.1 §recvfrom.  We can only hit
@@ -2818,7 +2825,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     // the source, every reply is dropped and getaddrinfo(3)
                     // times out.  A datagram socket has no orderly-EOF concept,
                     // so an empty result is WouldBlock → EAGAIN per recvmsg(2).
-                    bytes_read = match crate::net::socket::socket_recvfrom(socket_id) {
+                    // `cap` (iov[0] length) is the datagram-recv buffer; a
+                    // UDP datagram larger than it is truncated and the
+                    // excess discarded (recvmsg(2)). The drain dequeues the
+                    // whole datagram regardless, so the cap only bounds the
+                    // copy below — it is not threaded into the dequeue.
+                    bytes_read = match crate::net::socket::socket_recvfrom(socket_id, cap) {
                         Ok((data, src_ip, src_port)) => {
                             if data.is_empty() {
                                 -11 // EAGAIN
@@ -2858,7 +2870,14 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     // re-issued recvmsg in a tight loop, never yielding.  Use the
                     // status-aware recv so the two cases get their correct
                     // returns (WouldBlock → -EAGAIN, Eof → 0).
-                    bytes_read = match crate::net::socket::socket_recv_status(socket_id) {
+                    // Pass `cap` (iov[0] length) so a TCP stream drain
+                    // returns at most `cap` octets and leaves the surplus
+                    // queued for the next recvmsg (IEEE Std 1003.1-2017
+                    // §read; RFC 9293 §3.10.3). Without it the full buffer
+                    // was drained and the bytes past `cap` were dropped —
+                    // silently losing stream octets when the caller's iov
+                    // was smaller than the queued bytes.
+                    bytes_read = match crate::net::socket::socket_recv_status(socket_id, cap) {
                         Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                             let n = data.len().min(cap);
                             unsafe {
@@ -6375,7 +6394,12 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
         // reader does not mistake an empty queue for EOF and re-read in a
         // busy loop (mirrors the pipe path above, which already separates
         // EOF from would-block).
-        return match crate::net::socket::socket_recv_status(socket_id) {
+        // Pass the user buffer size `count` so a TCP stream drain returns
+        // at most `count` octets and leaves the surplus queued for the next
+        // read (IEEE Std 1003.1-2017 §read; RFC 9293 §3.10.3). Without it
+        // the full buffer was drained and the bytes past `count` were
+        // dropped — silently losing stream octets on a short read.
+        return match crate::net::socket::socket_recv_status(socket_id, count) {
             Ok(crate::net::socket::RecvOutcome::Data(data)) => {
                 let n = data.len().min(count);
                 unsafe {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2704,6 +2704,20 @@ pub fn run() -> ! {
     total += 1;
     if test_522_tcp_rx_poll_bell() { passed += 1; }
 
+    // ── Test 524: TCP stream recv is length-bounded (no truncation loss) ─
+    // Regression gate for the recv truncation seam: a short read must
+    // return at most the requested octet count AND leave the surplus
+    // queued for the next read (IEEE Std 1003.1-2017 §read; RFC 9293
+    // §3.10.3).  Pre-fix the socket layer drained the whole recv_buffer
+    // and the syscall layer copied only min(buffer, cap) — silently
+    // losing every octet past the caller's buffer.  Gated on `kdb`
+    // because it uses test_inject_established() (kdb-only).
+    #[cfg(feature = "kdb")]
+    {
+        total += 1;
+        if test_524_tcp_recv_length_bounded() { passed += 1; }
+    }
+
     // ── Test 274: UDP connect/sendto auto-bind (DNS unblocker) ──────────
     // Exercises the three socket-layer fixes that unblock outbound DNS
     // for any glibc/musl-linked Linux client:
@@ -32845,7 +32859,7 @@ fn test_tcp_inbound_3whs() -> bool {
         client_isn.wrapping_add(1), 0, tcp::PSH | tcp::ACK, PAYLOAD);
     tcp::handle_tcp(client_ip, our_ip, &data_seg);
 
-    let got = tcp::read(LOCAL_PORT);
+    let got = tcp::read(LOCAL_PORT, usize::MAX);
     if got != PAYLOAD {
         test_fail!("tcp_inbound_3whs", "read() returned {} bytes, expected {}",
                     got.len(), PAYLOAD.len());
@@ -32901,14 +32915,14 @@ fn test_tcp_read_from_isolation() -> bool {
     // Established TCB matched first — typically A, leaving B's bytes
     // unread or vice versa.  read_from() must return EXACTLY each
     // session's bytes, regardless of insertion order.
-    let got_a = tcp::read_from(LOCAL_PORT, a_ip, a_port);
+    let got_a = tcp::read_from(LOCAL_PORT, a_ip, a_port, usize::MAX);
     if got_a != PAYLOAD_A {
         test_fail!("tcp_read_from_isolation",
             "A: got {} bytes (expected {}); cross-TCB leak?",
             got_a.len(), PAYLOAD_A.len());
         return false;
     }
-    let got_b = tcp::read_from(LOCAL_PORT, b_ip, b_port);
+    let got_b = tcp::read_from(LOCAL_PORT, b_ip, b_port, usize::MAX);
     if got_b != PAYLOAD_B {
         test_fail!("tcp_read_from_isolation",
             "B: got {} bytes (expected {})",
@@ -32918,8 +32932,8 @@ fn test_tcp_read_from_isolation() -> bool {
 
     // Second drain on either tuple must return empty — recv_buffer
     // has been cleared by the first read_from().
-    if !tcp::read_from(LOCAL_PORT, a_ip, a_port).is_empty()
-        || !tcp::read_from(LOCAL_PORT, b_ip, b_port).is_empty()
+    if !tcp::read_from(LOCAL_PORT, a_ip, a_port, usize::MAX).is_empty()
+        || !tcp::read_from(LOCAL_PORT, b_ip, b_port, usize::MAX).is_empty()
     {
         test_fail!("tcp_read_from_isolation", "second drain returned bytes");
         return false;
@@ -32928,8 +32942,8 @@ fn test_tcp_read_from_isolation() -> bool {
     // Mismatched 4-tuples must return empty.  This guards against
     // a regression where read_from accidentally matches by partial
     // tuple (e.g. local_port-only).
-    if !tcp::read_from(LOCAL_PORT, a_ip, b_port).is_empty()
-        || !tcp::read_from(LOCAL_PORT, b_ip, a_port).is_empty()
+    if !tcp::read_from(LOCAL_PORT, a_ip, b_port, usize::MAX).is_empty()
+        || !tcp::read_from(LOCAL_PORT, b_ip, a_port, usize::MAX).is_empty()
     {
         test_fail!("tcp_read_from_isolation",
             "mismatched 4-tuple returned bytes (partial-match regression)");
@@ -33133,7 +33147,7 @@ fn test_af_inet_accept_end_to_end() -> bool {
     }
 
     // Drain A — must see exactly RX_A.
-    let got_a = match socket::socket_recv(sid_a) {
+    let got_a = match socket::socket_recv(sid_a, usize::MAX) {
         Ok(d) => d,
         Err(e) => {
             test_fail!("test270", "socket_recv A failed: {}", e);
@@ -33150,7 +33164,7 @@ fn test_af_inet_accept_end_to_end() -> bool {
         test_fail!("test270", "B's recv buffer drained when only A was read");
         return false;
     }
-    let got_b = match socket::socket_recv(sid_b) {
+    let got_b = match socket::socket_recv(sid_b, usize::MAX) {
         Ok(d) => d,
         Err(e) => {
             test_fail!("test270", "socket_recv B failed: {}", e);
@@ -33531,7 +33545,7 @@ fn test_tcp_lock_released_before_send() -> bool {
         return false;
     }
 
-    let got = tcp::read_from(SERVER_PORT, LB_IP, client_port);
+    let got = tcp::read_from(SERVER_PORT, LB_IP, client_port, usize::MAX);
     if got.as_slice() != DATA {
         test_fail!("tcp_lock_release",
             "server payload mismatch: got {} bytes, want {}", got.len(), DATA.len());
@@ -33686,7 +33700,7 @@ fn test_273_tcp_medium_payload_loopback() -> bool {
     // the server child's remote_ip carries the client's reflected
     // loopback addr.
     let server_remote_ip = server_child.remote_ip;
-    let received = tcp::read_from(SERVER_PORT, server_remote_ip, client_port);
+    let received = tcp::read_from(SERVER_PORT, server_remote_ip, client_port, usize::MAX);
 
     if received.len() != PAYLOAD_LEN {
         test_fail!("tcp_medium_payload",
@@ -33839,7 +33853,7 @@ fn test_276_tcp_send_buffer_drain() -> bool {
 
     // Drain the server child's receive buffer.
     let server_remote_ip = server_child.remote_ip;
-    let received = tcp::read_from(SERVER_PORT, server_remote_ip, client_port);
+    let received = tcp::read_from(SERVER_PORT, server_remote_ip, client_port, usize::MAX);
 
     if received.len() != PAYLOAD_LEN {
         test_fail!("tcp_send_buf_drain",
@@ -34008,7 +34022,7 @@ fn test_522_tcp_rx_poll_bell() -> bool {
                        0, tcp::PSH | tcp::ACK, PAYLOAD);
     tcp::handle_tcp(client_ip, our_ip, &seg);
     let after_data = BELL_RINGS_BY_SOURCE[inet_rx].load(Ordering::Relaxed);
-    let got = tcp::read_from(LOCAL_PORT, client_ip, client_port);
+    let got = tcp::read_from(LOCAL_PORT, client_ip, client_port, usize::MAX);
     if got != PAYLOAD {
         test_fail!("test_522_tcp_rx_poll_bell",
             "data not buffered: read {} bytes, expected {}", got.len(), PAYLOAD.len());
@@ -34030,6 +34044,115 @@ fn test_522_tcp_rx_poll_bell() -> bool {
     let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
 
     test_pass!("TCP RX rings InetRx poll-bell on accept + data readiness edges");
+    true
+}
+
+/// Test 524: TCP stream recv is length-bounded — a short read returns at
+/// most the requested octet count and the surplus stays queued for the
+/// next read (no truncation loss).
+///
+/// Regression gate for the recv truncation seam.  The socket layer's
+/// `tcp::read` / `tcp::read_from` cloned the entire `recv_buffer` and
+/// `clear()`ed it, while the syscall layer (read(2)/recvfrom(45)/
+/// recvmsg(47)) copied only `min(buffer_len, user_cap)` into the user
+/// buffer and dropped `data[cap..]` on the floor.  A reader whose buffer
+/// was smaller than the queued bytes therefore lost every octet past its
+/// buffer — a silent data-loss bug on every short stream read.
+///
+/// The fix bounds the drain at the source: `tcp::read{,_from}` take a
+/// `max_len` and remove only the leading `min(max_len, queued)` octets
+/// via `Vec::drain(..take)`, leaving the remainder at the front of
+/// `recv_buffer` for the next read (IEEE Std 1003.1-2017 §read — a read
+/// "shall return ... a number of bytes less than or equal to" the
+/// requested count, the rest remaining available; RFC 9293 §3.10.3 — the
+/// receive buffer advances by exactly the consumed octet count).
+///
+/// Self-contained: a synthetic Established TCB pre-loaded with a known
+/// payload (no wire / NIC), drained in three bounded reads that together
+/// reconstruct the payload exactly with no loss and no duplication.
+#[cfg(feature = "kdb")]
+fn test_524_tcp_recv_length_bounded() -> bool {
+    test_header!("TCP stream recv is length-bounded — short read keeps the tail queued");
+
+    use crate::net::tcp;
+
+    const LOCAL_PORT: u16 = 47019; // distinct from the 522/3WHS ports
+    let client_ip: [u8; 4] = [10, 0, 2, 24];
+    let client_port: u16   = 54401;
+
+    // 10 octets queued; the reader asks for 4, then 4, then the rest.
+    const PAYLOAD: &[u8] = b"ABCDEFGHIJ";
+
+    if let Err(e) = tcp::test_inject_established(
+        LOCAL_PORT, client_ip, client_port, PAYLOAD)
+    {
+        test_fail!("test_524_tcp_recv_length_bounded",
+            "test_inject_established failed: {}", e);
+        return false;
+    }
+
+    // ── Read 1: bounded to 4 octets — must return exactly the first 4,
+    // leaving 6 queued (not drain all 10 and discard 6). ──
+    let r1 = tcp::read_from(LOCAL_PORT, client_ip, client_port, 4);
+    if r1 != b"ABCD" {
+        test_fail!("test_524_tcp_recv_length_bounded",
+            "first bounded read: got {} bytes {:?}, expected 4 \"ABCD\"",
+            r1.len(), r1);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    test_println!("  read(max=4): returned exactly 4 octets, tail retained ✓");
+
+    // ── Read 2: bounded to 4 — must return the NEXT 4 (the tail survived
+    // read 1 instead of being dropped). ──
+    let r2 = tcp::read_from(LOCAL_PORT, client_ip, client_port, 4);
+    if r2 != b"EFGH" {
+        test_fail!("test_524_tcp_recv_length_bounded",
+            "second bounded read: got {} bytes {:?}, expected 4 \"EFGH\" \
+             (a regression here means the surplus was discarded)",
+            r2.len(), r2);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    test_println!("  read(max=4): returned the next 4 octets (no loss) ✓");
+
+    // ── Read 3: ask for more than remain (max=64) — must return exactly
+    // the remaining 2, never over-read. ──
+    let r3 = tcp::read_from(LOCAL_PORT, client_ip, client_port, 64);
+    if r3 != b"IJ" {
+        test_fail!("test_524_tcp_recv_length_bounded",
+            "final read: got {} bytes {:?}, expected 2 \"IJ\"", r3.len(), r3);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+    test_println!("  read(max=64): returned the final 2 octets ✓");
+
+    // ── Read 4: buffer now empty — a bounded read returns nothing. ──
+    let r4 = tcp::read_from(LOCAL_PORT, client_ip, client_port, 64);
+    if !r4.is_empty() {
+        test_fail!("test_524_tcp_recv_length_bounded",
+            "post-drain read returned {} unexpected bytes {:?}", r4.len(), r4);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+
+    // Cross-check: the three reads reconstruct the payload exactly — no
+    // bytes lost, none duplicated.
+    let mut reassembled = alloc::vec::Vec::new();
+    reassembled.extend_from_slice(&r1);
+    reassembled.extend_from_slice(&r2);
+    reassembled.extend_from_slice(&r3);
+    if reassembled != PAYLOAD {
+        test_fail!("test_524_tcp_recv_length_bounded",
+            "reassembled {:?} != original payload {:?}", reassembled, PAYLOAD);
+        let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+        return false;
+    }
+
+    // Hermetic teardown.
+    let _ = tcp::close_connection(LOCAL_PORT, client_ip, client_port);
+
+    test_pass!("TCP stream recv is length-bounded — short read keeps the tail queued");
     true
 }
 
@@ -34147,7 +34270,7 @@ fn test_523_tcp_graceful_close_fin_defer() -> bool {
     for _ in 0..48 { crate::net::poll(); }
 
     // (a) Full body must have arrived intact — no truncation.
-    let received = tcp::read_from(SERVER_PORT, server_child.remote_ip, client_port);
+    let received = tcp::read_from(SERVER_PORT, server_child.remote_ip, client_port, usize::MAX);
     if received.len() != PAYLOAD_LEN {
         test_fail!("tcp_graceful_close",
             "received {} B (expected {} — close orphaned the buffered tail)",
@@ -34514,7 +34637,7 @@ fn test_recvfrom_udp_returns_sender_4tuple() -> bool {
     udp::send([127, 0, 0, 1], CLIENT_PORT, SERVER_PORT, PAYLOAD);
     crate::net::poll();
 
-    let (data, src_ip, src_port) = match socket::socket_recvfrom(id) {
+    let (data, src_ip, src_port) = match socket::socket_recvfrom(id, usize::MAX) {
         Ok(t) => t,
         Err(e) => {
             socket::socket_close(id);
@@ -34571,7 +34694,7 @@ fn test_recvfrom_tcp_returns_peer_4tuple() -> bool {
     // recvfrom on the (just-connected, no data yet) client must still
     // report the peer 4-tuple — the address out-param is independent of
     // whether bytes were available.  We accept zero-length data here.
-    let (_data, peer_ip, peer_port) = match socket::socket_recvfrom(cid) {
+    let (_data, peer_ip, peer_port) = match socket::socket_recvfrom(cid, usize::MAX) {
         Ok(t) => t,
         Err(e) => {
             socket::socket_close(cid);
@@ -34628,7 +34751,7 @@ fn test_recvfrom_null_addr_ok() -> bool {
     udp::send([127, 0, 0, 1], 50032, PORT, PAYLOAD);
     crate::net::poll();
 
-    let result = socket::socket_recvfrom(id);
+    let result = socket::socket_recvfrom(id, usize::MAX);
     socket::socket_close(id);
 
     match result {
@@ -34784,7 +34907,7 @@ fn test_shutdown_tcp_rd_returns_eof() -> bool {
     };
     let _ = socket::socket_shutdown(id, socket::SHUT_RD);
     // Even though the TCB has QUEUED bytes pending, recv must return EOF.
-    let recv_result = socket::socket_recv(id);
+    let recv_result = socket::socket_recv(id, usize::MAX);
     let _ = tcp::abort(PORT);
     match recv_result {
         Ok(d) if d.is_empty() => {
@@ -34843,7 +34966,7 @@ fn test_shutdown_tcp_rdwr_breaks_both() -> bool {
         Some(i) => i, None => return false,
     };
     let _ = socket::socket_shutdown(id, socket::SHUT_RDWR);
-    let recv_ok    = matches!(socket::socket_recv(id), Ok(ref d) if d.is_empty());
+    let recv_ok    = matches!(socket::socket_recv(id, usize::MAX), Ok(ref d) if d.is_empty());
     let send_epipe = matches!(socket::socket_send(id, b"x"), Err("EPIPE"));
     let state = tcp::snapshot_connections().iter()
         .find(|c| c.local_port == PORT && c.remote_ip == peer).map(|c| c.state);
@@ -49069,7 +49192,7 @@ fn test_274_udp_connect_auto_bind() -> bool {
     const REPLY: &[u8] = b"AstryxOS-UDP-reply payload";
     udp::send([127, 0, 0, 1], PEER_PORT, lport_b, REPLY);
     crate::net::poll();
-    match socket::socket_recvfrom(sid_b) {
+    match socket::socket_recvfrom(sid_b, usize::MAX) {
         Ok((data, src_ip, src_port)) => {
             if data != REPLY {
                 test_fail!("274-C recvfrom",
@@ -50218,7 +50341,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
     }
 
     // (1) Empty queue, socket live → MUST be WouldBlock (the storm-fix case).
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::WouldBlock) => {
             test_println!("  empty bound UDP socket → WouldBlock ✓");
         }
@@ -50253,7 +50376,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
         pkt.extend_from_slice(PAYLOAD);
         crate::net::udp::handle_udp([10, 0, 2, 2], [10, 0, 2, 15], &pkt);
     }
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::Data(d)) if d == PAYLOAD => {
             test_println!("  injected datagram → Data({} bytes) ✓", d.len());
         }
@@ -50271,7 +50394,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
     // (3) After draining, the queue is empty again → WouldBlock, NOT Eof.
     //     This is the regression's heart: an empty-but-live socket must never
     //     read as EOF.
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::WouldBlock) => {
             test_println!("  drained socket → WouldBlock (not EOF) ✓");
         }
@@ -50287,7 +50410,7 @@ fn test_281_socket_recv_eagain_vs_eof() -> bool {
         test_fail!("recv_eagain", "socket_shutdown(SHUT_RD) failed");
         return false;
     }
-    match socket::socket_recv_status(sid) {
+    match socket::socket_recv_status(sid, usize::MAX) {
         Ok(RecvOutcome::Eof) => {
             test_println!("  after SHUT_RD → Eof ✓");
         }


### PR DESCRIPTION
## Problem

The TCP byte-stream receive path has a destructive **full-drain seam** between the socket layer and the syscall layer:

- `tcp::read` / `tcp::read_from` (`kernel/src/net/tcp.rs`) cloned the entire `recv_buffer` and `clear()`ed it unconditionally — no length argument.
- The syscall layer — `read(2)`, `recvfrom(45)`, `recvmsg(47)`, and the Aether-personality `recvfrom` — then copied only `min(buffer_len, user_cap)` octets into the caller's buffer and **dropped `data[cap..]` on the floor**.

A reader whose buffer is smaller than the bytes already queued therefore **loses every octet past its buffer** — a silent stream data-loss bug on every short read. (A `read(fd, buf, 0)` previously drained and discarded the entire buffer.)

This violates the POSIX `read(2)` contract and the TCP receive contract: a byte-stream read returns *at most* the requested number of bytes, and the bytes it does not return must remain available for the next read — IEEE Std 1003.1-2017 §read; RFC 9293 §3.10.3 (the receive buffer advances by exactly the consumed octet count).

## Fix

Bound the drain **at the source** (cleaner than re-buffering a tail in the syscall layer — avoids a double copy):

- `tcp::read` / `tcp::read_from` take a `max_len` and remove only the leading `min(max_len, queued)` octets via `Vec::drain(..take)`, shifting the remainder to the front of `recv_buffer` so the next read returns it. The invariant lives in one shared helper, `drain_recv`.
- The socket-layer recv functions (`socket_recv_status`, `socket_recv`, `socket_recvfrom`) thread the caller's buffer capacity through to the TCP drain.
- The `max_len` is **ignored on the datagram (UDP) path**: a whole datagram is dequeued and any excess over the buffer is truncated and discarded with `recvmsg(2)` `MSG_TRUNC` semantics — datagram framing is unchanged.

All syscall callers pass the user buffer size they already used as the copy clamp, so the drain now matches exactly what the copy accepts. In-kernel accumulator callers (`httpd_demo`, `kdb`) and the test harness pass `usize::MAX` to keep their drain-everything behaviour.

## Re-verification (before patching)

- `recvmsg(47)` consumes only `iov[0]` (it does **not** iterate all iovecs) — that pre-existing single-iovec behaviour is unrelated to this bug and was left untouched.
- No tail re-buffering exists anywhere (no `push_front`/leftover path) — confirmed the surplus was genuinely lost.
- The same truncation pattern was found and fixed in **four** recv sites, not just the two named in the audit: `read(2)` (`sys_read_linux`), `recvfrom(45)`, `recvmsg(47)` TCP branch, and the Aether-personality `recvfrom`.

## Test

**Test 524** (`test_524_tcp_recv_length_bounded`, gated on `kdb`): pre-loads a 10-octet payload into a synthetic Established TCB and drains it in bounded reads of 4, 4, and 64 — asserting each short read returns exactly the requested count, the surplus survives to the next read, an over-sized request returns only the remaining bytes, a post-drain read is empty, and the three reads reassemble the original payload with no loss and no duplication. Self-contained over the loopback short-circuit (no NIC/wire).

`cargo check` green on `default`, `test-mode`, `kdb`, and `firefox-test-core,kdb`.

## Specs

IEEE Std 1003.1-2017 §read / §recv / §recvfrom / §recvmsg; RFC 9293 §3.10.3 (TCP receive); RFC 768 (UDP datagram framing — unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)