### PR TITLE
mm: write through MAP_SHARED writable pages on a write fault (never copy-on-write)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1474,6 +1474,12 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             let new_pte = old_phys | page_flags | PAGE_PRESENT;
             crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
             crate::mm::tlb::shootdown_page(cr3, page_addr);
+            // NOTE: this does not set the PTE dirty bit nor mark the backing
+            // page-cache frame dirty.  Inert today (VFS writeback is not yet
+            // implemented; shared/memfd reads come back through the same
+            // frame), but once disk-backed MAP_SHARED writeback (msync/munmap
+            // flush) lands, an mmap-written-but-never-write(2)'d page would be
+            // skipped by a dirty-driven flush — mark the frame dirty here then.
             return true;
         }
 

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -270,6 +270,25 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
         }
     }
 
+    // CoW-private userspace breakpoint re-arm (debug-only).  A #DB (vector 1)
+    // from Ring 3 may be the TF single-step trap that a re-armable ubreak set
+    // after restoring the original byte; re-plant the int3 and clear TF.  Per
+    // Intel SDM Vol. 3B §17.3.1.1 (single-step), the #DB fires AFTER the stepped
+    // instruction with the saved RFLAGS.TF still set.  Runs after the (optional)
+    // w215-diag DR-watch #DB handler above — they never both claim the same
+    // trap (a re-arm is only ever pending from our own #BP path).
+    #[cfg(feature = "kdb")]
+    if vector == 1 && frame.cs & 3 == 3 {
+        let cr3_raw: u64;
+        unsafe { core::arch::asm!("mov {}, cr3", out(reg) cr3_raw, options(nomem, nostack)); }
+        let cr3 = cr3_raw & 0x000F_FFFF_FFFF_F000;
+        if crate::arch::x86_64::ubreak::on_debug_trap(cr3) {
+            // Clear TF so single-stepping stops (we only wanted one step).
+            frame.rflags &= !(1u64 << 8);
+            return;
+        }
+    }
+
     // CoW-private userspace breakpoint (debug-only).  A #BP (vector 3) from
     // Ring 3 may be a planted `int3` belonging to a registered userspace
     // breakpoint (see `arch::x86_64::ubreak`).  Match the faulting
@@ -290,12 +309,24 @@ extern "C" fn exception_handler(vector: u64, error_code: u64, frame: &mut Interr
             crate::arch::x86_64::ubreak::read_gprs_from_frame(base)
         };
         let mut new_rip = frame.rip;
-        let matched = crate::arch::x86_64::ubreak::on_breakpoint(
+        let action = crate::arch::x86_64::ubreak::on_breakpoint(
             cr3, frame.rip, frame.rsp, &gpr, &mut new_rip,
         );
-        if matched {
-            frame.rip = new_rip;
-            return;
+        match action {
+            crate::arch::x86_64::ubreak::BpAction::Handled => {
+                frame.rip = new_rip;
+                return;
+            }
+            crate::arch::x86_64::ubreak::BpAction::HandledRearm => {
+                // Re-armable: the original byte is restored and RIP rewound; set
+                // RFLAGS.TF (Intel SDM Vol. 3B §17.3.1.1) so the CPU raises #DB
+                // after the original instruction re-executes, where the vector-1
+                // hook re-plants the int3.  TF bit = 1<<8.
+                frame.rip = new_rip;
+                frame.rflags |= 1 << 8;
+                return;
+            }
+            crate::arch::x86_64::ubreak::BpAction::NotOurs => {}
         }
         // Unmatched #BP from Ring 3 with auto-arm enabled: emit one bounded
         // diagnostic so a mismatch (cr3/va) can be diagnosed, then fall through.

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1432,11 +1432,24 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
 
         // Determine page flags from the VMA if available; fall back to RW|User
         // for pages with no registered VMA (orphaned CoW pages after fork).
+        //
+        // `is_shared_writable` distinguishes a MAP_SHARED writable mapping from
+        // a MAP_PRIVATE one.  Copy-on-write is correct ONLY for private
+        // mappings: per POSIX mmap(2), a store through a MAP_SHARED mapping
+        // "shall be visible in all mappings of the same region" and (for a
+        // file-backed mapping) is carried through to the underlying object.
+        // CoW-copying a shared page to a private frame would strand the store
+        // in a frame no other mapper can see — the exact failure behind two
+        // mappings of one recycled memfd diverging (a writer's blob landing in
+        // a private copy while a reader keeps seeing the shared cache frame).
+        // Default for a VMA-less orphan page (post-fork CoW): copy-on-write.
+        let mut write_action = crate::mm::vma::WriteFaultAction::CopyOnWrite;
         let page_flags = match vm_space.find_vma(faulting_addr) {
             Some(vma) => {
                 if vma.prot & crate::mm::vma::PROT_WRITE == 0 {
                     return false; // Genuine write-protection fault — SIGSEGV
                 }
+                write_action = crate::mm::vma::write_fault_action(vma.flags);
                 vma.to_page_flags()
             }
             None => {
@@ -1444,6 +1457,25 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                 PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER
             }
         };
+        let is_shared_writable =
+            write_action == crate::mm::vma::WriteFaultAction::WriteThrough;
+
+        // MAP_SHARED + writable: write THROUGH the shared frame.  Never CoW —
+        // the store must be visible to every other mapping of this region
+        // (POSIX mmap(2); the canonical write-fault rule "do not copy-on-write
+        // a shared writable mapping").  Mark the existing PTE writable in
+        // place; the faulting store then lands in the shared (cache-resident)
+        // frame, which every other mapper already aliases.  A cross-CPU
+        // shootdown drops any sibling's stale read-only translation so its
+        // next write also write-throughs instead of faulting forever.
+        if is_shared_writable {
+            let pte = crate::mm::vmm::read_pte(cr3, page_addr);
+            let old_phys = pte & 0x000F_FFFF_FFFF_F000;
+            let new_pte = old_phys | page_flags | PAGE_PRESENT;
+            crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            crate::mm::tlb::shootdown_page(cr3, page_addr);
+            return true;
+        }
 
         // W216 H_5j-B (unified concurrency): sample VmSpace generation before
         // the CoW copy + install sequence.  A sibling CPU running

--- a/kernel/src/arch/x86_64/ubreak.rs
+++ b/kernel/src/arch/x86_64/ubreak.rs
@@ -36,9 +36,34 @@
 //! byte, rewinds `RIP`, and lets execution continue (one-shot).  The snapshots
 //! are drained out-of-band over the KDB protocol (`ubreak dump`).
 //!
-//! One-shot is deliberate: the primary use is breaking on a *panic branch* that
-//! executes exactly once before the process aborts, so no single-step/re-arm
-//! machinery (which would collide with the kernel's own #DB usage) is needed.
+//! One-shot is the default: the primary use is breaking on a *panic branch* that
+//! executes exactly once before the process aborts.
+//!
+//! ## Re-arm mode (TF single-step)
+//!
+//! A breakpoint may instead be armed **re-armable** so it fires every time the
+//! VA executes (e.g. a copy loop that runs once per message until a *corrupt*
+//! one appears).  Re-arm uses the trap flag, not a second `0xCC`:
+//!
+//!   1. On the `#BP` hit the original byte is restored and `RIP` rewound, but the
+//!      slot is NOT disarmed.  Instead `RFLAGS.TF` (Intel SDM Vol. 3B §17.3.1.1,
+//!      single-step) is set in the saved interrupt frame and the slot is recorded
+//!      as "pending re-arm".
+//!   2. The CPU re-executes the original instruction and then raises `#DB`
+//!      (vector 1) — the single-step trap.  The vector-1 hook re-plants the
+//!      `0xCC` at the (now-stepped-past) VA, clears `TF`, and returns.
+//!
+//! There is a one-instruction window where the byte is absent.  On a
+//! single-process, SMP=1 target that window is safe: no other thread can fetch
+//! that VA in the gap.  Re-arm is therefore restricted to that configuration and
+//! to the `kdb` build (which does NOT enable `w215-diag`, so vector 1 / `#DB` is
+//! otherwise unused — Intel SDM Vol. 3B §17.2 debug registers are untouched by
+//! TF single-step).
+//!
+//! A re-armable breakpoint may carry a **capture gate** (`gate_len`): the
+//! snapshot is only recorded when `RDX == gate_len` at the hit (the copy length
+//! at the consumer copy-site), so a hot loop only banks the message size of
+//! interest and the 16-deep ring keeps the most recent matching hits.
 //!
 //! Feature-gated behind `kdb`; absent from production builds.
 
@@ -66,6 +91,12 @@ struct UBreak {
     // Index into AUTO_ARM_OFFSETS/CONSUMED, or usize::MAX for a manually-armed
     // (kdb `ubreak set`) breakpoint with no auto-arm offset.
     auto_idx: AtomicUsize,
+    // Re-armable: on a hit, single-step (TF) and re-plant the int3 instead of
+    // disarming one-shot.  See the module docs (re-arm mode).
+    rearm: AtomicBool,
+    // Capture gate for re-armable breakpoints: snapshot only when RDX == gate_len
+    // at the hit.  0 = always capture.
+    gate_len: AtomicU64,
 }
 
 impl UBreak {
@@ -78,6 +109,8 @@ impl UBreak {
             private_phys: AtomicU64::new(0),
             hits: AtomicU64::new(0),
             auto_idx: AtomicUsize::new(usize::MAX),
+            rearm: AtomicBool::new(false),
+            gate_len: AtomicU64::new(0),
         }
     }
 }
@@ -166,6 +199,17 @@ static AUTO_ARM_OFFSETS: [AtomicU64; MAX_AUTO_ARM] = [
 static AUTO_ARM_SIGS: [AtomicU64; MAX_AUTO_ARM] = [
     AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
 ];
+// Per-offset re-arm flag: true = re-armable (TF single-step re-plant), false =
+// one-shot.  A re-armable offset is NEVER marked consumed on a hit, so the scan
+// keeps it armed for the whole run.
+static AUTO_ARM_REARM: [AtomicBool; MAX_AUTO_ARM] = [
+    AtomicBool::new(false), AtomicBool::new(false),
+    AtomicBool::new(false), AtomicBool::new(false),
+];
+// Per-offset capture gate length (0 = always capture; else only when RDX==len).
+static AUTO_ARM_GATELEN: [AtomicU64; MAX_AUTO_ARM] = [
+    AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
+];
 // Per-offset "consumed" flags.  A one-shot breakpoint disarms its slot on the
 // first hit and restores the original byte.  Without this flag the per-fault
 // `maybe_auto_arm_scan` would immediately RE-arm the freed slot (re-planting
@@ -181,27 +225,56 @@ static AUTO_ARM_CONSUMED: [AtomicBool; MAX_AUTO_ARM] = [
 // (De-dup of already-armed (cr3, va) pairs is handled by `is_armed`.)
 static AUTO_ARM_OFFSET: AtomicU64 = AtomicU64::new(0);
 
+// ── Pending re-arm (TF single-step re-plant) ────────────────────────────────────
+//
+// When a re-armable breakpoint hits, its original byte is restored and the slot
+// is recorded here so the vector-1 (#DB) single-step trap can re-plant the int3
+// after the original instruction re-executes.  SMP=1 + single debugged process
+// means exactly one re-arm can be pending at a time; the sentinel is
+// `usize::MAX`.  These are written by the #BP path and read/cleared by the #DB
+// path on the SAME CPU (TF single-step traps on the next instruction of the same
+// thread), so a plain atomic is sufficient.
+static PENDING_REARM_SLOT: AtomicUsize = AtomicUsize::new(usize::MAX);
+static PENDING_REARM_CR3: AtomicU64 = AtomicU64::new(0);
+static PENDING_REARM_VA: AtomicU64 = AtomicU64::new(0);
+
 /// Enable auto-arm at the given libxul-relative ELF offset with a 4-byte
-/// instruction signature (the first 4 code bytes expected at that offset, as a
-/// little-endian u32 — i.e. byte[0] in bits 0..7).  `sig`==0 disables the check
-/// for that offset.  (0 offset disables the slot.)
-pub fn set_auto_arm_offset_sig(off: u64, sig: u32) {
+/// instruction signature, an optional re-arm flag, and an optional capture-gate
+/// length.
+///
+/// * `sig`==0 disables the signature check for that offset.
+/// * `rearm`==true makes the breakpoint re-armable (TF single-step re-plant)
+///   instead of one-shot.
+/// * `gate_len`!=0 limits captures of a re-armable breakpoint to hits where
+///   `RDX == gate_len` (the copy length at the consumer copy-site).
+///
+/// (0 offset disables the slot.)
+pub fn set_auto_arm_full(off: u64, sig: u32, rearm: bool, gate_len: u64) {
     if off == 0 {
         return;
     }
     AUTO_ARM_OFFSET.store(off, Ordering::Release);
-    for (s, sg) in AUTO_ARM_OFFSETS.iter().zip(AUTO_ARM_SIGS.iter()) {
-        if s.load(Ordering::Acquire) == 0 {
-            sg.store(sig as u64, Ordering::Release);
-            s.store(off, Ordering::Release);
+    for idx in 0..MAX_AUTO_ARM {
+        if AUTO_ARM_OFFSETS[idx].load(Ordering::Acquire) == 0 {
+            AUTO_ARM_SIGS[idx].store(sig as u64, Ordering::Release);
+            AUTO_ARM_REARM[idx].store(rearm, Ordering::Release);
+            AUTO_ARM_GATELEN[idx].store(gate_len, Ordering::Release);
+            // Publish the offset LAST so a concurrent scan never sees an offset
+            // before its sig/rearm/gate metadata.
+            AUTO_ARM_OFFSETS[idx].store(off, Ordering::Release);
             return;
         }
     }
 }
 
+/// Enable auto-arm with a signature check (one-shot, no gate).
+pub fn set_auto_arm_offset_sig(off: u64, sig: u32) {
+    set_auto_arm_full(off, sig, false, 0);
+}
+
 /// Back-compat: enable auto-arm with no signature check (legacy single-offset).
 pub fn set_auto_arm_offset(off: u64) {
-    set_auto_arm_offset_sig(off, 0);
+    set_auto_arm_full(off, 0, false, 0);
 }
 
 /// Read the first 4 bytes at `va` in `cr3` as a little-endian u32 (0 if any
@@ -249,10 +322,12 @@ pub fn maybe_auto_arm(cr3: u64, load_base: u64, faulted_page: u64) {
         if sig != 0 && read_sig4(cr3, target_va) != sig {
             continue;
         }
-        if arm_at_cr3_idx(cr3, target_va, idx).is_ok() {
+        let rearm = AUTO_ARM_REARM[idx].load(Ordering::Acquire);
+        let gate_len = AUTO_ARM_GATELEN[idx].load(Ordering::Acquire);
+        if arm_at_cr3_idx(cr3, target_va, idx, rearm, gate_len).is_ok() {
             crate::serial_println!(
-                "[UBREAK] auto-armed cr3={:#x} load_base={:#x} target={:#x} (off={:#x})",
-                cr3, load_base, target_va, off
+                "[UBREAK] auto-armed cr3={:#x} load_base={:#x} target={:#x} (off={:#x} rearm={} gate={})",
+                cr3, load_base, target_va, off, rearm, gate_len
             );
         }
     }
@@ -316,10 +391,12 @@ pub fn maybe_auto_arm_scan(load_base: u64, cr3: u64) {
         if sig != 0 && read_sig4(cr3, target_va) != sig {
             continue;
         }
-        if arm_at_cr3_idx(cr3, target_va, idx).is_ok() {
+        let rearm = AUTO_ARM_REARM[idx].load(Ordering::Acquire);
+        let gate_len = AUTO_ARM_GATELEN[idx].load(Ordering::Acquire);
+        if arm_at_cr3_idx(cr3, target_va, idx, rearm, gate_len).is_ok() {
             crate::serial_println!(
-                "[UBREAK] auto-armed (scan) cr3={:#x} load_base={:#x} target={:#x} (off={:#x})",
-                cr3, load_base, target_va, off
+                "[UBREAK] auto-armed (scan) cr3={:#x} load_base={:#x} target={:#x} (off={:#x} rearm={} gate={})",
+                cr3, load_base, target_va, off, rearm, gate_len
             );
         }
     }
@@ -328,11 +405,18 @@ pub fn maybe_auto_arm_scan(load_base: u64, cr3: u64) {
 /// Arm a one-shot breakpoint at `va` in an explicit `cr3` (used by the auto-arm
 /// PF hook, which already knows the CR3).  Same mechanism as [`arm`] minus the
 /// pid→cr3 resolution.  Page must be present (it just faulted in).
+#[allow(dead_code)]
 fn arm_at_cr3(cr3: u64, va: u64) -> Result<(), &'static str> {
-    arm_at_cr3_idx(cr3, va, usize::MAX)
+    arm_at_cr3_idx(cr3, va, usize::MAX, false, 0)
 }
 
-fn arm_at_cr3_idx(cr3: u64, va: u64, auto_idx: usize) -> Result<(), &'static str> {
+fn arm_at_cr3_idx(
+    cr3: u64,
+    va: u64,
+    auto_idx: usize,
+    rearm: bool,
+    gate_len: u64,
+) -> Result<(), &'static str> {
     let page = va & !(PAGE_SIZE - 1);
     let old_pte = vmm::read_pte(cr3, page);
     if old_pte & vmm::PAGE_PRESENT == 0 {
@@ -392,6 +476,8 @@ fn arm_at_cr3_idx(cr3: u64, va: u64, auto_idx: usize) -> Result<(), &'static str
             slot.private_phys.store(new_phys, Ordering::Release);
             slot.hits.store(0, Ordering::Release);
             slot.auto_idx.store(auto_idx, Ordering::Release);
+            slot.rearm.store(rearm, Ordering::Release);
+            slot.gate_len.store(gate_len, Ordering::Release);
             return Ok(());
         }
     }
@@ -404,6 +490,38 @@ fn cr3_for_pid(pid: u64) -> Option<u64> {
     let pt = crate::proc::PROCESS_TABLE.try_lock()?;
     let c = pt.iter().find(|p| p.pid == pid).map(|p| p.cr3);
     c
+}
+
+/// Best-effort resolution of the file-backing (inode, file_offset) for a VA in
+/// `cr3`.  Returns `(0, 0)` if the VA is anonymous, has no VMA, or the
+/// PROCESS_TABLE lock is contended (ISR-safe: never blocks).  For a memfd
+/// MAP_SHARED segment this gives the (inode, file_offset) the producer wrote to
+/// / the consumer reads from, so a same-inode/same-offset pair with DIFFERENT
+/// physical frames is an aliasing bug (one memfd offset mapped to two frames),
+/// while a different inode/offset means the two sites reference distinct memfd
+/// segments (a gecko-level segment-ref mismatch).
+fn memfd_backing_of(cr3: u64, va: u64) -> (u64, u64) {
+    let pt = match crate::proc::PROCESS_TABLE.try_lock() {
+        Some(g) => g,
+        None => return (0, 0),
+    };
+    for p in pt.iter() {
+        if p.cr3 != cr3 {
+            continue;
+        }
+        let vms = match &p.vm_space {
+            Some(v) => v,
+            None => return (0, 0),
+        };
+        if let Some(vma) = vms.find_vma(va) {
+            if let crate::mm::vma::VmBacking::File { inode, offset, .. } = vma.backing {
+                let foff = offset.wrapping_add(va.wrapping_sub(vma.base));
+                return (inode, foff);
+            }
+        }
+        return (0, 0);
+    }
+    (0, 0)
 }
 
 /// Arm a one-shot userspace breakpoint at `va` in process `pid`.
@@ -469,6 +587,9 @@ pub fn arm(pid: u64, va: u64) -> Result<(u64, u64, u8), &'static str> {
             slot.orig_byte.store(orig as u64, Ordering::Release);
             slot.private_phys.store(new_phys, Ordering::Release);
             slot.hits.store(0, Ordering::Release);
+            slot.auto_idx.store(usize::MAX, Ordering::Release);
+            slot.rearm.store(false, Ordering::Release);
+            slot.gate_len.store(0, Ordering::Release);
             return Ok((cr3, new_phys, orig));
         }
     }
@@ -529,24 +650,36 @@ fn restore_byte(slot: &UBreak) {
     vmm::invlpg(page);
 }
 
+/// Result of [`on_breakpoint`]: tells the vector-3 caller what to do.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum BpAction {
+    /// Not one of our breakpoints — fall through to generic handling.
+    NotOurs,
+    /// Ours, one-shot: byte already restored, RIP rewound; just return.
+    Handled,
+    /// Ours, re-armable: byte restored, RIP rewound; the caller MUST set
+    /// `RFLAGS.TF` so the single-step trap re-plants the int3.
+    HandledRearm,
+}
+
 /// #BP handler hook.  Called from the vector-3 path in idt.rs for Ring-3
 /// breakpoints.  `gpr` is the 15-element GPR array as laid out by the ISR stub
-/// (see [`read_gprs_from_frame`]).  Returns true if this #BP belonged to a
-/// registered userspace breakpoint (so the caller skips the generic handling
-/// and returns to the rewound RIP).
+/// (see [`read_gprs_from_frame`]).
 ///
 /// `frame_rip` is the RIP *after* the int3 (points one byte past the 0xCC).
-/// On a match we capture, restore the byte (one-shot), and rewind `*rip_out` by
-/// one so the original instruction re-executes.
+/// On a match we capture (subject to the per-slot gate), restore the byte, and
+/// rewind `*rip_out` by one so the original instruction re-executes.  For a
+/// one-shot slot we disarm; for a re-armable slot we record a pending re-arm and
+/// return [`BpAction::HandledRearm`] so the caller sets TF.
 pub fn on_breakpoint(
     cr3: u64,
     frame_rip: u64,
     frame_rsp: u64,
     gpr: &Gprs,
     rip_out: &mut u64,
-) -> bool {
+) -> BpAction {
     let bp_va = frame_rip.wrapping_sub(1);
-    for slot in BREAKS.iter() {
+    for (slot_idx, slot) in BREAKS.iter().enumerate() {
         if !slot.active.load(Ordering::Acquire) {
             continue;
         }
@@ -558,23 +691,88 @@ pub fn on_breakpoint(
         }
         slot.hits.fetch_add(1, Ordering::AcqRel);
 
-        capture(cr3, bp_va, frame_rsp, gpr);
+        let rearm = slot.rearm.load(Ordering::Acquire);
+        // Capture gate: a re-armable slot with a non-zero gate_len only banks
+        // hits whose copy length (RDX) matches — so a hot copy loop records only
+        // the message size of interest.
+        let gate = slot.gate_len.load(Ordering::Acquire);
+        if gate == 0 || gpr.rdx == gate {
+            capture(cr3, bp_va, frame_rsp, gpr);
+        }
 
-        // One-shot: restore the original byte and rewind so the instruction
-        // re-executes normally.  Disarm the slot (we keep the private page).
-        // Mark this offset CONSUMED so the per-fault scan never re-arms it —
-        // re-arming would re-open the plant-without-active-slot window that
-        // turns a later #BP into an unhandled SIGSEGV.
+        // Restore the original byte and rewind so the instruction re-executes.
+        restore_byte(slot);
+        *rip_out = bp_va;
+
+        if rearm {
+            // Re-armable: keep the slot active and record a pending re-arm so
+            // the single-step (#DB) trap re-plants the int3 after the original
+            // instruction executes.  Do NOT mark the offset consumed.
+            PENDING_REARM_SLOT.store(slot_idx, Ordering::Release);
+            PENDING_REARM_CR3.store(cr3, Ordering::Release);
+            PENDING_REARM_VA.store(bp_va, Ordering::Release);
+            return BpAction::HandledRearm;
+        }
+
+        // One-shot: disarm the slot (we keep the private page) and mark the
+        // offset CONSUMED so the per-fault scan never re-arms it — re-arming
+        // would re-open the plant-without-active-slot window that turns a later
+        // #BP into an unhandled SIGSEGV.
         let idx = slot.auto_idx.load(Ordering::Acquire);
         if idx < MAX_AUTO_ARM {
             AUTO_ARM_CONSUMED[idx].store(true, Ordering::Release);
         }
-        restore_byte(slot);
         slot.active.store(false, Ordering::Release);
-        *rip_out = bp_va;
-        return true;
+        return BpAction::Handled;
     }
-    false
+    BpAction::NotOurs
+}
+
+/// #DB (vector 1) single-step hook for re-arm.  Called from the vector-1 path in
+/// idt.rs for a Ring-3 single-step trap.  If a re-arm is pending (the prior #BP
+/// set TF for this CR3), re-plant the int3 at the recorded VA, clear the pending
+/// state, and return true so the caller clears TF and returns.  Returns false if
+/// there is no pending re-arm (some other source of #DB).
+pub fn on_debug_trap(cr3: u64) -> bool {
+    let slot_idx = PENDING_REARM_SLOT.load(Ordering::Acquire);
+    if slot_idx >= MAX_UBREAKS {
+        return false;
+    }
+    if PENDING_REARM_CR3.load(Ordering::Acquire) != cr3 {
+        // The single-step trap belongs to a different address space (should not
+        // happen on SMP=1 single-process, but be conservative).
+        return false;
+    }
+    let va = PENDING_REARM_VA.load(Ordering::Acquire);
+    let slot = &BREAKS[slot_idx];
+    // Re-plant the int3 only if the slot is still the same armed (cr3, va) and
+    // the original byte is currently in place (it was restored by the #BP path).
+    if slot.active.load(Ordering::Acquire)
+        && slot.cr3.load(Ordering::Acquire) == cr3
+        && slot.va.load(Ordering::Acquire) == va
+    {
+        replant_byte(slot);
+    }
+    PENDING_REARM_SLOT.store(usize::MAX, Ordering::Release);
+    true
+}
+
+/// Re-plant the `0xCC` at a slot's VA through the LIVE PTE frame (mirrors
+/// [`restore_byte`]'s live-PTE discipline so a re-faulted page is handled).
+fn replant_byte(slot: &UBreak) {
+    let va = slot.va.load(Ordering::Acquire);
+    let off = (va & (PAGE_SIZE - 1)) as usize;
+    let page = va & !(PAGE_SIZE - 1);
+    let cr3 = slot.cr3.load(Ordering::Acquire);
+    let live_pte = vmm::read_pte(cr3, page);
+    let phys = if live_pte & vmm::PAGE_PRESENT != 0 {
+        live_pte & ADDR_MASK
+    } else {
+        slot.private_phys.load(Ordering::Acquire)
+    };
+    let byte_ptr = (PHYS_OFF + phys + off as u64) as *mut u8;
+    unsafe { core::ptr::write_volatile(byte_ptr, 0xCC); }
+    vmm::invlpg(page);
 }
 
 /// GPR snapshot passed from the ISR stub.
@@ -725,6 +923,62 @@ fn capture(cr3: u64, bp_va: u64, frame_rsp: u64, gpr: &Gprs) {
         crate::serial_println!(
             "[UBREAK] capture blob: rip={:#x} data(rdx)={:#x} blob_ptr={:#x} blob_len={}",
             bp_va, gpr.rdx, blob_ptr, blob_len);
+    }
+
+    // Dispositive consumer-read emit.  At the consumer copy-site (off 0x25b005f,
+    // `call <memcpy>` with RSI=shmem source ptr, RDX=copy length) RSI points
+    // INTO the recycled MAP_SHARED memfd segment that the render thread is about
+    // to read.  Resolve RSI's *physical frame* in this thread's address space and
+    // capture the first 16 bytes so a CORRUPT hit (font-path '/usr/share/fonts',
+    // first u32 = 0x2f757372) is distinguishable from a CLEAN one (kMagicInt,
+    // first u32 = 0xc001feed), and the source PHYS can be compared against the
+    // producer's write-dest phys.  Emitted to serial directly so it survives KDB
+    // starvation under heavy Firefox load.  RSI here is also valid at the moz2d
+    // add site, where the line is harmless extra context.
+    {
+        let src_va = gpr.rsi;
+        let src_page = src_va & !(PAGE_SIZE - 1);
+        let src_phys = vmm::virt_to_phys_in(cr3, src_page)
+            .map(|p| p | (src_va & (PAGE_SIZE - 1)))
+            .unwrap_or(0);
+        let mut srcbuf = [0u8; MEM_WINDOW_LEN];
+        let sn = read_user(cr3, src_va, &mut srcbuf);
+        let magic = if sn >= 4 {
+            u32::from_le_bytes([srcbuf[0], srcbuf[1], srcbuf[2], srcbuf[3]])
+        } else { 0 };
+        // Classify: kMagicInt = CLEAN; the font-path ASCII '/usr' = CORRUPT.
+        let verdict = match magic {
+            0xc001feed => "CLEAN(kMagicInt)",
+            0x2f757372 => "CORRUPT(font-path)",
+            _ => "OTHER",
+        };
+        // Resolve the memfd file-offset for the consumer source VA (best-effort,
+        // try-locked).  same (inode,offset) as the producer DEST but a different
+        // phys ⇒ our kernel aliasing (one memfd offset, two frames); a different
+        // (inode,offset) ⇒ gecko shipped a different segment ref.
+        let (src_inode, src_foff) = memfd_backing_of(cr3, src_va);
+        crate::serial_println!(
+            "[UBREAK] capture read: rip={:#x} pid={} tid={} cr3={:#x} src_va={:#x} src_phys={:#x} inode={} foff={:#x} len(rdx)={} first_u32={:#010x} verdict={}",
+            bp_va, snap.pid, snap.tid, cr3, src_va, src_phys, src_inode, src_foff, gpr.rdx, magic, verdict);
+    }
+
+    // Producer write-dest emit.  At the producer memcpy-into-shmem (off
+    // 0x25af556: `mov r13,rsi`=blob source, `mov r12,rdx`=len, RDI=shmem DEST)
+    // RDI points INTO the recycled MAP_SHARED memfd segment the writer is about
+    // to fill.  Resolve RDI's physical frame so the producer DEST phys can be
+    // compared against the consumer SOURCE phys captured above: same phys +
+    // consumer-stale ⇒ store-visibility-under-recycle (our kernel); different
+    // phys ⇒ aliasing/remap (our W215) or gecko shipped a different segment.
+    {
+        let dst_va = gpr.rdi;
+        let dst_page = dst_va & !(PAGE_SIZE - 1);
+        let dst_phys = vmm::virt_to_phys_in(cr3, dst_page)
+            .map(|p| p | (dst_va & (PAGE_SIZE - 1)))
+            .unwrap_or(0);
+        let (dst_inode, dst_foff) = memfd_backing_of(cr3, dst_va);
+        crate::serial_println!(
+            "[UBREAK] capture write-dest: rip={:#x} pid={} tid={} cr3={:#x} dst_va={:#x} dst_phys={:#x} inode={} foff={:#x} len(rdx)={}",
+            bp_va, snap.pid, snap.tid, cr3, dst_va, dst_phys, dst_inode, dst_foff, gpr.rdx);
     }
 
     // Publish into the ring.

--- a/kernel/src/boot_config.rs
+++ b/kernel/src/boot_config.rs
@@ -163,13 +163,21 @@ fn parse_ff_gui(buf: &[u8]) -> bool {
 /// Max comma-separated `astryx.ubreak=` offsets we accept.
 pub const MAX_UBREAK_OFFSETS: usize = 4;
 
-/// One parsed auto-arm entry: a libxul-relative ELF offset and an optional
-/// 4-byte instruction signature (the first 4 code bytes expected at that
-/// offset, little-endian; 0 = no check).
+/// One parsed auto-arm entry: a libxul-relative ELF offset, an optional 4-byte
+/// instruction signature (the first 4 code bytes expected at that offset,
+/// little-endian; 0 = no check), an optional re-arm flag, and an optional
+/// capture-gate length.
+///
+/// The grammar token `:<dec>` after an offset (and optional `/sig`) marks the
+/// breakpoint RE-ARMABLE with a capture gate of `<dec>` (the copy length, in
+/// bytes, at the consumer copy-site; only hits with `RDX == gate_len` are
+/// captured).  A `:0` marks it re-armable with no gate (capture every hit).
 #[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
 pub struct UbreakEntry {
     pub offset: u64,
     pub sig: u32,
+    pub rearm: bool,
+    pub gate_len: u64,
 }
 
 /// Read the debug-only `astryx.ubreak=<hex>[/<sig8>][,<hex>[/<sig8>]...]` token
@@ -216,6 +224,23 @@ fn parse_hex_at(buf: &[u8], p: &mut usize) -> (u64, bool) {
     (val, any)
 }
 
+/// Parse a decimal integer starting at `*p`; advances `*p` past it.  Returns the
+/// value and whether any digit was consumed.
+fn parse_dec_at(buf: &[u8], p: &mut usize) -> (u64, bool) {
+    let mut val: u64 = 0;
+    let mut any = false;
+    while *p < buf.len() {
+        let d = match buf[*p] {
+            c @ b'0'..=b'9' => (c - b'0') as u64,
+            _ => break,
+        };
+        val = val.wrapping_mul(10).wrapping_add(d);
+        any = true;
+        *p += 1;
+    }
+    (val, any)
+}
+
 /// Parse the `astryx.ubreak=` value into (offset, sig) entries.  Grammar:
 /// `<hex>[ / <sig8hex> ] ( , <hex>[ / <sig8hex> ] )*`.  The value runs to the
 /// first whitespace / control byte / NUL.  Exposed for unit tests.
@@ -238,8 +263,18 @@ fn parse_ubreak_offsets(buf: &[u8]) -> Option<([UbreakEntry; MAX_UBREAK_OFFSETS]
                 sig = s as u32;
             }
         }
+        // optional :<gate_dec> → re-armable with capture gate.  Parsed as a
+        // decimal length (the copy length at the consumer copy-site).
+        let mut rearm = false;
+        let mut gate_len: u64 = 0;
+        if p < buf.len() && buf[p] == b':' {
+            p += 1;
+            rearm = true;
+            let (g, _gany) = parse_dec_at(buf, &mut p);
+            gate_len = g;
+        }
         if count < MAX_UBREAK_OFFSETS {
-            out[count] = UbreakEntry { offset: off, sig };
+            out[count] = UbreakEntry { offset: off, sig, rearm, gate_len };
             count += 1;
         }
         if p < buf.len() && buf[p] == b',' && count < MAX_UBREAK_OFFSETS {
@@ -484,6 +519,37 @@ pub fn self_tests() -> usize {
         parse_ubreak_offsets(b"astryx.ubreak=0x1,0x2,0x3,0x4,0x5")
             .map(|(_, c)| c) == Some(MAX_UBREAK_OFFSETS),
         "ubreak offset count clamped to MAX_UBREAK_OFFSETS"
+    );
+    // Re-arm + capture-gate grammar: `:<dec>` after the offset (and optional
+    // /sig) marks the breakpoint re-armable with a capture gate.
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x25b005f:689")
+            .map(|(o, c)| (o[0].offset, o[0].rearm, o[0].gate_len, c))
+            == Some((0x25b005f, true, 689, 1)),
+        "ubreak rearm with gate length"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x25b005f/488d3c01:689")
+            .map(|(o, c)| (o[0].offset, o[0].sig, o[0].rearm, o[0].gate_len, c))
+            == Some((0x25b005f, 0x488d3c01, true, 689, 1)),
+        "ubreak rearm with /sig and gate length"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x25b005f:0")
+            .map(|(o, _)| (o[0].rearm, o[0].gate_len)) == Some((true, 0)),
+        "ubreak rearm with zero gate = capture every hit"
+    );
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x6e36c70")
+            .map(|(o, _)| (o[0].rearm, o[0].gate_len)) == Some((false, 0)),
+        "ubreak no-gate offset stays one-shot"
+    );
+    // Mixed: a one-shot producer offset and a re-armable gated consumer offset.
+    check!(
+        parse_ubreak_offsets(b"astryx.ubreak=0x25af4e0,0x25b005f:689")
+            .map(|(o, c)| (o[0].rearm, o[1].rearm, o[1].gate_len, c))
+            == Some((false, true, 689, 2)),
+        "ubreak mixed one-shot + re-armable gated"
     );
 
     crate::serial_println!("[BOOTCFG/SELFTEST] PASS ({} asserts)", n);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1534,10 +1534,12 @@ user_pref("security.sandbox.content.level", 0);
             #[cfg(feature = "kdb")]
             if let Some((entries, n)) = boot_config::ubreak_offsets() {
                 for e in entries.iter().take(n) {
-                    crate::arch::x86_64::ubreak::set_auto_arm_offset_sig(e.offset, e.sig);
+                    crate::arch::x86_64::ubreak::set_auto_arm_full(
+                        e.offset, e.sig, e.rearm, e.gate_len,
+                    );
                     serial_println!(
-                        "[UBREAK] auto-arm enabled at libxul offset {:#x} sig={:#010x}",
-                        e.offset, e.sig
+                        "[UBREAK] auto-arm enabled at libxul offset {:#x} sig={:#010x} rearm={} gate={}",
+                        e.offset, e.sig, e.rearm, e.gate_len
                     );
                 }
             }

--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -1397,6 +1397,34 @@ pub enum VmaError {
     PermissionDenied,
 }
 
+/// Disposition of a write-protection fault on a present, writable-VMA page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteFaultAction {
+    /// MAP_SHARED writable mapping: mark the existing frame writable in place
+    /// and write through it.  The store MUST be visible to every other mapping
+    /// of the same region (POSIX mmap(2) MAP_SHARED) — copy-on-write would
+    /// strand the store in a private frame no other mapper can see.
+    WriteThrough,
+    /// MAP_PRIVATE (or VMA-less orphan) writable mapping: copy-on-write — give
+    /// the writer a private frame so the store stays private to this mapping.
+    CopyOnWrite,
+}
+
+/// Decide how a write-protection fault on a present page must be resolved,
+/// given the VMA flags (`MAP_SHARED` / `MAP_PRIVATE`) of the faulting mapping.
+///
+/// This is the single source of truth shared by the page-fault handler and
+/// its unit test.  Per POSIX mmap(2): stores through a MAP_SHARED mapping are
+/// visible to all mappings of the region (write-through); stores through a
+/// MAP_PRIVATE mapping are private (copy-on-write).
+pub fn write_fault_action(vma_flags: VmFlags) -> WriteFaultAction {
+    if vma_flags & MAP_SHARED != 0 {
+        WriteFaultAction::WriteThrough
+    } else {
+        WriteFaultAction::CopyOnWrite
+    }
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2451,6 +2451,10 @@ fn resolve_user_write_page(cr3: u64, vaddr: u64) -> bool {
         }
         let old_phys = pte & ADDR_MASK;
         let flags = (pte & !ADDR_MASK) | PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER;
+        // This site only runs for the clone(2) clear_child_tid target, which is
+        // guaranteed a private anonymous libc global (never MAP_SHARED), so the
+        // refcount-keyed copy-vs-flip decision below is safe here and need not
+        // route through mm::vma::write_fault_action (which keys on MAP_SHARED).
         if crate::mm::refcount::page_ref_count(old_phys) > 1 {
             // Shared frame — copy to a private one.
             let new_phys = match crate::mm::pmm::alloc_page() {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2406,6 +2406,8 @@ pub fn run() -> ! {
         if test_234_cache_update_range_boundaries() { passed += 1; }
         total += 1;
         if test_240_vfs_truncate_page_cache_coherency() { passed += 1; }
+        total += 1;
+        if test_642_mapshared_write_fault_writethrough() { passed += 1; }
     }
 
     // ── Test 235: ELF loader hardening (H4) ──────────────────────────────
@@ -46282,6 +46284,83 @@ fn test_240_vfs_truncate_page_cache_coherency() -> bool {
     let _ = crate::mm::cache::evict(mount_idx, inode, 0);
     let _ = crate::vfs::remove(path);
     test_pass!("VFS truncate / page-cache coherency (POSIX ftruncate zero-fill)");
+    true
+}
+
+// ── Test 642: MAP_SHARED write fault must write-through, not copy-on-write ─
+//
+// Regression guard for the recycled-memfd stale-blob bug.  Two MAP_SHARED
+// mappings of one memfd alias a single shared page-cache frame.  When one
+// mapping takes a WRITE fault on that present-but-read-only page, the
+// page-fault handler's write-fault arm saw the frame's refcount > 1 (cache
+// ref + this PTE ref) and copy-on-write'd it to a PRIVATE frame — stranding
+// the store where no other mapper could see it.  Observed end-to-end as a
+// WebRender blob producer writing the valid blob into a private copy while
+// the consumer's mapping kept reading the stale (font-path) shared frame.
+//
+// Copy-on-write is correct ONLY for MAP_PRIVATE.  Per POSIX mmap(2), a store
+// through a MAP_SHARED mapping must be visible to all mappings of the same
+// region — so the handler must mark the existing shared frame writable in
+// place (write-through), never copy it.
+//
+// The handler routes the decision through `mm::vma::write_fault_action`, the
+// single source of truth.  This test asserts that disposition directly:
+// MAP_SHARED ⇒ WriteThrough; MAP_PRIVATE (and a VMA-less orphan) ⇒
+// CopyOnWrite.  Pinning the predicate guards the fix without depending on a
+// full user address space in the kernel-mode test context.
+//
+// References:
+//   - IEEE Std 1003.1-2017 mmap(2): MAP_SHARED — stores are visible to all
+//     mappings of the same region; MAP_PRIVATE — stores are private (CoW).
+//   - Intel SDM Vol. 3A §4.10.5: paging-structure changes propagate to all
+//     processors before a frame is repurposed.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_642_mapshared_write_fault_writethrough() -> bool {
+    test_header!("MAP_SHARED write fault writes through (no CoW)");
+    use crate::mm::vma::{write_fault_action, WriteFaultAction,
+                         MAP_SHARED, MAP_PRIVATE, MAP_ANONYMOUS};
+
+    // The page-fault handler's write-protection arm consults
+    // `write_fault_action(vma.flags)` to decide between writing through a
+    // shared frame (MAP_SHARED) and copy-on-write (MAP_PRIVATE).  This is the
+    // single source of truth; asserting it here pins the disposition that the
+    // recycled-memfd stale-blob fix depends on.
+
+    // (1) MAP_SHARED ⇒ WriteThrough.  Stores must reach the shared frame so
+    //     every other mapping of the region observes them (POSIX mmap(2)).
+    if write_fault_action(MAP_SHARED) != WriteFaultAction::WriteThrough {
+        test_fail!("test642", "MAP_SHARED must write through (got CoW) — stale-blob bug");
+        return false;
+    }
+    // A writable shared file mapping still maps to a single shared frame.
+    if write_fault_action(MAP_SHARED | MAP_ANONYMOUS) != WriteFaultAction::WriteThrough {
+        test_fail!("test642", "MAP_SHARED|MAP_ANONYMOUS must write through");
+        return false;
+    }
+    test_println!("  MAP_SHARED write fault ⇒ WriteThrough ✓");
+
+    // (2) MAP_PRIVATE ⇒ CopyOnWrite.  Stores stay private to the faulting
+    //     mapping (the .so GOT/relocation case must not corrupt the cache).
+    if write_fault_action(MAP_PRIVATE) != WriteFaultAction::CopyOnWrite {
+        test_fail!("test642", "MAP_PRIVATE must copy-on-write (regression)");
+        return false;
+    }
+    if write_fault_action(MAP_PRIVATE | MAP_ANONYMOUS) != WriteFaultAction::CopyOnWrite {
+        test_fail!("test642", "MAP_PRIVATE|MAP_ANONYMOUS must copy-on-write");
+        return false;
+    }
+    test_println!("  MAP_PRIVATE write fault ⇒ CopyOnWrite ✓");
+
+    // (3) Flags with neither bit set default to CopyOnWrite (a VMA-less
+    //     post-fork orphan page is treated as private — the conservative,
+    //     pre-fix-compatible default).
+    if write_fault_action(0) != WriteFaultAction::CopyOnWrite {
+        test_fail!("test642", "no MAP_* flag must default to CopyOnWrite");
+        return false;
+    }
+    test_println!("  no flag (orphan) ⇒ CopyOnWrite ✓");
+
+    test_pass!("MAP_SHARED write fault writes through (no CoW)");
     true
 }
 


### PR DESCRIPTION
## Summary

Fixes the windowed-Firefox Wikipedia render crash: the WebRender blob a content/render thread reads was flakily the **stale font-path bytes** instead of the producer's valid `kMagicInt` recording, tripping the moz2d slice panic (`MOZ_CRASH`, content tab dies).

Root cause is a **copy-on-write-on-a-MAP_SHARED-page** bug in the page-fault handler. A write-protection fault on a present, writable mapping took the CoW path whenever the backing frame's refcount was > 1 — which is the steady state for a MAP_SHARED page-cache frame (cache ref + PTE ref). Copying such a page to a private frame strands the store where no other mapping can see it.

Firefox maps the same WebRender shmem memfd **twice** (`MAP_SHARED`, both writable, both at offset 0) at different VAs; both alias one page-cache frame. The producer takes a write fault on the shared frame, gets a private copy, and writes the blob there. The consumer's mapping keeps reading the original (font-path) shared frame.

## Evidence (byte-level, dispositive)

Captured producer + consumer in the same boot, same process, same memfd inode/offset via re-armable userspace breakpoints:

- producer wrote `kMagicInt` (`0xc001feed`) blob to its mapping's frame
- consumer read the font path (`/usr/share/fonts/.../DejaVuSans.ttf`) from a **different** frame
- the page cache held exactly **one** frame for the (inode, offset); the producer's frame was a private CoW copy never inserted into the cache

Reproduced identically across multiple boots.

## Fix

The write-fault arm now consults `mm::vma::write_fault_action(vma.flags)`:

- `MAP_SHARED` writable → **write through** (mark the existing shared frame writable in place; cross-CPU TLB shootdown so siblings drop the stale read-only translation)
- `MAP_PRIVATE` writable / VMA-less orphan → **copy-on-write** (unchanged)

`write_fault_action` is the single source of truth shared by the handler and the regression test.

## Verification

- **Test 642** (`test_runner.rs`): pins the disposition (MAP_SHARED ⇒ WriteThrough; MAP_PRIVATE / orphan ⇒ CopyOnWrite). PASS.
- **End-to-end (verified pixels)**: 4 parallel SMP=1 Wikipedia boots — consumer blob read is now `CLEAN(kMagicInt)` in **0/4 corrupt** (was ~2/5 corrupt before). FF chrome composites cleanly with the live `https://en.wikipedia.org/wiki/Firefox` URL; the moz2d blob slice panic is gone.

A separate, pre-existing content-process crash (content-init / GType-signal residual, unrelated to the blob) still gates full content paint; that is out of scope for this fix.

Refs: IEEE Std 1003.1-2017 mmap(2) (MAP_SHARED / MAP_PRIVATE visibility); Intel SDM Vol. 3A §4.10.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)