### PR TITLE
net/arp: bound the cache and age entries out (TTL) (NDE-23)

### DIFF
--- a/kernel/src/net/arp.rs
+++ b/kernel/src/net/arp.rs
@@ -9,14 +9,44 @@ use spin::Mutex;
 use super::{MacAddress, Ipv4Address, our_mac, our_ip};
 use super::ethernet::{build_frame, ETHERTYPE_ARP};
 
+/// Maximum number of resolved IPv4→MAC mappings the cache will hold.
+///
+/// RFC 826 does not mandate a cache size; an unbounded cache lets a host that
+/// emits ARP traffic from many distinct (e.g. spoofed) source addresses grow
+/// the table without limit and exhaust kernel memory.  We therefore bound the
+/// table: once it is full a new mapping evicts the *least recently refreshed*
+/// entry, which is also the one most likely to already be stale.
+const ARP_CACHE_MAX: usize = 256;
+
+/// Time-to-live for a resolved entry, in timer ticks (~100 Hz → 10 ms/tick),
+/// i.e. 60 seconds.  RFC 826 leaves expiry to the implementation; common
+/// practice ages an entry out of the resolved (reachable) state on the order
+/// of tens of seconds to a few minutes so that a stale mapping cannot keep
+/// routing frames to a host that has since changed its NIC / MAC.  A lookup
+/// that finds only an expired entry behaves as a miss, triggering a fresh
+/// resolution.
+const ARP_CACHE_TTL_TICKS: u64 = 6_000;
+
 /// ARP cache entry.
 struct ArpEntry {
     ip: Ipv4Address,
     mac: MacAddress,
+    /// Monotonic tick at which this mapping was last learned or refreshed.
+    last_seen: u64,
 }
 
 /// ARP cache.
 static ARP_CACHE: Mutex<Vec<ArpEntry>> = Mutex::new(Vec::new());
+
+/// Monotonic tick source used to stamp and age cache entries.
+fn now_ticks() -> u64 {
+    crate::arch::x86_64::irq::get_ticks()
+}
+
+/// True if `entry` is older than the TTL relative to `now`.
+fn is_expired(entry: &ArpEntry, now: u64) -> bool {
+    now.wrapping_sub(entry.last_seen) >= ARP_CACHE_TTL_TICKS
+}
 
 /// ARP opcodes.
 const ARP_REQUEST: u16 = 1;
@@ -75,20 +105,63 @@ fn send_reply(target_mac: MacAddress, target_ip: Ipv4Address) {
     super::send_frame(&frame);
 }
 
-/// Update the ARP cache.
+/// Update the ARP cache, stamping the entry with the current tick.
 fn update_cache(ip: Ipv4Address, mac: MacAddress) {
+    update_cache_at(ip, mac, now_ticks());
+}
+
+/// Insert or refresh `ip → mac`, stamping `last_seen = now`.
+///
+/// Refreshing an existing IP updates both the MAC and the timestamp.  When the
+/// table is full and a *new* IP must be inserted, an expired entry is reclaimed
+/// if one exists; otherwise the least-recently-refreshed entry is evicted so
+/// the table never exceeds [`ARP_CACHE_MAX`] (bounds memory under a flood of
+/// distinct source addresses).  `now` is taken as a parameter so the aging /
+/// bounding logic is deterministically testable.
+fn update_cache_at(ip: Ipv4Address, mac: MacAddress, now: u64) {
     let mut cache = ARP_CACHE.lock();
+
     if let Some(entry) = cache.iter_mut().find(|e| e.ip == ip) {
         entry.mac = mac;
-    } else {
-        cache.push(ArpEntry { ip, mac });
+        entry.last_seen = now;
+        return;
     }
+
+    if cache.len() >= ARP_CACHE_MAX {
+        // Prefer reclaiming an already-expired slot; if none has expired, evict
+        // the oldest (smallest last_seen) so the cap is always respected.
+        let victim = cache
+            .iter()
+            .position(|e| is_expired(e, now))
+            .or_else(|| {
+                cache
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, e)| e.last_seen)
+                    .map(|(i, _)| i)
+            });
+        if let Some(i) = victim {
+            cache.swap_remove(i);
+        }
+    }
+
+    cache.push(ArpEntry { ip, mac, last_seen: now });
 }
 
 /// Look up a MAC address in the ARP cache.
 pub fn lookup(ip: Ipv4Address) -> Option<MacAddress> {
+    lookup_at(ip, now_ticks())
+}
+
+/// Look up `ip` as of tick `now`; an entry older than the TTL is treated as a
+/// miss (returns `None`) so a stale mapping is never used.  `now` is a
+/// parameter so the expiry behaviour is deterministically testable.
+fn lookup_at(ip: Ipv4Address, now: u64) -> Option<MacAddress> {
     let cache = ARP_CACHE.lock();
-    cache.iter().find(|e| e.ip == ip).map(|e| e.mac)
+    cache
+        .iter()
+        .find(|e| e.ip == ip && !is_expired(e, now))
+        .map(|e| e.mac)
 }
 
 /// Dump the full ARP cache for diagnostics.
@@ -112,4 +185,41 @@ pub fn send_request(target_ip: Ipv4Address) {
 
     let frame = build_frame([0xFF; 6], ETHERTYPE_ARP, &arp);
     super::send_frame(&frame);
+}
+
+// ── Test-only hooks ─────────────────────────────────────────────────────────
+// Exposed only under `test-mode` so the regression suite can exercise the
+// bounding / aging logic deterministically by injecting an explicit `now`,
+// without spinning on the real timer for the full TTL.
+
+/// Capacity bound of the cache (for assertions).
+#[cfg(feature = "test-mode")]
+pub fn test_cache_max() -> usize { ARP_CACHE_MAX }
+
+/// TTL in ticks (for assertions).
+#[cfg(feature = "test-mode")]
+pub fn test_cache_ttl_ticks() -> u64 { ARP_CACHE_TTL_TICKS }
+
+/// Empty the cache so a test starts from a known state.
+#[cfg(feature = "test-mode")]
+pub fn test_clear_cache() {
+    ARP_CACHE.lock().clear();
+}
+
+/// Current number of entries in the cache.
+#[cfg(feature = "test-mode")]
+pub fn test_cache_len() -> usize {
+    ARP_CACHE.lock().len()
+}
+
+/// Insert/refresh `ip → mac` as if at tick `now` (drives the aging/bound path).
+#[cfg(feature = "test-mode")]
+pub fn test_update_at(ip: Ipv4Address, mac: MacAddress, now: u64) {
+    update_cache_at(ip, mac, now);
+}
+
+/// Look up `ip` as of tick `now` (drives the expiry path).
+#[cfg(feature = "test-mode")]
+pub fn test_lookup_at(ip: Ipv4Address, now: u64) -> Option<MacAddress> {
+    lookup_at(ip, now)
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2711,6 +2711,16 @@ pub fn run() -> ! {
     total += 1;
     if test_526_unix_abstract_namespace() { passed += 1; }
 
+    // ── Test 527: ARP cache is bounded + ages out (TTL) ─────────────────
+    // The ARP cache must not grow without limit (a spoofed-source ARP flood
+    // would otherwise exhaust memory) and must not return a stale mapping
+    // after a host changes its MAC.  Asserts the MAX cap, TTL expiry, and
+    // that refreshing an IP updates both MAC and timestamp.  RFC 826 leaves
+    // cache management to the implementation; this is the bounding/aging
+    // discipline.
+    total += 1;
+    if test_527_arp_cache_bound_ttl() { passed += 1; }
+
     // ── Test 522: TCP RX rings the InetRx poll-bell on readiness edges ──
     // Asserts the TCP receive path wakes pollers (and blocking recv/accept)
     // on the accept-complete and data-arrival edges, matching the UDP path,
@@ -34517,6 +34527,135 @@ fn test_526_unix_abstract_namespace() -> bool {
     crate::syscall::dispatch_linux_kernel(3, srv as u64, 0, 0, 0, 0, 0);
     crate::syscall::dispatch_linux_kernel(3, c2 as u64, 0, 0, 0, 0, 0);
     test_pass!("AF_UNIX abstract namespace — leading-NUL bind/connect, embedded-NUL not truncated");
+    true
+}
+
+// ── Test 527: ARP cache is bounded + entries age out (TTL) ────────────────────
+//
+// RFC 826 specifies the ARP request/reply exchange but leaves cache management
+// to the implementation.  Two safety properties must hold regardless:
+//
+//   (1) Bound: the resolved-mapping table must not grow without limit.  A host
+//       that ARPs from many distinct (e.g. spoofed) source addresses would
+//       otherwise exhaust kernel memory.  Inserting MAX+N distinct IPs must
+//       leave the table at exactly MAX entries (oldest evicted).
+//   (2) Expiry (TTL): a mapping older than the TTL must not be returned by a
+//       lookup, so a frame is never routed to a host that has since changed its
+//       NIC/MAC.  A lookup that finds only an expired entry is a miss.
+//   (3) Refresh: re-learning an existing IP must update BOTH the MAC and the
+//       timestamp (the entry is rejuvenated, not duplicated, and a refreshed
+//       entry survives past the original TTL window).
+//
+// The cache stamps entries with the monotonic timer tick (≈100 Hz).  Spinning
+// for the full TTL (60 s) in a unit test is impractical, so the test drives the
+// internal aging/bounding path through the `test_*_at` hooks, injecting an
+// explicit `now` to make expiry and eviction deterministic.
+#[cfg(feature = "test-mode")]
+fn test_527_arp_cache_bound_ttl() -> bool {
+    test_header!("ARP cache — bounded at MAX, TTL expiry, refresh updates MAC+timestamp");
+
+    use crate::net::arp;
+
+    let max = arp::test_cache_max();
+    let ttl = arp::test_cache_ttl_ticks();
+
+    // Distinct, well-formed IPv4 addresses derived from an index; with MAX=256
+    // the low octet alone would collide, so spread across two octets.
+    let ip_for = |i: usize| -> [u8; 4] {
+        [10, 0, ((i >> 8) & 0xff) as u8, (i & 0xff) as u8]
+    };
+    let mac_for = |i: usize| -> [u8; 6] {
+        [0x02, 0, 0, 0, ((i >> 8) & 0xff) as u8, (i & 0xff) as u8]
+    };
+
+    // ── (1) Bound: insert MAX+16 distinct IPs at increasing ticks; the table
+    //     must never exceed MAX.  Using increasing `now` makes the eviction
+    //     victim (oldest last_seen) deterministic.
+    arp::test_clear_cache();
+    let overshoot = 16usize;
+    for i in 0..(max + overshoot) {
+        arp::test_update_at(ip_for(i), mac_for(i), 1000 + i as u64);
+        let len = arp::test_cache_len();
+        if len > max {
+            test_fail!("arp527",
+                "cache len {} exceeded MAX {} after {} inserts", len, max, i + 1);
+            arp::test_clear_cache();
+            return false;
+        }
+    }
+    if arp::test_cache_len() != max {
+        test_fail!("arp527",
+            "after MAX+{} inserts len = {} (expected exactly {})",
+            overshoot, arp::test_cache_len(), max);
+        arp::test_clear_cache();
+        return false;
+    }
+    // The earliest-inserted IPs were the oldest → evicted; the most-recent MAX
+    // distinct IPs must still resolve.  Check one freshly-inserted entry.
+    let last_i = max + overshoot - 1;
+    if arp::test_lookup_at(ip_for(last_i), 1000 + last_i as u64) != Some(mac_for(last_i)) {
+        test_fail!("arp527", "most-recent insert not resolvable after bound");
+        arp::test_clear_cache();
+        return false;
+    }
+    // An evicted early IP must now be a miss.
+    if arp::test_lookup_at(ip_for(0), 1000 + last_i as u64).is_some() {
+        test_fail!("arp527", "oldest entry was not evicted at the cap");
+        arp::test_clear_cache();
+        return false;
+    }
+    test_println!("  insert MAX+{} distinct IPs → len stays at MAX ({}), oldest evicted ✓",
+        overshoot, max);
+
+    // ── (2) TTL expiry: learn one IP at t0; a lookup just before TTL hits, a
+    //     lookup at/after TTL misses (entry treated as absent).
+    arp::test_clear_cache();
+    let ip = [192, 168, 1, 50];
+    let mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01];
+    let t0 = 5_000u64;
+    arp::test_update_at(ip, mac, t0);
+    if arp::test_lookup_at(ip, t0 + ttl - 1) != Some(mac) {
+        test_fail!("arp527", "entry expired one tick early (within TTL must hit)");
+        arp::test_clear_cache();
+        return false;
+    }
+    if arp::test_lookup_at(ip, t0 + ttl).is_some() {
+        test_fail!("arp527", "entry not expired at TTL boundary (must be a miss)");
+        arp::test_clear_cache();
+        return false;
+    }
+    test_println!("  entry hit at t0+TTL-1, miss at t0+TTL ({} ticks ≈ 60 s) ✓", ttl);
+
+    // ── (3) Refresh updates MAC + timestamp: re-learn the same IP with a new
+    //     MAC at a later tick; the new MAC resolves, and the refreshed entry
+    //     survives past the ORIGINAL TTL window (timestamp was rejuvenated).
+    let mac2 = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x02];
+    let t1 = t0 + 10; // still within original TTL
+    arp::test_update_at(ip, mac2, t1);
+    // No duplicate row created.
+    if arp::test_cache_len() != 1 {
+        test_fail!("arp527",
+            "refresh created a duplicate (len {} expected 1)", arp::test_cache_len());
+        arp::test_clear_cache();
+        return false;
+    }
+    // New MAC resolves.
+    if arp::test_lookup_at(ip, t1) != Some(mac2) {
+        test_fail!("arp527", "refresh did not update the MAC");
+        arp::test_clear_cache();
+        return false;
+    }
+    // Survives past the ORIGINAL expiry (t0+TTL) but inside the NEW window
+    // (t1+TTL) — proves the timestamp was refreshed, not just the MAC.
+    if arp::test_lookup_at(ip, t0 + ttl + 5) != Some(mac2) {
+        test_fail!("arp527", "refresh did not rejuvenate the timestamp");
+        arp::test_clear_cache();
+        return false;
+    }
+    test_println!("  refresh updates MAC + timestamp (no dup, survives past original TTL) ✓");
+
+    arp::test_clear_cache();
+    test_pass!("ARP cache — bounded at MAX, TTL expiry, refresh updates MAC+timestamp");
     true
 }
 


### PR DESCRIPTION
## Problem

The ARP cache was an unbounded `Vec<(ip, mac)>` with no timestamp:

- `update_cache()` pushed a fresh row for every newly-seen sender IP with **no size limit** → a host that ARPs from many distinct (e.g. spoofed) source addresses grows the table without bound and can **exhaust kernel memory**.
- entries were **never expired**, so after a peer changed its NIC/MAC the cache kept routing frames to the **dead MAC** indefinitely.

RFC 826 specifies the request/reply exchange but leaves cache management to the implementation, so neither problem is mandated away — both are the implementation's responsibility.

## Fix

- Add a `last_seen` monotonic tick (~100 Hz timer) to each entry, stamped on insert **and on every refresh**.
- `lookup()` treats an entry older than the TTL as **absent** (a miss → fresh resolution).
- `update_cache()` refresh of an existing IP updates **both** the MAC and the timestamp.
- **TTL = 6000 ticks (60 s).** RFC 826 leaves expiry to the implementation; common practice ages a resolved (reachable) mapping out on the order of tens of seconds to a few minutes so a stale entry cannot keep routing to a host that has changed its MAC. 60 s is a conservative reachable-cache timeout.
- **Bound the table at 256 entries** (mirrors the per-port queue cap discipline used elsewhere in the net stack). When full and a new IP must be inserted, an already-expired slot is reclaimed if one exists, else the least-recently-refreshed entry is evicted — the table never exceeds the cap under a spoofed-source flood.
- Wrapping tick comparison; a single lock acquisition per operation (lock order preserved, no nested locks).
- The aging/bounding logic takes `now` as a parameter internally (public wrappers read `get_ticks()`) so it is deterministically testable without spinning on the real timer for the full TTL.

## Test

**Test 527** (`test_527_arp_cache_bound_ttl`):
- inserts MAX+16 distinct IPs → table stays at exactly MAX, oldest evicted;
- learns an IP at `t0` → hit at `t0+TTL-1`, miss at `t0+TTL`;
- re-learns the IP with a new MAC → no duplicate row, new MAC resolves, refreshed entry survives past the original TTL window (timestamp rejuvenated, not just the MAC).

`cargo check` (target `x86_64-astryx`, `--features test-mode`, build-std) passes clean — no new warnings.

Refs: RFC 826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)