### PR TITLE
signal/w215: make [FAULT/CACHE-KEY] bucket-A classifier CR2/content-aware

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1421,6 +1421,12 @@ fn op_cache_aliasing(out: &mut String) {
 //   but the PTE was not shot down; PMM may have recycled the frame.  Next
 //   dispatch: VMA-shootdown-on-evict audit.
 //
+// clean_userspace_access_fault — the RIP frame's cache key matched its phys,
+//   but the fault (CR2) does NOT implicate that frame: an ordinary userspace
+//   NULL-deref or a fault against a different page.  NOT cache corruption; the
+//   code page is well-formed.  These were previously mis-counted as bucket-A
+//   (Intel SDM Vol. 3A §4.7 — CR2 names the faulting linear address).
+//
 // Requires: --features firefox-test,kdb.
 // Returns zero for all buckets before any W215-cluster fault fires (idle state).
 
@@ -1428,10 +1434,10 @@ fn op_fault_cache_keys(out: &mut String) {
     #[cfg(feature = "firefox-test-core")]
     {
         use core::fmt::Write;
-        let (a, b, c) = crate::signal::fault_cache_key_bucket_counts();
+        let (a, b, c, clean) = crate::signal::fault_cache_key_bucket_counts();
         out.push('{');
         let _ = write!(out,
-            r#""bucket_a_same_key_inplace":{a},"bucket_b_cross_key_aliased":{b},"bucket_c_post_evict_stale_pte":{c}"#,
+            r#""bucket_a_same_key_inplace":{a},"bucket_b_cross_key_aliased":{b},"bucket_c_post_evict_stale_pte":{c},"clean_userspace_access_fault":{clean}"#,
         );
         out.push('}');
     }

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1559,14 +1559,80 @@ pub static FAULT_CACHE_KEY_BUCKET_A: AtomicU64 = AtomicU64::new(0);
 pub static FAULT_CACHE_KEY_BUCKET_B: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "firefox-test-core")]
 pub static FAULT_CACHE_KEY_BUCKET_C: AtomicU64 = AtomicU64::new(0);
+//   Clean — "not a cache-content fault": the RIP frame's cache key matches its
+//     installed phys (so the code page is the page the cache says it should be),
+//     but the *faulting access itself* — the linear address in CR2 — does not
+//     implicate that frame.  The classic case is an ordinary userspace
+//     NULL-deref (e.g. `mov [0x0], esi` at a perfectly-valid libxul RIP,
+//     CR2=0x0): the instruction page is fine, the fault is a write to address 0.
+//     Per Intel SDM Vol. 3A §4.7, CR2 holds the linear address that faulted and
+//     the error-code W/I bits describe the access; a key-matching code page is
+//     not evidence of in-place corruption when the fault is against an unrelated
+//     (e.g. NULL) address.  Counting these as bucket-A poisoned W215 triage —
+//     investigators chased a cache-corruption ghost for an ordinary NULL-deref.
+#[cfg(feature = "firefox-test-core")]
+pub static FAULT_CACHE_KEY_CLEAN: AtomicU64 = AtomicU64::new(0);
+
+/// Verdict of the [FAULT/CACHE-KEY] bucket classifier for a key-matching
+/// RIP frame (`is_phys_in_cache(rip_phys) == Some(expected_key)`).
+///
+/// A key match alone is NOT sufficient to declare bucket-A "in-place
+/// corruption": the cache key only proves the *code page* the RIP runs from is
+/// the page the cache believes it should be.  Whether the *fault* implicates
+/// that page is determined by CR2 (the linear address that faulted, Intel SDM
+/// Vol. 3A §4.7):
+///
+///   * CR2 in the first page (`< 0x1000`) → a NULL / near-NULL deref.  The
+///     instruction page is valid; the fault is an access to address ~0.  This
+///     is NOT cache corruption → [`KeyMatchVerdict::CleanNullDeref`].
+///   * CR2 known and NOT on the same page as `user_rip` → the faulting access
+///     is to a different page than the (key-matching) code page; the match says
+///     nothing about the faulting address → [`KeyMatchVerdict::CleanOtherPage`].
+///   * CR2 on the same page as `user_rip` (an execute / same-page access fault
+///     on the very frame we matched), or CR2 unknown → the key-matching frame
+///     genuinely is the page implicated by the fault, so an in-place content
+///     corruption of that frame is the live hypothesis → [`KeyMatchVerdict::BucketA`].
+///
+/// Pure (no I/O, no locks) so it is unit-testable in `test_runner.rs`.
+#[cfg(feature = "firefox-test-core")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyMatchVerdict {
+    /// Real same-key in-place corruption candidate (fault implicates this frame).
+    BucketA,
+    /// Ordinary NULL / near-NULL deref — code page is fine, fault is at ~0.
+    CleanNullDeref,
+    /// Fault is against a different page than the key-matching code frame.
+    CleanOtherPage,
+}
+
+/// Decide whether a key-matching RIP frame is a genuine bucket-A corruption
+/// candidate or a clean userspace access fault.  See [`KeyMatchVerdict`].
+#[cfg(feature = "firefox-test-core")]
+pub fn classify_key_match(user_rip: u64, cr2: Option<u64>) -> KeyMatchVerdict {
+    match cr2 {
+        // NULL / near-NULL deref: the fault address is in the first page.  The
+        // executing code page can be perfectly valid; this is never cache
+        // corruption of that page.
+        Some(addr) if addr < 0x1000 => KeyMatchVerdict::CleanNullDeref,
+        // Fault against a page other than the one the RIP executes from.  The
+        // cache-key match on the code frame does not describe this fault.
+        Some(addr) if (addr & !0xFFF) != (user_rip & !0xFFF) => {
+            KeyMatchVerdict::CleanOtherPage
+        }
+        // Same-page (execute or in-page access) fault on the matched frame, or
+        // CR2 unavailable: the matched frame is the one implicated → bucket-A.
+        _ => KeyMatchVerdict::BucketA,
+    }
+}
 
 /// Read-only accessor for the kdb `fault-cache-keys` op.
 #[cfg(feature = "firefox-test-core")]
-pub fn fault_cache_key_bucket_counts() -> (u64, u64, u64) {
+pub fn fault_cache_key_bucket_counts() -> (u64, u64, u64, u64) {
     (
         FAULT_CACHE_KEY_BUCKET_A.load(Ordering::Relaxed),
         FAULT_CACHE_KEY_BUCKET_B.load(Ordering::Relaxed),
         FAULT_CACHE_KEY_BUCKET_C.load(Ordering::Relaxed),
+        FAULT_CACHE_KEY_CLEAN.load(Ordering::Relaxed),
     )
 }
 
@@ -1912,21 +1978,52 @@ pub(crate) fn emit_fault_phys_diagnostic(
             if let Some(expected_key) = vma_file_key(vma, user_rip) {
                 match crate::mm::cache::is_phys_in_cache(rip_phys) {
                     Some(actual_key) if actual_key == expected_key => {
-                        FAULT_CACHE_KEY_BUCKET_A.fetch_add(1, Ordering::Relaxed);
-                        crate::serial_println!(
-                            "[FAULT/CACHE-KEY] bucket=A (same-key in-place corruption) \
-                             rip_phys={:#x} key=(mount={},inode={:#x},off={:#x})",
-                            rip_phys,
-                            actual_key.0, actual_key.1, actual_key.2,
-                        );
-                        // W215 diagnostic Arm-1: dump the per-phys provenance
-                        // ring so the corrupting writer's history is visible
-                        // at the moment of fault.  Per Intel SDM Vol. 3A
-                        // §4.10.5, the page must have been alive in the
-                        // cache continuously from insert to fault — the ring
-                        // reveals which other operations touched it in that
-                        // window.
-                        crate::mm::w215_diag::dump_prov_for_phys(rip_phys);
+                        // A key match proves only that the code page the RIP
+                        // runs from is the page the cache believes it should
+                        // be.  Whether the *fault* implicates that page is
+                        // decided by CR2 (the linear address that faulted,
+                        // Intel SDM Vol. 3A §4.7).  A bare key match was being
+                        // mislabelled bucket-A "in-place corruption" even for
+                        // ordinary userspace NULL-derefs (`mov [0x0], esi` at a
+                        // valid libxul RIP, CR2=0x0) — poisoning W215 triage.
+                        match classify_key_match(user_rip, cr2) {
+                            KeyMatchVerdict::BucketA => {
+                                FAULT_CACHE_KEY_BUCKET_A.fetch_add(1, Ordering::Relaxed);
+                                crate::serial_println!(
+                                    "[FAULT/CACHE-KEY] bucket=A (same-key in-place corruption) \
+                                     rip_phys={:#x} key=(mount={},inode={:#x},off={:#x})",
+                                    rip_phys,
+                                    actual_key.0, actual_key.1, actual_key.2,
+                                );
+                                // W215 diagnostic Arm-1: dump the per-phys
+                                // provenance ring so the corrupting writer's
+                                // history is visible at the moment of fault.
+                                // Per Intel SDM Vol. 3A §4.10.5, the page must
+                                // have been alive in the cache continuously
+                                // from insert to fault — the ring reveals which
+                                // other operations touched it in that window.
+                                crate::mm::w215_diag::dump_prov_for_phys(rip_phys);
+                            }
+                            verdict => {
+                                // Clean userspace access fault on a frame whose
+                                // code page is well-formed.  NOT cache
+                                // corruption — do not poison the bucket-A count.
+                                FAULT_CACHE_KEY_CLEAN.fetch_add(1, Ordering::Relaxed);
+                                let reason = match verdict {
+                                    KeyMatchVerdict::CleanNullDeref => "null-deref",
+                                    KeyMatchVerdict::CleanOtherPage => "fault-off-code-page",
+                                    KeyMatchVerdict::BucketA => "bucket-a", // unreachable
+                                };
+                                crate::serial_println!(
+                                    "[FAULT/CACHE-KEY] bucket=clean ({}) \
+                                     rip_phys={:#x} cr2={:#x} key=(mount={},inode={:#x},off={:#x})",
+                                    reason,
+                                    rip_phys,
+                                    cr2.unwrap_or(0),
+                                    actual_key.0, actual_key.1, actual_key.2,
+                                );
+                            }
+                        }
                     }
                     Some(actual_key) => {
                         FAULT_CACHE_KEY_BUCKET_B.fetch_add(1, Ordering::Relaxed);

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -1621,6 +1621,13 @@ pub fn classify_key_match(user_rip: u64, cr2: Option<u64>) -> KeyMatchVerdict {
         }
         // Same-page (execute or in-page access) fault on the matched frame, or
         // CR2 unavailable: the matched frame is the one implicated → bucket-A.
+        //
+        // This preserves the genuine W215 symptom — an instruction-fetch fault
+        // on a zeroed/corrupt code page.  Per Intel SDM Vol. 3A §6.15, on an
+        // instruction-fetch #PF (error-code I=1) CR2 holds the fetched linear
+        // address, which is the faulting instruction address itself — so it
+        // lands on the same page as `user_rip` and is correctly kept as
+        // bucket-A rather than demoted to "clean".
         _ => KeyMatchVerdict::BucketA,
     }
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1446,6 +1446,8 @@ pub fn run() -> ! {
     {
         total += 1;
         if test_640_frame_recycle_zeroing_invariant() { passed += 1; }
+        total += 1;
+        if test_642_bucket_a_classifier_content_aware() { passed += 1; }
     }
 
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
@@ -53977,6 +53979,77 @@ fn test_640_frame_recycle_zeroing_invariant() -> bool {
 
     crate::mm::pmm::free_page(phys);
     crate::mm::pmm::free_page(clean);
+    test_pass!(NAME);
+    true
+}
+
+/// Test 642 — [FAULT/CACHE-KEY] bucket-A classifier is content/CR2-aware.
+///
+/// The W215 bucket classifier decides "bucket=A (same-key in-place corruption)"
+/// when the faulting RIP frame's page-cache key matches its installed phys.
+/// A key match alone proves only that the *code page* is the page the cache
+/// believes it should be — it says nothing about the address that actually
+/// faulted (CR2, Intel SDM Vol. 3A §4.7).  This regression test pins the
+/// `classify_key_match` decision so an ordinary userspace NULL-deref executing
+/// valid code (e.g. `mov [0x0], esi` at a real libxul RIP, CR2=0x0) is NOT
+/// mislabelled bucket-A, while a genuine same-page fault on a corrupt frame
+/// still is.
+///
+/// Cite: Intel SDM Vol. 3A §4.7 (#PF — CR2 holds the faulting linear address;
+/// the error code describes the access).
+#[cfg(feature = "firefox-test-core")]
+fn test_642_bucket_a_classifier_content_aware() -> bool {
+    use crate::signal::{classify_key_match, KeyMatchVerdict};
+    const NAME: &str = "[FAULT/CACHE-KEY] bucket-A CR2-aware classifier (Test 642)";
+    test_header!(NAME);
+
+    // A real libxul-style code RIP (page-aligned 0x...000 + in-page offset).
+    let rip: u64 = 0x0000_3ffa_d21_000 + 0x670;
+
+    // 1. NULL deref: CR2=0x0. Valid code page, fault at address 0 → NOT bucket-A.
+    if classify_key_match(rip, Some(0x0)) != KeyMatchVerdict::CleanNullDeref {
+        test_fail!(NAME, "CR2=0x0 NULL-deref was NOT classified CleanNullDeref");
+        return false;
+    }
+
+    // 2. Near-NULL deref (the Family-B `mov [rax+off],esi` with rax=0 family):
+    //    CR2 anywhere in the first page is still a NULL-class deref → NOT bucket-A.
+    if classify_key_match(rip, Some(0x7c)) != KeyMatchVerdict::CleanNullDeref {
+        test_fail!(NAME, "CR2 in first page was NOT classified CleanNullDeref");
+        return false;
+    }
+
+    // 3. Fault against an unrelated, well-formed page (CR2 on a different page
+    //    than the executing code frame) → clean, NOT corruption of the code page.
+    let other_page = (rip & !0xFFF) + 0x4000 + 0x10;
+    if classify_key_match(rip, Some(other_page)) != KeyMatchVerdict::CleanOtherPage {
+        test_fail!(NAME, "fault off the code page was NOT classified CleanOtherPage");
+        return false;
+    }
+
+    // 4. Genuine same-page fault on the matched frame: CR2 lands in the SAME
+    //    page the RIP executes from (e.g. FF executing a zeroed code page, the
+    //    real content-corruption variant) → still bucket-A.
+    let same_page = (rip & !0xFFF) + 0x40;
+    if classify_key_match(rip, Some(same_page)) != KeyMatchVerdict::BucketA {
+        test_fail!(NAME, "same-page fault on the matched frame was NOT bucket-A");
+        return false;
+    }
+
+    // 5. CR2 unavailable (some fatal paths pass cr2=None): the matched frame is
+    //    the only thing we can implicate → keep bucket-A (no regression in the
+    //    legacy "key match ⇒ bucket-A" behaviour for that case).
+    if classify_key_match(rip, None) != KeyMatchVerdict::BucketA {
+        test_fail!(NAME, "cr2=None did NOT preserve bucket-A");
+        return false;
+    }
+
+    // 6. Boundary: CR2 == first byte of the second page is NOT a NULL deref.
+    if classify_key_match(rip, Some(0x1000)) == KeyMatchVerdict::CleanNullDeref {
+        test_fail!(NAME, "CR2=0x1000 was wrongly classified as a NULL-deref");
+        return false;
+    }
+
     test_pass!(NAME);
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1447,7 +1447,7 @@ pub fn run() -> ! {
         total += 1;
         if test_640_frame_recycle_zeroing_invariant() { passed += 1; }
         total += 1;
-        if test_642_bucket_a_classifier_content_aware() { passed += 1; }
+        if test_643_bucket_a_classifier_content_aware() { passed += 1; }
     }
 
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
@@ -53983,7 +53983,7 @@ fn test_640_frame_recycle_zeroing_invariant() -> bool {
     true
 }
 
-/// Test 642 — [FAULT/CACHE-KEY] bucket-A classifier is content/CR2-aware.
+/// Test 643 — [FAULT/CACHE-KEY] bucket-A classifier is content/CR2-aware.
 ///
 /// The W215 bucket classifier decides "bucket=A (same-key in-place corruption)"
 /// when the faulting RIP frame's page-cache key matches its installed phys.
@@ -53998,9 +53998,9 @@ fn test_640_frame_recycle_zeroing_invariant() -> bool {
 /// Cite: Intel SDM Vol. 3A §4.7 (#PF — CR2 holds the faulting linear address;
 /// the error code describes the access).
 #[cfg(feature = "firefox-test-core")]
-fn test_642_bucket_a_classifier_content_aware() -> bool {
+fn test_643_bucket_a_classifier_content_aware() -> bool {
     use crate::signal::{classify_key_match, KeyMatchVerdict};
-    const NAME: &str = "[FAULT/CACHE-KEY] bucket-A CR2-aware classifier (Test 642)";
+    const NAME: &str = "[FAULT/CACHE-KEY] bucket-A CR2-aware classifier (Test 643)";
     test_header!(NAME);
 
     // A real libxul-style code RIP (page-aligned 0x...000 + in-page offset).

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -8644,13 +8644,25 @@ def cmd_fault_cache_keys(args):
     a = resp.get("bucket_a_same_key_inplace", -1)
     b = resp.get("bucket_b_cross_key_aliased", -1)
     c = resp.get("bucket_c_post_evict_stale_pte", -1)
+    # clean = key-matching RIP frame whose fault (CR2) did NOT implicate the
+    # frame (NULL-deref / fault off the code page).  NOT cache corruption.
+    # Older kernels lack this counter → default 0 so the verdict stays sound.
+    clean = resp.get("clean_userspace_access_fault", 0)
 
     if not all(isinstance(v, int) for v in [a, b, c]):
         resp["_verdict"] = "UNKNOWN: missing or malformed counter fields — check for error field"
     elif a == 0 and b == 0 and c == 0:
-        resp["_verdict"] = (
-            "INCONCLUSIVE — W215 cluster has not fired yet; re-run after a fault occurs"
-        )
+        if isinstance(clean, int) and clean > 0:
+            resp["_verdict"] = (
+                f"NO CACHE-CORRUPTION FAULTS — {clean} fault(s) had a key-matching RIP "
+                "frame but the fault address (CR2) did not implicate it (ordinary "
+                "NULL-deref / fault off the code page). NOT a W215 cache bug; look "
+                "elsewhere (userspace logic / unrelated access fault)."
+            )
+        else:
+            resp["_verdict"] = (
+                "INCONCLUSIVE — W215 cluster has not fired yet; re-run after a fault occurs"
+            )
     else:
         dom = max((a, "A"), (b, "B"), (c, "C"), key=lambda t: t[0])
         if dom[1] == "A":


### PR DESCRIPTION
## Problem

The W215 fault-triage classifier (`emit_fault_phys_diagnostic`, `kernel/src/signal.rs`) declared **`bucket=A (same-key in-place corruption)`** whenever the faulting RIP frame's page-cache key matched its installed phys. That comparison only proves the *code page* the RIP executes from is the page the cache believes it should be — it says **nothing about the address that actually faulted** (CR2).

Consequence: an ordinary userspace NULL-deref executing perfectly valid code — e.g. the Family-B crash `mov [0x0], esi` at a real libxul RIP with `CR2=0x0` — matched the code-page key and got mislabelled as **bucket-A cache corruption**. That poisoned W215 triage: investigators chased a cache-corruption ghost for a plain NULL-deref on a perfectly-good page. This exact mislabel cost real investigation time.

## Fix

Per Intel SDM Vol. 3A §4.7, **CR2 holds the linear address that faulted** and the error code describes the access. A key-matching code page is not evidence of in-place corruption when the fault is against an unrelated address. Bucket-A is now gated on the fault actually implicating the matched frame:

| CR2 vs RIP | Verdict |
|---|---|
| CR2 in first page (`< 0x1000`) | NULL/near-NULL deref → **NOT bucket-A** (`bucket=clean (null-deref)`) |
| CR2 on a different page than `user_rip` | fault off the code page → **NOT bucket-A** (`bucket=clean (fault-off-code-page)`) |
| CR2 on the same page as `user_rip`, or CR2 unknown | matched frame is implicated → **bucket-A** (unchanged) |

Non-bucket-A key matches are counted in a new `clean_userspace_access_fault` class and emitted as `bucket=clean (<reason>)` rather than inflating bucket-A. **Buckets B and C are unchanged.**

The decision is extracted into a pure, unit-testable `classify_key_match(user_rip, cr2)` function (`KeyMatchVerdict::{BucketA, CleanNullDeref, CleanOtherPage}`).

## Scope / blast radius

Diagnostic-only — the whole `[FAULT/CACHE-KEY]` path is `#[cfg(feature = "firefox-test-core")]` gated. **No functional/render change.** This does NOT fix any crash; it fixes the triage classifier so a NULL-deref is no longer mislabelled cache corruption.

The kdb `fault-cache-keys` op and its `scripts/qemu-harness.py` wrapper surface the new `clean_userspace_access_fault` counter **additively** (older kernels default it to 0; the `INCONCLUSIVE` verdict now distinguishes "no faults fired" from "faults fired but were all clean").

## Verification

- **Test 642** (`test_642_bucket_a_classifier_content_aware`, firefox-test-core): pins `classify_key_match` — CR2=0x0 NULL-deref, near-NULL, fault-off-code-page, same-page fault, CR2=None, and the 0x1000 page boundary. **PASS.**
- **Test 640** (regression, frame-recycle zeroing invariant): **PASS.**
- Built + booted via `scripts/qemu-harness.py start --features test-mode,firefox-test-core,kdb` (SMP=1, KVM). Pre-existing `dynamic_elf`/`TCC`/`busybox` FAILs are unrelated data.img artifacts in the worktree (binaries not staged), not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)