### PR TITLE
kdb/fd-map: report live socket readiness (avail + poll revents)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -2196,6 +2196,32 @@ fn op_fd_map(req: &str, out: &mut String) {
                         }
                     }
                 }
+
+                // Live socket readiness — the dispositive fields for the
+                // "poll(2) returns 0 while an fd is data/HUP-pending" check.
+                // `avail` is the raw bytes buffered in the AF_UNIX recv ring;
+                // `revents` is exactly what poll_revents(2) reports to the
+                // poller (POLLIN=0x1 POLLOUT=0x4 POLLHUP=0x10 POLLRDHUP=0x2000).
+                // A nonzero `avail` (or a HUP predicate) with revents==0 is a
+                // dropped readiness edge (kernel bug); a zero `avail` with
+                // revents==0 is a genuinely empty fd (userspace wall).
+                let uid = snap.inode;
+                let has_d  = crate::net::unix::has_data(uid);
+                let has_p  = crate::net::unix::has_pending(uid);
+                let avail  = crate::net::unix::bytes_available(uid);
+                let rdhup  = crate::net::unix::read_shutdown(uid);
+                let hup    = crate::net::unix::fully_hung_up(uid);
+                let wr     = crate::net::unix::writable(uid);
+                j_kv(out, "avail",       &alloc::format!("{}", avail));
+                j_kv_str(out, "has_data",    if has_d { "true" } else { "false" });
+                j_kv_str(out, "has_pending", if has_p { "true" } else { "false" });
+                j_kv_str(out, "rdhup",       if rdhup { "true" } else { "false" });
+                j_kv_str(out, "hup",         if hup   { "true" } else { "false" });
+                j_kv_str(out, "writable",    if wr    { "true" } else { "false" });
+                // The single authoritative figure: what poll(2) actually sees.
+                // Emit as a quoted hex string — bare 0x.. is not valid JSON.
+                let pr = crate::syscall::poll_revents(snap.pid, snap.fd, 0x0001 | 0x0004 | 0x2000);
+                j_kv_str(out, "revents", &alloc::format!("{:#x}", pr));
             }
             crate::vfs::FileType::EventFd => {
                 // GLib GWakeup source.  Report the live readiness so the


### PR DESCRIPTION
## What

Extends the `kdb fd-map` diagnostic so each AF_UNIX socket entry carries its **live readiness state**, not just the peer mapping. New per-socket fields:

| field | meaning |
|---|---|
| `avail` | raw bytes buffered in the recv ring |
| `has_data` | `recv_available() > 0` |
| `has_pending` | listen backlog non-empty |
| `rdhup` | read-side half-close |
| `hup` | full hang-up |
| `writable` | a `write(2)` would make progress |
| `revents` | the exact value `poll_revents` reports to a poller (quoted hex) |

## Why

This turns the "is poll(2) returning 0 while an fd is data/HUP-pending?" question — the central check when classifying a stalled event-loop process as a kernel dropped-edge vs a userspace wall — into a **one-shot structured query**:

- nonzero `avail` (or a HUP predicate) with `revents` clear ⇒ dropped readiness edge (kernel bug)
- zero `avail` with `revents` clear ⇒ genuinely empty fd (userspace wall)

Previously this required cross-referencing several kdb ops or a GDB autopsy of the poll() return. Used in the windowed-Firefox Wikipedia content-render classification to show the kernel correctly holds IPDL-channel readiness edges deliverable while userspace does not consume them.

## Safety / scope

- **Additive only** — existing `fd-map` consumers see extra keys and ignore them; no behavioural change.
- `revents` is a quoted hex string (bare `0x..` is not valid JSON — fixes a latent parse error for any future revents emit).
- Reuses existing `pub` readiness predicates (`net::unix::*`, `syscall::poll_revents`); no new locks held.
- 26-line diagnostic change in `kernel/src/kdb.rs`.

Per IEEE Std 1003.1-2017 `poll(2)` revents semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
