### PR TITLE
ff: move hot-path poll/read serial emitters to the trace profile

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -4382,7 +4382,13 @@ pub(crate) fn poll_revents(pid: u64, fd: usize, events: u16) -> u16 {
         // pure fd handoff (e.g. an IPC channel/shared-memory fd pass).
         let has_scm = has_scm_deliverable(uid, crate::net::unix::recv_consumed(uid));
         let readable = has_d || has_p || has_scm;
-        #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+        // [UNIXPOLL] fires on every poll(2) revents computation for an AF_UNIX
+        // fd with POLLIN interest — the single highest-frequency syscall-side
+        // emitter under Firefox (event-loop poll fan-out across ~100 threads),
+        // tens of thousands of lines per boot that saturate serial and throttle
+        // the system below the 60 Hz software-vsync cadence.  Trace profile only;
+        // `firefox-test-core` is the fast, low-serial functional profile.
+        #[cfg(any(feature = "firefox-test-trace", feature = "xeyes-test"))]
         if pid >= 1 && events & POLLIN != 0 {
             crate::serial_println!("[UNIXPOLL] pid={} fd={} uid={} has_data={} avail={} events={:#x}",
                 pid, fd, uid, has_d, crate::net::unix::bytes_available(uid), events);

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -600,7 +600,15 @@ pub fn poll() {
       for (i, sl) in s.clients.iter().enumerate() {
           if let Some(c) = sl {
               let hd = unix::has_data(c.fd);
-              #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+              // [X11POLL] is a per-poll high-frequency emitter: it fires on every
+              // X11 service-poll pass while a client has buffered data, which under
+              // Firefox load is thousands of lines that saturate the serial
+              // transport (~7 KB/s) and throttle the whole system — slow enough to
+              // starve the 60 Hz software-vsync cadence the compositor needs.  It
+              // belongs in the trace profile, not the functional `firefox-test-core`
+              // fast profile (Cargo.toml documents core as "the fast, low-serial
+              // profile").
+              #[cfg(any(feature = "firefox-test-trace", feature = "xeyes-test"))]
               if hd { crate::serial_println!("[X11POLL] svc_fd={} has_data=true avail={}", c.fd, unix::bytes_available(c.fd)); }
               if hd { pending[i] = c.fd; }
           }
@@ -651,7 +659,12 @@ fn service_fd(fd: u64) {
             break;
         }
         recv.extend_from_slice(&chunk[..n]);
-        #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+        // [X11SVC] read-chunk trace: one line per 4 KiB chunk drained from a
+        // client fd.  Under Firefox (which streams MOZ_LOG over its stderr fd
+        // through the in-kernel X11 server) this is the single largest serial
+        // consumer — tens of thousands of lines per boot.  Trace profile only;
+        // see the [X11POLL] note above for the cadence-starvation rationale.
+        #[cfg(any(feature = "firefox-test-trace", feature = "xeyes-test"))]
         crate::serial_println!("[X11SVC] fd={} read {} bytes (buffered={})", fd, n, recv.len());
     }
 


### PR DESCRIPTION
## Summary

Three unconditional `serial_println!` emitters fire on the hottest poll/read paths during a windowed Firefox launch but were compiled into the **`firefox-test-core`** profile — the profile Cargo.toml documents as *"the fast, low-serial profile."* This moves them to the **`firefox-test-trace`** profile that already exists for exactly this class of high-frequency diagnostic emitter.

The three emitters:
- `[UNIXPOLL]` — `poll(2)` revents per AF_UNIX fd with POLLIN interest (`syscall/mod.rs`)
- `[X11SVC]` — one line per 4 KiB chunk drained from a client fd; Firefox streams its stderr through the in-kernel X11 server (`x11/mod.rs`)
- `[X11POLL]` — per X11 service-poll pass while a client has buffered data (`x11/mod.rs`)

## Why this matters

Under Firefox's ~100-thread event-loop fan-out these produce tens of thousands of lines per boot and saturate the serial transport (the UART write path is the bottleneck). The resulting wall-clock throttle is enough to **starve the browser's 60 Hz software-vsync cadence**: the WebRender compositor's vsync-driven re-composite is delayed past the content render-completion deadline, so a real page loads over the network but its **content frame never composites to the window** (the tab "Times Out" with a blank content area while the chrome is painted).

## Verification (A/B, windowed Firefox → https://example.com, SMP=1)

- **Emitters gated (this PR):** the example.com content frame composites and the page renders — *"Example Domain"* heading, body paragraph, *"Learn more"* link, and the TLS padlock in the URL bar (verified pixels).
- **Emitters active (all else equal):** the content frame stays blank and the tab times out, despite the page loading over the network (TLS handshake completes, HTTP body delivered).

This is the first windowed Firefox real-web content render on AstryxOS.

## Risk

Debug-build-only: these lines are not compiled under the CI `test-mode` profile, so there is **no CI or production impact**. The emitters remain available on demand via the `firefox-test-trace` profile (`firefox-test` pulls in both core and trace).

## Known residual (not addressed here)

The windowed render is still timing-intermittent — some boots instead hit a thread-starvation wedge (`[SCHED/STARVE]`) or a content-init crash race mid-render. That underlying scheduling/timing fragility is a separate follow-up; this change removes the serial-throttle confound and is correct on its own merits.

Spec reference: Firefox MOZ_LOG / module logging docs; OpenGL/GLX software-rendering vsync model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
