### PR TITLE
harness: opt-in ASTRYX_FORCE_FRAME_POINTERS for reliable kernel RBP back-tracing

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -1501,6 +1501,30 @@ def _build(features: str) -> bool:
                    "-Zjson-target-spec"]
     kernel_cmd += coverage_extra
 
+    # Opt-in: force frame pointers for ONLY the astryx-kernel crate.  When
+    # `ASTRYX_FORCE_FRAME_POINTERS=1` is set in the environment, inject
+    # `-C force-frame-pointers=yes` via the same per-package rustflags
+    # mechanism the coverage path uses.  This makes the kernel's RBP-walk
+    # back-tracer (`caller_rip()` in mm/pmm.rs and mm/cache.rs) reliable: a
+    # release build normally omits frame pointers, so RBP is a scratch reg
+    # at call sites and `[rbp+8]` does not hold the return address.  Scoped
+    # to the astryx-kernel crate so `core`/`alloc`/`compiler_builtins` keep
+    # their normal codegen.  Additive; default builds are unaffected.
+    if os.environ.get("ASTRYX_FORCE_FRAME_POINTERS") == "1":
+        if coverage_extra:
+            # coverage already added a --config for the same key; cargo would
+            # reject a duplicate.  Not a combination this probe needs, so fail
+            # loudly rather than silently dropping one flag.
+            print("[HARNESS] ERROR: ASTRYX_FORCE_FRAME_POINTERS=1 is not "
+                  "compatible with the `coverage` feature (duplicate per-crate "
+                  "rustflags config). Build one at a time.", file=sys.stderr)
+            return False
+        kernel_cmd += [
+            "--config",
+            'profile.release.package."astryx-kernel".rustflags = '
+            '["-C","force-frame-pointers=yes"]',
+        ]
+
     r2 = subprocess.run(kernel_cmd, cwd=ROOT, env=env)
     if r2.returncode != 0:
         return False


### PR DESCRIPTION
Adds an opt-in `ASTRYX_FORCE_FRAME_POINTERS=1` env flag to `scripts/qemu-harness.py` `_build()` that injects `-C force-frame-pointers=yes` for the `astryx-kernel` crate only.

**Why:** the kernel's `caller_rip()` provenance back-tracer (`mm/pmm.rs`, `mm/cache.rs`) walks `[rbp+8]` to name a frame's allocator/freer for the ALLOCSHADOW/FREESHADOW/DEC-UNDERFLOW diagnostics. Release builds omit frame pointers → RBP is scratch → the walk returns a uniform false `0x0`. This flag restores reliable back-tracing for memory-provenance investigations without affecting normal builds.

**Scope/safety:** additive, default-off (builds byte-identical unless set); scoped to the kernel crate so `core`/`alloc`/`compiler_builtins` keep normal codegen; errors loudly if combined with the `coverage` feature (duplicate per-crate rustflags config). Harness-only — no kernel change.

**Verified:** with the flag, `page_ref_dec`/`free_process_memory`/`insert_with_expected` build with the `push %rbp; mov %rsp,%rbp` prologue and `caller_rip()` reads the true caller (used to name memory-provenance writers in a recent investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)