### PR TITLE
mm/heap: raise heap to 384 MiB + add HEAP_EXHAUSTED alloc-error bugcheck

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -2094,8 +2094,8 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                 let span_bytes =
                     (window_pages * 0x1000).min(span_by_file) as usize;
                 // Scratch holding the contiguous extent.  Heap-backed (the
-                // kernel heap is physically contiguous and 128 MiB); the
-                // 128 KiB worst case is negligible.  `None` means the bulk read
+                // kernel heap is physically contiguous); the 128 KiB worst
+                // case is negligible.  `None` means the bulk read
                 // was skipped or failed → the per-page loop falls back to an
                 // individual `fs.read` for every page, preserving old behaviour.
                 let mut bulk: Option<alloc::vec::Vec<u8>> = None;

--- a/kernel/src/drivers/virtio_blk.rs
+++ b/kernel/src/drivers/virtio_blk.rs
@@ -2156,8 +2156,8 @@ impl BlockDevice for VirtioBlkBlockDevice {
 /// 2048 sectors = 1 MiB per request.  Larger values further amortise the
 /// per-request overhead (one KVM/MMIO round trip, one doorbell write, one
 /// IRQ delivery) but require the caller's buffer to be physically
-/// contiguous over the same span.  1 MiB stays well within the 128 MiB
-/// kernel heap.
+/// contiguous over the same span.  1 MiB stays well within the kernel
+/// heap (`HEAP_SIZE`).
 fn do_io(req_type: u32, lba: u64, count: u32, buf: *mut u8) -> Result<(), BlockError> {
     if !VIRTIO_BLK_AVAILABLE.load(Ordering::Acquire) {
         return Err(BlockError::IoError);

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1530,7 +1530,7 @@ fn op_tlb_stats(out: &mut String) {
 //
 // Snapshots the kernel-heap allocator plus the few growable collections
 // that have been observed to leak over a long firefox-test soak.  The
-// 6-minute heap-guard panic at `HEAP_START + 128 MiB` (idt.rs page-fault
+// heap-guard panic at `HEAP_START + HEAP_SIZE` (idt.rs page-fault
 // handler) is, by definition, a slow-leak class — this op makes the
 // rate visible so a sampling caller can identify which collection is
 // climbing linearly with wall-clock.

--- a/kernel/src/ke/bugcheck.rs
+++ b/kernel/src/ke/bugcheck.rs
@@ -89,6 +89,17 @@ pub const BUGCHECK_KERNEL_GPF: u32 = 0xDEAD_0007;
 /// PTE on the PMM-recycled frame (the residual aliasing class behind
 /// W215).  P1=phys, P2=mount_idx, P3=inode, P4=page_offset.
 pub const BUGCHECK_W215_INSERT_WRONG_CONTENT: u32 = 0xDEAD_0008;
+/// AstryxOS: a kernel heap allocation failed (the global allocator returned
+/// null and the Rust runtime invoked the allocation-error handler).  Without
+/// this code the build's `panic = "abort"` strategy turns a failed
+/// `alloc`/`Box::new`/`Vec::push` into a silent whole-machine abort with no
+/// diagnostic — fatal mid-render and invisible.  Routing it through the
+/// bugcheck banner names the failure with the requested `Layout`.
+/// P1 = requested size in bytes, P2 = requested alignment in bytes,
+/// P3 = total heap bytes under management, P4 = currently-allocated bytes
+/// (P3/P4 give the at-failure occupancy without re-locking the allocator).
+/// See the Rust `core::alloc::{GlobalAlloc, Layout}` allocation-error contract.
+pub const BUGCHECK_HEAP_EXHAUSTED: u32 = 0xDEAD_0009;
 
 /// Human-readable bug-check name, returned as a `&'static str` from a
 /// match against rodata literals.  This MUST NOT allocate — the
@@ -107,6 +118,7 @@ pub fn bugcheck_name(code: u32) -> &'static str {
         BUGCHECK_KERNEL_PAGE_FAULT   => "KERNEL_PAGE_FAULT",
         BUGCHECK_KERNEL_GPF          => "KERNEL_GPF",
         BUGCHECK_W215_INSERT_WRONG_CONTENT => "W215_INSERT_WRONG_CONTENT",
+        BUGCHECK_HEAP_EXHAUSTED      => "HEAP_EXHAUSTED",
         _                            => "UNKNOWN_BUGCHECK",
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -15,6 +15,11 @@
 #![no_std]
 #![no_main]
 #![feature(abi_x86_interrupt)]
+// Enables the `#[alloc_error_handler]` attribute (mm/heap.rs) so a failed
+// kernel heap allocation routes to a HEAP_EXHAUSTED bugcheck banner instead of
+// the default silent panic-abort.  See the Rust `core::alloc` allocation-error
+// contract.
+#![feature(alloc_error_handler)]
 #![allow(dead_code, unused_imports)]
 
 // The crate root needs `alloc` in scope for the firefox-test launch path,

--- a/kernel/src/mm/heap.rs
+++ b/kernel/src/mm/heap.rs
@@ -27,8 +27,37 @@ use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Mutex;
 
-/// Kernel heap size: 128 MiB (sufficient for 1920×1080 GUI with multiple window surfaces).
-pub const HEAP_SIZE: usize = 128 * 1024 * 1024;
+/// Kernel heap size: 384 MiB.
+///
+/// Sized for heavy *windowed* rendering, where the kernel heap carries the
+/// X11 per-window/pixmap backing stores, the compositor back-buffer, per-frame
+/// transient `Vec`/`String` churn, and the IPC transfer buffers all at once —
+/// a working set that comfortably exceeded the previous 128 MiB on a
+/// multi-window page render and risked exhaustion mid-frame.
+///
+/// ## Why 384 MiB is safe for the physical layout
+///
+/// The heap is RAM-backed: [`compute_heap_layout`] reserves a contiguous
+/// physical range `[phys_start, phys_start + HEAP_SIZE)` and `vmm::init` calls
+/// `pmm::reserve_range` over it before any other frame is handed out.  Default
+/// builds pin `phys_start = 0x80_0000` (8 MiB), so the heap occupies physical
+/// `0x80_0000 .. 0x1880_0000` (8 .. 392 MiB).  This is bounded on three sides:
+///
+/// * **Below the 1 GiB assertion** — [`init`] asserts `phys_end <= 0x4000_0000`
+///   (1 GiB); 392 MiB clears it with room to spare, and the assertion remains
+///   a loud build-misconfiguration tripwire for any future kernel grown so
+///   large that the heap would reach MMIO territory.
+/// * **Inside the mapped window** — the bootloader maps physical 0..4 GiB into
+///   the higher-half (PML4[256]) with 2 MiB huge pages, so every heap VA is
+///   backed by a present translation. See Intel SDM Vol. 3A §4.3.
+/// * **Within guest RAM** — the smallest boot profile provisions 1 GiB of
+///   guest RAM (heavier render profiles get 2 GiB), leaving the PMM well over
+///   half its frames after the heap reservation.
+///
+/// Raising this constant grows only the runtime physical *reservation*; it does
+/// not change the linker image or BSS size, so it cannot move the kernel image
+/// relative to the BootInfo handoff page (a distinct, image-size concern).
+pub const HEAP_SIZE: usize = 384 * 1024 * 1024;
 
 /// Minimum heap base virtual address — phys 8 MiB in the higher-half map.
 ///
@@ -191,7 +220,7 @@ const BLOCK_ALIGN: usize = core::mem::align_of::<FreeBlock>();
 
 /// Generous upper bound on the number of distinct free blocks the walk may
 /// visit before we declare the list corrupt (cycle / runaway chase).  The heap
-/// is 128 MiB and the minimum block is `MIN_BLOCK_SIZE` (16 B); the true block
+/// is `HEAP_SIZE` and the minimum block is `MIN_BLOCK_SIZE` (16 B); the true block
 /// count can never exceed `HEAP_SIZE / MIN_BLOCK_SIZE`.  We add headroom and
 /// cap at a fixed constant so the bound is independent of fragmentation.
 const MAX_WALK_ITERS: usize = (HEAP_SIZE / MIN_BLOCK_SIZE) + 16;
@@ -795,6 +824,56 @@ pub fn stats() -> (usize, usize, usize) {
     (alloc.total_bytes, alloc.allocated_bytes, free)
 }
 
+/// Non-blocking snapshot of `(total_bytes, allocated_bytes)` for use from the
+/// allocation-error path, which must never block on the heap lock.
+///
+/// `GlobalAlloc::alloc` drops its `MutexGuard` before returning the null
+/// pointer that triggers the runtime's allocation-error handler, so the lock is
+/// normally free here.  We nonetheless use `try_lock` and return `None` on
+/// contention (e.g. a second CPU mid-allocation) rather than risk a spin in the
+/// fault path.  Mirrors the bugcheck fault-immunity discipline in
+/// `crate::ke::bugcheck` (no blocking locks once the system is already failing).
+fn stats_nonblocking() -> Option<(usize, usize)> {
+    ALLOCATOR
+        .0
+        .try_lock()
+        .map(|alloc| (alloc.total_bytes, alloc.allocated_bytes))
+}
+
+/// Rust allocation-error handler.
+///
+/// The kernel is built with `panic = "abort"`, so without an explicit handler a
+/// failed kernel allocation (`alloc` returning null → the runtime invokes the
+/// allocation-error handler) would become a silent, undiagnosable whole-machine
+/// abort — fatal mid-render with no signal on the wire.  Routing it through
+/// [`crate::ke::ke_bugcheck`] with [`BUGCHECK_HEAP_EXHAUSTED`] turns heap
+/// exhaustion into a structured, greppable bugcheck banner that names the
+/// failed [`Layout`] (size + alignment) and the at-failure heap occupancy.
+///
+/// Registered via the `#[alloc_error_handler]` attribute (gated by
+/// `#![feature(alloc_error_handler)]` at the crate root).  The attribute is the
+/// supported interception point: it emits the `__rg_oom` symbol that the
+/// compiler-generated `__rust_alloc_error_handler` dispatcher forwards to in
+/// place of the default panicking handler.  The handler takes the failing
+/// [`core::alloc::Layout`] by value and diverges; see the Rust `core::alloc`
+/// allocation-error contract.
+///
+/// This handler is itself fault-immune: it does not allocate, and it reads the
+/// heap occupancy through a non-blocking `try_lock` ([`stats_nonblocking`]) so
+/// it can never deadlock on the very lock whose allocator just failed.
+#[alloc_error_handler]
+fn kernel_alloc_error_handler(layout: Layout) -> ! {
+    // Best-effort occupancy snapshot (sentinel u64::MAX if the lock is held).
+    let (total, allocated) = stats_nonblocking().unwrap_or((usize::MAX, usize::MAX));
+    crate::ke::bugcheck::ke_bugcheck(
+        crate::ke::bugcheck::BUGCHECK_HEAP_EXHAUSTED,
+        layout.size() as u64,
+        layout.align() as u64,
+        total as u64,
+        allocated as u64,
+    );
+}
+
 /// Initialize the kernel heap.
 ///
 /// Computes the heap base from the linker's `__kernel_end` symbol so the
@@ -834,7 +913,7 @@ pub fn init() {
 /// # Guard layout
 /// ```
 /// heap_guard_below_va()         (not-present PTE)  ← underflow trap
-/// heap_start()                  (heap, 128 MiB)
+/// heap_start()                  (heap, HEAP_SIZE)
 /// heap_start() + HEAP_SIZE  (= heap_guard_above_va(), not-present PTE) ← overflow trap
 /// ```
 ///

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -42,7 +42,7 @@ const TIMEWAIT_TICKS: u64 = 200;
 /// outbound or accepted connection allocates one entry; without an
 /// upper bound, long-soak workloads (a periodic host-side probe loop,
 /// a retry-storming client, or simply many short-lived control flows)
-/// accumulate Closed entries on the kernel heap until the 128 MiB heap
+/// accumulate Closed entries on the kernel heap until the heap
 /// guard at `HEAP_START + HEAP_SIZE` fires (idt.rs page-fault handler).
 ///
 /// 1024 is generous for the in-kernel TCP stack — the demo workload has
@@ -941,7 +941,7 @@ pub fn tcp_timer_tick() {
         // long-soak `TCP_CONNECTIONS` growth: every accepted/connected flow
         // eventually transitions to `Closed`, and without this sweep the
         // entries (plus their `Vec` send/recv buffers) accumulate on the
-        // kernel heap until the 128 MiB heap guard fires.  Driven from the
+        // kernel heap until the heap guard fires.  Driven from the
         // 100 Hz timer tick — adds one O(n) retain per second.
         gc_closed_in(&mut conns, now);
     }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1256,6 +1256,9 @@ pub fn run() -> ! {
     total += 1;
     if test_heap_guard_pte() { passed += 1; }
 
+    total += 1;
+    if test_heap_region_and_oom_bugcheck() { passed += 1; }
+
     // ── Test 106: po::shutdown driver-stop sweep (dry-run) ────────────────
 
     total += 1;
@@ -26586,6 +26589,87 @@ fn test_heap_guard_pte() -> bool {
         below_frame, above_frame);
 
     test_pass!("Heap guard pages — PTE present-bit + frame-reservation verification");
+    true
+}
+
+/// Heap-region sizing math + the HEAP_EXHAUSTED bugcheck wiring.
+///
+/// Guards the 384 MiB heap raise and the allocation-error handler that routes
+/// kernel OOM to a `HEAP_EXHAUSTED` bugcheck banner:
+///
+/// 1. `HEAP_SIZE` is exactly 384 MiB.
+/// 2. The computed physical layout is self-consistent
+///    (`phys_end == phys_start + HEAP_SIZE`) and lands in a valid free region:
+///    base at or above the historical 8 MiB floor, `phys_end <= 1 GiB` (the
+///    `heap::init` assertion bound — the heap stays inside the bootloader's
+///    0..4 GiB higher-half huge-page map and never reaches MMIO territory).
+/// 3. The VA base equals `phys_start + PHYS_OFF` (higher-half identity offset).
+/// 4. `BUGCHECK_HEAP_EXHAUSTED` resolves to the `"HEAP_EXHAUSTED"` name, so the
+///    bugcheck banner labels a real OOM rather than `UNKNOWN_BUGCHECK`.
+///
+/// This is a pure-arithmetic + table-lookup test — it never actually exhausts
+/// the heap (that would abort the whole run), it only certifies that an
+/// exhaustion *would* be diagnosable and that the region math is sound.
+fn test_heap_region_and_oom_bugcheck() -> bool {
+    test_header!("Heap region math (384 MiB) + HEAP_EXHAUSTED bugcheck wiring");
+
+    use crate::mm::heap::{compute_heap_layout, HEAP_SIZE};
+    use crate::ke::bugcheck::{bugcheck_name, BUGCHECK_HEAP_EXHAUSTED};
+
+    // 1. HEAP_SIZE is the intended 384 MiB.
+    const EXPECT_SIZE: usize = 384 * 1024 * 1024;
+    if HEAP_SIZE != EXPECT_SIZE {
+        test_fail!("heap_region",
+            "HEAP_SIZE={:#x} ({} MiB) — expected {:#x} (384 MiB)",
+            HEAP_SIZE, HEAP_SIZE / (1024 * 1024), EXPECT_SIZE);
+        return false;
+    }
+    test_println!("  HEAP_SIZE = {} MiB ✓", HEAP_SIZE / (1024 * 1024));
+
+    // 2. Layout self-consistency + free-region/bound checks.
+    const PHYS_OFF_T: u64 = 0xFFFF_8000_0000_0000;
+    const ONE_GIB: u64 = 0x4000_0000;
+    const FLOOR_8MIB: u64 = 0x80_0000;
+    let (va_start, phys_start, phys_end) = compute_heap_layout();
+
+    if phys_end != phys_start + HEAP_SIZE as u64 {
+        test_fail!("heap_region",
+            "phys_end={:#x} != phys_start({:#x}) + HEAP_SIZE({:#x})",
+            phys_end, phys_start, HEAP_SIZE);
+        return false;
+    }
+    if phys_start < FLOOR_8MIB {
+        test_fail!("heap_region",
+            "phys_start={:#x} below the 8 MiB floor {:#x}", phys_start, FLOOR_8MIB);
+        return false;
+    }
+    if phys_end > ONE_GIB {
+        test_fail!("heap_region",
+            "phys_end={:#x} exceeds 1 GiB ({:#x}) — would trip heap::init assertion \
+             and/or leave the bootloader's mapped window",
+            phys_end, ONE_GIB);
+        return false;
+    }
+    if va_start as u64 != phys_start + PHYS_OFF_T {
+        test_fail!("heap_region",
+            "va_start={:#x} != phys_start({:#x}) + PHYS_OFF({:#x})",
+            va_start, phys_start, PHYS_OFF_T);
+        return false;
+    }
+    test_println!("  layout phys=[{:#x}..{:#x}) va={:#x} — 8MiB<=base, phys_end<=1GiB ✓",
+        phys_start, phys_end, va_start);
+
+    // 3. The OOM bugcheck code is wired into the name table (not UNKNOWN).
+    let name = bugcheck_name(BUGCHECK_HEAP_EXHAUSTED);
+    if name != "HEAP_EXHAUSTED" {
+        test_fail!("heap_region",
+            "bugcheck_name({:#x}) = {:?} — expected \"HEAP_EXHAUSTED\"",
+            BUGCHECK_HEAP_EXHAUSTED, name);
+        return false;
+    }
+    test_println!("  bugcheck_name({:#x}) = {:?} ✓", BUGCHECK_HEAP_EXHAUSTED, name);
+
+    test_pass!("Heap region math + HEAP_EXHAUSTED bugcheck wiring");
     true
 }
 


### PR DESCRIPTION
## Why

Mandatory pre-fire fix for heavy-site **windowed** Firefox rendering. Two coupled problems on master:

1. `HEAP_SIZE` was **128 MiB** (`heap.rs:31`).
2. The kernel builds `panic = "abort"` and had **no allocation-error handler** — so a failed kernel allocation became a *silent whole-machine abort with no diagnostic*. Heavy windowed rendering adds in-kernel X11 per-window/pixmap backing stores + the compositor back-buffer + per-frame transient `Vec`/`String` churn + IPC buffers on the kernel heap; 128 MiB risked exhaustion mid-frame with no signal.

## What

### 1. Heap 128 MiB → 384 MiB
The heap is RAM-backed: `compute_heap_layout` reserves a contiguous physical range and `vmm::init` calls `pmm::reserve_range` over it before any other frame is handed out. Default builds pin `phys_start = 8 MiB`, so the heap now spans phys **8 .. 392 MiB**. Safety bounds (all hold):
- **Below the 1 GiB assertion** — `heap::init` already asserts `phys_end <= 0x4000_0000`; 392 MiB clears it (the assertion stays a loud tripwire).
- **Inside the mapped window** — the bootloader maps phys 0..4 GiB into the higher-half (PML4[256]) with 2 MiB huge pages (Intel SDM Vol. 3A §4.3), so every heap VA is backed.
- **Within guest RAM** — smallest boot profile = 1 GiB, render/Firefox profiles = 2 GiB; PMM keeps well over half its frames after the reservation.

Raising a runtime *reservation* constant does **not** grow the linker image or BSS, so it cannot move the kernel image relative to the BootInfo handoff page (that was an image/BSS-size concern, not this).

### 2. `alloc_error_handler` → `HEAP_EXHAUSTED` bugcheck
- New `BUGCHECK_HEAP_EXHAUSTED = 0xDEAD_0009` carrying P1=size, P2=align, P3=total heap bytes, P4=allocated bytes.
- `#[alloc_error_handler] kernel_alloc_error_handler` (gated by `#![feature(alloc_error_handler)]`) routes heap OOM to `ke_bugcheck`. Fault-immune: no allocation, non-blocking `try_lock` for the occupancy snapshot.

**Mechanism note:** I first tried a `#[no_mangle] __rust_alloc_error_handler` symbol override; it *compiled and linked clean* but disassembly showed the compiler's dispatcher still jumped to the default panicking `__rdl_alloc_error_handler` (my symbol was dead-eliminated). The `#[alloc_error_handler]` attribute is the supported interception point. Re-verified: the dispatcher now `call`s `mm::heap::kernel_alloc_error_handler` directly (machine-code confirmed).

## Tests / verification
- `test_heap_region_and_oom_bugcheck` (new): `HEAP_SIZE == 384 MiB`; layout self-consistency (`phys_end == phys_start + HEAP_SIZE`, base ≥ 8 MiB, `phys_end ≤ 1 GiB`, `va == phys + PHYS_OFF`); `BUGCHECK_HEAP_EXHAUSTED → "HEAP_EXHAUSTED"`.
- `cargo +nightly` build/check clean on **default desktop**, **test-mode**, and **firefox-test-core** profiles.
- Symbol routing verified at the disassembly level (dispatcher → my handler → `ke_bugcheck`).

This was authored/verified via `cargo` build + the new unit test + CI (per the non-booting constraint — a concurrent heavy FF VM OOM-kills the box). No local FF boot performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
