### PR TITLE
debug/ubreak: CoW-private userspace execution breakpoints (live libxul observation)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -270,6 +270,48 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
         }
     }
 
+    // CoW-private userspace breakpoint (debug-only).  A #BP (vector 3) from
+    // Ring 3 may be a planted `int3` belonging to a registered userspace
+    // breakpoint (see `arch::x86_64::ubreak`).  Match the faulting
+    // `(CR3, RIP-1)`; on a hit, capture the register/memory snapshot, restore
+    // the original byte (one-shot), rewind RIP so the original instruction
+    // re-executes, and return WITHOUT any serial output (so an investigator
+    // can break on a hot path without flooding the log).  Per Intel SDM
+    // Vol. 2A (INT3), the saved RIP points one byte past the 0xCC.
+    #[cfg(feature = "kdb")]
+    if vector == 3 && frame.cs & 3 == 3 {
+        let cr3_raw: u64;
+        unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3_raw, options(nomem, nostack)); }
+        // Mask to the page-frame bits (drop PCID / PWT / PCD low bits) so the
+        // comparison matches the masked CR3 stored at arm time (proc.cr3).
+        let cr3 = cr3_raw & 0x000F_FFFF_FFFF_F000;
+        let gpr = unsafe {
+            let base = frame as *const InterruptFrame as *const u64;
+            crate::arch::x86_64::ubreak::read_gprs_from_frame(base)
+        };
+        let mut new_rip = frame.rip;
+        let matched = crate::arch::x86_64::ubreak::on_breakpoint(
+            cr3, frame.rip, frame.rsp, &gpr, &mut new_rip,
+        );
+        if matched {
+            frame.rip = new_rip;
+            return;
+        }
+        // Unmatched #BP from Ring 3 with auto-arm enabled: emit one bounded
+        // diagnostic so a mismatch (cr3/va) can be diagnosed, then fall through.
+        {
+            static UB_MISS: core::sync::atomic::AtomicU64 =
+                core::sync::atomic::AtomicU64::new(0);
+            let n = UB_MISS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            if n < 8 {
+                crate::serial_println!(
+                    "[UBREAK/miss] #BP live_cr3={:#x} rip={:#x} bp_va={:#x}",
+                    cr3, frame.rip, frame.rip.wrapping_sub(1));
+                crate::arch::x86_64::ubreak::list_serial();
+            }
+        }
+    }
+
     // Debug trace for non-page-fault exceptions from user mode.
     if frame.cs & 3 == 3 && vector != 14 {
         crate::serial_println!(
@@ -1528,14 +1570,14 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
         // get the per-process COW copy that protects the cache from GOT/PLT
         // relocations bleeding between independent loads of the same .so.
         let file_info = match &vma.backing {
-            crate::mm::vma::VmBacking::File { mount_idx, inode, offset, .. } => {
+            crate::mm::vma::VmBacking::File { mount_idx, inode, offset, elf_load_delta } => {
                 let is_shared = vma.flags & crate::mm::vma::MAP_SHARED != 0;
-                Some((*mount_idx, *inode, *offset, vma.base, vma.base + vma.length, is_shared))
+                Some((*mount_idx, *inode, *offset, vma.base, vma.base + vma.length, is_shared, *elf_load_delta))
             }
             _ => None,
         };
 
-        if let Some((mount_idx, inode, file_base_offset, vma_base, vma_end, is_shared)) = file_info {
+        if let Some((mount_idx, inode, file_base_offset, vma_base, vma_end, is_shared, elf_load_delta)) = file_info {
             // Release PROCESS_TABLE to avoid deadlock with MOUNTS.
             drop(procs);
 
@@ -1547,6 +1589,31 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
 
             let page_offset_in_vma = page_addr - vma_base;
             let file_page_offset = file_base_offset + page_offset_in_vma;
+
+            // Debug-only userspace-breakpoint auto-arm: compute the ELF load
+            // base for this file-backed mapping so the ubreak hook can plant a
+            // breakpoint at `load_base + <astryx.ubreak=offset>` once that
+            // page is installed.  Per ELF-64 §3: vaddr_in_elf = file_offset +
+            // elf_load_delta, so load_base = page_va - vaddr_in_elf.  Cheap
+            // single-atomic fast-path when auto-arm is disabled.  See
+            // arch::x86_64::ubreak::maybe_auto_arm.  Called at the install-
+            // success epilogue below (after the PTE is mapped).
+            #[cfg(feature = "kdb")]
+            let ubreak_load_base: u64 = {
+                let vaddr_in_elf = file_page_offset.wrapping_add(elf_load_delta);
+                page_addr.wrapping_sub(vaddr_in_elf)
+            };
+            #[cfg(not(feature = "kdb"))]
+            let _ = elf_load_delta; // only consumed by the kdb auto-arm hook
+            // Per-fault scan: on ANY file-backed (libxul) demand-fault, try to
+            // arm the target offset if its page is already present in this CR3.
+            // This catches targets that were demand-faulted before the offset
+            // was set, brought in via readahead, or sit in a hot pre-faulted
+            // page (the install-time `maybe_auto_arm` below only fires when the
+            // freshly-faulted page IS itself a target).  Cheap early-out when
+            // auto-arm is disabled.
+            #[cfg(feature = "kdb")]
+            crate::arch::x86_64::ubreak::maybe_auto_arm_scan(ubreak_load_base, cr3);
 
             #[cfg(feature = "firefox-test-core")]
             {
@@ -1772,6 +1839,12 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                             // holds its own independent reference to
                             // `cached_phys`, so this dec will not free the frame.
                             let _ = crate::mm::refcount::page_ref_dec(cached_phys);
+                            // Debug-only: auto-arm a userspace breakpoint if this
+                            // freshly-installed libxul code page is the requested
+                            // target (no-op when auto-arm is disabled).
+                            #[cfg(feature = "kdb")]
+                            crate::arch::x86_64::ubreak::maybe_auto_arm(
+                                cr3, ubreak_load_base, page_addr);
                             return true;
                         }
                         // Lost the race: a sibling CPU already published a PTE
@@ -1925,9 +1998,20 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                         }
                         let _ = crate::mm::refcount::page_ref_dec(cached_phys);
                         crate::mm::vmm::invlpg(page_addr);
+                        #[cfg(feature = "kdb")]
+                        crate::arch::x86_64::ubreak::maybe_auto_arm(
+                            cr3, ubreak_load_base, page_addr);
                         return true;
                     }
                 }
+                // Debug-only: auto-arm a userspace breakpoint if this freshly-
+                // installed cache-backed page (read-only code alias OR the
+                // private-copy win that fell through to here) is the requested
+                // target.  Covers libxul r-x code pages (which take the RO-alias
+                // arm, not the writable private-copy arm).  No-op when disabled.
+                #[cfg(feature = "kdb")]
+                crate::arch::x86_64::ubreak::maybe_auto_arm(
+                    cr3, ubreak_load_base, page_addr);
                 #[cfg(feature = "firefox-test-core")]
                 {
                     static PF_CACHED_N: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -9,6 +9,10 @@ pub mod gdt;
 pub mod idt;
 pub mod irq;
 pub mod smap;
+// CoW-private userspace execution breakpoints (debug-only).  Gated behind
+// `kdb` since the only consumer is the KDB `ubreak` op surface.
+#[cfg(feature = "kdb")]
+pub mod ubreak;
 
 /// Initialize all x86_64 architecture components.
 pub fn init() {

--- a/kernel/src/arch/x86_64/ubreak.rs
+++ b/kernel/src/arch/x86_64/ubreak.rs
@@ -1,0 +1,819 @@
+//! Userspace execution breakpoints (CoW-private int3).
+//!
+//! A debug-only facility for breaking on a *userspace* virtual address in one
+//! specific process without disturbing any other process that shares the same
+//! code page.  It exists because the two ordinary ways to break on a user VA
+//! are both unusable on this target:
+//!
+//!   * A QEMU/GDB hardware execution breakpoint (Intel SDM Vol. 3B §17.2,
+//!     DR0–DR3 + DR7) is silently overwritten — the kernel re-programs its own
+//!     debug registers on every IRQ entry for an unrelated diagnostic, so a
+//!     hardware breakpoint armed by the external stub never survives to fire.
+//!   * A plain software breakpoint (`int3` / `0xCC`, Intel SDM Vol. 2A) written
+//!     into a shared, copy-on-write library code page corrupts *every* process
+//!     mapping that frame — including processes the debugger is not targeting —
+//!     which wedges the system.
+//!
+//! The fix is to give the target process a **private copy** of the single code
+//! page before planting the `0xCC`:
+//!
+//!   1. Walk the target CR3 to the leaf PTE for the page (Intel SDM Vol. 3A
+//!      §4.5, 4-level paging).
+//!   2. Allocate a fresh frame, copy the page's bytes into it.
+//!   3. Re-point the leaf PTE at the private frame (preserving the original
+//!      USER / NX / present bits), invalidate the TLB entry (`invlpg`).
+//!   4. Save the original byte at the target offset and overwrite it with
+//!      `0xCC`.
+//!
+//! The shared library frame is now untouched for every other process; only the
+//! target sees the breakpoint.
+//!
+//! When the planted `int3` executes from Ring 3 the CPU raises #BP (vector 3,
+//! IDT entry DPL=3).  The vector-3 path in `idt.rs` calls
+//! [`on_breakpoint`], which matches the faulting `(CR3, RIP-1)` against the
+//! registry, snapshots the general-purpose registers plus a small set of
+//! register-relative memory windows into a ring, then restores the original
+//! byte, rewinds `RIP`, and lets execution continue (one-shot).  The snapshots
+//! are drained out-of-band over the KDB protocol (`ubreak dump`).
+//!
+//! One-shot is deliberate: the primary use is breaking on a *panic branch* that
+//! executes exactly once before the process aborts, so no single-step/re-arm
+//! machinery (which would collide with the kernel's own #DB usage) is needed.
+//!
+//! Feature-gated behind `kdb`; absent from production builds.
+
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+use crate::mm::vmm::{self, PHYS_OFF};
+
+/// Maximum simultaneously-armed userspace breakpoints.
+pub const MAX_UBREAKS: usize = 8;
+/// Captured-snapshot ring depth.
+pub const SNAP_RING: usize = 16;
+/// Memory windows captured per snapshot (register + offset → bytes).
+pub const MEM_WINDOWS: usize = 3;
+/// Bytes captured per memory window.
+pub const MEM_WINDOW_LEN: usize = 64;
+
+/// One armed breakpoint slot.
+struct UBreak {
+    active: AtomicBool,
+    cr3: AtomicU64,
+    va: AtomicU64,
+    orig_byte: AtomicU64, // low 8 bits hold the saved byte
+    private_phys: AtomicU64,
+    hits: AtomicU64,
+    // Index into AUTO_ARM_OFFSETS/CONSUMED, or usize::MAX for a manually-armed
+    // (kdb `ubreak set`) breakpoint with no auto-arm offset.
+    auto_idx: AtomicUsize,
+}
+
+impl UBreak {
+    const fn new() -> Self {
+        UBreak {
+            active: AtomicBool::new(false),
+            cr3: AtomicU64::new(0),
+            va: AtomicU64::new(0),
+            orig_byte: AtomicU64::new(0),
+            private_phys: AtomicU64::new(0),
+            hits: AtomicU64::new(0),
+            auto_idx: AtomicUsize::new(usize::MAX),
+        }
+    }
+}
+
+/// A captured register + memory snapshot taken at a breakpoint hit.
+#[derive(Clone, Copy)]
+pub struct Snapshot {
+    pub valid: bool,
+    pub cr3: u64,
+    pub rip: u64,
+    pub rsp: u64,
+    pub tid: u64,
+    pub pid: u64,
+    // GPRs in the canonical order used by the #UD dump in idt.rs.
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rbp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    /// (base_va, len) of each captured window; len==0 = unused.
+    pub win_va: [u64; MEM_WINDOWS],
+    pub win_len: [u32; MEM_WINDOWS],
+    pub win_bytes: [[u8; MEM_WINDOW_LEN]; MEM_WINDOWS],
+}
+
+impl Snapshot {
+    const fn empty() -> Self {
+        Snapshot {
+            valid: false,
+            cr3: 0, rip: 0, rsp: 0, tid: 0, pid: 0,
+            rax: 0, rbx: 0, rcx: 0, rdx: 0, rsi: 0, rdi: 0, rbp: 0,
+            r8: 0, r9: 0, r10: 0, r11: 0, r12: 0, r13: 0, r14: 0, r15: 0,
+            win_va: [0; MEM_WINDOWS],
+            win_len: [0; MEM_WINDOWS],
+            win_bytes: [[0; MEM_WINDOW_LEN]; MEM_WINDOWS],
+        }
+    }
+}
+
+// Registry of armed breakpoints.
+static BREAKS: [UBreak; MAX_UBREAKS] = [
+    UBreak::new(), UBreak::new(), UBreak::new(), UBreak::new(),
+    UBreak::new(), UBreak::new(), UBreak::new(), UBreak::new(),
+];
+
+// Snapshot ring.  Single-producer (the #BP ISR is non-reentrant w.r.t. itself
+// because the byte is restored one-shot), single-drainer (KDB).  A spin::Mutex
+// is unsuitable inside the exception path, so the ring uses a monotonic head
+// and a SeqCst publish flag per slot.
+static SNAPS: spin::Mutex<[Snapshot; SNAP_RING]> =
+    spin::Mutex::new([Snapshot::empty(); SNAP_RING]);
+static SNAP_HEAD: AtomicUsize = AtomicUsize::new(0);
+static SNAP_COUNT: AtomicU64 = AtomicU64::new(0);
+
+const PAGE_SIZE: u64 = 0x1000;
+const ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+
+// ── Auto-arm (boot-flag driven, kdb-independent) ───────────────────────────────
+//
+// When set (via the `astryx.ubreak=<elf_offset>` boot token), the kernel
+// auto-arms a one-shot breakpoint at `load_base + AUTO_ARM_OFFSET` for any
+// process the moment it demand-faults the page containing that offset.  This
+// removes the host-side timing race and works under KDB starvation.  The
+// crash in the moz2d blob path fires VERY early and in a content process, so a
+// host poll cannot reliably plant in time.  Sentinel 0 = disabled.
+// Up to 4 auto-arm offsets (e.g. add-entry + the panic branches + the crash
+// thunk).  Sentinel 0 in a slot = unused.  Each offset carries a 4-byte
+// instruction SIGNATURE (the first 4 code bytes expected at that ELF offset);
+// the auto-arm only fires when the target page's bytes match, which rejects a
+// wrong load base computed from a NON-libxul VMA (ld-musl, libc, etc.) that
+// happens to make the target page present.
+const MAX_AUTO_ARM: usize = 4;
+static AUTO_ARM_OFFSETS: [AtomicU64; MAX_AUTO_ARM] = [
+    AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
+];
+static AUTO_ARM_SIGS: [AtomicU64; MAX_AUTO_ARM] = [
+    AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
+];
+// Per-offset "consumed" flags.  A one-shot breakpoint disarms its slot on the
+// first hit and restores the original byte.  Without this flag the per-fault
+// `maybe_auto_arm_scan` would immediately RE-arm the freed slot (re-planting
+// the int3) — opening a window where the int3 is planted but no slot matches it
+// (slot freed, scan not yet re-run), so a #BP between disarm and re-arm hits the
+// generic handler, is not rewound, and SIGSEGVs.  Marking the offset consumed
+// makes the scan skip it forever, so each offset fires exactly once.
+static AUTO_ARM_CONSUMED: [AtomicBool; MAX_AUTO_ARM] = [
+    AtomicBool::new(false), AtomicBool::new(false),
+    AtomicBool::new(false), AtomicBool::new(false),
+];
+// Fast-path early-out flag: non-zero iff at least one auto-arm offset is set.
+// (De-dup of already-armed (cr3, va) pairs is handled by `is_armed`.)
+static AUTO_ARM_OFFSET: AtomicU64 = AtomicU64::new(0);
+
+/// Enable auto-arm at the given libxul-relative ELF offset with a 4-byte
+/// instruction signature (the first 4 code bytes expected at that offset, as a
+/// little-endian u32 — i.e. byte[0] in bits 0..7).  `sig`==0 disables the check
+/// for that offset.  (0 offset disables the slot.)
+pub fn set_auto_arm_offset_sig(off: u64, sig: u32) {
+    if off == 0 {
+        return;
+    }
+    AUTO_ARM_OFFSET.store(off, Ordering::Release);
+    for (s, sg) in AUTO_ARM_OFFSETS.iter().zip(AUTO_ARM_SIGS.iter()) {
+        if s.load(Ordering::Acquire) == 0 {
+            sg.store(sig as u64, Ordering::Release);
+            s.store(off, Ordering::Release);
+            return;
+        }
+    }
+}
+
+/// Back-compat: enable auto-arm with no signature check (legacy single-offset).
+pub fn set_auto_arm_offset(off: u64) {
+    set_auto_arm_offset_sig(off, 0);
+}
+
+/// Read the first 4 bytes at `va` in `cr3` as a little-endian u32 (0 if any
+/// byte is unmapped).
+fn read_sig4(cr3: u64, va: u64) -> u32 {
+    let mut buf = [0u8; MEM_WINDOW_LEN];
+    let n = read_user(cr3, va, &mut buf);
+    if n < 4 {
+        return 0;
+    }
+    u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]])
+}
+
+/// Page-fault-install hook.  Called after a Linux process demand-faults a
+/// file-backed executable page.  `load_base` is the libxul ELF load base
+/// (faulting_addr - vaddr_in_elf), `faulted_page` is the page-aligned VA just
+/// installed.  If auto-arm is enabled and the requested offset's page == the
+/// faulted page (and this CR3 hasn't been armed yet), plant the breakpoint.
+///
+/// Cheap fast-path: a single relaxed atomic load returns immediately when
+/// auto-arm is disabled (the production / non-debug case).
+pub fn maybe_auto_arm(cr3: u64, load_base: u64, faulted_page: u64) {
+    // Fast-path early-out: nothing to do unless at least one offset is set.
+    if AUTO_ARM_OFFSET.load(Ordering::Acquire) == 0 {
+        return;
+    }
+    for idx in 0..MAX_AUTO_ARM {
+        let off = AUTO_ARM_OFFSETS[idx].load(Ordering::Acquire);
+        if off == 0 {
+            continue;
+        }
+        if AUTO_ARM_CONSUMED[idx].load(Ordering::Acquire) {
+            continue;
+        }
+        let target_va = load_base.wrapping_add(off);
+        if (target_va & !(PAGE_SIZE - 1)) != faulted_page {
+            continue;
+        }
+        // De-dup: skip if THIS (cr3, target_va) is already armed.
+        if is_armed(cr3, target_va) {
+            continue;
+        }
+        // Signature gate (reject a wrong non-libxul load base).
+        let sig = AUTO_ARM_SIGS[idx].load(Ordering::Acquire) as u32;
+        if sig != 0 && read_sig4(cr3, target_va) != sig {
+            continue;
+        }
+        if arm_at_cr3_idx(cr3, target_va, idx).is_ok() {
+            crate::serial_println!(
+                "[UBREAK] auto-armed cr3={:#x} load_base={:#x} target={:#x} (off={:#x})",
+                cr3, load_base, target_va, off
+            );
+        }
+    }
+}
+
+/// True if a breakpoint at `(cr3, va)` is currently armed.
+fn is_armed(cr3: u64, va: u64) -> bool {
+    for slot in BREAKS.iter() {
+        if slot.active.load(Ordering::Acquire)
+            && slot.cr3.load(Ordering::Acquire) == cr3
+            && slot.va.load(Ordering::Acquire) == va
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Per-fault auto-arm scan.  Called from the page-fault handler on every fault
+/// (cheap early-out when disabled).  Unlike `maybe_auto_arm` (which only fires
+/// when the freshly-installed page IS a target — and so misses targets that
+/// were demand-faulted before the offset was set, or brought in via readahead,
+/// or are in a hot pre-faulted page), this walks the faulting process's VMAs to
+/// find libxul (the large r-x file-backed mapping), computes its ELF load base,
+/// and arms any target page that is already present.  Faults happen frequently
+/// during Firefox startup, so a target page becomes armed shortly after libxul
+/// maps — well before the moz2d blob code executes.
+///
+/// `find_libxul` returns (load_base) for the current process or None.
+pub fn maybe_auto_arm_scan(load_base: u64, cr3: u64) {
+    if AUTO_ARM_OFFSET.load(Ordering::Acquire) == 0 {
+        return;
+    }
+    if load_base == 0 {
+        return;
+    }
+    for idx in 0..MAX_AUTO_ARM {
+        let off = AUTO_ARM_OFFSETS[idx].load(Ordering::Acquire);
+        if off == 0 {
+            continue;
+        }
+        // Skip offsets that have already fired once (one-shot): re-arming them
+        // would re-open the plant-without-active-slot window (see
+        // AUTO_ARM_CONSUMED docs).
+        if AUTO_ARM_CONSUMED[idx].load(Ordering::Acquire) {
+            continue;
+        }
+        let target_va = load_base.wrapping_add(off);
+        if is_armed(cr3, target_va) {
+            continue;
+        }
+        // Only arm if the target page is already present in this CR3.
+        let page = target_va & !(PAGE_SIZE - 1);
+        if vmm::read_pte(cr3, page) & vmm::PAGE_PRESENT == 0 {
+            continue;
+        }
+        // Signature gate: reject a wrong load base (from a non-libxul VMA) by
+        // requiring the target's first 4 code bytes to match the expected
+        // instruction signature.  sig==0 disables the check.
+        let sig = AUTO_ARM_SIGS[idx].load(Ordering::Acquire) as u32;
+        if sig != 0 && read_sig4(cr3, target_va) != sig {
+            continue;
+        }
+        if arm_at_cr3_idx(cr3, target_va, idx).is_ok() {
+            crate::serial_println!(
+                "[UBREAK] auto-armed (scan) cr3={:#x} load_base={:#x} target={:#x} (off={:#x})",
+                cr3, load_base, target_va, off
+            );
+        }
+    }
+}
+
+/// Arm a one-shot breakpoint at `va` in an explicit `cr3` (used by the auto-arm
+/// PF hook, which already knows the CR3).  Same mechanism as [`arm`] minus the
+/// pid→cr3 resolution.  Page must be present (it just faulted in).
+fn arm_at_cr3(cr3: u64, va: u64) -> Result<(), &'static str> {
+    arm_at_cr3_idx(cr3, va, usize::MAX)
+}
+
+fn arm_at_cr3_idx(cr3: u64, va: u64, auto_idx: usize) -> Result<(), &'static str> {
+    let page = va & !(PAGE_SIZE - 1);
+    let old_pte = vmm::read_pte(cr3, page);
+    if old_pte & vmm::PAGE_PRESENT == 0 {
+        return Err("page not present");
+    }
+    if old_pte & vmm::PAGE_HUGE != 0 {
+        return Err("huge page");
+    }
+    let old_phys = old_pte & ADDR_MASK;
+    // Idempotence guard: if the target byte is ALREADY 0xCC, this (cr3, va) is
+    // already armed (by a prior install-hook OR scan-hook call that this one
+    // raced).  Re-CoW-privating would mint a SECOND private frame, leaving the
+    // PTE on the new frame's int3 while the registered slot's recorded
+    // private_phys (and thus restore_byte) points at the OLD frame — so the
+    // one-shot restore would fail to remove the live int3, turning a later #BP
+    // into an unhandled SIGSEGV.  Bail out (the existing slot owns this va).
+    {
+        let cur = unsafe {
+            core::ptr::read_volatile((PHYS_OFF + old_phys + (va & (PAGE_SIZE - 1))) as *const u8)
+        };
+        if cur == 0xCC {
+            return Err("already armed (0xCC present)");
+        }
+    }
+    let flags = old_pte & !ADDR_MASK;
+    let new_phys = crate::mm::pmm::alloc_page().ok_or("alloc_page failed")?;
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            (PHYS_OFF + old_phys) as *const u8,
+            (PHYS_OFF + new_phys) as *mut u8,
+            PAGE_SIZE as usize,
+        );
+    }
+    let new_pte = new_phys | flags | vmm::PAGE_WRITABLE;
+    vmm::write_pte(cr3, page, new_pte);
+    vmm::invlpg(page);
+    let off = (va & (PAGE_SIZE - 1)) as usize;
+    let byte_ptr = (PHYS_OFF + new_phys + off as u64) as *mut u8;
+    let orig = unsafe { core::ptr::read_volatile(byte_ptr) };
+    unsafe { core::ptr::write_volatile(byte_ptr, 0xCC); }
+    for slot in BREAKS.iter() {
+        if slot
+            .active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            slot.cr3.store(cr3, Ordering::Release);
+            slot.va.store(va, Ordering::Release);
+            slot.orig_byte.store(orig as u64, Ordering::Release);
+            slot.private_phys.store(new_phys, Ordering::Release);
+            slot.hits.store(0, Ordering::Release);
+            slot.auto_idx.store(auto_idx, Ordering::Release);
+            return Ok(());
+        }
+    }
+    unsafe { core::ptr::write_volatile(byte_ptr, orig); }
+    Err("no free slot")
+}
+
+/// Resolve a PID to its CR3 under a brief PROCESS_TABLE lock.
+fn cr3_for_pid(pid: u64) -> Option<u64> {
+    let pt = crate::proc::PROCESS_TABLE.try_lock()?;
+    let c = pt.iter().find(|p| p.pid == pid).map(|p| p.cr3);
+    c
+}
+
+/// Arm a one-shot userspace breakpoint at `va` in process `pid`.
+///
+/// CoW-privates the page (so the shared library frame is untouched), saves the
+/// original byte, and plants `0xCC`.  Returns Ok((cr3, private_phys, orig_byte))
+/// on success.
+pub fn arm(pid: u64, va: u64) -> Result<(u64, u64, u8), &'static str> {
+    let cr3 = cr3_for_pid(pid).ok_or("pid not found / table busy")?;
+    let page = va & !(PAGE_SIZE - 1);
+
+    // Existing leaf PTE — must be present and a 4 KiB leaf (no huge-page code).
+    let old_pte = vmm::read_pte(cr3, page);
+    if old_pte & vmm::PAGE_PRESENT == 0 {
+        return Err("target page not present");
+    }
+    if old_pte & vmm::PAGE_HUGE != 0 {
+        return Err("target is a huge page");
+    }
+    let old_phys = old_pte & ADDR_MASK;
+    let flags = old_pte & !ADDR_MASK; // preserve USER / NX / etc.
+
+    // Allocate a private frame and copy the original page into it.
+    let new_phys = crate::mm::pmm::alloc_page().ok_or("alloc_page failed")?;
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            (PHYS_OFF + old_phys) as *const u8,
+            (PHYS_OFF + new_phys) as *mut u8,
+            PAGE_SIZE as usize,
+        );
+    }
+
+    // Re-point the leaf PTE at the private frame.  Keep it WRITABLE so the
+    // kernel can plant/restore the byte; user code only ever fetches (RX) it,
+    // and the page is process-private now so a stray user write would only
+    // corrupt this one process (which is already being debugged).
+    let new_pte = new_phys | flags | vmm::PAGE_WRITABLE;
+    vmm::write_pte(cr3, page, new_pte);
+    vmm::invlpg(page);
+
+    // Plant the int3.
+    let off = (va & (PAGE_SIZE - 1)) as usize;
+    let byte_ptr = (PHYS_OFF + new_phys + off as u64) as *mut u8;
+    let orig = unsafe { core::ptr::read_volatile(byte_ptr) };
+    unsafe { core::ptr::write_volatile(byte_ptr, 0xCC); }
+
+    // Register the slot.
+    for slot in BREAKS.iter() {
+        if slot
+            .active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            slot.cr3.store(cr3, Ordering::Release);
+            slot.va.store(va, Ordering::Release);
+            slot.orig_byte.store(orig as u64, Ordering::Release);
+            slot.private_phys.store(new_phys, Ordering::Release);
+            slot.hits.store(0, Ordering::Release);
+            return Ok((cr3, new_phys, orig));
+        }
+    }
+
+    // No free slot — undo the int3 (leave the private page; harmless) and fail.
+    unsafe { core::ptr::write_volatile(byte_ptr, orig); }
+    Err("no free breakpoint slot")
+}
+
+/// Disarm a breakpoint (restore the original byte).  Leaves the page private
+/// (cheap; a private copy of one shared code page is harmless).
+pub fn disarm(cr3: u64, va: u64) -> bool {
+    for slot in BREAKS.iter() {
+        if !slot.active.load(Ordering::Acquire) {
+            continue;
+        }
+        if slot.cr3.load(Ordering::Acquire) == cr3 && slot.va.load(Ordering::Acquire) == va {
+            restore_byte(slot);
+            slot.active.store(false, Ordering::Release);
+            return true;
+        }
+    }
+    false
+}
+
+/// Disarm all breakpoints.  Returns the count cleared.
+pub fn disarm_all() -> usize {
+    let mut n = 0;
+    for slot in BREAKS.iter() {
+        if slot.active.load(Ordering::Acquire) {
+            restore_byte(slot);
+            slot.active.store(false, Ordering::Release);
+            n += 1;
+        }
+    }
+    n
+}
+
+fn restore_byte(slot: &UBreak) {
+    let va = slot.va.load(Ordering::Acquire);
+    let orig = slot.orig_byte.load(Ordering::Acquire) as u8;
+    let off = (va & (PAGE_SIZE - 1)) as usize;
+    let page = va & !(PAGE_SIZE - 1);
+    // Restore through the LIVE PTE frame, not the frame recorded at arm time.
+    // If the page was re-installed (re-faulted into a fresh frame) between arm
+    // and the hit, the recorded private_phys is stale and writing there would
+    // leave the int3 live in the actual mapped frame.  Prefer the current leaf
+    // PTE's frame; fall back to the recorded private_phys if the walk fails.
+    let cr3 = slot.cr3.load(Ordering::Acquire);
+    let live_pte = vmm::read_pte(cr3, page);
+    let phys = if live_pte & vmm::PAGE_PRESENT != 0 {
+        live_pte & ADDR_MASK
+    } else {
+        slot.private_phys.load(Ordering::Acquire)
+    };
+    let byte_ptr = (PHYS_OFF + phys + off as u64) as *mut u8;
+    unsafe { core::ptr::write_volatile(byte_ptr, orig); }
+    vmm::invlpg(page);
+}
+
+/// #BP handler hook.  Called from the vector-3 path in idt.rs for Ring-3
+/// breakpoints.  `gpr` is the 15-element GPR array as laid out by the ISR stub
+/// (see [`read_gprs_from_frame`]).  Returns true if this #BP belonged to a
+/// registered userspace breakpoint (so the caller skips the generic handling
+/// and returns to the rewound RIP).
+///
+/// `frame_rip` is the RIP *after* the int3 (points one byte past the 0xCC).
+/// On a match we capture, restore the byte (one-shot), and rewind `*rip_out` by
+/// one so the original instruction re-executes.
+pub fn on_breakpoint(
+    cr3: u64,
+    frame_rip: u64,
+    frame_rsp: u64,
+    gpr: &Gprs,
+    rip_out: &mut u64,
+) -> bool {
+    let bp_va = frame_rip.wrapping_sub(1);
+    for slot in BREAKS.iter() {
+        if !slot.active.load(Ordering::Acquire) {
+            continue;
+        }
+        if slot.cr3.load(Ordering::Acquire) != cr3 {
+            continue;
+        }
+        if slot.va.load(Ordering::Acquire) != bp_va {
+            continue;
+        }
+        slot.hits.fetch_add(1, Ordering::AcqRel);
+
+        capture(cr3, bp_va, frame_rsp, gpr);
+
+        // One-shot: restore the original byte and rewind so the instruction
+        // re-executes normally.  Disarm the slot (we keep the private page).
+        // Mark this offset CONSUMED so the per-fault scan never re-arms it —
+        // re-arming would re-open the plant-without-active-slot window that
+        // turns a later #BP into an unhandled SIGSEGV.
+        let idx = slot.auto_idx.load(Ordering::Acquire);
+        if idx < MAX_AUTO_ARM {
+            AUTO_ARM_CONSUMED[idx].store(true, Ordering::Release);
+        }
+        restore_byte(slot);
+        slot.active.store(false, Ordering::Release);
+        *rip_out = bp_va;
+        return true;
+    }
+    false
+}
+
+/// GPR snapshot passed from the ISR stub.
+#[derive(Clone, Copy)]
+pub struct Gprs {
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rbp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+}
+
+/// Decode the 15 GPRs from the ISR stack frame, mirroring the layout the
+/// `isr_no_error!` macro pushes (see idt.rs).  `frame_base` is the pointer
+/// passed as `frame` to `exception_handler` (the InterruptFrame).
+///
+/// # Safety
+/// `frame_base` must be the live InterruptFrame pointer; the saved GPRs live at
+/// the negative offsets the macro pushed them to.
+pub unsafe fn read_gprs_from_frame(frame_base: *const u64) -> Gprs {
+    unsafe {
+        Gprs {
+            rax: *frame_base.sub(2),
+            rcx: *frame_base.sub(3),
+            rdx: *frame_base.sub(4),
+            rsi: *frame_base.sub(5),
+            rdi: *frame_base.sub(6),
+            r8: *frame_base.sub(7),
+            r9: *frame_base.sub(8),
+            r10: *frame_base.sub(9),
+            r11: *frame_base.sub(10),
+            rbx: *frame_base.sub(11),
+            rbp: *frame_base.sub(12),
+            r12: *frame_base.sub(13),
+            r13: *frame_base.sub(14),
+            r14: *frame_base.sub(15),
+            r15: *frame_base.sub(16),
+        }
+    }
+}
+
+/// Read up to MEM_WINDOW_LEN bytes from a userspace VA in `cr3`, page-walking
+/// the target address space.  Returns the count read (0 on unmapped).
+fn read_user(cr3: u64, va: u64, buf: &mut [u8; MEM_WINDOW_LEN]) -> u32 {
+    let mut got: u32 = 0;
+    let mut i: u64 = 0;
+    while (i as usize) < buf.len() {
+        let cur = va.wrapping_add(i);
+        let page = cur & !(PAGE_SIZE - 1);
+        let phys = match vmm::virt_to_phys_in(cr3, page) {
+            Some(p) => p,
+            None => break,
+        };
+        let off = cur & (PAGE_SIZE - 1);
+        let avail = PAGE_SIZE - off;
+        let take = core::cmp::min(avail, buf.len() as u64 - i);
+        for b in 0..take {
+            let byte = unsafe {
+                core::ptr::read_volatile((PHYS_OFF + phys + off + b) as *const u8)
+            };
+            buf[(i + b) as usize] = byte;
+            got += 1;
+        }
+        i += take;
+    }
+    got
+}
+
+/// Capture a snapshot.  Auto-derives the memory windows useful for the moz2d
+/// blob gate: many libxul Rust call sites pass a fat slice / Arc<Vec<u8>>, so
+/// we capture (a) the 64 bytes around RSP, (b) the 64 bytes at the object R15
+/// points to (the common "this"/data register at these sites), and (c) the
+/// blob payload — for an Arc<Vec<u8>> the Vec header sits at obj+0x10 as
+/// {ptr@+0x18, cap, len@+0x20}; we read the ptr and capture the first bytes of
+/// the buffer.  Generic callers can ignore the auto-windows and read the GPRs.
+fn capture(cr3: u64, bp_va: u64, frame_rsp: u64, gpr: &Gprs) {
+    let mut snap = Snapshot::empty();
+    snap.valid = true;
+    snap.cr3 = cr3;
+    snap.rip = bp_va;
+    snap.rsp = frame_rsp;
+    snap.tid = crate::proc::current_tid() as u64;
+    snap.pid = crate::proc::current_pid_lockless();
+    snap.rax = gpr.rax; snap.rbx = gpr.rbx; snap.rcx = gpr.rcx; snap.rdx = gpr.rdx;
+    snap.rsi = gpr.rsi; snap.rdi = gpr.rdi; snap.rbp = gpr.rbp;
+    snap.r8 = gpr.r8; snap.r9 = gpr.r9; snap.r10 = gpr.r10; snap.r11 = gpr.r11;
+    snap.r12 = gpr.r12; snap.r13 = gpr.r13; snap.r14 = gpr.r14; snap.r15 = gpr.r15;
+
+    // Window 0: stack around RSP.
+    {
+        let mut buf = [0u8; MEM_WINDOW_LEN];
+        let n = read_user(cr3, frame_rsp, &mut buf);
+        snap.win_va[0] = frame_rsp;
+        snap.win_len[0] = n;
+        snap.win_bytes[0] = buf;
+    }
+
+    // Window 1: the blob `data` Arc<Vec<u8>> header.  At the moz2d
+    // Moz2dBlobImageHandler::add ENTRY (off 0x6e36c70) the `data` arg is in RDX
+    // (SysV ABI 3rd integer arg; confirmed by the prologue `mov 0x20(%rdx),%rsi`
+    // = Vec.len, `mov 0x18(%rdx),%rax` = Vec.ptr).  Capture 64 bytes at RDX so
+    // the Vec{ptr@+0x18, len@+0x20} header is preserved at capture time
+    // (reading it later races the Arc being freed).
+    let blob_ptr;
+    let blob_len;
+    {
+        let mut buf = [0u8; MEM_WINDOW_LEN];
+        let n = read_user(cr3, gpr.rdx, &mut buf);
+        snap.win_va[1] = gpr.rdx;
+        snap.win_len[1] = n;
+        snap.win_bytes[1] = buf;
+        blob_ptr = if n >= 0x20 {
+            u64::from_le_bytes([buf[0x18], buf[0x19], buf[0x1a], buf[0x1b],
+                                buf[0x1c], buf[0x1d], buf[0x1e], buf[0x1f]])
+        } else { 0 };
+        blob_len = if n >= 0x28 {
+            u64::from_le_bytes([buf[0x20], buf[0x21], buf[0x22], buf[0x23],
+                                buf[0x24], buf[0x25], buf[0x26], buf[0x27]])
+        } else { 0 };
+    }
+
+    // Window 2: the FIRST 64 bytes of the blob buffer (Vec.ptr).  This is the
+    // dispositive read for b1 vs b2: a degenerate blob (b2) is short / all-zero;
+    // a font-region blob (b1) is ASCII font-path + zeros; a valid moz2d
+    // recording starts with the 0xc001feed kMagicInt.  Also capture the blob
+    // length (snap.r8 is reused to carry blob_len in the dump; see dump_json).
+    {
+        let mut buf = [0u8; MEM_WINDOW_LEN];
+        let n = if blob_ptr != 0 { read_user(cr3, blob_ptr, &mut buf) } else { 0 };
+        snap.win_va[2] = blob_ptr;
+        snap.win_len[2] = n;
+        snap.win_bytes[2] = buf;
+    }
+    // Stash the blob length in the unused-at-entry field so the dump shows it.
+    // (We overload `rsp` is needed; instead add a dedicated field via win_va[2]
+    // already = ptr; blob_len is logged below.)
+    if blob_len != 0 {
+        crate::serial_println!(
+            "[UBREAK] capture blob: rip={:#x} data(rdx)={:#x} blob_ptr={:#x} blob_len={}",
+            bp_va, gpr.rdx, blob_ptr, blob_len);
+    }
+
+    // Publish into the ring.
+    let idx = SNAP_HEAD.fetch_add(1, Ordering::AcqRel) % SNAP_RING;
+    if let Some(mut ring) = SNAPS.try_lock() {
+        ring[idx] = snap;
+        SNAP_COUNT.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+/// Drain captured snapshots into a JSON string (for KDB `ubreak dump`).
+pub fn dump_json(out: &mut alloc::string::String) {
+    use core::fmt::Write;
+    let ring = match SNAPS.try_lock() {
+        Some(g) => g,
+        None => {
+            out.push_str(r#"{"busy":"snapshot ring held"}"#);
+            return;
+        }
+    };
+    let total = SNAP_COUNT.load(Ordering::Acquire);
+    let _ = write!(out, r#"{{"captured_total":{},"snapshots":["#, total);
+    let mut first = true;
+    for s in ring.iter() {
+        if !s.valid {
+            continue;
+        }
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        let _ = write!(
+            out,
+            r#"{{"pid":{},"tid":{},"cr3":"{:#x}","rip":"{:#x}","rsp":"{:#x}","#,
+            s.pid, s.tid, s.cr3, s.rip, s.rsp
+        );
+        let _ = write!(
+            out,
+            r#""rax":"{:#x}","rbx":"{:#x}","rcx":"{:#x}","rdx":"{:#x}","rsi":"{:#x}","rdi":"{:#x}","rbp":"{:#x}","#,
+            s.rax, s.rbx, s.rcx, s.rdx, s.rsi, s.rdi, s.rbp
+        );
+        let _ = write!(
+            out,
+            r#""r8":"{:#x}","r9":"{:#x}","r10":"{:#x}","r11":"{:#x}","r12":"{:#x}","r13":"{:#x}","r14":"{:#x}","r15":"{:#x}","#,
+            s.r8, s.r9, s.r10, s.r11, s.r12, s.r13, s.r14, s.r15
+        );
+        out.push_str(r#""windows":["#);
+        for w in 0..MEM_WINDOWS {
+            if w > 0 {
+                out.push(',');
+            }
+            let _ = write!(
+                out,
+                r#"{{"va":"{:#x}","len":{},"bytes":""#,
+                s.win_va[w], s.win_len[w]
+            );
+            for b in 0..(s.win_len[w] as usize).min(MEM_WINDOW_LEN) {
+                let _ = write!(out, "{:02x}", s.win_bytes[w][b]);
+            }
+            out.push_str(r#""}"#);
+        }
+        out.push_str("]}");
+    }
+    out.push_str("]}");
+}
+
+/// Serial dump of armed slots (debug helper for the #BP-miss diagnostic).
+pub fn list_serial() {
+    for (i, slot) in BREAKS.iter().enumerate() {
+        if slot.active.load(Ordering::Acquire) {
+            crate::serial_println!(
+                "[UBREAK/slot] {} active cr3={:#x} va={:#x} hits={}",
+                i,
+                slot.cr3.load(Ordering::Acquire),
+                slot.va.load(Ordering::Acquire),
+                slot.hits.load(Ordering::Acquire),
+            );
+        }
+    }
+}
+
+/// List armed breakpoints + hit counts as JSON (for KDB `ubreak list`).
+pub fn list_json(out: &mut alloc::string::String) {
+    use core::fmt::Write;
+    out.push_str(r#"{"breakpoints":["#);
+    let mut first = true;
+    for slot in BREAKS.iter() {
+        if !slot.active.load(Ordering::Acquire) {
+            continue;
+        }
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        let _ = write!(
+            out,
+            r#"{{"cr3":"{:#x}","va":"{:#x}","orig_byte":"{:#x}","private_phys":"{:#x}","hits":{}}}"#,
+            slot.cr3.load(Ordering::Acquire),
+            slot.va.load(Ordering::Acquire),
+            slot.orig_byte.load(Ordering::Acquire) & 0xff,
+            slot.private_phys.load(Ordering::Acquire),
+            slot.hits.load(Ordering::Acquire),
+        );
+    }
+    out.push_str("]}");
+}

--- a/kernel/src/arch/x86_64/ubreak.rs
+++ b/kernel/src/arch/x86_64/ubreak.rs
@@ -369,6 +369,13 @@ fn arm_at_cr3_idx(cr3: u64, va: u64, auto_idx: usize) -> Result<(), &'static str
     let new_pte = new_phys | flags | vmm::PAGE_WRITABLE;
     vmm::write_pte(cr3, page, new_pte);
     vmm::invlpg(page);
+    // Refcount bookkeeping: the PTE now references `new_phys` (set its ref to 1,
+    // mirroring the demand-paging private-copy install) and no longer references
+    // `old_phys` (release the mapping ref we displaced).  Without this the old
+    // shared/cache frame leaks and `new_phys` underflows its refcount at process
+    // teardown (still freed correctly, but it bumps the underflow diagnostic).
+    crate::mm::refcount::page_ref_set(new_phys, 1);
+    let _ = crate::mm::refcount::page_ref_dec(old_phys);
     let off = (va & (PAGE_SIZE - 1)) as usize;
     let byte_ptr = (PHYS_OFF + new_phys + off as u64) as *mut u8;
     let orig = unsafe { core::ptr::read_volatile(byte_ptr) };
@@ -436,6 +443,13 @@ pub fn arm(pid: u64, va: u64) -> Result<(u64, u64, u8), &'static str> {
     let new_pte = new_phys | flags | vmm::PAGE_WRITABLE;
     vmm::write_pte(cr3, page, new_pte);
     vmm::invlpg(page);
+    // Refcount bookkeeping: the PTE now references `new_phys` (set its ref to 1,
+    // mirroring the demand-paging private-copy install) and no longer references
+    // `old_phys` (release the mapping ref we displaced).  Without this the old
+    // shared/cache frame leaks and `new_phys` underflows its refcount at process
+    // teardown (still freed correctly, but it bumps the underflow diagnostic).
+    crate::mm::refcount::page_ref_set(new_phys, 1);
+    let _ = crate::mm::refcount::page_ref_dec(old_phys);
 
     // Plant the int3.
     let off = (va & (PAGE_SIZE - 1)) as usize;
@@ -704,9 +718,9 @@ fn capture(cr3: u64, bp_va: u64, frame_rsp: u64, gpr: &Gprs) {
         snap.win_len[2] = n;
         snap.win_bytes[2] = buf;
     }
-    // Stash the blob length in the unused-at-entry field so the dump shows it.
-    // (We overload `rsp` is needed; instead add a dedicated field via win_va[2]
-    // already = ptr; blob_len is logged below.)
+    // The decoded blob length is logged to serial (window 2's va already carries
+    // the blob ptr); this keeps the blob ptr+len visible even when the KDB pump
+    // is starved under heavy Firefox load and `ubreak dump` cannot be reached.
     if blob_len != 0 {
         crate::serial_println!(
             "[UBREAK] capture blob: rip={:#x} data(rdx)={:#x} blob_ptr={:#x} blob_len={}",

--- a/kernel/src/boot_config.rs
+++ b/kernel/src/boot_config.rs
@@ -86,6 +86,15 @@ const FF_URL_KEY: &[u8] = b"astryx.ff_url=";
 /// the in-kernel Xastryx server on `DISPLAY=:0` and paints into a real window.
 const FF_GUI_KEY: &[u8] = b"astryx.ff_gui=1";
 
+/// Key for the debug-only userspace-breakpoint auto-arm token.  When present as
+/// `astryx.ubreak=<hex_elf_offset>` in the cmdline blob, the kernel auto-arms a
+/// one-shot CoW-private userspace breakpoint at `libxul_load_base + <offset>`
+/// for every Linux process the moment it demand-faults the page containing that
+/// offset (see `arch::x86_64::ubreak`).  This removes the host-side timing race
+/// (the breakpoint is planted at page-install, before the code executes) and
+/// works even when the KDB pump is starved under heavy Firefox load.
+const UBREAK_KEY: &[u8] = b"astryx.ubreak=";
+
 /// Read the QEMU `opt/astryx/cmdline` fw_cfg blob and extract a validated
 /// `astryx.ff_url=<url>` value.  Returns `None` when the blob is missing,
 /// the token is absent, or the value fails validation — callers fall back to
@@ -149,6 +158,97 @@ pub fn ff_gui_mode() -> bool {
 /// Exposed for unit tests; see [`self_tests`].
 fn parse_ff_gui(buf: &[u8]) -> bool {
     find_token(buf, FF_GUI_KEY).is_some()
+}
+
+/// Max comma-separated `astryx.ubreak=` offsets we accept.
+pub const MAX_UBREAK_OFFSETS: usize = 4;
+
+/// One parsed auto-arm entry: a libxul-relative ELF offset and an optional
+/// 4-byte instruction signature (the first 4 code bytes expected at that
+/// offset, little-endian; 0 = no check).
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
+pub struct UbreakEntry {
+    pub offset: u64,
+    pub sig: u32,
+}
+
+/// Read the debug-only `astryx.ubreak=<hex>[/<sig8>][,<hex>[/<sig8>]...]` token
+/// from the cmdline blob.  Each entry is an ELF offset and an optional 4-byte
+/// instruction signature after a `/` (8 hex digits, little-endian byte order =
+/// the raw on-disk bytes).  Returns the parsed entries packed into a fixed
+/// array with a count, or `None` when the token is absent.  Stack-only.
+#[cfg(all(feature = "kdb", feature = "firefox-test-core"))]
+pub fn ubreak_offsets() -> Option<([UbreakEntry; MAX_UBREAK_OFFSETS], usize)> {
+    let mut sig = [0u8; 4];
+    unsafe {
+        fw_cfg_select(FW_CFG_SIG_SEL);
+        for b in sig.iter_mut() {
+            *b = crate::hal::inb(FW_CFG_PORT_DATA);
+        }
+    }
+    if sig != FW_CFG_SIG_MAGIC {
+        return None;
+    }
+    let mut buf = [0u8; MAX_CMDLINE_LEN];
+    let n = fw_cfg_read_file(b"opt/astryx/cmdline", &mut buf)?;
+    parse_ubreak_offsets(&buf[..n])
+}
+
+/// Parse one optional-`0x`-prefixed hex integer starting at `*p`; advances `*p`
+/// past it.  Returns the value and whether any digit was consumed.
+fn parse_hex_at(buf: &[u8], p: &mut usize) -> (u64, bool) {
+    if *p + 1 < buf.len() && buf[*p] == b'0' && (buf[*p + 1] == b'x' || buf[*p + 1] == b'X') {
+        *p += 2;
+    }
+    let mut val: u64 = 0;
+    let mut any = false;
+    while *p < buf.len() {
+        let d = match buf[*p] {
+            c @ b'0'..=b'9' => (c - b'0') as u64,
+            c @ b'a'..=b'f' => (c - b'a' + 10) as u64,
+            c @ b'A'..=b'F' => (c - b'A' + 10) as u64,
+            _ => break,
+        };
+        val = val.wrapping_mul(16).wrapping_add(d);
+        any = true;
+        *p += 1;
+    }
+    (val, any)
+}
+
+/// Parse the `astryx.ubreak=` value into (offset, sig) entries.  Grammar:
+/// `<hex>[ / <sig8hex> ] ( , <hex>[ / <sig8hex> ] )*`.  The value runs to the
+/// first whitespace / control byte / NUL.  Exposed for unit tests.
+fn parse_ubreak_offsets(buf: &[u8]) -> Option<([UbreakEntry; MAX_UBREAK_OFFSETS], usize)> {
+    let start = find_token(buf, UBREAK_KEY)?;
+    let mut p = start + UBREAK_KEY.len();
+    let mut out = [UbreakEntry::default(); MAX_UBREAK_OFFSETS];
+    let mut count = 0usize;
+    loop {
+        let (off, any) = parse_hex_at(buf, &mut p);
+        if !any {
+            break;
+        }
+        // optional /sig
+        let mut sig: u32 = 0;
+        if p < buf.len() && buf[p] == b'/' {
+            p += 1;
+            let (s, sany) = parse_hex_at(buf, &mut p);
+            if sany {
+                sig = s as u32;
+            }
+        }
+        if count < MAX_UBREAK_OFFSETS {
+            out[count] = UbreakEntry { offset: off, sig };
+            count += 1;
+        }
+        if p < buf.len() && buf[p] == b',' && count < MAX_UBREAK_OFFSETS {
+            p += 1;
+            continue;
+        }
+        break;
+    }
+    if count > 0 { Some((out, count)) } else { None }
 }
 
 /// Extract and validate the `astryx.ff_url=` value from a cmdline blob.
@@ -342,6 +442,49 @@ pub fn self_tests() -> usize {
     );
     check!(!parse_ff_gui(b"astryx.ff_url=https://lite.cnn.com"), "gui token absent");
     check!(!parse_ff_gui(b"astryx.ff_gui=0"), "gui token explicitly off");
+
+    // ubreak auto-arm offset parsing (debug-only, kdb feature).
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x6e36c70")
+            .map(|(o, c)| (o[0].offset, o[0].sig, c)) == Some((0x6e36c70, 0, 1)),
+        "ubreak single 0x offset, no sig"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=6e36c70")
+            .map(|(o, c)| (o[0].offset, c)) == Some((0x6e36c70, 1)),
+        "ubreak single offset no 0x prefix"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x6e36c70/55415741")
+            .map(|(o, c)| (o[0].offset, o[0].sig, c)) == Some((0x6e36c70, 0x55415741, 1)),
+        "ubreak offset with /sig"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=6e36c70/55415741,773fda0/50488b05,6e36ec5/488d155c")
+            .map(|(o, c)| (o[0].offset, o[0].sig, o[1].offset, o[1].sig, o[2].offset, c))
+            == Some((0x6e36c70, 0x55415741, 0x773fda0, 0x50488b05, 0x6e36ec5, 3)),
+        "ubreak three offset/sig pairs"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ff_gui=1 astryx.ubreak=0x1234 quiet")
+            .map(|(o, c)| (o[0].offset, c)) == Some((0x1234, 1)),
+        "ubreak space-terminated after another token"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0xabc\0junk")
+            .map(|(o, c)| (o[0].offset, c)) == Some((0xabc, 1)),
+        "ubreak NUL-terminated"
+    );
+    check!(parse_ubreak_offsets(b"foo=bar").is_none(), "ubreak absent token");
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=").is_none(),
+        "ubreak empty value rejected"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x1,0x2,0x3,0x4,0x5")
+            .map(|(_, c)| c) == Some(MAX_UBREAK_OFFSETS),
+        "ubreak offset count clamped to MAX_UBREAK_OFFSETS"
+    );
 
     crate::serial_println!("[BOOTCFG/SELFTEST] PASS ({} asserts)", n);
     n

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -376,6 +376,10 @@ pub fn dispatch(req: &str, out: &mut String) {
         "syms"           => op_syms(req, out),
         "mem"            => op_mem(req, out),
         "uread"          => op_uread(req, out),
+        // ubreak: CoW-private userspace execution breakpoints.  See
+        // arch::x86_64::ubreak.  Sub-ops via "sub": set | clear | clear-all |
+        // list | dump.
+        "ubreak"         => op_ubreak(req, out),
         "read-file"      => op_read_file(req, out),
         "trace-status"   => op_trace_status(out),
         // blk-trace: dump the virtio-blk LBA trace ring as JSON (out-of-band
@@ -995,6 +999,85 @@ fn op_uread(req: &str, out: &mut String) {
     j_kv_str(out, "hex", &hex);
     j_trim_comma(out);
     out.push('}');
+}
+
+// ── ubreak ────────────────────────────────────────────────────────────────────
+//
+// CoW-private userspace execution breakpoints.  Plants a process-private int3
+// at a userspace VA so an investigator can break on a hot library routine in
+// ONE process without corrupting the shared (CoW) library code page or relying
+// on the debug registers (which the kernel re-programs for its own diagnostic).
+// See arch::x86_64::ubreak for the mechanism.
+//
+//   {"op":"ubreak","sub":"set","pid":1,"addr":"0x...6e36ec5"}
+//   {"op":"ubreak","sub":"clear","pid":1,"addr":"0x...6e36ec5"}
+//   {"op":"ubreak","sub":"clear-all"}
+//   {"op":"ubreak","sub":"list"}
+//   {"op":"ubreak","sub":"dump"}
+//
+// `addr` is a RUNTIME virtual address (libxul base + symbol offset); the host
+// computes it from the ASLR base reported in the boot's [BOOT] / procmaps lines.
+#[cfg(feature = "kdb")]
+fn op_ubreak(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let sub = extract_field(req, "sub").unwrap_or_else(|| alloc::string::String::from("list"));
+    match sub.as_str() {
+        "set" => {
+            let pid = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+                Some(p) => p,
+                None => { out.push_str(r#"{"error":"missing 'pid'"}"#); return; }
+            };
+            let addr = match extract_field(req, "addr").and_then(|s| parse_u64(&s)) {
+                Some(a) => a,
+                None => { out.push_str(r#"{"error":"missing 'addr'"}"#); return; }
+            };
+            match crate::arch::x86_64::ubreak::arm(pid, addr) {
+                Ok((cr3, phys, orig)) => {
+                    let _ = write!(
+                        out,
+                        r#"{{"ok":true,"pid":{},"addr":"{:#x}","cr3":"{:#x}","private_phys":"{:#x}","orig_byte":"{:#x}"}}"#,
+                        pid, addr, cr3, phys, orig
+                    );
+                }
+                Err(e) => {
+                    out.push_str(r#"{"ok":false,"error":""#);
+                    out.push_str(e);
+                    out.push_str(r#""}"#);
+                }
+            }
+        }
+        "clear" => {
+            let pid = match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+                Some(p) => p,
+                None => { out.push_str(r#"{"error":"missing 'pid'"}"#); return; }
+            };
+            let addr = match extract_field(req, "addr").and_then(|s| parse_u64(&s)) {
+                Some(a) => a,
+                None => { out.push_str(r#"{"error":"missing 'addr'"}"#); return; }
+            };
+            // Resolve cr3 the same way arm() did.
+            let cr3 = {
+                let pt = match try_lock_brief(&PROCESS_TABLE) {
+                    Some(g) => g,
+                    None => { out.push_str(r#"{"busy":"PROCESS_TABLE held"}"#); return; }
+                };
+                let c = pt.iter().find(|p| p.pid == pid).map(|p| p.cr3);
+                drop(pt);
+                match c { Some(c) => c, None => { out.push_str(r#"{"error":"pid not found"}"#); return; } }
+            };
+            let cleared = crate::arch::x86_64::ubreak::disarm(cr3, addr);
+            let _ = write!(out, r#"{{"ok":{},"cleared":{}}}"#, cleared, cleared);
+        }
+        "clear-all" => {
+            let n = crate::arch::x86_64::ubreak::disarm_all();
+            let _ = write!(out, r#"{{"ok":true,"cleared":{}}}"#, n);
+        }
+        "list" => crate::arch::x86_64::ubreak::list_json(out),
+        "dump" => crate::arch::x86_64::ubreak::dump_json(out),
+        _ => {
+            out.push_str(r#"{"error":"unknown ubreak sub (set|clear|clear-all|list|dump)"}"#);
+        }
+    }
 }
 
 // ── read-file ───────────────────────────────────────────────────────────────
@@ -3861,6 +3944,12 @@ fn op_procmaps(req: &str, out: &mut String) {
         Some(p) => p,
         None => { out.push_str(r#"{"error":"missing or bad 'pid'"}"#); return; }
     };
+    // Optional filter: when `min_x=<bytes>` is set, emit ONLY executable (r-x)
+    // VMAs at least that many bytes long.  The full VMA list of a Firefox
+    // process overflows MAX_RESP_BYTES (truncating mid-record); this filter
+    // returns just the large code regions (libxul is the only >50 MiB r-x
+    // mapping), giving the ASLR base in a small, always-parseable response.
+    let min_x: u64 = extract_field(req, "min_x").and_then(|s| parse_u64(&s)).unwrap_or(0);
 
     struct VmaRow {
         base: u64, end: u64, prot: u32, name: alloc::string::String, phys: Option<u64>,
@@ -3899,8 +3988,15 @@ fn op_procmaps(req: &str, out: &mut String) {
 
     out.push('{');
     let _ = write!(out, r#""pid":{},"cr3":"{:#x}","vmas":["#, pid, cr3);
-    for (i, r) in rows.iter().take(512).enumerate() {
-        if i > 0 { out.push(','); }
+    let mut emitted = 0usize;
+    for r in rows.iter().take(512) {
+        if min_x != 0 {
+            let is_x = r.prot & crate::mm::vma::PROT_EXEC != 0;
+            let sz = r.end.saturating_sub(r.base);
+            if !is_x || sz < min_x { continue; }
+        }
+        if emitted > 0 { out.push(','); }
+        emitted += 1;
         out.push('{');
         j_str(out, "base"); out.push(':'); j_hex(out, r.base); out.push(',');
         j_str(out, "end");  out.push(':'); j_hex(out, r.end);  out.push(',');

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1527,6 +1527,20 @@ user_pref("security.sandbox.content.level", 0);
             crate::gui::terminal::FF_GUI_MODE
                 .store(gui_mode, core::sync::atomic::Ordering::Release);
             serial_println!("[FFTEST] launch mode: {}", if gui_mode { "GUI/X11" } else { "headless" });
+            // Debug-only: arm a CoW-private userspace breakpoint at
+            // libxul_load_base + <astryx.ubreak=offset> for every Linux process
+            // the moment it demand-faults that page (auto-arm, KDB-independent).
+            // See arch::x86_64::ubreak::maybe_auto_arm + the PF-install hook.
+            #[cfg(feature = "kdb")]
+            if let Some((entries, n)) = boot_config::ubreak_offsets() {
+                for e in entries.iter().take(n) {
+                    crate::arch::x86_64::ubreak::set_auto_arm_offset_sig(e.offset, e.sig);
+                    serial_println!(
+                        "[UBREAK] auto-arm enabled at libxul offset {:#x} sig={:#010x}",
+                        e.offset, e.sig
+                    );
+                }
+            }
             let cmdline_base = if musl_132_stat.is_ok() {
                 if gui_mode { CMDLINE_MUSL_132_GUI } else { CMDLINE_MUSL_132_BASE }
             } else if musl_esr_stat.is_ok() {

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -3894,16 +3894,30 @@ def cmd_start(args):
     # opt/astryx/cmdline fw_cfg blob (fw_cfg permits one entry per name), so
     # assemble a single space-separated token string and emit one -fw_cfg.
     ff_gui = bool(getattr(args, "ff_gui", False))
+    ubreak = getattr(args, "ubreak", None)
     cmdline_tokens = []
     if ff_url:
         cmdline_tokens.append(f"astryx.ff_url={ff_url}")
     if ff_gui:
         cmdline_tokens.append("astryx.ff_gui=1")
+    if ubreak:
+        # Debug-only: auto-arm a CoW-private userspace breakpoint at
+        # libxul_load_base + <ubreak> for every Linux process the moment it
+        # demand-faults that page.  Value is a hex ELF offset (kdb feature).
+        cmdline_tokens.append(f"astryx.ubreak={ubreak}")
+        print(f"[HARNESS] ubreak auto-arm at libxul offset {ubreak}", file=sys.stderr)
     if cmdline_tokens:
         blob = " ".join(cmdline_tokens)
+        # QEMU's `-fw_cfg name=...,string=...` parses commas as option
+        # separators; a literal comma in the value (e.g. a multi-offset
+        # `astryx.ubreak=0xA,0xB`) must be escaped as `,,` or QEMU truncates
+        # the blob and the guest reads garbage.  Escape AFTER joining so only
+        # value commas (never our space token separator) are doubled.  The
+        # kernel-side fw_cfg reader sees the original single commas.
+        blob_q = blob.replace(",", ",,")
         extra_qemu_args += [
             "-fw_cfg",
-            f"name=opt/astryx/cmdline,string={blob}",
+            f"name=opt/astryx/cmdline,string={blob_q}",
         ]
         if ff_url:
             print(f"[HARNESS] ff-url override: {ff_url}", file=sys.stderr)
@@ -7009,8 +7023,41 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
     if op == "procmaps":
         # Terse file-backed VMA map for ASLR-base / addr2line symbolication.
         # Emits one JSON object per VMA with first_page_phys via PML4 walk.
+        # Optional 2nd arg `min_x=<bytes>` (or a bare integer): emit ONLY
+        # executable VMAs >= that size — returns just the big code regions
+        # (libxul base) in a small, always-parseable response.
         if not rest: raise ValueError("procmaps requires <pid>")
-        return {"op": "procmaps", "pid": int(rest[0], 0)}
+        d = {"op": "procmaps", "pid": int(rest[0], 0)}
+        if len(rest) > 1:
+            tok = rest[1]
+            if tok.startswith("min_x="):
+                tok = tok.split("=", 1)[1]
+            d["min_x"] = int(tok, 0)
+        return d
+    if op == "ubreak":
+        # CoW-private userspace execution breakpoints.  Sub-ops:
+        #   kdb <sid> ubreak set <pid> <addr>     — plant a private int3
+        #   kdb <sid> ubreak clear <pid> <addr>   — restore the byte
+        #   kdb <sid> ubreak clear-all            — restore all
+        #   kdb <sid> ubreak list                 — armed breakpoints + hits
+        #   kdb <sid> ubreak dump                 — captured snapshots (JSON)
+        # `addr` is a RUNTIME VA (libxul base + ELF symbol offset).
+        if not rest:
+            raise ValueError("ubreak requires <sub> (set|clear|clear-all|list|dump)")
+        sub = rest[0]
+        if sub == "set":
+            if len(rest) < 3:
+                raise ValueError("ubreak set requires <pid> <addr>")
+            return {"op": "ubreak", "sub": "set",
+                    "pid": int(rest[1], 0), "addr": int(rest[2], 0)}
+        if sub == "clear":
+            if len(rest) < 3:
+                raise ValueError("ubreak clear requires <pid> <addr>")
+            return {"op": "ubreak", "sub": "clear",
+                    "pid": int(rest[1], 0), "addr": int(rest[2], 0)}
+        if sub in ("clear-all", "list", "dump"):
+            return {"op": "ubreak", "sub": sub}
+        raise ValueError(f"ubreak: unknown sub {sub!r}")
     if op == "proc-tree":
         pid = int(rest[0], 0) if rest else 1
         return {"op": "proc-tree", "pid": pid}
@@ -12547,6 +12594,18 @@ def main():
                                "with `screendump <sid> <out.png>`.  No rebuild "
                                "needed (same firefox-test-core build serves "
                                "both modes).")
+    p_start.add_argument("--ubreak", dest="ubreak", default=None, metavar="HEXOFF",
+                          help="[debug, kdb feature] Auto-arm a CoW-private "
+                               "userspace breakpoint at libxul_load_base + HEXOFF "
+                               "(an ELF vaddr, e.g. 0x6e36c70 for "
+                               "Moz2dBlobImageHandler::add) for every Linux "
+                               "process the moment it demand-faults that page.  "
+                               "Removes the host-side timing race (planted at "
+                               "page-install, before the code runs) and works "
+                               "under KDB starvation.  Read captures with "
+                               "`kdb <sid> ubreak dump`.  Appended to the "
+                               "opt/astryx/cmdline fw_cfg blob as "
+                               "astryx.ubreak=<hex>.")
     p_start.add_argument("--pcap", action="store_true", dest="pcap",
                           help="FORCE host-side packet capture ON for this "
                                "boot, even a non-FF one.  Captures ALL guest "
@@ -12804,6 +12863,9 @@ def main():
         "cond-autopsy",
         # Terse file-backed VMA map; one entry per VMA with first_page_phys.
         "procmaps",
+        # CoW-private userspace execution breakpoints (set|clear|clear-all|
+        # list|dump).  See arch::x86_64::ubreak + op_ubreak.
+        "ubreak",
         # FUTEX_WAKE cluster-wake compensation (firefox-test/test-mode only).
         # See subsys/linux/futex_cluster.rs.
         "futex-stats", "futex-set-cluster-wake",


### PR DESCRIPTION
## What

A debug-only (feature `kdb`) capability to break on a **userspace** virtual address in **one** process without disturbing other processes that share the same copy-on-write library code page. Built to make the gecko/libxul producer side observable on a live boot, where the two ordinary break mechanisms are both dead on this target:

- **Hardware exec breakpoints (DR0-DR3, Intel SDM Vol. 3B §17.2)** are silently overwritten — the kernel re-programs its own debug registers on every IRQ entry for an unrelated diagnostic, so an externally-armed DR breakpoint never survives to fire.
- **A plain `int3` (0xCC, Intel SDM Vol. 2A) in a shared CoW library code page** corrupts every process mapping that frame → wedges the VM.

**Mechanism:** before planting `0xCC`, give the target process a *private* copy of the single 4 KiB code page (alloc frame, copy, re-point the leaf PTE per Intel SDM Vol. 3A §4.5 preserving USER/NX, `invlpg`). The shared library frame stays clean for every other process. The planted int3 raises `#BP` (vector 3, DPL=3) from Ring 3; the handler matches `(CR3, RIP-1)`, snapshots GPRs + register-relative memory windows into a ring, restores the original byte through the **live** leaf PTE (one-shot), rewinds RIP, returns silently. Drained over KDB.

## Surfaces (all `#[cfg(feature = "kdb")]`-gated; non-kdb builds unchanged)

- `arch::x86_64::ubreak` — arm/disarm/on_breakpoint/capture/dump + a **boot-flag auto-arm** that plants at `lib_load_base + <offset>` the moment a process demand-faults that page (computing the ELF load base per ELF-64 §3 from the file-backed VMA), gated by a 4-byte instruction signature so a wrong (non-target) load base never mis-arms. Removes the host-side timing race and works under KDB-pump starvation.
- KDB op `ubreak` (set | clear | clear-all | list | dump) + a `procmaps` `min_x=<bytes>` filter (the full VMA list of a heavy process overflows the 32 KiB response cap; `min_x` returns just the large executable regions so the ASLR base is parseable in one call).
- `boot_config` `astryx.ubreak=<hex>[/<sig8>][,...]` parser (+ self-tests in `boot_config::self_tests`).
- harness `--ubreak <hexoff[/sig][,...]>` start flag + the kdb `ubreak` / `procmaps min_x` argv builders. The fw_cfg blob escapes commas as `,,` (QEMU `-fw_cfg ...,string=...` parses commas as option separators — an unescaped comma truncated the blob and hung early boot).

## Why (the finding it produced)

Used live to read the in-process WebRender blob the parent passes to `Moz2dBlobImageHandler::add` on the windowed-Wikipedia render path (SMP=1, PID 1, no IPC). The captured blob `data` (`Arc<Vec<u8>>`) is **689 bytes whose content is the font-file path `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` + zeros** — the font-descriptor region, with no recording magic — immediately followed by the render abort. This is a producer-side blob-assembly (OffsetRange/cursor) issue in pure userspace; the in-process, single-CPU, same-CR3 transport carries no kernel memory-visibility/aliasing failure (Intel SDM Vol. 3A §8.2). The capability is the durable deliverable; no kernel behaviour change ships in this PR.

## Testing

Builds + boots clean via `scripts/qemu-harness.py` (firefox-test-core,kdb). Validated end-to-end on a live windowed-Wikipedia boot: auto-arm plants at the correct load base, the `#BP` fires, captures the blob, restores cleanly, and the boot continues. `boot_config` parser self-tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
