### PR TITLE
net/unix: connect(2) ENOENT vs ECONNREFUSED + abstract-namespace addresses (NDE-22)

### DIFF
--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -247,6 +247,41 @@ pub struct PeerCreds {
     pub gid: u32,
 }
 
+/// Normalise an AF_UNIX address slice into the byte sequence that is stored
+/// in (and matched against) a socket slot's `path`.
+///
+/// Two namespaces per `man 7 unix`:
+///   * **pathname** — `addr[0] != 0`: a NUL-terminated filesystem path.  The
+///     stored name is the bytes up to (excluding) the first NUL.  This is the
+///     historical behaviour; pathnames never contain a leading NUL.
+///   * **abstract** — `addr[0] == 0`: an abstract-namespace name.  Its length
+///     is taken from the address length (`addr.len()` here, since the syscall
+///     layer already sliced to `addrlen - sizeof(sa_family)`), it is NOT
+///     NUL-terminated, and it MAY contain embedded NULs.  The stored name is
+///     the *entire* slice, leading NUL included — which makes it disjoint from
+///     every pathname name (a pathname can never begin with a NUL) and keeps
+///     embedded NULs significant rather than truncating at the first one.
+///
+/// Returns the slice to store/match, capped at `UNIX_PATH_MAX`.  An empty
+/// `addr` returns an empty slice (the caller maps that to EINVAL where the
+/// contract requires a non-empty name).
+fn unix_name(addr: &[u8]) -> &[u8] {
+    if addr.first() == Some(&0) {
+        // Abstract namespace: length is addrlen-derived; embedded NULs kept.
+        &addr[..addr.len().min(UNIX_PATH_MAX)]
+    } else {
+        // Pathname: NUL-terminated C string.
+        let raw_len = addr.iter().position(|&b| b == 0).unwrap_or(addr.len());
+        &addr[..raw_len.min(UNIX_PATH_MAX)]
+    }
+}
+
+/// True if `name` (as returned by [`unix_name`]) is an abstract-namespace
+/// name (leading NUL) rather than a filesystem pathname.
+fn is_abstract(name: &[u8]) -> bool {
+    name.first() == Some(&0)
+}
+
 pub fn create(kind: SockKind, creds: PeerCreds) -> u64 {
     let mut t = TABLE.lock();
     for (i, s) in t.0.iter_mut().enumerate() {
@@ -266,10 +301,18 @@ pub fn create(kind: SockKind, creds: PeerCreds) -> u64 {
 
 pub fn bind(id: u64, path: &[u8]) -> i64 {
     if id as usize >= MAX_UNIX_SOCKETS { return -9; }
-    // Strip trailing NUL so paths stored by bind always match paths from connect.
-    let raw_len = path.iter().position(|&b| b == 0).unwrap_or(path.len());
-    let plen = raw_len.min(UNIX_PATH_MAX);
-    let new_path = &path[..plen];
+    // Select pathname vs abstract namespace per `man 7 unix`.  A pathname is
+    // NUL-terminated (stored up to the first NUL); an abstract name (leading
+    // NUL) keeps its full addrlen-derived length and any embedded NULs.  Using
+    // the same normaliser for bind and connect guarantees a name bound here
+    // matches a name connected later in *both* namespaces.
+    let new_path = unix_name(path);
+    let plen = new_path.len();
+    // A zero-length name is not bindable (POSIX/`man 7 unix`: an autobind
+    // would be requested with addrlen == sizeof(sa_family); here addrlen > 2
+    // is already guaranteed by the syscall layer, but an all-empty slice is
+    // still rejected defensively as EINVAL).
+    if plen == 0 { return -22; }
     let mut t = TABLE.lock();
     for (i, s) in t.0.iter().enumerate() {
         if i as u64 == id { continue; }
@@ -301,17 +344,40 @@ pub fn listen(id: u64) -> i64 {
 
 pub fn connect(id: u64, path: &[u8], _client_creds: PeerCreds) -> i64 {
     if id as usize >= MAX_UNIX_SOCKETS { return -9; }
-    // Strip trailing NUL to match paths stored by bind.
-    let raw_len = path.iter().position(|&b| b == 0).unwrap_or(path.len());
-    let plen = raw_len.min(UNIX_PATH_MAX);
-    let search = &path[..plen];
+    // Select pathname vs abstract namespace per `man 7 unix`, using the same
+    // normaliser as bind() so a bound name matches.  Abstract names keep their
+    // full addrlen-derived length and embedded NULs; pathnames are NUL-stripped.
+    let search = unix_name(path);
+    if search.is_empty() { return -22; } // EINVAL — empty name is not connectable
+    let abstract_ns = is_abstract(search);
     let mut t = TABLE.lock();
 
+    // Distinguish the two failure modes the contract requires (`man 2 connect`,
+    // `man 7 unix`):
+    //   * a *listening* socket bound to this name → connect succeeds;
+    //   * a socket bound (but not listening) to a *pathname* → the socket file
+    //     exists but nobody is accepting → ECONNREFUSED;
+    //   * NO socket bound to this *pathname* at all → the socket file does not
+    //     exist → ENOENT;
+    //   * an *abstract* name with no listener → ECONNREFUSED (there is no
+    //     filesystem object, so a missing abstract name maps to "refused",
+    //     never ENOENT).
     let server_id = t.0.iter().enumerate()
-        .find(|(_, s)| s.state == UnixState::Listening && &s.path[..s.path_len] == search)
+        .find(|(_, s)| s.state == UnixState::Listening
+            && &s.path[..s.path_len] == search)
         .map(|(i, _)| i as u64)
         .unwrap_or(u64::MAX);
-    if server_id == u64::MAX { return -111; }
+    if server_id == u64::MAX {
+        if abstract_ns {
+            return -111; // ECONNREFUSED — abstract name has no listener
+        }
+        // Pathname: does a (non-listening) bound socket exist at this path?
+        let exists = t.0.iter().any(|s|
+            (s.state == UnixState::Bound || s.state == UnixState::Connected)
+            && !is_abstract(&s.path[..s.path_len])
+            && &s.path[..s.path_len] == search);
+        return if exists { -111 } else { -2 }; // ECONNREFUSED vs ENOENT
+    }
 
     // The accepted peer (server-side end of the new connection) inherits the
     // server's socket type per `man 7 unix` — a SEQPACKET listener must yield

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1697,12 +1697,24 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     let s = unsafe { core::slice::from_raw_parts((addr_ptr + 2) as *const u8, (addrlen - 2).min(108)) };
                     s.to_vec()
                 } else { return -22; };
+                // Pass the FULL address slice (length from addrlen) down to
+                // net::unix, which decides pathname vs abstract namespace.
+                // Per `man 7 unix`: a sun_path beginning with a NUL byte is an
+                // *abstract* name whose length is taken from addrlen (it may
+                // contain embedded NULs and is NOT NUL-terminated); a sun_path
+                // beginning with a non-NUL byte is a NUL-terminated filesystem
+                // pathname.  Stripping at the first NUL here would truncate an
+                // abstract name to the empty string — so namespace selection
+                // must happen below where the leading byte is still visible.
                 let path_bytes: &[u8] = &path_owned;
-                // Strip trailing NUL
-                let plen = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
                 #[cfg(feature = "firefox-test-core")]
                 if pid >= 1 {
-                    if let Ok(p) = core::str::from_utf8(&path_bytes[..plen]) {
+                    let dbg_len = if path_bytes.first() == Some(&0) {
+                        path_bytes.len()
+                    } else {
+                        path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len())
+                    };
+                    if let Ok(p) = core::str::from_utf8(&path_bytes[..dbg_len]) {
                         crate::serial_println!("[FF/connect] pid={} path={}", pid, p);
                     }
                 }
@@ -1712,7 +1724,7 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // per unix(7) — finding H7 (CWE-287).
                 let (cpid, cuid, cgid) = crate::proc::current_creds_lockless();
                 let creds = crate::net::unix::PeerCreds { pid: cpid, uid: cuid, gid: cgid };
-                crate::net::unix::connect(unix_id, &path_bytes[..plen], creds)
+                crate::net::unix::connect(unix_id, path_bytes, creds)
             } else {
                 if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
@@ -2917,9 +2929,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                     let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
                     unsafe { core::slice::from_raw_parts((addr_ptr + 2) as *const u8, (addrlen - 2).min(108)) }.to_vec()
                 } else { return -22; };
+                // Pass the FULL address slice (length from addrlen); net::unix
+                // selects pathname vs abstract namespace from the leading byte
+                // per `man 7 unix` (a leading-NUL sun_path is an abstract name
+                // whose length is addrlen, not NUL-terminated).
                 let path_bytes: &[u8] = &path_owned;
-                let plen = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
-                crate::net::unix::bind(unix_id, &path_bytes[..plen])
+                crate::net::unix::bind(unix_id, path_bytes)
             } else if family == 2 && addrlen >= 8 {
                 if !crate::syscall::is_socket_fd(pid, fd) { return -9; }
                 let socket_id = crate::syscall::get_socket_id(pid, fd);

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2697,6 +2697,20 @@ pub fn run() -> ! {
         if test_523_tcp_graceful_close_fin_defer() { passed += 1; }
     }
 
+    // ── Test 525: AF_UNIX connect(2) errno — ENOENT vs ECONNREFUSED ─────
+    // connect to an absent pathname → ENOENT (-2); a pathname bound but not
+    // listening → ECONNREFUSED (-111).  Pre-fix conflated both into -111.
+    // Refs: man 2 connect, man 7 unix.
+    total += 1;
+    if test_525_unix_connect_enoent_vs_econnrefused() { passed += 1; }
+
+    // ── Test 526: AF_UNIX abstract namespace (leading-NUL) ──────────────
+    // A leading-NUL sun_path is an abstract name (no FS lookup, length from
+    // addrlen, embedded NULs significant); an unbound abstract name connects
+    // to ECONNREFUSED (never ENOENT).  Refs: man 7 unix §"Abstract sockets".
+    total += 1;
+    if test_526_unix_abstract_namespace() { passed += 1; }
+
     // ── Test 522: TCP RX rings the InetRx poll-bell on readiness edges ──
     // Asserts the TCP receive path wakes pollers (and blocking recv/accept)
     // on the accept-complete and data-arrival edges, matching the UDP path,
@@ -34198,6 +34212,188 @@ fn test_523_tcp_graceful_close_fin_defer() -> bool {
     let _ = tcp::abort(client_port);
     let _ = tcp::abort(SERVER_PORT);
     test_pass!("TCP graceful close — close() with pending send_buffer delivers full body (loopback)");
+    true
+}
+
+// ── Test 525: AF_UNIX connect(2) errno — ENOENT vs ECONNREFUSED ───────────────
+//
+// Per `man 2 connect` / `man 7 unix`, connect(2) on an AF_UNIX pathname socket
+// distinguishes two failure modes that the pre-fix code conflated into a blanket
+// ECONNREFUSED:
+//   * the socket pathname does not exist at all          → ENOENT       (-2)
+//   * the pathname exists (a socket is bound there) but
+//     nobody is listening on it                          → ECONNREFUSED (-111)
+//
+// Drives the real syscall path (connect == nr 42) so both the syscall-layer
+// addrlen threading and the net::unix lookup are exercised end to end.
+fn test_525_unix_connect_enoent_vs_econnrefused() -> bool {
+    test_header!("AF_UNIX connect(2) errno — absent path → ENOENT, bound-not-listening → ECONNREFUSED");
+
+    // Build a sockaddr_un for /tmp/nde525.sock.
+    let mut addr = [0u8; 110];
+    addr[0] = 1; addr[1] = 0; // sa_family = AF_UNIX
+    let path = b"/tmp/nde525.sock\0";
+    addr[2..2 + path.len()].copy_from_slice(path);
+    let addrlen = (2 + path.len()) as u64;
+
+    // (1) connect to a path with NO bound socket at all → ENOENT (-2).
+    let c1 = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    if c1 < 0 { test_fail!("unix525", "socket() returned {}", c1); return false; }
+    let r1 = crate::syscall::dispatch_linux_kernel(
+        42, c1 as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if r1 != -2 {
+        test_fail!("unix525", "connect to absent path returned {} (expected -2 ENOENT)", r1);
+        crate::syscall::dispatch_linux_kernel(3, c1 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    crate::syscall::dispatch_linux_kernel(3, c1 as u64, 0, 0, 0, 0, 0);
+    test_println!("  connect(absent path) → ENOENT (-2) ✓");
+
+    // (2) bind a socket at the path but do NOT listen → connect → ECONNREFUSED.
+    let srv = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    if srv < 0 { test_fail!("unix525", "server socket() returned {}", srv); return false; }
+    let rb = crate::syscall::dispatch_linux_kernel(
+        49, srv as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if rb != 0 {
+        test_fail!("unix525", "bind() returned {} (expected 0)", rb);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+
+    let c2 = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    if c2 < 0 { test_fail!("unix525", "client2 socket() returned {}", c2); return false; }
+    let r2 = crate::syscall::dispatch_linux_kernel(
+        42, c2 as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if r2 != -111 {
+        test_fail!("unix525",
+            "connect to bound-not-listening path returned {} (expected -111 ECONNREFUSED)", r2);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  connect(bound, not listening) → ECONNREFUSED (-111) ✓");
+
+    // (3) sanity: once the server listen()s, connect succeeds (no regression).
+    let rl = crate::syscall::dispatch_linux_kernel(50, srv as u64, 5, 0, 0, 0, 0);
+    if rl != 0 {
+        test_fail!("unix525", "listen() returned {}", rl);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    let c3 = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    let r3 = crate::syscall::dispatch_linux_kernel(
+        42, c3 as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if r3 != 0 {
+        test_fail!("unix525", "connect to listening path returned {} (expected 0)", r3);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c3 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  connect(listening) → 0 (no regression) ✓");
+
+    crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, c3 as u64, 0, 0, 0, 0, 0);
+    test_pass!("AF_UNIX connect(2) errno — ENOENT vs ECONNREFUSED");
+    true
+}
+
+// ── Test 526: AF_UNIX abstract namespace (leading-NUL) connect ────────────────
+//
+// Per `man 7 unix` §"Abstract sockets": a sun_path beginning with a NUL byte
+// names an abstract socket, which:
+//   * lives in a distinct namespace with NO filesystem lookup;
+//   * has its length taken from addrlen (it is NOT NUL-terminated);
+//   * MAY contain embedded NUL bytes, which are significant.
+// Drives the real syscall path so addrlen threading from the syscall layer into
+// net::unix is exercised — the pre-fix code truncated the name at the leading
+// NUL (empty string) and could never bind or match an abstract name.
+fn test_526_unix_abstract_namespace() -> bool {
+    test_header!("AF_UNIX abstract namespace — leading-NUL bind/connect, embedded-NUL not truncated");
+
+    // Abstract name with an EMBEDDED NUL: sun_path = "\0nde\0526" (8 bytes).
+    // A C-string truncation at the first NUL would reduce this to length 0;
+    // a truncation at the embedded NUL would reduce it to "\0nde" and collide
+    // with any other "\0nde*" name.  Both must be avoided.
+    let abstract_name: &[u8] = b"\0nde\0526";
+    let mut addr = [0u8; 110];
+    addr[0] = 1; addr[1] = 0; // sa_family = AF_UNIX
+    addr[2..2 + abstract_name.len()].copy_from_slice(abstract_name);
+    let addrlen = (2 + abstract_name.len()) as u64;
+
+    // (1) connect to an unbound abstract name → ECONNREFUSED (-111), NEVER
+    //     ENOENT — there is no filesystem object for an abstract name.
+    let c1 = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    if c1 < 0 { test_fail!("unix526", "socket() returned {}", c1); return false; }
+    let r1 = crate::syscall::dispatch_linux_kernel(
+        42, c1 as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if r1 != -111 {
+        test_fail!("unix526",
+            "connect to unbound abstract name returned {} (expected -111 ECONNREFUSED)", r1);
+        crate::syscall::dispatch_linux_kernel(3, c1 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    crate::syscall::dispatch_linux_kernel(3, c1 as u64, 0, 0, 0, 0, 0);
+    test_println!("  connect(unbound abstract) → ECONNREFUSED (-111), not ENOENT ✓");
+
+    // (2) bind + listen on the abstract name, then connect → 0.  This proves
+    //     the leading NUL was NOT stripped (else bind/connect would both see an
+    //     empty name) and that bind/connect agree on the addrlen-derived name.
+    let srv = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    if srv < 0 { test_fail!("unix526", "server socket() returned {}", srv); return false; }
+    let rb = crate::syscall::dispatch_linux_kernel(
+        49, srv as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if rb != 0 {
+        test_fail!("unix526", "bind(abstract) returned {} (expected 0)", rb);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    let rl = crate::syscall::dispatch_linux_kernel(50, srv as u64, 5, 0, 0, 0, 0);
+    if rl != 0 {
+        test_fail!("unix526", "listen(abstract) returned {}", rl);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    let c2 = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    let r2 = crate::syscall::dispatch_linux_kernel(
+        42, c2 as u64, addr.as_ptr() as u64, addrlen, 0, 0, 0);
+    if r2 != 0 {
+        test_fail!("unix526", "connect(listening abstract) returned {} (expected 0)", r2);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  bind+listen+connect(abstract \"\\0nde\\0526\") → 0 ✓");
+
+    // (3) embedded-NUL significance: a connect to the truncated-at-embedded-NUL
+    //     prefix "\0nde" must NOT match the "\0nde\0526" listener — it is a
+    //     different abstract name → ECONNREFUSED.  This fails if the name were
+    //     ever truncated at an embedded NUL.
+    let prefix: &[u8] = b"\0nde";
+    let mut paddr = [0u8; 110];
+    paddr[0] = 1; paddr[1] = 0;
+    paddr[2..2 + prefix.len()].copy_from_slice(prefix);
+    let plen = (2 + prefix.len()) as u64;
+    let c3 = crate::syscall::dispatch_linux_kernel(41, 1, 1, 0, 0, 0, 0);
+    let r3 = crate::syscall::dispatch_linux_kernel(
+        42, c3 as u64, paddr.as_ptr() as u64, plen, 0, 0, 0);
+    if r3 != -111 {
+        test_fail!("unix526",
+            "connect to embedded-NUL prefix \"\\0nde\" returned {} (expected -111 — \
+             distinct abstract name; embedded NUL was truncated)", r3);
+        crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, c3 as u64, 0, 0, 0, 0, 0);
+        return false;
+    }
+    crate::syscall::dispatch_linux_kernel(3, c3 as u64, 0, 0, 0, 0, 0);
+    test_println!("  connect(\"\\0nde\") ≠ \"\\0nde\\0526\" → ECONNREFUSED (embedded NUL kept) ✓");
+
+    crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
+    test_pass!("AF_UNIX abstract namespace — leading-NUL bind/connect, embedded-NUL not truncated");
     true
 }
 


### PR DESCRIPTION
## Summary

Two AF_UNIX `connect(2)` correctness gaps, with `bind(2)` brought into
symmetry so a bound name matches the same name on a later connect.

### 1. connect(2) errno: ENOENT vs ECONNREFUSED

Per `man 2 connect` / `man 7 unix`, connect to a **pathname** AF_UNIX
socket distinguishes two failure modes the pre-fix code conflated into a
blanket `ECONNREFUSED`:

| Case | Correct errno |
|---|---|
| pathname socket does not exist at all | `ENOENT` (-2) |
| pathname is bound but nobody is listening | `ECONNREFUSED` (-111) |
| a listening socket is bound to the path | success (0) |

The old lookup searched only for a `Listening` socket and returned `-111`
whenever none was found, so a never-created / typo'd socket path reported
"connection refused" instead of "no such file or directory" — a divergence
glibc/musl clients act on (retry-on-`ECONNREFUSED` vs fail-on-`ENOENT`).

### 2. Abstract namespace (leading-NUL addresses)

Per `man 7 unix` §"Abstract sockets", a `sun_path` whose first byte is NUL
names an **abstract** socket: a distinct namespace with no filesystem
lookup, whose length is taken from `addrlen` (not NUL-terminated, may
contain embedded NULs). The nr-42 (`connect`) and nr-49 (`bind`) syscall
handlers previously stripped the address at the first NUL, which reduces any
abstract name to the empty string — so an abstract address could never be
bound or matched.

The fix threads the full `addrlen`-derived address slice from the syscall
layer into `net::unix`, which selects the namespace from the leading byte:
- **pathname** (`addr[0] != 0`): NUL-terminated, stored up to the first NUL — unchanged behaviour;
- **abstract** (`addr[0] == 0`): the whole `addrlen`-derived slice with the leading and any embedded NULs intact.

A leading-NUL name is disjoint from every pathname (a pathname can never
begin with a NUL), so the two namespaces never collide. A missing abstract
listener maps to `ECONNREFUSED`, never `ENOENT` (no filesystem object).

## Scope / non-regression

- No new bind registry was introduced — the existing in-slot path storage is
  reused for both namespaces, so the AF_UNIX paths the FF/X11 demo depends on
  are untouched (pathname behaviour is byte-for-byte unchanged; new code only
  fires on the missing-listener and leading-NUL branches).
- Kernel-internal callers (`x11/mod.rs` bind, `main.rs` connect) pass
  NUL-terminated pathnames and route through the pathname branch unchanged.

## Tests

- **Test 525** — drives nr-42 over the real syscall path: connect to an absent
  path → `ENOENT`; bound-not-listening → `ECONNREFUSED`; listening → 0.
- **Test 526** — binds/listens/connects an abstract name `\0nde\0526` with an
  embedded NUL; asserts an unbound abstract name → `ECONNREFUSED` (not
  `ENOENT`), and that a connect to the embedded-NUL prefix `\0nde` does **not**
  match the longer listener (embedded NUL is significant, not truncated).

## Verification

`cargo check` (kernel target + `-Zbuild-std`, with and without `test-mode`)
is clean. Per the dispatch constraints this lane does not boot QEMU; remote
`kernel smoke` performs boot-verification.

Refs: `man 2 connect`, `man 7 unix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)