### PR TITLE
virtio-blk: cond_resched in the completion busy-poll so it stops starving CPU0

### DIFF
--- a/kernel/src/drivers/virtio_blk.rs
+++ b/kernel/src/drivers/virtio_blk.rs
@@ -1972,13 +1972,31 @@ fn wait_adaptive(slot: usize) -> Result<u16, BlockError> {
             return Err(BlockError::IoError);
         }
 
-        // Only yield for genuinely slow I/O (wait already > YIELD_AFTER_TICKS),
-        // and only when a real peer can take the core — never `schedule()` into
-        // the empty-run-queue hlt that would tick-stall the completion.  In the
-        // common early-slow window we keep polling, because yielding would cost
-        // a ~45 ms run-queue re-selection (see the doc comment) — far more than
-        // the few extra microseconds of polling.
-        if now >= yield_after && crate::sched::ready_depth() > 0 {
+        // Decide whether to yield the core this iteration.  Two reasons:
+        //
+        //  (a) cond_resched: the scheduler has decided our quantum is up
+        //      (`reschedule_pending()` — the timer ISR set NEED_RESCHEDULE at a
+        //      quantum boundary).  Ring-0 code is otherwise NOT preempted (the
+        //      timer stub only reschedules when it interrupts user mode), so a
+        //      tight disk poll would monopolise the core across the whole
+        //      request — back-to-back during a page-fault storm that is seconds
+        //      of non-yielding spin, starving the cooperatively-scheduled X11 /
+        //      compositor / network-poll BSP thread (the windowed-Firefox
+        //      content-composite stall).  Honouring the pending preemption here
+        //      makes this loop a good scheduling citizen, the AstryxOS analogue
+        //      of Linux's cond_resched() in long kernel paths (kernel/sched).
+        //      Bounded to at most once per quantum (TIME_SLICE ticks), so the
+        //      yield cost is amortised and the busy-poll still catches sub-
+        //      quantum completions without a switch.
+        //
+        //  (b) genuinely slow I/O: the wait already exceeds YIELD_AFTER_TICKS,
+        //      where the device latency dominates the re-selection cost.
+        //
+        // In both cases yield only when a real peer can take the core — never
+        // `schedule()` into the empty-run-queue hlt that would tick-stall the
+        // completion until the next 100 Hz tick.
+        let cond_resched = crate::sched::reschedule_pending();
+        if (cond_resched || now >= yield_after) && crate::sched::ready_depth() > 0 {
             crate::sched::schedule();
             yields = yields.saturating_add(1);
         } else {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -573,6 +573,28 @@ pub fn request_reschedule() {
     }
 }
 
+/// Non-consuming peek at this CPU's pending-preemption flag.
+///
+/// The timer ISR sets `NEED_RESCHEDULE` at each quantum boundary
+/// (`timer_tick_schedule`), but a long-running Ring-0 path is never preempted
+/// — the timer stub calls `check_reschedule()` only when it interrupted user
+/// mode (see the kernel-mode skip in the timer ISR).  A cooperative kernel loop
+/// that wants to be a good scheduling citizen can poll this and voluntarily
+/// `schedule()` when it returns `true`, the AstryxOS analogue of Linux's
+/// `cond_resched()` / `need_resched()` (kernel/sched/core.c): yield the CPU at a
+/// safe point when the scheduler has decided this thread's quantum is up, rather
+/// than monopolising the core across the whole operation.  Unlike
+/// `check_reschedule`, this does NOT clear the flag (the eventual `schedule()`
+/// clears it) and does NOT itself switch — it is a cheap relaxed read.
+#[inline]
+pub fn reschedule_pending() -> bool {
+    if !is_active() {
+        return false;
+    }
+    let cpu = cpu_index();
+    cpu < MAX_CPUS && NEED_RESCHEDULE[cpu].load(Ordering::Relaxed)
+}
+
 /// Check if a reschedule is pending (called after returning from interrupt).
 ///
 /// Returns immediately if the scheduler is not yet active — this avoids


### PR DESCRIPTION
## Summary

The virtio-blk completion wait (`wait_adaptive`) busy-polls the used ring without yielding for the first `YIELD_AFTER_TICKS` of a request — a deliberate choice, since the completion IRQ does not deliver on this host (the waiter retires its own slot) and yielding a sub-millisecond wait into a multi-quantum run-queue re-selection was net-negative.

But kernel-mode code is **not preempted** — the timer ISR delivers a reschedule only when it interrupts user mode, never mid-syscall — so that non-yielding poll holds the CPU for the **whole** request. The wait-amplification histogram confirms it: **`yielded: 0` across ~60k requests**, mean ~630 µs, with single-request spins observed up to ~148 ms. Back-to-back during a page-fault storm (a browser cold-loading ~130 MB of libxul) this is long stretches of non-yielding Ring-0 spin that starve the cooperatively-scheduled BSP poll thread (CPU 0) — the thread that drives the in-kernel X11 server, the framebuffer compositor and the network poll. Starve it and a windowed app's content frame never composites (the chrome-painted-but-content-blank / "Transferring data…" stall).

## Fix

Honour a pending preemption in the poll loop: when the scheduler has flagged this CPU's quantum as expired (the new non-consuming `sched::reschedule_pending()` peek at `NEED_RESCHEDULE`) **and** a real peer is `Ready`, `schedule()` to give the peer the core — the AstryxOS analogue of Linux's `cond_resched()` in long kernel paths.

This is bounded to at most once per quantum (`TIME_SLICE` ticks), so the busy-poll still catches sub-quantum completions without a context switch and the per-request yield cost stays amortised — but CPU 0 is no longer starved across a request, so the compositor and X11 server keep being serviced under disk-I/O load. The genuinely-slow-I/O yield (wait > `YIELD_AFTER_TICKS`) is unchanged; this only **adds** the quantum-boundary yield, still gated on `ready_depth() > 0` so it never `schedule()`s into the empty-run-queue `hlt`.

## Impact

Part of the windowed-Firefox render-reliability fix set. General improvement: any disk-I/O-bound workload stops monopolising the CPU across its requests. Full kernel test suite green (only pre-existing data-image-provisioning fails: tcc/busybox binaries absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
