### PR TITLE
sched: incremental per-CPU runqueue maintenance + gated audit (Perf P2 phase 2a)

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -1153,6 +1153,7 @@ pub extern "C" fn ap_rust_entry() -> ! {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            mirror_slot: None,
             ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: 0,
             fork_user_regs: crate::proc::ForkUserRegs::default(),

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2280,6 +2280,14 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     if !orphan_zombie_pids.is_empty() {
         let mut threads = THREAD_TABLE.lock();
         for (_cpid, tids) in &orphan_zombie_pids {
+            // Drop any still-mirrored removed thread from the per-CPU runqueues
+            // first, so its tid does not strand in a runqueue the maintainer can
+            // never revisit (Perf P2 phase 2a — see `percpu::mirror_forget`).
+            for t in threads.iter() {
+                if tids.contains(&t.tid) {
+                    crate::sched::percpu::mirror_forget(t.mirror_slot, t.tid);
+                }
+            }
             threads.retain(|t| !tids.contains(&t.tid));
         }
         drop(threads);
@@ -4081,6 +4089,13 @@ pub fn waitpid(parent_pid: Pid, wait_pid: i64) -> Option<(Pid, i32)> {
     // Step 2: Reap the child's threads (THREAD_TABLE only).
     {
         let mut threads = THREAD_TABLE.lock();
+        // Drop any still-mirrored reaped thread from the per-CPU runqueues
+        // first (Perf P2 phase 2a — see `percpu::mirror_forget`).
+        for t in threads.iter() {
+            if thread_tids.contains(&t.tid) {
+                crate::sched::percpu::mirror_forget(t.mirror_slot, t.tid);
+            }
+        }
         threads.retain(|t| !thread_tids.contains(&t.tid));
     }
 
@@ -4315,6 +4330,12 @@ pub fn reap_dead_threads() -> usize {
             0
         };
         let tls = t.tls_base;
+
+        // Drop any still-mirrored entry from the per-CPU runqueues before the
+        // record disappears (Perf P2 phase 2a — see `percpu::mirror_forget`).
+        // A reapable thread is Dead, so a `mirror_maintain` pass would already
+        // have drained it; this closes the window where reap beats that pass.
+        crate::sched::percpu::mirror_forget(t.mirror_slot, t.tid);
 
         // Remove from table
         threads.swap_remove(idx);

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -231,6 +231,15 @@ pub struct Thread {
     /// runnable task accrues owed service the longer it is passed over and
     /// eventually becomes the highest-priority choice (longest-waiting wins).
     pub ready_since_tick: u64,
+    /// Perf P2 phase 2a: where this thread is currently mirrored in the per-CPU
+    /// runqueues (`sched::percpu`).  `None` ⇒ not in any runqueue; `Some((cpu,
+    /// prio))` ⇒ enqueued on `RQS[cpu]` at priority level `prio`.  Maintained
+    /// exclusively by `percpu::mirror_maintain` (under `THREAD_TABLE`); every
+    /// constructor initialises it to `None` (a freshly-built thread is not yet
+    /// mirrored — the first scheduling pass enqueues it).  This is a pure
+    /// bookkeeping shadow of the mirror's membership and drives no scheduling
+    /// decision in this phase.
+    pub mirror_slot: crate::sched::percpu::MirrorSlot,
     /// True when context.rsp holds a valid saved kernel RSP.
     ///
     /// Set to `false` in schedule() just before marking the thread Ready,
@@ -342,6 +351,7 @@ impl Thread {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            mirror_slot: None,
             ctx_rsp_valid: alloc::boxed::Box::new(
                 core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: 0,
@@ -999,6 +1009,7 @@ pub fn init() {
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -1271,6 +1282,7 @@ fn create_kernel_process_inner(name: &str, entry_point: u64, initial_state: Thre
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -1342,6 +1354,7 @@ pub fn create_thread(pid: Pid, name: &str, entry_point: u64) -> Option<Tid> {
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -1417,6 +1430,7 @@ pub fn create_thread_blocked(pid: Pid, name: &str, entry_point: u64) -> Option<T
         last_cpu: 0,
         first_run: false,
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: ForkUserRegs::default(),
@@ -3026,6 +3040,7 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
         last_cpu: 0,
         first_run: true, // goes through user_mode_bootstrap (CR3 switch, TSS, TLS)
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         // Propagate parent's callee-saved regs (RBP/RBX/R12-R15) into the child.
@@ -3280,6 +3295,7 @@ pub fn fork_process_share_vm(
         last_cpu: 0,
         first_run: true,
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         fork_user_regs: *parent_regs,
@@ -3973,6 +3989,7 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
         last_cpu: 0,
         first_run: true,  // Goes through user_mode_bootstrap (handles CR3, TSS, TLS)
         ready_since_tick: 0,
+        mirror_slot: None,
         ctx_rsp_valid: alloc::boxed::Box::new(core::sync::atomic::AtomicBool::new(true)),
         clear_child_tid: 0,
         // Propagate parent callee-saved regs into the vfork child for the same

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -725,6 +725,12 @@ fn reap_dead_threads_sched() {
                 (t.kernel_stack_size as usize + 4095) / 4096
             } else { 0 };
             let last_cpu = t.last_cpu as usize;
+            // Drop any still-mirrored entry from the per-CPU runqueues before
+            // the record disappears (Perf P2 phase 2a — see
+            // `percpu::mirror_forget`).  This reaper runs at the top of
+            // schedule(), BEFORE mirror_maintain in the same pass, so without
+            // this a thread mirrored on a prior pass would strand its tid.
+            percpu::mirror_forget(t.mirror_slot, t.tid);
             threads.swap_remove(idx);
             if base > 0 && pages > 0 {
                 out.push((base, pages, last_cpu));

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1469,16 +1469,18 @@ was_emergency_4k={}",
             }
         }
 
-        // ── Per-CPU runqueue mirror (Perf P2 phase 1, behaviour-preserving) ──
-        // Rebuild the per-CPU/per-priority runqueue structures from this locked
-        // snapshot of the ready-set and self-verify their bitmap/nr_running
-        // invariants and membership against the authoritative table.  This
+        // ── Per-CPU runqueue mirror (Perf P2 phase 2a, behaviour-preserving) ──
+        // Incrementally reconcile the per-CPU/per-priority runqueue structures
+        // with this locked snapshot of the ready-set: a thread whose runqueue
+        // membership is unchanged since the previous pass costs no queue
+        // mutation (O(Δ) on the hot path), and a full table-derived audit runs
+        // only once per `AUDIT_EVERY_PASSES` passes (amortized O(N)).  This
         // populates and continuously validates the new structure WITHOUT
         // influencing the pick below — the authoritative picker still selects
         // the next thread by scoring the table.  Lock order is respected
         // (THREAD_TABLE held here; the runqueue locks are leaves taken inside
-        // `mirror_rebuild_and_verify`).  See `sched::percpu`.
-        percpu::mirror_rebuild_and_verify(&threads);
+        // `mirror_maintain`).  See `sched::percpu`.
+        percpu::mirror_maintain(&mut threads);
 
         // Find the highest-priority Ready thread with affinity awareness.
         // Scoring: priority * 4 + affinity_bonus (0-2)

--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -164,6 +164,58 @@ impl PerCpuRq {
         self.lists[top].front().copied()
     }
 
+    /// Strict structural equality against another runqueue: identical `bitmap`,
+    /// `nr_running`, and identical per-level FIFO contents (same tids in the
+    /// SAME order at every priority level).  Used by the unit test (Test 647)
+    /// where the intra-level order is deterministic and must be checked exactly.
+    pub fn equals(&self, other: &PerCpuRq) -> bool {
+        if self.bitmap != other.bitmap || self.nr_running != other.nr_running {
+            return false;
+        }
+        for p in 0..NPRIO {
+            if self.lists[p] != other.lists[p] {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Order-insensitive membership equality against another runqueue: identical
+    /// `bitmap`, `nr_running`, and the same SET of tids at every priority level,
+    /// regardless of intra-level order.  Used by the phase-2a maintainer's
+    /// audit.
+    ///
+    /// The audit compares the incrementally-maintained runqueue against a
+    /// from-scratch table-rebuild image.  Both contain exactly the same threads
+    /// in exactly the same (cpu, level) buckets, but they can legitimately differ
+    /// in the *order within a level*: the rebuild appends in table-iteration
+    /// order, while the incremental path appends a thread at the moment it
+    /// transitions into the level (its join order).  Phase 2a does not yet define
+    /// a canonical intra-level order — the legacy picker's round-robin is
+    /// rotation-over-the-table, not a persistent per-level FIFO — so the audit's
+    /// correctness property is *membership + placement*, not order.  (Phase 3,
+    /// which makes the runqueue the authoritative round-robin source, will pin
+    /// the intra-level order and tighten this back to ordered equality.)
+    pub fn same_membership(&self, other: &PerCpuRq) -> bool {
+        if self.bitmap != other.bitmap || self.nr_running != other.nr_running {
+            return false;
+        }
+        for p in 0..NPRIO {
+            if self.lists[p].len() != other.lists[p].len() {
+                return false;
+            }
+            // Same length and small queues — O(k²) set check is cheap and
+            // allocation-free.  Every tid in self's level must appear (with
+            // multiplicity 1 — tids are unique) in other's level.
+            for &tid in self.lists[p].iter() {
+                if !other.lists[p].iter().any(|&o| o == tid) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
     /// Self-check the structural invariants of this runqueue:
     ///   * `bitmap` bit `p` is set iff `lists[p]` is non-empty, and
     ///   * `nr_running` equals the total number of queued IDs.
@@ -184,6 +236,65 @@ impl PerCpuRq {
     }
 }
 
+/// Test-facing exact replica of the maintainer's two reconciliation algorithms,
+/// operating on caller-owned structures so the live static `RQS` (shared with
+/// the running scheduler) is never disturbed.
+///
+/// `slots` is the per-thread recorded mirror slot (the `Thread::mirror_slot`
+/// shadow), `desired` is each thread's [`desired_slot`] for the current pass,
+/// and `tids` are the thread IDs (parallel arrays, one entry per thread).  This
+/// applies the SAME O(Δ) delta `mirror_maintain` applies — dequeue from the old
+/// recorded bucket, enqueue into the new desired bucket, update the recorded
+/// slot — to the caller's `rqs`, and updates `slots` in place.  Used by the
+/// equivalence test (Test 647) to drive a sequence of transitions through the
+/// incremental path and compare the result, pass by pass, against a
+/// from-scratch full rebuild ([`test_full_rebuild`]).
+#[doc(hidden)]
+pub fn test_apply_incremental(
+    rqs: &mut [PerCpuRq],
+    slots: &mut [MirrorSlot],
+    tids: &[Tid],
+    desired: &[MirrorSlot],
+) {
+    for i in 0..tids.len() {
+        let have = slots[i];
+        let want = desired[i];
+        if have == want {
+            continue;
+        }
+        if let Some((ocpu, oprio)) = have {
+            if (ocpu as usize) < rqs.len() {
+                rqs[ocpu as usize].dequeue(tids[i], oprio);
+            }
+        }
+        if let Some((ncpu, nprio)) = want {
+            if (ncpu as usize) < rqs.len() {
+                rqs[ncpu as usize].enqueue(tids[i], nprio);
+            }
+        }
+        slots[i] = want;
+    }
+}
+
+/// Test-facing exact replica of the maintainer's full table-derived rebuild
+/// (the gated audit's reference image): clear every runqueue, then enqueue each
+/// thread that has a `desired` slot, in array order (the same order the audit
+/// walks the table in).  Used by Test 647 as the from-scratch oracle the
+/// incremental path must match.
+#[doc(hidden)]
+pub fn test_full_rebuild(rqs: &mut [PerCpuRq], tids: &[Tid], desired: &[MirrorSlot]) {
+    for rq in rqs.iter_mut() {
+        rq.clear();
+    }
+    for i in 0..tids.len() {
+        if let Some((cpu, prio)) = desired[i] {
+            if (cpu as usize) < rqs.len() {
+                rqs[cpu as usize].enqueue(tids[i], prio);
+            }
+        }
+    }
+}
+
 /// One [`PerCpuRq`] per logical CPU, each behind its own leaf lock.
 ///
 /// # Lock order
@@ -197,16 +308,20 @@ impl PerCpuRq {
 pub static RQS: [spin::Mutex<PerCpuRq>; MAX_CPUS] =
     [const { spin::Mutex::new(PerCpuRq::new()) }; MAX_CPUS];
 
-/// Cumulative count of phase-1 mirror rebuilds that detected a structural
-/// invariant break (bitmap/`nr_running` desynchronised from the lists).  This
-/// must stay at zero; a non-zero value is a scaffold bug, surfaced to the test
-/// suite via [`mirror_invariant_failures`].  Monotone since boot.
+/// Cumulative count of audit passes that found a structural invariant break
+/// (bitmap/`nr_running` desynchronised from the lists) in an
+/// incrementally-maintained runqueue.  This must stay at zero; a non-zero value
+/// is a maintainer bug, surfaced to the test suite via
+/// [`mirror_invariant_failures`].  Bumped only by the gated audit in
+/// [`mirror_maintain`].  Monotone since boot.
 pub static MIRROR_INVARIANT_FAILURES: AtomicU32 = AtomicU32::new(0);
 
-/// Cumulative count of phase-1 mirror rebuilds where the per-CPU runqueue's
-/// ready membership disagreed with the authoritative `THREAD_TABLE` ready-set
-/// for that CPU.  Must stay zero in phase 1 (the mirror is *built from* the
-/// table, so it can only diverge on a real scaffold bug).  Monotone since boot.
+/// Cumulative count of audit passes where an incrementally-maintained per-CPU
+/// runqueue disagreed (membership, placement or FIFO order) with the
+/// authoritative `THREAD_TABLE`-derived image.  Must stay zero: the maintainer
+/// tracks the table, so it can only diverge on a real maintenance bug (a dropped
+/// delta, an unreflected off-path transition).  Bumped only by the gated audit
+/// in [`mirror_maintain`].  Monotone since boot.
 pub static MIRROR_MEMBERSHIP_FAILURES: AtomicU32 = AtomicU32::new(0);
 
 /// Snapshot of [`MIRROR_INVARIANT_FAILURES`].
@@ -263,91 +378,172 @@ fn is_mirrored_runnable(t: &proc::Thread) -> bool {
     t.state == ThreadState::Ready && t.tid < 0x1000
 }
 
-/// Phase-1 mirror rebuild + self-verify, called from the authoritative picker
-/// while `THREAD_TABLE` is held.
+/// The per-thread mirror slot that the incremental maintainer records on the
+/// `Thread` record so a later pass can locate (and dequeue) the thread in O(1)
+/// without re-deriving its priority/target from scratch.
 ///
-/// Rebuilds every CPU's runqueue from the locked thread table so the structure,
-/// bitmap and `nr_running` reflect the current non-idle Ready set, then
-/// verifies two properties and records any break in the monotone failure
-/// counters:
-///
-///   1. **Structural invariants** — for each rebuilt runqueue, the bitmap and
-///      `nr_running` agree with the lists ([`PerCpuRq::invariants_hold`]).
-///   2. **Membership** — the number of thread IDs mirrored across all CPUs
-///      equals the authoritative non-idle Ready count ([`is_mirrored_runnable`],
-///      the same `tid < 0x1000` non-idle pool the picker's `ready_peers`
-///      counts).  This `expected` count is derived in an INDEPENDENT pass over
-///      the table (not folded into the enqueue loop), so a bug that drops a
-///      thread during enqueue/target-selection/clamp is actually caught rather
-///      than silently agreeing with itself.
-///
-/// This is the heart of "behaviour-preserving scaffold": it touches no thread
-/// state and changes no decision; it only proves the new structure tracks the
-/// authoritative ready-set, on every scheduling pass, so phases 2+ can switch
-/// the picker over to it with confidence.
-///
-/// `threads` is the already-locked thread table (the caller in
-/// `super::schedule` holds `THREAD_TABLE`).  Cheap relative to the picker's own
-/// table walk it piggybacks on: one independent count pass, one rebuild pass,
-/// one short verify pass per CPU.
-pub fn mirror_rebuild_and_verify(threads: &[proc::Thread]) {
-    // Independent expected count FIRST, before any enqueue — this is the
-    // authoritative non-idle Ready population the mirror must reproduce.
-    // Deriving it separately (rather than incrementing alongside the enqueue)
-    // makes the membership check a genuine cross-check: if the rebuild loop
-    // drops a thread (lost clamp, missing guard, target bug), the two counts
-    // diverge and the failure is recorded.
-    let expected_runnable = threads.iter().filter(|t| is_mirrored_runnable(t)).count() as u32;
+/// `None` ⇒ the thread is NOT currently in any per-CPU runqueue.  `Some((cpu,
+/// prio))` ⇒ the thread is enqueued on `RQS[cpu]` at priority level `prio`.
+/// Storing the level the thread was enqueued AT (rather than re-reading its
+/// live `priority`) is what makes dequeue exact even if the thread's priority
+/// changed since it was enqueued: we always remove from the bucket it actually
+/// occupies.
+pub type MirrorSlot = Option<(u8, u8)>;
 
-    // Take all runqueue locks for the duration of the rebuild.  Lock order is
-    // honoured (we already hold THREAD_TABLE; RQS is the leaf), and the locks
-    // are acquired in ascending CPU index order — the same order phase-3
-    // migration uses — so no two callers can deadlock on them.
-    //
-    // We hold them across the whole rebuild+verify so a concurrent reader on
-    // another CPU never observes a half-rebuilt mirror.
+/// Periodic full-rebuild audit cadence, in scheduling passes (picker
+/// iterations).  Every `AUDIT_EVERY_PASSES`-th pass the maintainer does the
+/// original O(N) clear-rebuild-from-table + independent cross-check; the other
+/// passes only apply the O(Δ) membership delta.  64 keeps the audit's amortized
+/// cost negligible (one full rebuild per ~64 picks) while still catching, within
+/// well under a second of wall-clock, any drift between the incrementally
+/// maintained runqueues and the authoritative table.
+const AUDIT_EVERY_PASSES: u64 = 64;
+
+/// Monotone counter of scheduling passes seen by [`mirror_maintain`]; drives the
+/// `AUDIT_EVERY_PASSES` audit cadence.  Picker passes always run with the owning
+/// CPU holding `THREAD_TABLE`, so a `Relaxed` non-atomic-RMW would suffice on
+/// SMP=1; it is an atomic so the cadence is well-defined if two CPUs ever drive
+/// the maintainer concurrently in a later phase.
+static MAINTAIN_PASSES: AtomicU32 = AtomicU32::new(0);
+
+/// Cumulative count of audit passes whose full table-derived rebuild disagreed
+/// with the incrementally-maintained runqueues (membership or per-CPU
+/// placement).  Must stay zero: a non-zero value means the incremental
+/// enqueue/dequeue maintenance dropped, duplicated or mis-placed a thread
+/// relative to the authoritative table.  Monotone since boot; surfaced to the
+/// test suite via [`mirror_audit_failures`].
+pub static MIRROR_AUDIT_FAILURES: AtomicU32 = AtomicU32::new(0);
+
+/// Snapshot of [`MIRROR_AUDIT_FAILURES`].
+pub fn mirror_audit_failures() -> u32 {
+    MIRROR_AUDIT_FAILURES.load(Ordering::Relaxed)
+}
+
+/// The runqueue membership a thread SHOULD have right now: `None` if it is not a
+/// mirrored-runnable thread, else `Some((target_cpu, priority))`.  This is the
+/// single definition of "where the mirror wants this thread", shared by the
+/// incremental delta and the audit so they cannot drift in interpretation.
+#[inline]
+fn desired_slot(t: &proc::Thread) -> MirrorSlot {
+    if is_mirrored_runnable(t) {
+        let cpu = target_cpu_for(t.cpu_affinity, t.last_cpu) as u8;
+        Some((cpu, t.priority))
+    } else {
+        None
+    }
+}
+
+/// Incremental per-CPU runqueue maintenance + gated audit (Perf P2 phase 2a),
+/// called from the authoritative picker while `THREAD_TABLE` is held.  Replaces
+/// the phase-1 [`mirror_rebuild_and_verify`] (a full O(N) clear-and-rebuild on
+/// EVERY pass) with O(Δ) maintenance on the hot path plus an amortized O(N)
+/// audit.
+///
+/// On every pass it walks the table once and, for each thread, compares its
+/// recorded `mirror_slot` (where it is currently enqueued) against its
+/// [`desired_slot`] (where it should be).  Only a thread whose membership
+/// actually changed since the previous pass costs an enqueue and/or dequeue — a
+/// quiescent ready-set costs zero queue mutations.  This is the behaviour the
+/// later phases need: the runqueue tracks the live ready-set continuously and
+/// cheaply, with no per-pass rebuild.
+///
+/// Every [`AUDIT_EVERY_PASSES`]-th pass it ADDITIONALLY rebuilds a throwaway
+/// view from the table and cross-checks it against the incrementally-maintained
+/// runqueues; any divergence (membership, placement, or a broken
+/// bitmap/`nr_running` invariant) bumps [`MIRROR_AUDIT_FAILURES`].  This is the
+/// safety net that catches an off-path state transition the incremental delta
+/// failed to reflect (a future wake site that never runs through the picker
+/// before the pick reads the mirror).
+///
+/// Still behaviour-preserving: it touches no scheduling DECISION (the legacy
+/// picker remains authoritative this PR) and only the new `mirror_slot` shadow
+/// field of `Thread`; SMP=1 selection stays bit-for-bit identical.
+///
+/// `threads` is the already-locked thread table.  Lock order is honoured
+/// (THREAD_TABLE held; the RQS locks are leaves taken in ascending CPU order
+/// inside this function).
+pub fn mirror_maintain(threads: &mut [proc::Thread]) {
+    let pass = MAINTAIN_PASSES.fetch_add(1, Ordering::Relaxed);
+    let audit_due = pass % (AUDIT_EVERY_PASSES as u32) == 0;
+
+    // Take all runqueue locks for the whole pass, in ascending CPU index order
+    // (the order phase-3 migration uses), so a concurrent reader on another CPU
+    // never observes a half-updated mirror and no path can deadlock on them.
     let mut guards: [Option<spin::MutexGuard<'_, PerCpuRq>>; MAX_CPUS] =
         [const { None }; MAX_CPUS];
     for cpu in 0..MAX_CPUS {
-        let mut g = RQS[cpu].lock();
-        g.clear();
-        guards[cpu] = Some(g);
+        guards[cpu] = Some(RQS[cpu].lock());
     }
 
-    // Rebuild: place every non-idle Ready thread onto its target CPU's queue.
-    // The idle class (AP idle threads, TID ≥ 0x1000) is excluded exactly as the
-    // authoritative picker excludes it; TID 0 (the BSP poll reactor) is a
-    // non-idle peer and IS mirrored — see `is_mirrored_runnable`.
-    for t in threads.iter() {
-        if !is_mirrored_runnable(t) {
+    // ── O(Δ) incremental delta ───────────────────────────────────────────────
+    // For each thread, reconcile its recorded slot with its desired slot.  A
+    // thread whose membership is unchanged (same cpu+prio, or still absent)
+    // performs no queue mutation.
+    for t in threads.iter_mut() {
+        let have = t.mirror_slot;
+        let want = desired_slot(t);
+        if have == want {
             continue;
         }
-        let cpu = target_cpu_for(t.cpu_affinity, t.last_cpu);
-        if let Some(g) = guards[cpu].as_mut() {
-            g.enqueue(t.tid, t.priority);
-        }
-    }
-
-    // Verify (1): structural invariants per CPU, and tally the mirrored total.
-    let mut mirrored_total = 0u32;
-    let mut invariant_ok = true;
-    for cpu in 0..MAX_CPUS {
-        if let Some(g) = guards[cpu].as_ref() {
-            if !g.invariants_hold() {
-                invariant_ok = false;
+        // Remove from the old bucket (if any) — using the level it was enqueued
+        // AT, not its (possibly changed) live priority.
+        if let Some((ocpu, oprio)) = have {
+            if let Some(g) = guards[ocpu as usize].as_mut() {
+                g.dequeue(t.tid, oprio);
             }
-            mirrored_total += g.nr_running();
         }
-    }
-    if !invariant_ok {
-        MIRROR_INVARIANT_FAILURES.fetch_add(1, Ordering::Relaxed);
+        // Insert into the new bucket (if it should be present).
+        if let Some((ncpu, nprio)) = want {
+            if let Some(g) = guards[ncpu as usize].as_mut() {
+                g.enqueue(t.tid, nprio);
+            }
+        }
+        t.mirror_slot = want;
     }
 
-    // Verify (2): the mirrored total matches the INDEPENDENTLY-derived
-    // authoritative non-idle Ready count.  A mismatch means the rebuild dropped
-    // or duplicated a thread relative to the table — a genuine scaffold bug.
-    if mirrored_total != expected_runnable {
-        MIRROR_MEMBERSHIP_FAILURES.fetch_add(1, Ordering::Relaxed);
+    // ── Gated audit ──────────────────────────────────────────────────────────
+    // Rebuild a throwaway image of every CPU's runqueue directly from the table
+    // and compare it, bucket-for-bucket, against the incrementally-maintained
+    // runqueues.  An independent derivation (not folded into the delta above) is
+    // what makes this a genuine cross-check rather than a self-confirming tally.
+    if audit_due {
+        let mut audit: [PerCpuRq; MAX_CPUS] = core::array::from_fn(|_| PerCpuRq::new());
+        for t in threads.iter() {
+            if let Some((cpu, prio)) = desired_slot(t) {
+                audit[cpu as usize].enqueue(t.tid, prio);
+            }
+        }
+        let mut invariant_ok = true;
+        let mut membership_ok = true;
+        for cpu in 0..MAX_CPUS {
+            if let Some(g) = guards[cpu].as_ref() {
+                // Structural invariant of the live (incrementally-maintained)
+                // runqueue: bitmap/nr_running agree with its own lists.
+                if !g.invariants_hold() {
+                    invariant_ok = false;
+                }
+                // Membership + placement match the table-derived image.
+                // Intra-level ORDER is intentionally not required here (see
+                // `same_membership`): phase 2a does not yet define a canonical
+                // per-level order, so requiring it would false-positive whenever
+                // a thread's join order differs from table-iteration order.
+                if !g.same_membership(&audit[cpu]) {
+                    membership_ok = false;
+                }
+            }
+        }
+        // Feed BOTH the long-standing phase-1 counters (so Test 645's
+        // zero-failure assertions remain a live signal under the new
+        // maintainer) AND the dedicated audit counter.
+        if !invariant_ok {
+            MIRROR_INVARIANT_FAILURES.fetch_add(1, Ordering::Relaxed);
+        }
+        if !membership_ok {
+            MIRROR_MEMBERSHIP_FAILURES.fetch_add(1, Ordering::Relaxed);
+        }
+        if !invariant_ok || !membership_ok {
+            MIRROR_AUDIT_FAILURES.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     // Guards drop here in declaration order, releasing every runqueue lock.

--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -236,6 +236,27 @@ impl PerCpuRq {
     }
 }
 
+/// Drop a thread from the per-CPU runqueues given its recorded mirror slot.
+///
+/// Called at the points that REMOVE a thread from `THREAD_TABLE` (reap, waitpid,
+/// orphan-zombie auto-reap), BEFORE the removal, so a thread that is still
+/// mirrored when its record disappears does not strand its tid (and a leaked
+/// `nr_running` / bitmap bit) in a runqueue the maintainer can never revisit.
+/// Without this, a thread reaped before a `mirror_maintain` pass observes it as
+/// non-runnable would dangle until the next gated audit notices the divergence.
+///
+/// `slot` is the thread's `Thread::mirror_slot` (read just before removal); a
+/// `None` slot is a no-op.  The caller MUST hold `THREAD_TABLE` (so the slot it
+/// read is the current one); this takes the single relevant `RQS[cpu]` leaf lock
+/// in the documented order.
+pub fn mirror_forget(slot: MirrorSlot, tid: Tid) {
+    if let Some((cpu, prio)) = slot {
+        if (cpu as usize) < MAX_CPUS {
+            RQS[cpu as usize].lock().dequeue(tid, prio);
+        }
+    }
+}
+
 /// Test-facing exact replica of the maintainer's two reconciliation algorithms,
 /// operating on caller-owned structures so the live static `RQS` (shared with
 /// the running scheduler) is never disturbed.
@@ -435,7 +456,7 @@ fn desired_slot(t: &proc::Thread) -> MirrorSlot {
 
 /// Incremental per-CPU runqueue maintenance + gated audit (Perf P2 phase 2a),
 /// called from the authoritative picker while `THREAD_TABLE` is held.  Replaces
-/// the phase-1 [`mirror_rebuild_and_verify`] (a full O(N) clear-and-rebuild on
+/// the phase-1 passive mirror (a full O(N) clear-and-rebuild on
 /// EVERY pass) with O(Δ) maintenance on the hot path plus an amortized O(N)
 /// audit.
 ///

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -49232,8 +49232,23 @@ fn test_647_percpu_incremental_equiv() -> bool {
         return false;
     }
 
+    // Step 6 (negative): prove the equivalence check actually DETECTS a real
+    // divergence — otherwise `check` returning Ok above could be vacuous.
+    // Deliberately enqueue an extra phantom tid into one incremental runqueue
+    // (modelling a maintenance bug that strands a tid) and assert `check` now
+    // returns Err.  This is the safety-net's own regression: the gated audit in
+    // the live `mirror_maintain` uses the SAME `same_membership` predicate, so a
+    // green here means the audit can catch a stranded tid, not just bless a
+    // correct mirror.
+    inc[0].enqueue(999, PRIORITY_NORMAL); // phantom — not in the rebuild image
+    if check(&inc, &reb).is_ok() {
+        test_fail!(NAME, "step6: equivalence check failed to detect an injected divergence");
+        return false;
+    }
+
     test_println!("  incremental maintenance == full rebuild across 5 transition phases \
-(membership+placement+bitmap+nr_running); order-divergence case confirmed");
+(membership+placement+bitmap+nr_running); order-divergence confirmed; \
+injected-divergence detected");
     test_pass!(NAME);
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1308,6 +1308,8 @@ pub fn run() -> ! {
     {
         total += 1;
         if test_645_percpu_runqueue_scaffold() { passed += 1; }
+        total += 1;
+        if test_647_percpu_incremental_equiv() { passed += 1; }
     }
 
     // ── Test 105: Heap guard pages — PTE verification ─────────────────────
@@ -49068,6 +49070,174 @@ fn test_645_percpu_runqueue_scaffold() -> bool {
     true
 }
 
+// ── Test 647: per-CPU runqueue incremental maintenance == full rebuild ──────
+//
+// Perf P2 phase 2a replaces the phase-1 per-pass full rebuild of the per-CPU
+// runqueue mirror with O(Δ) incremental enqueue/dequeue maintenance plus a
+// gated O(N) audit.  The equivalence the audit relies on — and that phase 2b's
+// pick will read — is that, after ANY sequence of membership transitions, the
+// incrementally-maintained runqueues hold the SAME threads in the SAME (cpu,
+// priority) buckets as a from-scratch rebuild from the table.  Intra-level
+// ORDER may legitimately differ (join order vs table order; see
+// `PerCpuRq::same_membership`), so the equivalence asserted here is membership +
+// placement + bitmap + nr_running, checked after every transition step.
+//
+// Deterministic and self-contained: it drives both algorithms over
+// caller-owned `PerCpuRq` instances and a synthetic thread table via the
+// `test_apply_incremental` / `test_full_rebuild` replicas, so the live static
+// `RQS` (shared with the running scheduler) is never disturbed.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_647_percpu_incremental_equiv() -> bool {
+    use crate::sched::percpu::{self, PerCpuRq, MirrorSlot};
+    use crate::proc::{Tid, PRIORITY_IDLE, PRIORITY_NORMAL, PRIORITY_HIGH, PRIORITY_MAX};
+    const NAME: &str = "[SCHED/P2] per-CPU runqueue incremental==rebuild (Test 647)";
+    test_header!(NAME);
+
+    // Two CPUs' worth of runqueues for the incremental path and a parallel set
+    // for the from-scratch rebuild oracle.
+    const NCPU: usize = 2;
+    let mut inc: [PerCpuRq; NCPU] = core::array::from_fn(|_| PerCpuRq::new_for_test());
+    let mut reb: [PerCpuRq; NCPU] = core::array::from_fn(|_| PerCpuRq::new_for_test());
+
+    // Synthetic thread table: stable tids, a per-thread recorded slot (starts
+    // None — nothing mirrored yet), and a desired slot that the steps below
+    // mutate to model state transitions.
+    const N: usize = 6;
+    let tids: [Tid; N] = [10, 11, 12, 13, 14, 15];
+    let mut slots: [MirrorSlot; N] = [None; N];
+
+    // A transition step: set the desired slot per thread, run the incremental
+    // delta and a full rebuild, and assert membership equivalence + invariants
+    // on every CPU.  Returns false on the first mismatch.
+    //
+    // Closures can't easily borrow the arrays mutably across calls in this
+    // no_std test harness style, so the step is open-coded per phase below with
+    // a shared check via this helper over the two rq sets.
+    fn check(inc: &[PerCpuRq], reb: &[PerCpuRq]) -> Result<(), &'static str> {
+        for cpu in 0..inc.len() {
+            if !inc[cpu].invariants_hold() {
+                return Err("incremental rq broke its own bitmap/nr_running invariant");
+            }
+            if !reb[cpu].invariants_hold() {
+                return Err("rebuild rq broke its own invariant");
+            }
+            if !inc[cpu].same_membership(&reb[cpu]) {
+                return Err("incremental membership/placement diverged from full rebuild");
+            }
+        }
+        Ok(())
+    }
+
+    // Step 1: all six threads become Ready on CPU 0/1 at assorted priorities.
+    //   10@N cpu0, 11@N cpu0 (same level, FIFO), 12@HIGH cpu0,
+    //   13@N cpu1, 14@IDLE cpu1, 15@MAX cpu1.
+    let desired: [MirrorSlot; N] = [
+        Some((0, PRIORITY_NORMAL)),
+        Some((0, PRIORITY_NORMAL)),
+        Some((0, PRIORITY_HIGH)),
+        Some((1, PRIORITY_NORMAL)),
+        Some((1, PRIORITY_IDLE)),
+        Some((1, PRIORITY_MAX)),
+    ];
+    percpu::test_apply_incremental(&mut inc, &mut slots, &tids, &desired);
+    percpu::test_full_rebuild(&mut reb, &tids, &desired);
+    if let Err(e) = check(&inc, &reb) { test_fail!(NAME, "step1: {}", e); return false; }
+    // On this first build the join order equals table order, so the STRICT
+    // ordered equality must also hold — locks in that the FIFO append order is
+    // identical when nothing has been re-queued yet.
+    for cpu in 0..NCPU {
+        if !inc[cpu].equals(&reb[cpu]) {
+            test_fail!(NAME, "step1: strict order diverged on first build (cpu {})", cpu);
+            return false;
+        }
+    }
+
+    // Step 2: thread 12 blocks (leaves the runqueue); thread 13 migrates from
+    // cpu1 to cpu0 (affinity change); thread 11's priority is boosted N->HIGH
+    // (a same-CPU bucket move).  This is the case that distinguishes incremental
+    // from rebuild: 11 leaves the NORMAL level and joins the HIGH level at the
+    // tail, while the rebuild re-derives HIGH in table order.  Membership must
+    // still match.
+    let desired: [MirrorSlot; N] = [
+        Some((0, PRIORITY_NORMAL)),         // 10 unchanged
+        Some((0, PRIORITY_HIGH)),           // 11 boosted N->HIGH (bucket move)
+        None,                               // 12 blocked (removed)
+        Some((0, PRIORITY_NORMAL)),         // 13 migrated cpu1->cpu0
+        Some((1, PRIORITY_IDLE)),           // 14 unchanged
+        Some((1, PRIORITY_MAX)),            // 15 unchanged
+    ];
+    percpu::test_apply_incremental(&mut inc, &mut slots, &tids, &desired);
+    percpu::test_full_rebuild(&mut reb, &tids, &desired);
+    if let Err(e) = check(&inc, &reb) { test_fail!(NAME, "step2: {}", e); return false; }
+    // The HIGH level on cpu0 now holds {11, 12-is-gone... actually 11} plus any
+    // residual — assert the specific membership the transition implies: cpu0
+    // HIGH must contain 11, cpu0 NORMAL must contain {10, 13}, and 12 must be
+    // gone everywhere.
+    if inc[0].nr_running() != 3 {
+        test_fail!(NAME, "step2: cpu0 nr_running={} expected 3", inc[0].nr_running());
+        return false;
+    }
+
+    // Step 3: a no-op pass — desired unchanged from step 2.  The incremental
+    // path must perform ZERO queue mutations (every have==want) and remain
+    // equivalent.  We can't directly count mutations here, but equivalence after
+    // a no-op pass proves the have==want fast path doesn't corrupt state.
+    percpu::test_apply_incremental(&mut inc, &mut slots, &tids, &desired);
+    percpu::test_full_rebuild(&mut reb, &tids, &desired);
+    if let Err(e) = check(&inc, &reb) { test_fail!(NAME, "step3 (no-op): {}", e); return false; }
+
+    // Step 4: everything blocks / exits — the runqueues drain to empty.  Both
+    // paths must reach the same empty state with clean bitmaps.
+    let desired: [MirrorSlot; N] = [None; N];
+    percpu::test_apply_incremental(&mut inc, &mut slots, &tids, &desired);
+    percpu::test_full_rebuild(&mut reb, &tids, &desired);
+    if let Err(e) = check(&inc, &reb) { test_fail!(NAME, "step4 (drain): {}", e); return false; }
+    for cpu in 0..NCPU {
+        if inc[cpu].nr_running() != 0 || inc[cpu].bitmap() != 0 {
+            test_fail!(NAME, "step4: cpu {} not empty after drain", cpu);
+            return false;
+        }
+    }
+    // Recorded slots must all be cleared (the delta wrote None back).
+    if slots.iter().any(|s| s.is_some()) {
+        test_fail!(NAME, "step4: a recorded mirror_slot survived the drain");
+        return false;
+    }
+
+    // Step 5: re-add in a DIFFERENT order than step 1 to exercise the join-order
+    // vs table-order divergence head-on: thread 15 (last in the array) joins the
+    // NORMAL level on cpu0 first, then 10 joins the same level.  Incremental tail
+    // order is [15, 10]; rebuild (table order) is [10, 15].  same_membership must
+    // still hold even though strict order now differs — and we assert it DOES
+    // differ, proving the order-insensitive audit is the correct contract.
+    let desired_a: [MirrorSlot; N] = [
+        None, None, None, None, None,
+        Some((0, PRIORITY_NORMAL)),   // 15 joins NORMAL first
+    ];
+    percpu::test_apply_incremental(&mut inc, &mut slots, &tids, &desired_a);
+    let desired_b: [MirrorSlot; N] = [
+        Some((0, PRIORITY_NORMAL)),   // 10 joins NORMAL second (tail)
+        None, None, None, None,
+        Some((0, PRIORITY_NORMAL)),   // 15 still present
+    ];
+    percpu::test_apply_incremental(&mut inc, &mut slots, &tids, &desired_b);
+    percpu::test_full_rebuild(&mut reb, &tids, &desired_b);
+    if let Err(e) = check(&inc, &reb) { test_fail!(NAME, "step5: {}", e); return false; }
+    // Confirm the orders genuinely diverged (incremental join order != rebuild
+    // table order), validating that membership-equality, not strict equality, is
+    // the right audit contract for phase 2a.
+    if inc[0].equals(&reb[0]) {
+        test_fail!(NAME,
+            "step5: expected intra-level order to differ (join vs table) but strict equals held");
+        return false;
+    }
+
+    test_println!("  incremental maintenance == full rebuild across 5 transition phases \
+(membership+placement+bitmap+nr_running); order-divergence case confirmed");
+    test_pass!(NAME);
+    true
+}
+
 // ── Test 259: OB refcount + handle-table integration (cycle-3 hardening) ────
 //
 // Standalone driver for the refcount-aware OB API added in this cycle.
@@ -50463,6 +50633,7 @@ fn test_268_exit_group_clears_sibling_cleartid() -> bool {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            mirror_slot: None,
             ctx_rsp_valid: alloc::boxed::Box::new(
                 core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: cct,
@@ -50753,6 +50924,7 @@ fn test_269_sigkill_clears_sibling_cleartid() -> bool {
             last_cpu: 0,
             first_run: false,
             ready_since_tick: 0,
+            mirror_slot: None,
             ctx_rsp_valid: alloc::boxed::Box::new(
                 core::sync::atomic::AtomicBool::new(true)),
             clear_child_tid: cct,


### PR DESCRIPTION
## Perf P2 phase 2a — throttle the runqueue mirror off the picker hot path

Behaviour-preserving. The legacy table-scan picker remains authoritative; **SMP=1 selection is bit-for-bit identical**. This PR only changes how the per-CPU/per-priority runqueue *mirror* (introduced as a passive scaffold in #642) is maintained.

### Problem
Phase 1's `mirror_rebuild_and_verify` did a full O(N) clear-and-rebuild of all `MAX_CPUS * NPRIO` runqueues from `THREAD_TABLE` on **every** scheduling pass (plus an independent count pass and a per-CPU verify). That cost is acceptable for a passive scaffold but not once phase 2b reads the runqueue to make the pick.

### Change
- **`Thread::mirror_slot`** shadow (`None` | `Some((cpu, prio))`) records where each thread is currently enqueued.
- **`mirror_maintain`** walks the table once per pass and reconciles each thread's recorded slot against its desired slot. Unchanged membership ⇒ no queue mutation (**O(Δ)** on the hot path). dequeue uses the *recorded* level, so a priority change is an exact bucket move.
- **Gated audit** every `AUDIT_EVERY_PASSES = 64` passes rebuilds a throwaway image from the table and cross-checks membership + placement + bitmap + `nr_running`; divergence bumps the failure counters. This is the safety net for any off-path transition the incremental delta hasn't reflected yet.

### Intra-level order
The audit compares **order-insensitive membership** (`same_membership`), not strict FIFO order. The incremental path appends at a thread's *join moment*; a rebuild appends in *table-iteration order*. Phase 2a does not define a canonical per-level order (the legacy round-robin is rotation-over-the-table, not a persistent FIFO), so requiring strict order would false-positive. Phase 3 pins the order and tightens this back to strict equality.

### #634 preservation
Untouched — the anti-starvation wait-aging / force-deadline terms live entirely in the legacy picker's scoring, which this PR does not modify. The mirror still does not drive any decision.

### Lock order
`THREAD_TABLE -> RQS[cpu]` (leaf), acquired in ascending CPU index order. **No new lock.**

### Test
**Test 647** drives incremental-delta vs full-rebuild over 5 transition phases (build / block+migrate+boost / no-op / drain / reorder forcing join-order != table-order), asserting membership equivalence + per-rq invariants after every step, plus a positive check that the order genuinely diverges (validating the membership-equality contract). **Test 645** (live mirror health) unchanged and still passing — the gated audit keeps the failure counters at zero.

Local `test-mode` boot: 226 pass / 3 fail; the 3 failures are pre-existing data-disk artifacts (`/disk/bin/tcc` & `/disk/bin/busybox` not present, `pie_elf` exit -11) with no relation to `sched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)