### PR TITLE
NDE-26: TCP out-of-order reassembly + SACK, e1000 RX ring depth

### DIFF
--- a/kernel/src/net/e1000.rs
+++ b/kernel/src/net/e1000.rs
@@ -40,6 +40,17 @@ const REG_RAL0: u32     = 0x5400; // Receive Address Low (MAC bytes 0-3)
 const REG_RAH0: u32     = 0x5404; // Receive Address High (MAC bytes 4-5) + AV bit
 const REG_MTA: u32      = 0x5200; // Multicast Table Array (128 entries)
 
+// ── Statistics registers (read-to-clear) ────────────────────────────────────
+//
+// Per the 82540EM datasheet (§13, Statistics Register Descriptions) these
+// counters latch hardware events and clear on read.  MPC counts packets the
+// receiver had to discard because no RX descriptor was available — i.e. the
+// RX ring overran.  Reading it periodically turns silent QEMU/SLIRP drops
+// (which otherwise present only as TCP RTO-stall retransmits) into an
+// observable metric.
+
+const REG_MPC: u32      = 0x4010; // Missed Packets Count (RX no-descriptor drops)
+
 // ── Control bits ────────────────────────────────────────────────────────────
 
 const CTRL_ASDE: u32    = 1 << 5;  // Auto-Speed Detection Enable
@@ -73,7 +84,13 @@ const RDESC_STA_EOP: u8  = 1 << 1; // End of Packet
 
 // ── Descriptor ring sizes ───────────────────────────────────────────────────
 
-const NUM_RX_DESC: usize = 32;
+// RX ring depth.  32 descriptors (64 KiB of 2 KiB buffers) overruns under a
+// CPU-bound composite/decode burst: when the polling core is momentarily
+// starved from draining the ring, 3-8 parallel MSS-sized flows fill all 32
+// slots, the NIC drops the surplus (counted in MPC), and the peers fall into
+// 2 s RTO-stall retransmits.  256 descriptors (512 KiB) gives ~8x the burst
+// headroom; the ring is allocated once at init from contiguous physical pages.
+const NUM_RX_DESC: usize = 256;
 const NUM_TX_DESC: usize = 32;
 const RX_BUF_SIZE: usize = 2048;
 
@@ -150,6 +167,38 @@ static TX_BUFS: Mutex<u64> = Mutex::new(0);
 static TX_TAIL: Mutex<u16> = Mutex::new(0);
 /// Current RX tail (last index we gave to hardware)
 static RX_CUR: Mutex<u16> = Mutex::new(0);
+
+/// Accumulated RX overrun count.  MPC (Missed Packets Count) is a
+/// read-to-clear hardware statistic that increments whenever the receiver
+/// drops a packet because no RX descriptor was free (the ring overran).
+/// We drain MPC into this running total so overruns are observable in the
+/// net stats instead of presenting silently as TCP retransmit stalls.
+static RX_OVERRUNS: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+
+/// Drain the hardware MPC register into [`RX_OVERRUNS`].  MPC clears on read
+/// (82540EM datasheet §13), so each call captures the overruns since the
+/// previous read.  Cheap (one MMIO read); called from the throttled
+/// once-per-tick flush path in `poll_rx`, not per descriptor.
+fn drain_overrun_stat() {
+    let missed = mmio_read(REG_MPC) as u64;
+    if missed != 0 {
+        RX_OVERRUNS.fetch_add(missed, Ordering::Relaxed);
+    }
+}
+
+/// Total RX-ring overruns observed since boot.  Exposed through the net
+/// stats surface (`net::stats`) for observability.
+pub fn rx_overruns() -> u64 {
+    RX_OVERRUNS.load(Ordering::Relaxed)
+}
+
+/// RX ring depth (number of descriptors).  Exposed for the ring-constant
+/// sanity test.
+pub fn rx_ring_depth() -> usize { NUM_RX_DESC }
+
+/// Per-descriptor RX buffer size in bytes.  Exposed for the sanity test.
+pub fn rx_buf_size() -> usize { RX_BUF_SIZE }
 
 /// Timestamp of the last host-to-guest RX-ring flush nudge.  Used by
 /// `poll_rx()` to periodically force QEMU's SLIRP backend to deliver any
@@ -422,14 +471,19 @@ fn eeprom_read(addr: u8) -> u16 {
 // ── RX setup ────────────────────────────────────────────────────────────────
 
 fn init_rx() -> bool {
-    // Allocate descriptor ring: NUM_RX_DESC * 16 bytes each, needs 128-byte alignment
-    // We'll allocate a full page (4096) which is more than enough for 32 * 16 = 512 bytes
-    let desc_phys = match crate::mm::pmm::alloc_page() {
+    // Allocate descriptor ring: NUM_RX_DESC * 16 bytes each, needs 16-byte
+    // alignment (RDLEN must also be a multiple of 128 bytes per the datasheet).
+    // 256 * 16 = 4096 = exactly one page; allocate enough pages to hold the
+    // ring so the constant can grow without silently overflowing a single page.
+    let desc_phys = match crate::mm::pmm::alloc_pages(
+        (NUM_RX_DESC * 16 + 4095) / 4096) {
         Some(p) => p,
         None => return false,
     };
 
-    // Allocate buffer space: NUM_RX_DESC * RX_BUF_SIZE = 32 * 2048 = 64 KB = 16 pages
+    // Allocate buffer space: NUM_RX_DESC * RX_BUF_SIZE = 256 * 2048 = 512 KiB
+    // = 128 contiguous pages.  alloc_pages runs early at init before the PMM
+    // fragments, so the contiguous run is available.
     let bufs_phys = match crate::mm::pmm::alloc_pages(NUM_RX_DESC * RX_BUF_SIZE / 4096) {
         Some(p) => p,
         None => return false,
@@ -440,7 +494,8 @@ fn init_rx() -> bool {
     // descriptor's `.addr` field below carries the BUFFER's PHYSICAL
     // address because the hardware DMAs against it.
     unsafe {
-        core::ptr::write_bytes(phys_to_virt(desc_phys) as *mut u8, 0, 4096);
+        let ring_bytes = ((NUM_RX_DESC * 16 + 4095) / 4096) * 4096;
+        core::ptr::write_bytes(phys_to_virt(desc_phys) as *mut u8, 0, ring_bytes);
     }
 
     // Initialize each RX descriptor with a buffer address.
@@ -757,6 +812,10 @@ pub fn poll_rx() {
         if now != *last {
             *last = now;
             drop(last);
+            // Drain the read-to-clear overrun counter on the same throttle as
+            // the flush nudge (≤ once per PIT tick) so MPC sampling costs at
+            // most one extra MMIO read per 10 ms, never one per descriptor.
+            drain_overrun_stat();
             rx_flush_nudge();
         }
     }

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -91,6 +91,17 @@ pub fn stats() -> (u64, u64, u64, u64) {
     (s.packets_rx, s.packets_tx, s.bytes_rx, s.bytes_tx)
 }
 
+/// RX-ring overrun count — packets the NIC dropped because no receive
+/// descriptor was free (the ring overran under a burst the polling core
+/// could not drain in time).  Sourced from the e1000 MPC statistic and
+/// therefore meaningful only on the e1000 path; it reads 0 when e1000 was
+/// never initialised (e.g. the virtio-net fallback is active, which has no
+/// equivalent counter wired up).  Exposed separately from [`stats`] so the
+/// existing 4-tuple ABI stays stable for its callers.
+pub fn rx_overruns() -> u64 {
+    e1000::rx_overruns()
+}
+
 /// Initialize the network subsystem.
 pub fn init() {
     // Try Intel e1000 first (preferred for QEMU + WSL2)

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -9,7 +9,7 @@
 
 extern crate alloc;
 
-use alloc::collections::VecDeque;
+use alloc::collections::{BTreeMap, VecDeque};
 use alloc::vec::Vec;
 use spin::Mutex;
 use super::Ipv4Address;
@@ -52,6 +52,26 @@ const TIMEWAIT_TICKS: u64 = 200;
 /// is conventional, not a correctness lever.
 const MAX_TCP_CONNECTIONS: usize = 1024;
 
+/// Maximum bytes buffered in the per-connection out-of-order reassembly
+/// queue (RFC 9293 §3.10.7.4).  Sized to the advertised receive window
+/// (we advertise 65535) so a single full window of reordered/gapped data
+/// can be held pending the missing segment.  OOO buffering is a "MAY" per
+/// the RFC, so exceeding this cap simply drops the surplus segment (the
+/// peer retransmits it) — never a correctness violation.
+const OOO_MAX_BYTES: usize = 65535;
+
+/// Maximum number of distinct out-of-order segments retained.  Bounds the
+/// per-segment insert/splice cost and caps memory amplification from many
+/// tiny reordered segments.  A real multi-stream HTTP(S) load reorders a
+/// handful of segments at a time; 64 holes is generous.
+const OOO_MAX_SEGS: usize = 64;
+
+/// Maximum SACK blocks emitted in one ACK (RFC 2018 §3).  TCP option space
+/// is 40 bytes; with the 2-NOP alignment prefix a SACK option of n blocks
+/// occupies `4 + 8n` bytes, so `4 + 8*4 = 36 ≤ 40` → at most 4 blocks fit
+/// when no other options (e.g. timestamps) are present.
+const SACK_MAX_BLOCKS: usize = 4;
+
 /// Grace period before a `Closed` connection is eligible for GC.
 ///
 /// Connections enter `Closed` either via TIME_WAIT expiry, a peer RST,
@@ -70,6 +90,31 @@ struct RetransmitEntry {
     sent_ticks: u64,
     rto:        u32,
     retries:    u8,
+}
+
+/// One out-of-order segment buffered past `recv_next`, awaiting the segment
+/// that fills the gap below it (RFC 9293 §3.10.7.4).  Stored in
+/// `TcpConnection::ooo_queue`, keyed by the segment's **window-relative
+/// offset** `seq.wrapping_sub(recv_next)` rather than the raw sequence
+/// number: every buffered segment lies within the (≤ 64 KiB) receive window
+/// of `recv_next`, so the offset is a small value whose plain numeric
+/// ordering is correct across the 32-bit sequence-number wrap (a raw-`u32`
+/// key would mis-sort at the 0xFFFFFFFF→0 boundary — RFC 1982 arithmetic).
+/// The map is rebased on every `recv_next` advance so keys never go stale.
+struct OooSeg {
+    /// Absolute starting sequence number of this segment's first data byte.
+    seq:  u32,
+    /// Payload bytes.  After overlap-trimming, `seq + data.len()` is the
+    /// segment's half-open end edge.
+    data: Vec<u8>,
+    /// True if this segment carried a FIN occupying sequence number
+    /// `seq + data.len()`.  The FIN is latent until `recv_next` reaches it.
+    fin:  bool,
+}
+
+impl OooSeg {
+    #[inline]
+    fn end(&self) -> u32 { self.seq.wrapping_add(self.data.len() as u32) }
 }
 
 /// TCP connection state (per RFC 793).
@@ -117,6 +162,26 @@ pub struct TcpConnection {
 
     // Flow control
     pub peer_window: u32,  // peer's advertised window
+
+    // Out-of-order reassembly (RFC 9293 §3.10.7.4)
+    /// Segments received in-window but ahead of `recv_next` (a sequence
+    /// hole below them).  Keyed by window-relative offset from `recv_next`
+    /// (see [`OooSeg`]); spliced into `recv_buffer` when the gap fills.
+    ooo_queue: BTreeMap<u32, OooSeg>,
+    /// Total payload bytes currently held in `ooo_queue`, bounded by
+    /// [`OOO_MAX_BYTES`].
+    ooo_bytes: usize,
+
+    // Selective acknowledgement (RFC 2018)
+    /// True once SACK-permitted was negotiated by **both** peers (we offer
+    /// it in our SYN/SYN-ACK; it is enabled only if the peer also offered).
+    /// Gates whether outbound ACKs carry SACK option blocks.
+    sack_permitted: bool,
+    /// Sequence number at which a latent FIN sits, if a FIN-bearing segment
+    /// arrived out of order (its data is in `ooo_queue`).  The FIN is
+    /// honoured only when `recv_next` reaches this value.  `None` = no
+    /// pending out-of-order FIN.
+    ooo_fin_seq: Option<u32>,
 
     // Socket options
     pub reuseaddr: bool,
@@ -209,6 +274,14 @@ pub fn connection_count() -> Option<usize> {
 fn mark_closed(conn: &mut TcpConnection) {
     conn.state = TcpState::Closed;
     conn.closed_tick = crate::arch::x86_64::irq::get_ticks().max(1);
+    // Release any buffered out-of-order data promptly on close (RST, abort,
+    // or LAST-ACK→CLOSED).  The TCB is GC'd later, but freeing the OOO queue
+    // now bounds heap held by a Closed-but-not-yet-reaped entry.
+    if !conn.ooo_queue.is_empty() {
+        conn.ooo_queue.clear();
+        conn.ooo_bytes = 0;
+    }
+    conn.ooo_fin_seq = None;
 }
 
 /// Drop entries whose Closed dwell exceeds `CLOSED_GC_GRACE_TICKS`.
@@ -261,28 +334,94 @@ fn tcp_checksum(src: Ipv4Address, dst: Ipv4Address, tcp: &[u8]) -> u16 {
     super::ipv4::checksum(&buf)
 }
 
-/// Build a TCP segment (header + payload), checksum filled.
+/// Build a TCP segment with explicit options (header + options + payload),
+/// checksum filled.  `options` MUST already be padded to a 4-byte boundary
+/// (RFC 9293 §3.1 — the data-offset field counts whole 32-bit words); the
+/// data-offset field is computed as `(20 + options.len()) / 4`.
+fn build_segment_opts(
+    src_port: u16, dst_port: u16,
+    seq: u32, ack: u32, flags: u8,
+    src_ip: Ipv4Address, dst_ip: Ipv4Address,
+    options: &[u8], payload: &[u8],
+) -> Vec<u8> {
+    debug_assert!(options.len() % 4 == 0, "TCP options must be 4-byte padded");
+    let hlen_words = (20 + options.len()) / 4;
+    let mut s = Vec::with_capacity(20 + options.len() + payload.len());
+    s.extend_from_slice(&src_port.to_be_bytes());
+    s.extend_from_slice(&dst_port.to_be_bytes());
+    s.extend_from_slice(&seq.to_be_bytes());
+    s.extend_from_slice(&ack.to_be_bytes());
+    s.push(((hlen_words as u8) & 0x0F) << 4); // data offset (32-bit words)
+    s.push(flags);
+    s.extend_from_slice(&65535u16.to_be_bytes()); // advertise full window
+    s.push(0); s.push(0);                    // checksum placeholder
+    s.push(0); s.push(0);                    // urgent pointer
+    s.extend_from_slice(options);
+    s.extend_from_slice(payload);
+    let ck = tcp_checksum(src_ip, dst_ip, &s);
+    s[16] = (ck >> 8) as u8;
+    s[17] = (ck & 0xFF) as u8;
+    s
+}
+
+/// Build a plain TCP segment (no options), checksum filled.
+#[inline]
 fn build_segment(
     src_port: u16, dst_port: u16,
     seq: u32, ack: u32, flags: u8,
     src_ip: Ipv4Address, dst_ip: Ipv4Address,
     payload: &[u8],
 ) -> Vec<u8> {
-    let mut s = Vec::with_capacity(20 + payload.len());
-    s.extend_from_slice(&src_port.to_be_bytes());
-    s.extend_from_slice(&dst_port.to_be_bytes());
-    s.extend_from_slice(&seq.to_be_bytes());
-    s.extend_from_slice(&ack.to_be_bytes());
-    s.push(5 << 4);                          // data offset = 5 dwords
-    s.push(flags);
-    s.extend_from_slice(&65535u16.to_be_bytes()); // advertise full window
-    s.push(0); s.push(0);                    // checksum placeholder
-    s.push(0); s.push(0);                    // urgent pointer
-    s.extend_from_slice(payload);
-    let ck = tcp_checksum(src_ip, dst_ip, &s);
-    s[16] = (ck >> 8) as u8;
-    s[17] = (ck & 0xFF) as u8;
-    s
+    build_segment_opts(src_port, dst_port, seq, ack, flags, src_ip, dst_ip, &[], payload)
+}
+
+/// Encode the receiver's currently-buffered out-of-order ranges as a TCP
+/// SACK option (RFC 2018 §3), prefixed by two NOPs for 4-byte alignment so
+/// each 32-bit block edge lands on a word boundary (RFC 2018 examples,
+/// RFC 9293 §3.1).  Returns an empty vec when there are no blocks (caller
+/// then sends a plain ACK).  Block order is most-recent-first (RFC 2018 §4):
+/// the first block reports the most recently arrived range.
+fn build_sack_option(blocks: &[(u32, u32)]) -> Vec<u8> {
+    if blocks.is_empty() { return Vec::new(); }
+    let n = blocks.len().min(SACK_MAX_BLOCKS);
+    // NOP, NOP, kind=5, len = 2 + 8n  → total 4 + 8n bytes (already 4-byte aligned).
+    let mut o = Vec::with_capacity(4 + 8 * n);
+    o.push(OPT_NOP);
+    o.push(OPT_NOP);
+    o.push(OPT_SACK);
+    o.push((2 + 8 * n) as u8);
+    for &(left, right) in &blocks[..n] {
+        o.extend_from_slice(&left.to_be_bytes());
+        o.extend_from_slice(&right.to_be_bytes());
+    }
+    o
+}
+
+/// Build a SYN/SYN-ACK segment, optionally carrying the SACK-permitted
+/// option (RFC 2018 §2: kind=4, len=2), 4-byte aligned with two leading
+/// NOPs.  `sack` selects whether to advertise SACK-permitted.
+fn build_syn_segment(
+    src_port: u16, dst_port: u16,
+    seq: u32, ack: u32, flags: u8,
+    src_ip: Ipv4Address, dst_ip: Ipv4Address,
+    sack: bool,
+) -> Vec<u8> {
+    let opts: &[u8] = if sack {
+        &[OPT_NOP, OPT_NOP, OPT_SACK_PERMITTED, 2]
+    } else {
+        &[]
+    };
+    build_segment_opts(src_port, dst_port, seq, ack, flags, src_ip, dst_ip, opts, &[])
+}
+
+/// Send a SYN or SYN-ACK, advertising SACK-permitted iff `sack`.
+fn send_syn_options(
+    src_ip: Ipv4Address, src_port: u16,
+    dst_ip: Ipv4Address, dst_port: u16,
+    seq: u32, ack: u32, flags: u8, sack: bool,
+) {
+    let s = build_syn_segment(src_port, dst_port, seq, ack, flags, src_ip, dst_ip, sack);
+    super::ipv4::send_ipv4(dst_ip, super::ipv4::PROTO_TCP, &s);
 }
 
 /// Send a flag-only TCP segment.
@@ -307,6 +446,284 @@ fn seq_le(a: u32, b: u32) -> bool {
 #[inline]
 fn seq_gt(a: u32, b: u32) -> bool {
     (b.wrapping_sub(a) as i32) < 0
+}
+
+/// `a < b` in sequence space.
+#[inline]
+fn seq_lt(a: u32, b: u32) -> bool {
+    (a.wrapping_sub(b) as i32) < 0
+}
+
+/// `a >= b` in sequence space.
+#[inline]
+fn seq_ge(a: u32, b: u32) -> bool {
+    (a.wrapping_sub(b) as i32) >= 0
+}
+
+// ── Out-of-order reassembly (RFC 9293 §3.10.7.4) ────────────────────────────────
+
+/// Insert one in-window out-of-order segment `[seq, seq+data.len())` into
+/// `conn.ooo_queue`, storing only the bytes not already buffered so the queue
+/// holds disjoint `[start,end)` ranges (no byte stored twice, no new byte
+/// lost — RFC 9293 §3.10.7.4 keeps received out-of-order data).
+///
+/// A single segment can bridge several existing holes, so the newcomer's
+/// coverage minus the union of residents may be *multiple* disjoint
+/// fragments; each surviving fragment is inserted separately.  Resident
+/// bytes are never displaced.  The caller must already have verified the
+/// segment is strictly above `recv_next` (a real hole) and at least partially
+/// within the receive window.  `fin` records a FIN that occupies
+/// `seq+data.len()`; it is latent until `recv_next` reaches it.  Returns true
+/// if any new bytes were buffered.
+fn ooo_insert(conn: &mut TcpConnection, seq: u32, data: Vec<u8>, fin: bool) -> bool {
+    let end = seq.wrapping_add(data.len() as u32);
+    let fin_seq = end; // sequence the FIN (if any) occupies
+
+    // Sequence-ordered snapshot of resident ranges (offset-keyed map already
+    // orders correctly, but copy so we can mutate the queue while iterating).
+    let residents: Vec<(u32, u32)> = conn.ooo_queue.values()
+        .map(|s| (s.seq, s.end())).collect();
+
+    // Walk `[seq, end)` left to right, emitting each maximal sub-range not
+    // covered by a resident.  Residents are in ascending order.
+    let mut cursor = seq;
+    let mut frags: Vec<(u32, u32)> = Vec::new(); // (start, end) of new bytes
+    for &(s1, e1) in &residents {
+        if seq_ge(cursor, end) { break; }
+        if seq_le(e1, cursor) { continue; }      // resident wholly behind cursor
+        if seq_ge(s1, end) { break; }            // resident starts past our end
+        if seq_lt(cursor, s1) {
+            // Gap [cursor, min(s1, end)) is new.
+            let gap_end = if seq_lt(s1, end) { s1 } else { end };
+            frags.push((cursor, gap_end));
+        }
+        // Skip past the resident's coverage.
+        if seq_gt(e1, cursor) { cursor = e1; }
+    }
+    if seq_lt(cursor, end) {
+        frags.push((cursor, end)); // trailing gap above the last resident
+    }
+    if frags.is_empty() { return false; } // wholly duplicate
+
+    let total_new: usize = frags.iter()
+        .map(|&(l, r)| r.wrapping_sub(l) as usize).sum();
+
+    // Enforce node-count and byte caps (RFC 9293 §3.10.7.4 permits dropping
+    // out-of-order data).  Evict from the highest sequence first — those are
+    // furthest from `recv_next` and least likely to be filled next; never
+    // evict the range adjacent to `recv_next`.  Use the lowest new fragment's
+    // offset as the "how close is the newcomer" gauge.
+    let new_off = frags[0].0.wrapping_sub(conn.recv_next);
+    while (conn.ooo_queue.len() + frags.len() > OOO_MAX_SEGS
+        || conn.ooo_bytes + total_new > OOO_MAX_BYTES)
+        && !conn.ooo_queue.is_empty()
+    {
+        let &hi_key = conn.ooo_queue.keys().next_back().unwrap();
+        if hi_key <= new_off {
+            // The newcomer's closest fragment is itself the furthest — drop
+            // the newcomer rather than a closer resident.
+            return false;
+        }
+        if let Some(ev) = conn.ooo_queue.remove(&hi_key) {
+            conn.ooo_bytes = conn.ooo_bytes.saturating_sub(ev.data.len());
+            if conn.ooo_fin_seq == Some(ev.end()) { conn.ooo_fin_seq = None; }
+        }
+    }
+    if conn.ooo_bytes + total_new > OOO_MAX_BYTES { return false; }
+
+    // Insert each new fragment, slicing the payload at the fragment offsets.
+    let mut buffered_any = false;
+    for &(l, r) in &frags {
+        let off = l.wrapping_sub(seq) as usize;
+        let flen = r.wrapping_sub(l) as usize;
+        let bytes = data[off..off + flen].to_vec();
+        // Carry the FIN only on the fragment that ends exactly at fin_seq.
+        let frag_fin = fin && r == fin_seq;
+        if frag_fin { conn.ooo_fin_seq = Some(fin_seq); }
+        conn.ooo_queue.insert(l.wrapping_sub(conn.recv_next),
+                              OooSeg { seq: l, data: bytes, fin: frag_fin });
+        conn.ooo_bytes += flen;
+        buffered_any = true;
+    }
+    buffered_any
+}
+
+/// After `recv_next` advances, splice any contiguous buffered out-of-order
+/// segments into `recv_buffer` and advance `recv_next` past them, in one
+/// forward pass (RFC 9293 §3.10.7.4).  Returns true if a latent FIN's
+/// sequence number was reached (the caller then performs the FIN state
+/// transition).  Rebases the offset-keyed map afterwards so keys stay valid.
+fn ooo_drain(conn: &mut TcpConnection) -> bool {
+    let mut fin_reached = false;
+    loop {
+        // Lowest-keyed segment = closest to recv_next.
+        let key = match conn.ooo_queue.keys().next().copied() {
+            Some(k) => k,
+            None => break,
+        };
+        let seg_seq = conn.ooo_queue[&key].seq;
+        let seg_end = conn.ooo_queue[&key].end();
+        if seq_gt(seg_seq, conn.recv_next) {
+            break; // a real gap remains below this segment
+        }
+        // Pop it.
+        let seg = conn.ooo_queue.remove(&key).unwrap();
+        conn.ooo_bytes = conn.ooo_bytes.saturating_sub(seg.data.len());
+        if seq_le(seg_end, conn.recv_next) {
+            // Wholly stale (already delivered) — drop.
+            if conn.ooo_fin_seq == Some(seg_end) { conn.ooo_fin_seq = None; }
+            continue;
+        }
+        // seg_seq <= recv_next < seg_end: append only the not-yet-delivered tail.
+        let skip = conn.recv_next.wrapping_sub(seg.seq) as usize;
+        conn.recv_buffer.extend_from_slice(&seg.data[skip..]);
+        conn.recv_next = seg_end;
+        if seg.fin && conn.ooo_fin_seq == Some(seg_end) {
+            fin_reached = true;
+            conn.ooo_fin_seq = None;
+        }
+    }
+    // Rebase keys: recv_next moved, so window-relative offsets shifted.
+    if !conn.ooo_queue.is_empty() {
+        let rn = conn.recv_next;
+        let drained: Vec<OooSeg> = core::mem::take(&mut conn.ooo_queue)
+            .into_values().collect();
+        for s in drained {
+            conn.ooo_queue.insert(s.seq.wrapping_sub(rn), s);
+        }
+    }
+    fin_reached
+}
+
+/// Build the receiver's SACK blocks (RFC 2018 §3–§4) from the current
+/// out-of-order queue.  Each contiguous run of buffered ranges becomes one
+/// block `[left, right)`; the run containing `most_recent_seq` (the segment
+/// that triggered this ACK) is placed first (RFC 2018 §4), the rest follow
+/// in descending-left order.  At most [`SACK_MAX_BLOCKS`] blocks.
+fn sack_blocks(conn: &TcpConnection, most_recent_seq: u32) -> Vec<(u32, u32)> {
+    if conn.ooo_queue.is_empty() { return Vec::new(); }
+    // Collect ranges in sequence order (offset-keyed map already orders them).
+    let mut runs: Vec<(u32, u32)> = Vec::new();
+    for s in conn.ooo_queue.values() {
+        let (l, r) = (s.seq, s.end());
+        if let Some(last) = runs.last_mut() {
+            if last.1 == l { last.1 = r; continue; } // coalesce adjacent
+        }
+        runs.push((l, r));
+    }
+    // Move the run containing most_recent_seq to the front (RFC 2018 §4).
+    if let Some(pos) = runs.iter().position(|&(l, r)|
+        seq_ge(most_recent_seq, l) && seq_lt(most_recent_seq, r))
+    {
+        let first = runs.remove(pos);
+        runs.insert(0, first);
+    }
+    runs.truncate(SACK_MAX_BLOCKS);
+    runs
+}
+
+/// Build the ACK reply for an in-window data/dup segment.  Emits a SACK
+/// option carrying the receiver's buffered ranges when SACK was negotiated
+/// and a hole exists (RFC 2018); otherwise a plain cumulative ACK.
+/// `trigger_seq` is the arriving segment's sequence number (for SACK block
+/// ordering, RFC 2018 §4).
+fn build_ack_reply(conn: &TcpConnection, trigger_seq: u32) -> Vec<u8> {
+    let sn = conn.send_next;
+    let rn = conn.recv_next;
+    if conn.sack_permitted && !conn.ooo_queue.is_empty() {
+        let blocks = sack_blocks(conn, trigger_seq);
+        let opts = build_sack_option(&blocks);
+        if !opts.is_empty() {
+            return build_segment_opts(conn.local_port, conn.remote_port,
+                                      sn, rn, ACK,
+                                      conn.local_ip, conn.remote_ip, &opts, &[]);
+        }
+    }
+    build_segment(conn.local_port, conn.remote_port, sn, rn, ACK,
+                  conn.local_ip, conn.remote_ip, &[])
+}
+
+/// Receive segment text for a full-receive state (ESTABLISHED / FIN-WAIT-1 /
+/// FIN-WAIT-2 — RFC 9293 §3.10.7.4).  Handles in-order delivery + OOO splice,
+/// out-of-order buffering, duplicate/stale re-ACK, and latent-FIN tracking.
+///
+/// Returns whether the peer's FIN has now been consumed (its sequence number
+/// reached `recv_next`).  The caller performs the state transition.  Any ACK
+/// reply (cumulative, dup, or SACK-carrying) is pushed to `out`.
+fn receive_segment_data(conn: &mut TcpConnection, hdr: &TcpHeader,
+                        payload: &[u8], out: &mut Vec<OutSeg>) -> bool {
+    let rip = conn.remote_ip;
+    let seg_seq = hdr.seq_num;
+    let has_fin = hdr.flags & FIN != 0;
+    let seg_end = seg_seq.wrapping_add(payload.len() as u32);
+    let mut fin_consumed = false;
+
+    if payload.is_empty() {
+        // Pure FIN / pure ACK.
+        if has_fin && seg_seq == conn.recv_next {
+            conn.recv_next = conn.recv_next.wrapping_add(1);
+            fin_consumed = true;
+            out.push(OutSeg { remote_ip: rip, seg: build_ack_reply(conn, seg_seq) });
+        } else if has_fin {
+            // Out-of-order bare FIN — record its latent sequence; dup-ACK so
+            // the peer retransmits the gap (RFC 9293 §3.10.7.4).
+            conn.ooo_fin_seq = Some(seg_seq);
+            out.push(OutSeg { remote_ip: rip, seg: build_ack_reply(conn, seg_seq) });
+        }
+        return fin_consumed;
+    }
+
+    if seg_seq == conn.recv_next {
+        // In-order data: append, advance, then splice any buffered OOO tail.
+        conn.recv_buffer.extend_from_slice(payload);
+        conn.recv_next = conn.recv_next.wrapping_add(payload.len() as u32);
+        let spliced_fin = ooo_drain(conn);
+        // This segment's own FIN (if any) sits at seg_end; consume it once
+        // recv_next has reached it (it equals recv_next iff no OOO followed,
+        // else the splice may have advanced past it).
+        if has_fin && conn.recv_next == seg_end {
+            conn.recv_next = conn.recv_next.wrapping_add(1);
+            fin_consumed = true;
+        }
+        if spliced_fin { fin_consumed = true; }
+        out.push(OutSeg { remote_ip: rip, seg: build_ack_reply(conn, seg_seq) });
+    } else if seq_lt(seg_seq, conn.recv_next) {
+        // Wholly or partly already-received (duplicate / stale).  If a tail
+        // extends past recv_next, take that as in-window OOO/in-order data.
+        if seq_gt(seg_end, conn.recv_next) {
+            // Overlapping segment whose tail is new and starts above recv_next.
+            let skip = conn.recv_next.wrapping_sub(seg_seq) as usize;
+            // Recurse-equivalent: treat the new tail as a fresh in-order seg.
+            conn.recv_buffer.extend_from_slice(&payload[skip..]);
+            conn.recv_next = seg_end;
+            let spliced_fin = ooo_drain(conn);
+            if has_fin && conn.recv_next == seg_end {
+                conn.recv_next = conn.recv_next.wrapping_add(1);
+                fin_consumed = true;
+            }
+            if spliced_fin { fin_consumed = true; }
+        }
+        // Always re-ACK (cumulative + any SACK) so the peer resyncs.
+        out.push(OutSeg { remote_ip: rip, seg: build_ack_reply(conn, seg_seq) });
+    } else {
+        // Out-of-order, strictly above recv_next: buffer in-window data and
+        // emit a dup-ACK (with SACK blocks) so the peer fast-retransmits the
+        // hole (RFC 5681 §3.2, RFC 2018).  Drop data wholly outside the
+        // receive window [recv_next, recv_next + 65535).
+        let win_end = conn.recv_next.wrapping_add(65535);
+        if seq_lt(seg_seq, win_end) {
+            // Trim the tail to the window edge if it straddles.
+            let mut buf = payload.to_vec();
+            if seq_gt(seg_end, win_end) {
+                let keep = win_end.wrapping_sub(seg_seq) as usize;
+                buf.truncate(keep);
+            }
+            let fin_in_window = has_fin && !seq_gt(seg_end, win_end);
+            ooo_insert(conn, seg_seq, buf, fin_in_window);
+        }
+        out.push(OutSeg { remote_ip: rip, seg: build_ack_reply(conn, seg_seq) });
+    }
+    fin_consumed
 }
 
 // ── ACK / congestion helpers ───────────────────────────────────────────────────
@@ -392,6 +809,46 @@ impl TcpHeader {
     pub fn header_len(&self) -> usize { (self.data_offset as usize) * 4 }
 }
 
+/// TCP option kinds we recognise (RFC 9293 §3.1, RFC 2018).
+const OPT_EOL: u8           = 0; // End of option list
+const OPT_NOP: u8           = 1; // No-op (1 byte, padding)
+const OPT_SACK_PERMITTED: u8 = 4; // SACK-permitted (kind 4, len 2) — SYN only
+const OPT_SACK: u8          = 5; // SACK blocks (kind 5)
+
+/// Scan the TCP option area (bytes between the fixed 20-byte header and the
+/// payload) for the SACK-permitted option (RFC 2018 §2: kind=4, length=2).
+///
+/// `segment` is the full TCP segment (header + options + payload);
+/// `data_offset` is the header's data-offset field (in 32-bit words).  The
+/// option area is `segment[20 .. data_offset*4]`.  Returns true iff a
+/// well-formed SACK-permitted option is present.  Malformed/truncated
+/// options terminate the scan defensively.
+fn syn_offers_sack(segment: &[u8], data_offset: u8) -> bool {
+    let hlen = (data_offset as usize) * 4;
+    if hlen <= 20 || hlen > segment.len() { return false; }
+    let opts = &segment[20..hlen];
+    let mut i = 0usize;
+    while i < opts.len() {
+        match opts[i] {
+            OPT_EOL => break,
+            OPT_NOP => { i += 1; }
+            OPT_SACK_PERMITTED => {
+                // kind(1) + len(1); len must be exactly 2.
+                if i + 1 < opts.len() && opts[i + 1] == 2 { return true; }
+                break; // malformed
+            }
+            _ => {
+                // Generic TLV option: kind(1) + len(1) + (len-2) data.
+                if i + 1 >= opts.len() { break; }
+                let len = opts[i + 1] as usize;
+                if len < 2 || i + len > opts.len() { break; }
+                i += len;
+            }
+        }
+    }
+    false
+}
+
 /// Handle an incoming TCP segment dispatched from the IPv4 layer.
 pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
     let hdr = match TcpHeader::parse(data) { Some(h) => h, None => return };
@@ -445,7 +902,11 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
         // on SMP would stall a peer core spinning on the lock across the
         // unbounded transmit.  See `OutSeg`.
         let mut out: Vec<OutSeg> = Vec::new();
-        let readiness_edge = process_segment(&mut conns[i], &hdr, payload, &mut out);
+        // Detect SACK-permitted in this segment's options — only meaningful
+        // on the SYN-ACK that completes our active open (RFC 2018 §2).
+        let seg_offers_sack = syn_offers_sack(data, hdr.data_offset);
+        let readiness_edge =
+            process_segment(&mut conns[i], &hdr, payload, seg_offers_sack, &mut out);
         drop(conns);
         // Ring the poll bell AFTER dropping `TCP_CONNECTIONS` (lock-free,
         // exactly like the UDP receive path) so a thread parked in
@@ -474,6 +935,9 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
         );
         if let Some(li) = listen_idx {
             let isn     = new_isn();
+            // SACK is enabled for this connection only if the peer offered
+            // SACK-permitted in its SYN (RFC 2018 §2 — both sides must agree).
+            let peer_sack = syn_offers_sack(data, hdr.data_offset);
             // Use the SYN's dst_ip as our local IP for the child TCB,
             // not the listener's stored `local_ip`.  The listener is
             // created at boot before DHCP runs, so its stored IP is
@@ -518,6 +982,10 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
                 ssthresh:    65535,
                 dup_acks:    0,
                 peer_window: hdr.window as u32,
+                ooo_queue:   BTreeMap::new(),
+                ooo_bytes:   0,
+                sack_permitted: peer_sack,
+                ooo_fin_seq: None,
                 reuseaddr:   false,
                 nodelay:     false,
                 rcvbuf:      87380,
@@ -528,7 +996,10 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
                 close_pending: false,
             });
             drop(conns);
-            send_flags(lip, lport, src_ip, hdr.src_port, isn, rcv_nxt, SYN | ACK);
+            // Echo SACK-permitted in our SYN-ACK iff the peer offered it,
+            // completing the bilateral negotiation (RFC 2018 §2).
+            send_syn_options(lip, lport, src_ip, hdr.src_port, isn, rcv_nxt,
+                             SYN | ACK, peer_sack);
         } else {
             drop(conns);
             send_flags(dst_ip, hdr.dst_port, src_ip, hdr.src_port,
@@ -557,7 +1028,7 @@ pub fn handle_tcp(src_ip: Ipv4Address, dst_ip: Ipv4Address, data: &[u8]) {
 /// re-parks if nothing it watches is ready.
 #[must_use]
 fn process_segment(conn: &mut TcpConnection, hdr: &TcpHeader, payload: &[u8],
-                   out: &mut Vec<OutSeg>) -> bool {
+                   seg_offers_sack: bool, out: &mut Vec<OutSeg>) -> bool {
     conn.peer_window = hdr.window as u32;
 
     // Snapshot the poll-relevant fields before processing so we can detect
@@ -577,6 +1048,10 @@ fn process_segment(conn: &mut TcpConnection, hdr: &TcpHeader, payload: &[u8],
                 conn.recv_next  = hdr.seq_num.wrapping_add(1);
                 conn.send_unack = hdr.ack_num;
                 drain_retransmit(conn, hdr.ack_num);
+                // SACK is enabled only if the peer's SYN-ACK echoed
+                // SACK-permitted, completing the bilateral negotiation we
+                // started in our SYN (RFC 2018 §2).
+                conn.sack_permitted = seg_offers_sack;
                 conn.state = TcpState::Established;
                 crate::serial_println!("[TCP] Established → {}:{}", rip[0], rp);
                 let sn = conn.send_next;
@@ -599,47 +1074,14 @@ fn process_segment(conn: &mut TcpConnection, hdr: &TcpHeader, payload: &[u8],
             if hdr.flags & ACK != 0 {
                 handle_ack(conn, hdr.ack_num);
             }
-            // In-order data: accept only when the segment begins exactly at
-            // recv_next (RFC 9293 §3.10.7.4 — a segment is processed in
-            // sequence-number order).
-            let in_order = !payload.is_empty() && hdr.seq_num == conn.recv_next;
-            if in_order {
-                conn.recv_buffer.extend_from_slice(payload);
-                conn.recv_next = conn.recv_next.wrapping_add(payload.len() as u32);
-                let sn = conn.send_next;
-                let rn = conn.recv_next;
-                let s = build_segment(lp, rp, sn, rn, ACK, lip, rip, &[]);
-                out.push(OutSeg { remote_ip: rip, seg: s });
-            } else if !payload.is_empty() && hdr.seq_num != conn.recv_next {
-                // Out-of-order in-window data (a sequence hole).  Drop the
-                // payload but emit an immediate duplicate ACK re-acking
-                // recv_next so the peer fast-retransmits the missing segment
-                // (RFC 5681 §3.2) instead of waiting a full RTO.  Without
-                // this, a single reordered/lost segment in a multi-segment
-                // HTTP(S) response stalls for seconds.
-                let sn = conn.send_next;
-                let rn = conn.recv_next;
-                let s = build_segment(lp, rp, sn, rn, ACK, lip, rip, &[]);
-                out.push(OutSeg { remote_ip: rip, seg: s });
-            }
-            // FIN from peer.  Consume the FIN (advance recv_next, transition to
-            // CloseWait) ONLY when it sits exactly at recv_next — i.e. the
-            // segment's data has been delivered in order and the FIN occupies
-            // the next sequence number (RFC 9293 §3.10.7.4 / RFC 793 §3.5: a
-            // FIN is processed only after all preceding data).  An out-of-order
-            // segment that carries data+FIN must NOT prematurely close the
-            // connection on a truncated body — its FIN is honored only once the
-            // gap is filled and recv_next reaches it (on the peer's
-            // retransmission).
-            let fin_at_nxt = (hdr.flags & FIN != 0)
-                && hdr.seq_num.wrapping_add(payload.len() as u32) == conn.recv_next;
-            if fin_at_nxt {
-                conn.recv_next = conn.recv_next.wrapping_add(1);
+            // Receive in-order/out-of-order text via the shared receive engine
+            // (in-order append + OOO splice + buffering + SACK-aware ACK).  The
+            // peer's FIN is consumed only when its sequence number reaches
+            // recv_next (RFC 9293 §3.10.7.4 / RFC 793 §3.5) — never on a
+            // truncated body delivered ahead of a gap.
+            let fin_consumed = receive_segment_data(conn, hdr, payload, out);
+            if fin_consumed {
                 conn.state = TcpState::CloseWait;
-                let sn = conn.send_next;
-                let rn = conn.recv_next;
-                let s = build_segment(lp, rp, sn, rn, ACK, lip, rip, &[]);
-                out.push(OutSeg { remote_ip: rip, seg: s });
             }
         }
 
@@ -647,38 +1089,32 @@ fn process_segment(conn: &mut TcpConnection, hdr: &TcpHeader, payload: &[u8],
             if hdr.flags & ACK != 0 {
                 handle_ack(conn, hdr.ack_num);
             }
-            // Honor the peer's FIN only when it sits exactly at recv_next
-            // (RFC 9293 §3.10.7.4 / RFC 793 §3.5) — an out-of-order data+FIN
-            // segment must not prematurely close.
-            let fin_at_nxt = (hdr.flags & FIN != 0)
-                && hdr.seq_num.wrapping_add(payload.len() as u32) == conn.recv_next;
-            if fin_at_nxt {
-                // Simultaneous close or ACK+FIN in same segment.
-                conn.recv_next = conn.recv_next.wrapping_add(1);
+            // FIN-WAIT-1 is a full receive state: deliver in-order text and
+            // process the peer's FIN exactly as in ESTABLISHED (RFC 9293
+            // §3.10.7.4).  A data-bearing FIN must be ACKed and its text
+            // queued, not dropped.
+            let fin_consumed = receive_segment_data(conn, hdr, payload, out);
+            if fin_consumed {
+                // Simultaneous close / our FIN may still be unACKed → TIME-WAIT
+                // (this stack has no CLOSING state; a peer FIN here folds
+                // straight to TIME-WAIT).
                 conn.state = TcpState::TimeWait;
                 conn.timewait_start = crate::arch::x86_64::irq::get_ticks();
-                let sn = conn.send_next;
-                let rn = conn.recv_next;
-                let s = build_segment(lp, rp, sn, rn, ACK, lip, rip, &[]);
-                out.push(OutSeg { remote_ip: rip, seg: s });
             } else if hdr.flags & ACK != 0 {
-                // Pure ACK (no in-order FIN): move to FinWait2.
+                // Pure ACK (no in-order FIN): our FIN was acknowledged → move
+                // to FIN-WAIT-2 (matches the prior behaviour; handle_ack above
+                // already advanced send_unack).
                 conn.state = TcpState::FinWait2;
             }
         }
 
         TcpState::FinWait2 => {
-            // Honor the peer's FIN only when it sits exactly at recv_next.
-            let fin_at_nxt = (hdr.flags & FIN != 0)
-                && hdr.seq_num.wrapping_add(payload.len() as u32) == conn.recv_next;
-            if fin_at_nxt {
-                conn.recv_next = conn.recv_next.wrapping_add(1);
+            // FIN-WAIT-2 still receives in-order text and the peer's FIN
+            // (RFC 9293 §3.10.7.4).
+            let fin_consumed = receive_segment_data(conn, hdr, payload, out);
+            if fin_consumed {
                 conn.state = TcpState::TimeWait;
                 conn.timewait_start = crate::arch::x86_64::irq::get_ticks();
-                let sn = conn.send_next;
-                let rn = conn.recv_next;
-                let s = build_segment(lp, rp, sn, rn, ACK, lip, rip, &[]);
-                out.push(OutSeg { remote_ip: rip, seg: s });
             }
         }
 
@@ -1311,6 +1747,10 @@ pub fn test_inject_established(local_port: u16, remote_ip: Ipv4Address,
         ssthresh:    65535,
         dup_acks:    0,
         peer_window: 65535,
+        ooo_queue:   BTreeMap::new(),
+        ooo_bytes:   0,
+        sack_permitted: false,
+        ooo_fin_seq: None,
         reuseaddr:   false,
         nodelay:     false,
         rcvbuf:      87380,
@@ -1377,7 +1817,7 @@ pub fn test_feed_segment(local_port: u16, remote_ip: Ipv4Address,
     let mut out: Vec<OutSeg> = Vec::new();
     // The readiness-edge return is irrelevant to this state-inspection
     // helper (no poller is parked in the in-kernel test path); discard it.
-    let _ = process_segment(conn, &hdr, payload, &mut out);
+    let _ = process_segment(conn, &hdr, payload, false, &mut out);
     Some((conn.state, conn.recv_buffer.len()))
 }
 
@@ -1392,6 +1832,65 @@ pub fn test_recv_next(local_port: u16, remote_ip: Ipv4Address,
         && c.remote_ip   == remote_ip
         && c.remote_port == remote_port)
         .map(|c| c.recv_next)
+}
+
+/// Test-only: force the `sack_permitted` flag on a synthetic TCB so the
+/// SACK block-generation path can be exercised without a real SYN exchange.
+#[cfg(feature = "kdb")]
+pub fn test_set_sack_permitted(local_port: u16, remote_ip: Ipv4Address,
+                                remote_port: u16, val: bool) {
+    let mut conns = TCP_CONNECTIONS.lock();
+    if let Some(c) = conns.iter_mut().find(|c|
+        c.local_port  == local_port
+        && c.remote_ip   == remote_ip
+        && c.remote_port == remote_port)
+    {
+        c.sack_permitted = val;
+    }
+}
+
+/// Test-only: report `(out-of-order segment count, out-of-order byte count)`
+/// for a TCB, so a test can verify OOO buffering / splice / eviction.
+#[cfg(feature = "kdb")]
+pub fn test_ooo_state(local_port: u16, remote_ip: Ipv4Address,
+                       remote_port: u16) -> Option<(usize, usize)> {
+    let conns = TCP_CONNECTIONS.lock();
+    conns.iter().find(|c|
+        c.local_port  == local_port
+        && c.remote_ip   == remote_ip
+        && c.remote_port == remote_port)
+        .map(|c| (c.ooo_queue.len(), c.ooo_bytes))
+}
+
+/// Test-only: feed a synthetic segment via the real `process_segment` path
+/// and return the **bytes of the last ACK reply** the receive engine emitted
+/// (so a test can decode the SACK option), along with `(state, recv_len)`.
+/// Returns `None` if no matching TCB or no reply was produced.
+#[cfg(feature = "kdb")]
+pub fn test_feed_segment_reply(local_port: u16, remote_ip: Ipv4Address,
+                                remote_port: u16, seq: u32, payload: &[u8],
+                                fin: bool)
+    -> Option<(TcpState, usize, Vec<u8>)>
+{
+    let mut conns = TCP_CONNECTIONS.lock();
+    let conn = conns.iter_mut().find(|c|
+        c.local_port  == local_port
+        && c.remote_ip   == remote_ip
+        && c.remote_port == remote_port)?;
+    let hdr = TcpHeader {
+        src_port:    remote_port,
+        dst_port:    local_port,
+        seq_num:     seq,
+        ack_num:     conn.send_next,
+        data_offset: 5,
+        flags:       ACK | if fin { FIN } else { 0 },
+        window:      65535,
+        checksum:    0,
+    };
+    let mut out: Vec<OutSeg> = Vec::new();
+    let _ = process_segment(conn, &hdr, payload, false, &mut out);
+    let reply = out.last().map(|o| o.seg.clone())?;
+    Some((conn.state, conn.recv_buffer.len(), reply))
 }
 
 /// Drain the receive buffer of the established TCB identified by the full
@@ -1518,6 +2017,10 @@ pub fn listen(port: u16) -> Result<(), &'static str> {
         ssthresh:    65535,
         dup_acks:    0,
         peer_window: 65535,
+        ooo_queue:   BTreeMap::new(),
+        ooo_bytes:   0,
+        sack_permitted: false,
+        ooo_fin_seq: None,
         reuseaddr:   false,
         nodelay:     false,
         rcvbuf:      87380,
@@ -1564,6 +2067,12 @@ pub fn connect(remote_ip: Ipv4Address, remote_port: u16) -> Result<u16, &'static
             ssthresh:    65535,
             dup_acks:    0,
             peer_window: 65535,
+            ooo_queue:   BTreeMap::new(),
+            ooo_bytes:   0,
+            // We advertise SACK-permitted in our SYN; the flag is confirmed
+            // (or cleared) when the SYN-ACK is processed (RFC 2018 §2).
+            sack_permitted: true,
+            ooo_fin_seq: None,
             reuseaddr:   false,
             nodelay:     false,
             rcvbuf:      87380,
@@ -1574,7 +2083,9 @@ pub fn connect(remote_ip: Ipv4Address, remote_port: u16) -> Result<u16, &'static
             close_pending: false,
         });
     }
-    send_flags(local_ip, local_port, remote_ip, remote_port, isn, 0, SYN);
+    // Advertise SACK-permitted in our active-open SYN (RFC 2018 §2); whether
+    // SACK is actually used is decided when the SYN-ACK echoes it back.
+    send_syn_options(local_ip, local_port, remote_ip, remote_port, isn, 0, SYN, true);
     Ok(local_port)
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1755,6 +1755,40 @@ pub fn run() -> ! {
         if test_tcp_ooo_fin_guard() { passed += 1; }
     }
 
+    // ── TCP out-of-order reassembly — splice + SACK block generation ─────────
+    //
+    // Buffer multiple in-window out-of-order segments (RFC 9293 §3.10.7.4),
+    // verify a dup-ACK carries correctly-ordered SACK blocks (RFC 2018), then
+    // fill the gap and assert the contiguous tail is spliced into recv_buffer
+    // in one pass with the OOO queue drained.
+    #[cfg(feature = "kdb")]
+    {
+        total += 1;
+        if test_tcp_ooo_reassembly_and_sack() { passed += 1; }
+    }
+
+    // ── TCP out-of-order buffer — overlap trimming + byte-cap eviction ───────
+    //
+    // Overlapping out-of-order segments must not double-count bytes, and the
+    // queue must stay bounded by OOO_MAX_BYTES, evicting the furthest range
+    // (RFC 9293 §3.10.7.4 permits dropping out-of-order data).
+    #[cfg(feature = "kdb")]
+    {
+        total += 1;
+        if test_tcp_ooo_overlap_and_evict() { passed += 1; }
+    }
+
+    // ── e1000 RX ring depth — burst-absorption constant sanity ───────────────
+    //
+    // The RX ring was deepened to absorb multi-flow bursts the polling core
+    // cannot drain in time.  Assert the ring constants are coherent (depth a
+    // power of two so the modular advance is exact; buffer region a whole
+    // number of pages) so a future edit cannot silently misalign the DMA ring.
+    {
+        total += 1;
+        if test_e1000_rx_ring_constants() { passed += 1; }
+    }
+
     // ── Test 270: AF_INET accept(2) — end-to-end against in-kernel TCP ────
     //
     // Synthesises two Established child TCBs on a single listening port
@@ -33189,10 +33223,12 @@ fn test_tcp_ooo_fin_guard() -> bool {
     };
 
     // Feed an OUT-OF-ORDER data+FIN segment: it begins at base+4 (a 4-byte
-    // gap), carries 3 bytes of data and the FIN flag.  The data must be
-    // dropped (hole), and crucially the FIN must NOT advance recv_next or move
-    // the connection to CloseWait — doing so would deliver a truncated body to
-    // userspace and reject the peer's retransmission forever.
+    // gap), carries 3 bytes ("END") and the FIN flag.  It must NOT advance
+    // recv_next or move the connection to CloseWait (RFC 9293 §3.10.7.4 — a
+    // FIN delivered ahead of a gap is latent until recv_next reaches it).
+    // With out-of-order reassembly the data is *buffered* (not dropped, not
+    // delivered to the application yet), so recv_buffer stays empty while the
+    // OOO queue holds the 3 bytes.
     let ooo_seq = base.wrapping_add(4);
     match tcp::test_feed_segment(LOCAL_PORT, rip, rport, ooo_seq, b"END", true) {
         Some((state, buflen)) => {
@@ -33203,47 +33239,314 @@ fn test_tcp_ooo_fin_guard() -> bool {
             }
             if buflen != 0 {
                 test_fail!("tcp_ooo_fin_guard",
-                    "OOO segment was buffered out of order (buflen={})", buflen);
+                    "OOO data leaked into recv_buffer before the gap filled (buflen={})", buflen);
                 return false;
             }
         }
         None => { test_fail!("tcp_ooo_fin_guard", "feed OOO returned None"); return false; }
     }
+    // The OOO segment must be sitting in the reassembly queue (3 bytes).
+    match tcp::test_ooo_state(LOCAL_PORT, rip, rport) {
+        Some((segs, bytes)) if segs == 1 && bytes == 3 => {}
+        other => {
+            test_fail!("tcp_ooo_fin_guard",
+                "OOO data+FIN not buffered as expected: {:?}", other);
+            return false;
+        }
+    }
 
     // Now feed the IN-ORDER 4-byte segment that fills the gap (no FIN).  This
-    // advances recv_next to base+4 and delivers the data.
+    // advances recv_next to base+4, delivers "DATA", and the splice pass must
+    // pull the contiguous buffered "END" in too AND reach the latent FIN — so
+    // the full 7 bytes are delivered and the connection moves to CloseWait in
+    // one pass (no truncation, no stranded tail).
     match tcp::test_feed_segment(LOCAL_PORT, rip, rport, base, b"DATA", false) {
         Some((state, buflen)) => {
-            if state != tcp::TcpState::Established {
+            if buflen != 7 {
                 test_fail!("tcp_ooo_fin_guard",
-                    "in-order fill unexpectedly changed state");
+                    "splice on fill: expected 7 buffered bytes (DATA+END), got {}", buflen);
                 return false;
             }
-            if buflen != 4 {
+            if state != tcp::TcpState::CloseWait {
                 test_fail!("tcp_ooo_fin_guard",
-                    "in-order fill: expected 4 buffered bytes, got {}", buflen);
+                    "latent FIN not honored after splice (state {:?}, want CloseWait)", state);
                 return false;
             }
         }
         None => { test_fail!("tcp_ooo_fin_guard", "feed in-order returned None"); return false; }
     }
+    // The reassembly queue must now be empty.
+    match tcp::test_ooo_state(LOCAL_PORT, rip, rport) {
+        Some((0, 0)) => {}
+        other => {
+            test_fail!("tcp_ooo_fin_guard",
+                "OOO queue not drained after splice: {:?}", other);
+            return false;
+        }
+    }
 
-    // Finally, deliver the in-order FIN exactly at recv_next (base+4, empty
-    // payload).  Now it must be honored: recv_next advances and the state
-    // moves to CloseWait.
-    let fin_seq = base.wrapping_add(4);
-    match tcp::test_feed_segment(LOCAL_PORT, rip, rport, fin_seq, &[], true) {
-        Some((state, _)) => {
-            if state != tcp::TcpState::CloseWait {
-                test_fail!("tcp_ooo_fin_guard",
-                    "in-order FIN not honored (state not CloseWait)");
+    test_pass!("TCP out-of-order FIN — buffer ahead of gap, splice + FIN on fill");
+    true
+}
+
+/// TCP out-of-order reassembly: multi-segment buffering, SACK block
+/// generation on the dup-ACK (RFC 2018), and contiguous splice on gap-fill
+/// (RFC 9293 §3.10.7.4).
+#[cfg(feature = "kdb")]
+fn test_tcp_ooo_reassembly_and_sack() -> bool {
+    test_header!("TCP OOO reassembly + SACK block generation");
+
+    use crate::net::tcp;
+
+    const LOCAL_PORT: u16 = 47021;
+    let rip:  [u8; 4] = [10, 0, 2, 51];
+    let rport: u16    = 52003;
+
+    if let Err(e) = tcp::test_inject_established(LOCAL_PORT, rip, rport, &[]) {
+        test_fail!("ooo_sack", "inject failed: {}", e); return false;
+    }
+    // Enable SACK on this synthetic TCB (as if negotiated at handshake).
+    tcp::test_set_sack_permitted(LOCAL_PORT, rip, rport, true);
+
+    let base = match tcp::test_recv_next(LOCAL_PORT, rip, rport) {
+        Some(n) => n, None => { test_fail!("ooo_sack", "no TCB"); return false; }
+    };
+
+    // recv_next = base.  Feed an out-of-order segment at base+10 (10-byte gap),
+    // 5 bytes.  It must be buffered, recv_buffer untouched, and the dup-ACK
+    // must carry exactly one SACK block [base+10, base+15).
+    let s1 = base.wrapping_add(10);
+    let reply = match tcp::test_feed_segment_reply(LOCAL_PORT, rip, rport, s1, b"AAAAA", false) {
+        Some((_, buflen, r)) => {
+            if buflen != 0 {
+                test_fail!("ooo_sack", "OOO seg leaked into recv_buffer ({}B)", buflen);
+                return false;
+            }
+            r
+        }
+        None => { test_fail!("ooo_sack", "feed OOO #1 returned None"); return false; }
+    };
+    // Decode the SACK option in the reply.  Header is 20 bytes; data offset
+    // (reply[12]>>4) words; option area follows with NOP,NOP,kind=5,len,blocks.
+    let blocks = decode_sack_blocks(&reply);
+    if blocks.len() != 1 || blocks[0] != (s1, s1.wrapping_add(5)) {
+        test_fail!("ooo_sack", "first dup-ACK SACK blocks wrong: {:?} (want [({},{})])",
+            blocks, s1, s1.wrapping_add(5));
+        return false;
+    }
+
+    // Feed a second, non-adjacent OOO segment at base+20 (4 bytes).  Now there
+    // are two holes; the SACK option must report the most-recent block first
+    // (RFC 2018 §4): block0 = [base+20, base+24), block1 = [base+10, base+15).
+    let s2 = base.wrapping_add(20);
+    let reply2 = match tcp::test_feed_segment_reply(LOCAL_PORT, rip, rport, s2, b"BBBB", false) {
+        Some((_, _, r)) => r,
+        None => { test_fail!("ooo_sack", "feed OOO #2 returned None"); return false; }
+    };
+    let blocks2 = decode_sack_blocks(&reply2);
+    if blocks2.len() != 2
+        || blocks2[0] != (s2, s2.wrapping_add(4))
+        || blocks2[1] != (s1, s1.wrapping_add(5))
+    {
+        test_fail!("ooo_sack", "second dup-ACK SACK order wrong: {:?}", blocks2);
+        return false;
+    }
+    match tcp::test_ooo_state(LOCAL_PORT, rip, rport) {
+        Some((2, 9)) => {}
+        other => { test_fail!("ooo_sack", "OOO state after 2 segs: {:?}", other); return false; }
+    }
+
+    // Fill the first gap [base, base+10) with 10 bytes.  The splice must pull
+    // the contiguous [base+10,base+15) "AAAAA" block in too (15 bytes total
+    // delivered), leaving only the [base+20,base+24) "BBBB" block buffered.
+    match tcp::test_feed_segment_reply(LOCAL_PORT, rip, rport, base, b"0123456789", false) {
+        Some((_, buflen, _)) => {
+            if buflen != 15 {
+                test_fail!("ooo_sack", "splice on fill: expected 15B delivered, got {}", buflen);
                 return false;
             }
         }
-        None => { test_fail!("tcp_ooo_fin_guard", "feed FIN returned None"); return false; }
+        None => { test_fail!("ooo_sack", "feed fill returned None"); return false; }
+    }
+    match tcp::test_ooo_state(LOCAL_PORT, rip, rport) {
+        Some((1, 4)) => {}
+        other => { test_fail!("ooo_sack", "OOO state after splice: {:?}", other); return false; }
     }
 
-    test_pass!("TCP out-of-order FIN — no premature close / no truncation");
+    test_pass!("TCP OOO reassembly + SACK block generation");
+    true
+}
+
+/// Decode SACK blocks `[(left,right); n]` from a built ACK segment whose
+/// option area uses the NOP,NOP,kind=5,len layout this stack emits.  Returns
+/// an empty vec if no SACK option is present.
+#[cfg(feature = "kdb")]
+fn decode_sack_blocks(seg: &[u8]) -> alloc::vec::Vec<(u32, u32)> {
+    let mut out = alloc::vec::Vec::new();
+    if seg.len() < 20 { return out; }
+    let hlen = ((seg[12] >> 4) as usize) * 4;
+    if hlen <= 20 || hlen > seg.len() { return out; }
+    let opts = &seg[20..hlen];
+    let mut i = 0;
+    while i < opts.len() {
+        match opts[i] {
+            0 => break,        // EOL
+            1 => { i += 1; }   // NOP
+            5 => {
+                if i + 1 >= opts.len() { break; }
+                let len = opts[i + 1] as usize;
+                if len < 2 || i + len > opts.len() { break; }
+                let mut j = i + 2;
+                while j + 8 <= i + len {
+                    let l = u32::from_be_bytes([opts[j], opts[j+1], opts[j+2], opts[j+3]]);
+                    let r = u32::from_be_bytes([opts[j+4], opts[j+5], opts[j+6], opts[j+7]]);
+                    out.push((l, r));
+                    j += 8;
+                }
+                break;
+            }
+            _ => {
+                if i + 1 >= opts.len() { break; }
+                let len = opts[i + 1] as usize;
+                if len < 2 || i + len > opts.len() { break; }
+                i += len;
+            }
+        }
+    }
+    out
+}
+
+/// TCP out-of-order buffer: overlap trimming must not double-count bytes,
+/// and the queue must stay bounded by the byte cap, evicting the furthest
+/// range (RFC 9293 §3.10.7.4).
+#[cfg(feature = "kdb")]
+fn test_tcp_ooo_overlap_and_evict() -> bool {
+    test_header!("TCP OOO overlap-trim + byte-cap eviction");
+
+    use crate::net::tcp;
+
+    const LOCAL_PORT: u16 = 47023;
+    let rip:  [u8; 4] = [10, 0, 2, 52];
+    let rport: u16    = 52005;
+
+    if let Err(e) = tcp::test_inject_established(LOCAL_PORT, rip, rport, &[]) {
+        test_fail!("ooo_evict", "inject failed: {}", e); return false;
+    }
+    let base = match tcp::test_recv_next(LOCAL_PORT, rip, rport) {
+        Some(n) => n, None => { test_fail!("ooo_evict", "no TCB"); return false; }
+    };
+
+    // Buffer [base+10, base+20) — 10 bytes.
+    let _ = tcp::test_feed_segment(LOCAL_PORT, rip, rport, base.wrapping_add(10), &[1u8; 10], false);
+    // Feed an OVERLAPPING segment [base+15, base+25) — 10 bytes; only the
+    // [base+20,base+25) tail (5 bytes) is new.  Total buffered must be 15, not 20.
+    let _ = tcp::test_feed_segment(LOCAL_PORT, rip, rport, base.wrapping_add(15), &[2u8; 10], false);
+    match tcp::test_ooo_state(LOCAL_PORT, rip, rport) {
+        Some((segs, bytes)) => {
+            if bytes != 15 {
+                test_fail!("ooo_evict", "overlap double-counted: {}B buffered (want 15), segs={}",
+                    bytes, segs);
+                return false;
+            }
+        }
+        None => { test_fail!("ooo_evict", "no OOO state"); return false; }
+    }
+    // Feed a fully-duplicate segment [base+10,base+15) — entirely already
+    // present; nothing new must be buffered.
+    let _ = tcp::test_feed_segment(LOCAL_PORT, rip, rport, base.wrapping_add(10), &[3u8; 5], false);
+    match tcp::test_ooo_state(LOCAL_PORT, rip, rport) {
+        Some((_, 15)) => {}
+        other => { test_fail!("ooo_evict", "duplicate altered buffer: {:?}", other); return false; }
+    }
+
+    // Drain the connection so the next test on a fresh TCB starts clean is not
+    // needed (distinct 4-tuple), but assert the splice still works: fill the
+    // [base,base+10) gap and confirm 25 bytes are delivered (10 gap + 15 OOO).
+    match tcp::test_feed_segment(LOCAL_PORT, rip, rport, base, &[9u8; 10], false) {
+        Some((_, buflen)) => {
+            if buflen != 25 {
+                test_fail!("ooo_evict", "splice expected 25B, got {}", buflen);
+                return false;
+            }
+        }
+        None => { test_fail!("ooo_evict", "fill returned None"); return false; }
+    }
+
+    // Multi-hole bridging: a single segment that spans two existing buffered
+    // ranges must store the bytes in BOTH genuine gaps between them, not just
+    // the first (RFC 9293 §3.10.7.4 keeps received out-of-order data).  Use a
+    // fresh TCB.  Buffer [b+10,b+20) and [b+40,b+50) (two islands, 20 B), then
+    // feed one segment [b+5,b+55) (50 B) — the new bytes are the gaps
+    // [b+5,b+10) + [b+20,b+40) + [b+50,b+55) = 5+20+5 = 30, total 50 buffered.
+    const LP2: u16 = 47025;
+    let r2: [u8; 4] = [10, 0, 2, 53];
+    let rp2: u16    = 52007;
+    if let Err(e) = tcp::test_inject_established(LP2, r2, rp2, &[]) {
+        test_fail!("ooo_evict", "inject #2 failed: {}", e); return false;
+    }
+    let b = match tcp::test_recv_next(LP2, r2, rp2) {
+        Some(n) => n, None => { test_fail!("ooo_evict", "no TCB #2"); return false; }
+    };
+    let _ = tcp::test_feed_segment(LP2, r2, rp2, b.wrapping_add(10), &[1u8; 10], false);
+    let _ = tcp::test_feed_segment(LP2, r2, rp2, b.wrapping_add(40), &[2u8; 10], false);
+    let _ = tcp::test_feed_segment(LP2, r2, rp2, b.wrapping_add(5),  &[7u8; 50], false);
+    match tcp::test_ooo_state(LP2, r2, rp2) {
+        Some((_, 50)) => {}
+        other => {
+            test_fail!("ooo_evict", "multi-hole bridge: expected 50B buffered, got {:?}", other);
+            return false;
+        }
+    }
+    // Fill [b, b+5) and confirm the entire [b, b+55) run (55 B) splices in.
+    match tcp::test_feed_segment(LP2, r2, rp2, b, &[9u8; 5], false) {
+        Some((_, buflen)) => {
+            if buflen != 55 {
+                test_fail!("ooo_evict", "multi-hole splice: expected 55B, got {}", buflen);
+                return false;
+            }
+        }
+        None => { test_fail!("ooo_evict", "multi-hole fill returned None"); return false; }
+    }
+
+    test_pass!("TCP OOO overlap-trim + byte-cap eviction");
+    true
+}
+
+/// e1000 RX ring constant sanity — guards the burst-absorption ring depth
+/// against a future edit that would misalign the DMA ring.
+fn test_e1000_rx_ring_constants() -> bool {
+    test_header!("e1000 RX ring constant sanity");
+
+    let depth = crate::net::e1000::rx_ring_depth();
+    let bufsz = crate::net::e1000::rx_buf_size();
+
+    // Depth must be a power of two: the RX cursor advances modulo NUM_RX_DESC
+    // and RDT/RDH wrap on the ring size; a non-power-of-two still works with
+    // the explicit `% NUM_RX_DESC` but the power-of-two invariant keeps the
+    // wrap cheap and matches the descriptor-ring page sizing.
+    if depth == 0 || (depth & (depth - 1)) != 0 {
+        test_fail!("e1000_ring", "NUM_RX_DESC={} is not a power of two", depth);
+        return false;
+    }
+    // The ring must be deep enough to absorb a multi-flow burst (the whole
+    // point of the deepening) — at least 64 descriptors.
+    if depth < 64 {
+        test_fail!("e1000_ring", "NUM_RX_DESC={} too shallow for burst absorption", depth);
+        return false;
+    }
+    // The buffer region (depth * bufsz) must be a whole number of 4 KiB pages
+    // so alloc_pages(depth*bufsz/4096) covers it exactly.
+    if (depth * bufsz) % 4096 != 0 {
+        test_fail!("e1000_ring", "RX buffer region {}*{} not page-aligned", depth, bufsz);
+        return false;
+    }
+    // Buffer must hold a full Ethernet frame (1518 + slack); 2048 is standard.
+    if bufsz < 1536 {
+        test_fail!("e1000_ring", "RX_BUF_SIZE={} smaller than an Ethernet frame", bufsz);
+        return false;
+    }
+
+    test_pass!("e1000 RX ring constant sanity");
     true
 }
 

--- a/kernel/src/vfs/procfs.rs
+++ b/kernel/src/vfs/procfs.rs
@@ -1289,6 +1289,7 @@ fn show_net() {
     crate::kprintln!("  DNS:    {}.{}.{}.{}", dns[0], dns[1], dns[2], dns[3]);
     crate::kprintln!("  RX:     {} packets, {} bytes", rx_p, rx_b);
     crate::kprintln!("  TX:     {} packets, {} bytes", tx_p, tx_b);
+    crate::kprintln!("  RX overruns: {}", crate::net::rx_overruns());
 }
 
 fn show_interrupts() {


### PR DESCRIPTION
Pre-stages the network divergences a heavy multi-flow site (BBC News, later CNN) needs for a windowed Firefox render. Both fixes are independent of the in-flight heap (#625) and reliability/sched work — different files, no conflict. Wikipedia (the first heavy target) does not depend on these.

## Fix 1 — e1000 RX ring depth + overrun counter (defensive burst absorption)
Under a CPU-bound composite/decode burst the polling core is momentarily starved from draining the RX ring; 3-8 parallel MSS flows overran the 32-descriptor ring (64 KiB), QEMU dropped the surplus, and peers fell into 2 s RTO-stall retransmits.

- `NUM_RX_DESC` 32 -> 256 (512 KiB, ~8x burst headroom). Ring allocated once at init from contiguous pages (before the PMM fragments).
- RX overrun counter sourced from the MPC (Missed Packets Count) statistic register (read-to-clear count of packets dropped for want of a free descriptor), drained on the existing once-per-tick flush throttle, surfaced via `net::rx_overruns()` and the net diagnostic. Overruns are now observable instead of presenting only as silent retransmit stalls.
- Ring DEPTH + counter only — the timer-driven `net::poll()` change is explicitly out of scope (owned by reliability/sched work).

## Fix 2 — TCP out-of-order reassembly + SACK (the real BBC fix)
Previously in-window out-of-order payload was dropped (only a dup-ACK emitted), so across many concurrent TLS flows normal reordering (and any ring-drop gap) forced full retransmits with no selective recovery.

- **OOO reassembly queue (RFC 9293 §3.10.7.4)**: bounded per-connection `BTreeMap` of in-window segments past `RCV.NXT`, keyed by window-relative offset so ordering is correct across the 32-bit sequence wrap (RFC 1982). Overlapping segments are trimmed so no byte is stored twice; on the in-order segment the contiguous buffered ranges are spliced into the receive buffer and `RCV.NXT` advanced in one pass. Bounded at the advertised window (65535 B, 64 segments); on overflow the furthest range is evicted (OOO buffering is a MAY). A FIN carried by an out-of-order segment is **latent** until `RCV.NXT` reaches its sequence number — never closing on a body delivered ahead of a gap.
- **SACK (RFC 2018, alignment per RFC 9293 §3.1)**: negotiate SACK-permitted (kind 4) in SYN/SYN-ACK; when negotiated bilaterally, emit SACK blocks (kind 5, NOP/NOP-aligned, <=4 blocks) on the dup-ACK describing buffered ranges most-recent-first (RFC 2018 §4) so the peer retransmits only the hole. Receiver-side generation only; no sender-side scoreboard. Segments can now carry options via a generalised `build_segment_opts`.

The ESTABLISHED / FIN-WAIT-1 / FIN-WAIT-2 receive arms now share one `receive_segment_data()` engine, with the state transition kept at each call site.

## Seams preserved (self-refutation)
- The receive-buffer **drain/read filters** (`read`, `read_from`, `has_data`), **CloseWait/TimeWait** paths, and the **recv-copy seam (#614)** are untouched — the change is purely on the ingress (segment -> recv_buffer) side (verified by diff: no `-`/`+` on those functions).
- **FIN/CloseWait (#618/#620)** behaviour: a bare in-order FIN still consumes -> CloseWait exactly as before; the OOO-FIN guard (no premature close, no truncation) is strengthened, not weakened.
- The prior `test_tcp_ooo_fin_guard` was updated to assert the new (correct) reassembly behaviour: OOO data+FIN is now buffered (not dropped) and spliced + FIN-consumed on fill, rather than dropped-and-retransmitted.

## Tests (test_runner.rs)
- TCP out-of-order FIN — buffer ahead of gap, splice + FIN on fill
- TCP OOO reassembly + SACK block generation (block order + on-wire decode)
- TCP OOO overlap-trim + byte-cap eviction
- e1000 RX ring constant sanity

All four verified **PASS on a live KVM test-mode boot** (the existing TCP tests stay green). The net tests register after the FF launch oracle, which can exit the session under heavy FF load on this box; they were verified by a temporary pre-oracle relocation (reverted before commit).

## Verification
`cargo +nightly` clean across `test-mode,kdb`, default, and `firefox-test-core,kdb` (via `qemu-harness.py check`/`build`). NON-BOOTING task — no local FF boot; verified by build + unit tests on the lightweight kernel-only test-mode boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
