### PR TITLE
vfs: /dev/urandom must be a CSPRNG (fixes HTTPS — NSS softoken FIPS continuous-RNG test)

### DIFF
--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1436,6 +1436,11 @@ pub fn run() -> ! {
     total += 1;
     if test_getrandom_fills_buffer() { passed += 1; }
 
+    // ── Test 529: /dev/urandom consecutive reads differ (NSS TLS RNG gate) ───
+
+    total += 1;
+    if test_dev_urandom_consecutive_reads_differ() { passed += 1; }
+
     // ── Test 126: mremap shrink — first 2 pages still readable ───────────────
 
     total += 1;
@@ -28277,6 +28282,71 @@ fn test_getrandom_fills_buffer() -> bool {
 
     test_println!("  buf[0..4] = {:02X} {:02X} {:02X} {:02X} (non-zero ✓)", buf[0], buf[1], buf[2], buf[3]);
     test_pass!("getrandom: 64 bytes, non-zero ✓");
+    true
+}
+
+// ── Test 529: /dev/urandom — consecutive reads must differ ───────────────────
+//
+// A correct /dev/urandom is a CSPRNG: two back-to-back reads must (with
+// overwhelming probability) return different bytes.  NSS softoken's FIPS
+// 140-2 §4.9.2 continuous-RNG health test reads two consecutive entropy
+// blocks at C_Initialize time and treats an identical pair as a hardware-RNG
+// failure (CKR_DEVICE_ERROR), which aborts TLS initialization.  A prior
+// implementation seeded a single LCG from the timer tick once per read, so
+// two reads serviced within one tick were byte-identical and tripped that
+// test — breaking HTTPS in the browser.  This reproduces the continuous-test
+// pattern (two reads with no delay between them) and asserts they differ.
+// See random(4) / getrandom(2).
+
+fn test_dev_urandom_consecutive_reads_differ() -> bool {
+    test_header!("/dev/urandom: two back-to-back reads differ (FIPS continuous-RNG invariant, Test 529)");
+
+    let pid = crate::proc::current_pid_lockless();
+    // The special-device read path is selected by the bit-24 (0x0100_0000)
+    // device flag the Linux open(2) dispatch ORs onto the fd for
+    // /dev/urandom; pass it directly to vfs::open here (it is stored verbatim
+    // into the fd's flags) so this in-kernel test exercises the same read
+    // path libc does, without going through the Linux open dispatch.
+    const DEV_URANDOM_FLAG: u32 = 0x0100_0000;
+    let fd = match crate::vfs::open(pid, "/dev/urandom", DEV_URANDOM_FLAG) {
+        Ok(fd) => fd,
+        Err(e) => {
+            test_fail!("dev_urandom_consecutive", "open(/dev/urandom) failed: {:?}", e);
+            return false;
+        }
+    };
+
+    // Two reads with nothing in between — the worst case for a clock-seeded
+    // RNG (both reads land in the same timer tick).
+    let mut a = [0u8; 32];
+    let mut b = [0u8; 32];
+    let ra = crate::vfs::fd_read(pid, fd, a.as_mut_ptr(), a.len());
+    let rb = crate::vfs::fd_read(pid, fd, b.as_mut_ptr(), b.len());
+    let _ = crate::vfs::close(pid, fd);
+
+    let na = ra.unwrap_or(0);
+    let nb = rb.unwrap_or(0);
+    if na != a.len() || nb != b.len() {
+        test_fail!("dev_urandom_consecutive", "short read: {} then {}", na, nb);
+        return false;
+    }
+
+    // Neither block may be all-zero (would also break NSS) ...
+    if a.iter().all(|&x| x == 0) || b.iter().all(|&x| x == 0) {
+        test_fail!("dev_urandom_consecutive", "an entropy block was all-zero");
+        return false;
+    }
+
+    // ... and the two consecutive blocks must differ (the FIPS continuous
+    // self-test invariant).
+    if a == b {
+        test_fail!("dev_urandom_consecutive", "two consecutive /dev/urandom reads were byte-identical");
+        return false;
+    }
+
+    test_println!("  a[0..4]={:02X}{:02X}{:02X}{:02X}  b[0..4]={:02X}{:02X}{:02X}{:02X} (differ ✓)",
+        a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3]);
+    test_pass!("/dev/urandom: consecutive reads differ ✓");
     true
 }
 

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2635,13 +2635,31 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                 }
                 return Ok(count);
             }
-            // bit 24 = /dev/urandom | /dev/random  → fill with pseudo-random bytes
+            // bit 24 = /dev/urandom | /dev/random  → fill with random bytes
+            //
+            // MUST draw from the same RDRAND-backed entropy source as
+            // getrandom(2) (`security::rand::rand_u64`, RDRAND with a
+            // RDTSC/LAPIC-seeded xorshift fallback), advancing the value on
+            // every 8-byte word.  A correct /dev/urandom NEVER returns
+            // identical consecutive blocks: NSS softoken's FIPS 140-2 §4.9.2
+            // continuous-RNG self-test (and similar health tests) compare two
+            // back-to-back entropy reads and treat a match as a hardware RNG
+            // failure (CKR_DEVICE_ERROR), which would abort TLS init.  The
+            // previous implementation seeded a single LCG from get_ticks()
+            // once per read, so two reads serviced within one timer tick were
+            // byte-identical and tripped that test.  See random(4) /
+            // getrandom(2): /dev/urandom is a CSPRNG, not a clock-derived
+            // sequence.
             if flags & 0x0100_0000 != 0 {
-                let t = crate::arch::x86_64::irq::get_ticks();
                 unsafe {
                     let _g = crate::arch::x86_64::smap::UserGuard::new();
-                    for i in 0..count {
-                        *buf.add(i) = (t.wrapping_add(i as u64).wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407) & 0xFF) as u8;
+                    let mut i = 0usize;
+                    while i < count {
+                        let val = crate::security::rand::rand_u64();
+                        let bytes = val.to_le_bytes();
+                        let n = core::cmp::min(8, count - i);
+                        core::ptr::copy_nonoverlapping(bytes.as_ptr(), buf.add(i), n);
+                        i += n;
                     }
                 }
                 return Ok(count);


### PR DESCRIPTION
## Summary

`/dev/urandom` (and `/dev/random`) read returned a **clock-seeded sequence**, not random data. The read path seeded a single LCG from the timer tick (`get_ticks()`) **once per read**, so two reads serviced within the **same timer tick** returned **byte-identical** output.

This violated the invariant that a CSPRNG never returns identical consecutive blocks, and it broke HTTPS:

- NSS softoken's **FIPS 140-2 §4.9.2 continuous-RNG self-test** (run at PKCS#11 `C_Initialize`) reads two consecutive entropy blocks and treats an **identical pair** as a hardware-RNG failure → `CKR_DEVICE_ERROR`.
- That aborted NSS initialization in the process doing TLS (`nsNSSComponent::InitializeNSS` failed with `SEC_ERROR_PKCS11_DEVICE_ERROR`, -8023).
- With NSS uninitialized, necko could not register the `ssl` socket provider → every HTTPS load failed with `NS_ERROR_UNKNOWN_SOCKET_TYPE` (the browser's "Personal Security Manager" error page). **Zero SYNs were ever sent to :443.**

## Fix

Route `/dev/urandom` / `/dev/random` through the **same RDRAND-backed entropy source as `getrandom(2)`** (`security::rand::rand_u64` — RDRAND with a RDTSC/LAPIC-seeded xorshift fallback), advancing the value on every 8-byte word, so consecutive reads never repeat a block. This matches `random(4)` / `getrandom(2)` semantics: `/dev/urandom` is a CSPRNG, not a clock-derived sequence.

## Test

Adds **Test 529** (`test_dev_urandom_consecutive_reads_differ`): two back-to-back `/dev/urandom` reads must be non-zero and **must differ** — the exact FIPS continuous-RNG invariant the bug violated.

## Verification (end-to-end, windowed browser, real HTTPS host)

| | before | after |
|---|---|---|
| parent NSS init (pipnss log) | `failed to initialize NSS with codes -8023 -8023` → `InitializeNSS() failed` | `initialized NSS in r/w mode` → `NSS Initialization done` |
| network to :443 | 0 SYN ever | full SYN/SYN-ACK/ACK + 517-byte TLS ClientHello + server response (verified pcap) |
| page | `about:neterror` (Personal Security Manager) | secure (HTTPS lock), neterror gone |

A residual content-paint/composite gate remains downstream (separate graphics/compositor lane), but the NSS/HTTPS connect path is fully fixed: TLS handshakes complete and HTTP data is delivered (`OnStopRequest status=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
