### PR TITLE
sched: per-CPU runqueue pick + pick-equivalence proof (Perf P2 phase 2b)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -5,6 +5,17 @@ edition.workspace = true
 
 [features]
 default = []
+# `sched-pick-xcheck` — Perf P2 phase 2b live pick-equivalence cross-check. On
+# every scheduling pass (SMP=1 only) the per-CPU runqueue pick is computed
+# alongside the authoritative legacy table-scan pick and any divergence is
+# logged + counted (`sched::percpu::PICK_DIVERGENCES`). The legacy result still
+# drives the switch, so this is observation-only — the live half of the Test
+# 648 proof. Off by default and NOT pulled into `test-mode` (it does per-sample
+# heap allocation off the schedule() path, which must stay allocation-free in
+# the default kernel); enable explicitly for a dedicated equivalence soak. The
+# deterministic Test 648 is the authoritative merge gate; this is supplementary
+# live evidence.
+sched-pick-xcheck = []
 # `heap-canary` — fence every live kernel-heap allocation with front/rear
 # magic red-zone words (validated on free) so an out-of-bounds write that
 # clobbers free-list metadata is caught at free-time, naming the victim

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1223,6 +1223,244 @@ pub fn test_cpu_switch_gen(cpu: usize) -> u64 {
     cpu_switch_gen(cpu)
 }
 
+/// Pure selection core: the scoring loop + two-pass split + force-backstop
+/// resolution, with NO side effects (no `READY_DEPTH` publish, no
+/// `SCHED_STARVE_FORCE_TOTAL` bump, no diagnostic).  Returns the selected table
+/// index, the run-queue depth observed, and — when the force backstop chose the
+/// pick — the forced thread's `(index, raw_wait_age)` so the caller can apply
+/// the side effects exactly once.  Extracted verbatim from the legacy in-line
+/// picker (Perf P2 phase 2b): same `score = priority*4 + aff_bonus(0..2) +
+/// wait_age_bonus(age)`, same strict-max first-in-candidate-order tie-break,
+/// same two-pass non-idle-then-idle split, same per-thread force deadline
+/// (`STARVE_FORCE_TICKS_BSP` for TID 0 else `STARVE_FORCE_TICKS`).  Candidates
+/// must be supplied **in the picker's rotation order** so the tie-break matches.
+fn select_next_core(
+    threads: &[proc::Thread],
+    cpu: u8,
+    candidate_indices: impl Iterator<Item = usize>,
+    now: u64,
+) -> (Option<usize>, u64, Option<(usize, u64)>) {
+    let mut best_idx: Option<usize> = None;
+    let mut best_score: u16 = 0;
+    let mut idle_best_idx: Option<usize> = None;
+    let mut idle_best_score: u16 = 0;
+    let mut force_idx: Option<usize> = None;
+    let mut force_age: u64 = 0;
+    let mut force_margin: i64 = i64::MIN;
+    let mut ready_peers: u64 = 0;
+
+    for idx in candidate_indices {
+        let t = &threads[idx];
+        if t.state != ThreadState::Ready {
+            continue;
+        }
+        if t.tid < 0x1000 {
+            ready_peers += 1;
+        }
+        if !t.ctx_rsp_valid.load(core::sync::atomic::Ordering::Acquire) {
+            continue;
+        }
+        if let Some(aff) = t.cpu_affinity {
+            if aff != cpu {
+                continue;
+            }
+        }
+
+        let wait_age = now.saturating_sub(t.ready_since_tick);
+        let is_idle_thread = t.tid >= 0x1000;
+
+        let mut score = (t.priority as u16) * 4;
+        if t.cpu_affinity == Some(cpu) {
+            score += 2;
+        } else if t.last_cpu == cpu {
+            score += 1;
+        }
+        if !is_idle_thread {
+            score += wait_age_bonus(wait_age);
+            let deadline: u64 = if t.tid == 0 {
+                STARVE_FORCE_TICKS_BSP
+            } else {
+                STARVE_FORCE_TICKS
+            };
+            let margin = wait_age as i64 - deadline as i64;
+            if margin > force_margin {
+                force_margin = margin;
+                force_age = wait_age;
+                force_idx = Some(idx);
+            }
+        }
+
+        if is_idle_thread {
+            if score > idle_best_score || idle_best_idx.is_none() {
+                idle_best_idx = Some(idx);
+                idle_best_score = score;
+            }
+        } else if score > best_score || best_idx.is_none() {
+            best_idx = Some(idx);
+            best_score = score;
+        }
+    }
+
+    if best_idx.is_none() {
+        best_idx = idle_best_idx;
+    }
+
+    let mut forced: Option<(usize, u64)> = None;
+    if force_margin >= 0 {
+        if let Some(fidx) = force_idx {
+            if best_idx != Some(fidx) {
+                best_idx = Some(fidx);
+                forced = Some((fidx, force_age));
+            }
+        }
+    }
+    (best_idx, ready_peers, forced)
+}
+
+/// The authoritative per-CPU selection (Perf P2 phase 2b), with the original
+/// inline-picker side effects: publishes `READY_DEPTH`, bumps
+/// `SCHED_STARVE_FORCE_TOTAL` and emits the throttled `[SCHED/STARVE]
+/// force-select` diagnostic on a force.  Returns `(selected_index, ready_peers)`.
+/// The legacy path calls this with the full rotated `1..len` candidate sequence
+/// — proving the extraction is byte-identical to the old inline loop.
+fn select_next(
+    threads: &[proc::Thread],
+    cpu: u8,
+    candidate_indices: impl Iterator<Item = usize>,
+    now: u64,
+) -> (Option<usize>, u64) {
+    let (best_idx, ready_peers, forced) =
+        select_next_core(threads, cpu, candidate_indices, now);
+
+    READY_DEPTH.store(ready_peers, Ordering::Relaxed);
+
+    if let Some((fidx, force_age)) = forced {
+        let n = SCHED_STARVE_FORCE_TOTAL.fetch_add(1, Ordering::Relaxed);
+        let deadline: u64 = if threads[fidx].tid == 0 {
+            STARVE_FORCE_TICKS_BSP
+        } else {
+            STARVE_FORCE_TICKS
+        };
+        if n == 0 || n % STARVE_FORCE_LOG_EVERY == 0 {
+            crate::serial_println!(
+                "[SCHED/STARVE] force-select tid={} (waited {} ticks >= {}) on cpu={} \
+                 total={} — anti-starvation backstop",
+                threads[fidx].tid, force_age, deadline, cpu, n + 1,
+            );
+        }
+    }
+    (best_idx, ready_peers)
+}
+
+/// Side-effect-free selection used by the phase-2b equivalence cross-check: the
+/// pure [`select_next_core`], returning only the selected table index.  Must not
+/// drive the authoritative path (it skips the READY_DEPTH/force-counter side
+/// effects, which would then never fire).
+#[cfg(feature = "sched-pick-xcheck")]
+fn select_next_no_side_effects(
+    threads: &[proc::Thread],
+    cpu: u8,
+    candidate_indices: impl Iterator<Item = usize>,
+    now: u64,
+) -> Option<usize> {
+    select_next_core(threads, cpu, candidate_indices, now).0
+}
+
+/// Test entry point (Perf P2 phase 2b pick-equivalence proof, Test 648).
+///
+/// Runs the selection core over a caller-built synthetic thread table for a
+/// given running CPU, current index and tick, with TWO candidate orderings:
+///
+///   * `legacy` — the full rotated `(current_idx + i) % len` walk, and
+///   * `percpu` — the candidate set the per-CPU path would derive (built here by
+///     [`test_percpu_candidates`] from the same rules `percpu_candidate_indices`
+///     uses, but over the supplied `runnable_tids` so the test need not touch
+///     the live static `RQS`).
+///
+/// Returns the selected TID for each ordering so the test can assert they are
+/// identical.  Uses the side-effect-free [`select_next_core`], so it perturbs no
+/// live scheduler counters.
+pub fn test_pick_equivalence(
+    threads: &[proc::Thread],
+    cpu: u8,
+    current_idx: usize,
+    now: u64,
+    runnable_tids: &[proc::Tid],
+) -> (Option<proc::Tid>, Option<proc::Tid>) {
+    let len = threads.len();
+    let percpu = test_percpu_candidates(threads, current_idx, runnable_tids);
+
+    let legacy_idx =
+        select_next_core(threads, cpu, (1..len).map(|i| (current_idx + i) % len), now).0;
+    let percpu_idx = select_next_core(threads, cpu, percpu.iter().copied(), now).0;
+    (
+        legacy_idx.map(|i| threads[i].tid),
+        percpu_idx.map(|i| threads[i].tid),
+    )
+}
+
+/// Build the per-CPU candidate index ordering for [`test_pick_equivalence`] from
+/// an explicit list of runnable Tids (modelling `RQS[cpu]`'s membership),
+/// applying the SAME rotation-distance ordering `percpu_candidate_indices` uses.
+fn test_percpu_candidates(
+    threads: &[proc::Thread],
+    current_idx: usize,
+    runnable_tids: &[proc::Tid],
+) -> alloc::vec::Vec<usize> {
+    let len = threads.len();
+    let mut out: alloc::vec::Vec<usize> = alloc::vec::Vec::new();
+    for &tid in runnable_tids {
+        if let Some(idx) = threads.iter().position(|t| t.tid == tid) {
+            // Exclude the current thread's own index: the legacy rotation walk
+            // is `i in 1..len` (it never re-considers `current_idx`), so the
+            // per-CPU candidate set must drop it too for an exact match.
+            if idx != current_idx % len {
+                out.push(idx);
+            }
+        }
+    }
+    out.sort_by_key(|&idx| (idx + len - (current_idx % len)) % len);
+    out
+}
+
+/// Build the candidate index sequence for [`select_next`] from this CPU's
+/// per-CPU runqueue (Perf P2 phase 2b), in the picker's rotation order.
+///
+/// The runqueue stores Tids; this maps each queued Tid back to its table index
+/// and orders the result by rotation distance from `current_idx`
+/// (`(idx - current_idx) mod len`), so the candidate order — and therefore
+/// `select_next`'s strict-max tie-break — matches the legacy `(current_idx + i)
+/// % len` walk exactly.  Threads in the runqueue whose Tid is not found in the
+/// table (a transient the next maintain pass will reconcile) are skipped.
+///
+/// On SMP=1 the runqueue's non-idle pool equals the legacy eligible non-idle
+/// Ready set, so the candidate set is identical; this function only re-imposes
+/// the rotation ORDER on it.
+#[cfg(feature = "sched-pick-xcheck")]
+fn percpu_candidate_indices(
+    threads: &[proc::Thread],
+    cpu: usize,
+    current_idx: usize,
+) -> alloc::vec::Vec<usize> {
+    let len = threads.len();
+    // Snapshot the queued Tids for this CPU under the runqueue lock.
+    let tids = percpu::rq_snapshot_tids(cpu);
+    let mut out: alloc::vec::Vec<usize> = alloc::vec::Vec::with_capacity(tids.len());
+    for tid in tids {
+        if let Some(idx) = threads.iter().position(|t| t.tid == tid) {
+            // Exclude the current thread's own index: the legacy rotation walk
+            // is `i in 1..len` and never re-considers `current_idx`.
+            if idx != current_idx % len {
+                out.push(idx);
+            }
+        }
+    }
+    // Order by rotation distance from current_idx so the tie-break matches the
+    // legacy `(current_idx + i) % len` walk.
+    out.sort_by_key(|&idx| (idx + len - (current_idx % len)) % len);
+    out
+}
+
 /// Schedule the next thread to run.
 ///
 /// This is the core scheduling function. It:
@@ -1488,218 +1726,74 @@ was_emergency_4k={}",
         // `mirror_maintain`).  See `sched::percpu`.
         percpu::mirror_maintain(&mut threads);
 
-        // Find the highest-priority Ready thread with affinity awareness.
-        // Scoring: priority * 4 + affinity_bonus (0-2)
-        //   - affinity match (pinned to this cpu): +2
-        //   - last_cpu match (cache-warm): +1
-        //   - no match: +0
+        // ── Pick the next thread (Perf P2 phase 2b: per-CPU runqueue pick) ────
+        // The selection is computed by `select_next`, the verbatim extraction of
+        // the legacy in-line picker, driven over a candidate-index sequence.
         //
-        // INVARIANT (POSIX SCHED_OTHER hardening): a CPU MUST NEVER pick an idle thread
-        // while a non-idle Ready peer exists.  POSIX SCHED_OTHER and sched(7)
-        // both require that the per-CPU idle thread is the "schedule of last
-        // resort" — it runs ONLY when no runnable user/kernel work is
-        // available on this CPU.  The picker enforces this by doing TWO
-        // passes: pass 1 considers only NON-IDLE Ready peers; pass 2 (run
-        // only when pass 1 finds nothing) considers idle peers.  Without the
-        // two-pass split, a per-CPU idle thread with `cpu_affinity=Some(cpu)`
-        // (+2 affinity bonus) could in principle tie or beat a worker that
-        // has never run on this CPU (+0) at sufficiently low worker priority,
-        // even though SCHED_OTHER says workers must always win.  The two-pass
-        // structure also reads as a clear invariant in the source, making
-        // future picker edits less likely to regress.
-        let mut best_idx: Option<usize> = None;
-        let mut best_score: u16 = 0;
-        let mut idle_best_idx: Option<usize> = None;
-        let mut idle_best_score: u16 = 0;
-        // Anti-starvation backstop: the schedulable-on-this-CPU Ready peer that
-        // is the most OVERDUE relative to its own force-deadline.  Each thread
-        // has a per-thread deadline — `STARVE_FORCE_TICKS_BSP` for the BSP poll
-        // reactor (TID 0), `STARVE_FORCE_TICKS` for everyone else — so the
-        // latency-critical reactor becomes force-eligible far sooner than a
-        // compute-bound worker.  We track the candidate with the largest
-        // `wait_age - deadline` (its overdue margin); a non-overdue thread has a
-        // negative margin and is never the force pick.  `force_age` records that
-        // winner's raw wait age for the diagnostic.  Idle threads (TID >=
-        // 0x1000) are deliberately excluded — they are the schedule-of-last-
-        // resort and must never pre-empt real work via the backstop.
-        let mut force_idx: Option<usize> = None;
-        let mut force_age: u64 = 0;
-        // Most-overdue margin seen so far (`wait_age - deadline`), as a signed
-        // value.  `i64::MIN` means "no overdue candidate yet".
-        let mut force_margin: i64 = i64::MIN;
-        // Run-queue depth: count of non-idle Ready peers considered this pass.
-        // Published lock-free into READY_DEPTH after the scan so disk-I/O
-        // waiters (and the wait-amplification histogram) can read, without the
-        // table lock, how many runnable peers a yield competes against.
-        let mut ready_peers: u64 = 0;
+        //   * LEGACY path — candidates are the full rotated `1..len` walk
+        //     (`(current_idx + i) % len`).  This is byte-identical to the old
+        //     inline loop and remains the AUTHORITATIVE result.
+        //   * PER-CPU path — candidates come from this CPU's runqueue
+        //     (`RQS[cpu]`, the Ready-eligible set), re-ordered by rotation
+        //     distance.  On SMP=1 the runqueue's non-idle pool equals the legacy
+        //     eligible set, so this selects the identical thread while iterating
+        //     only Ready threads (not the whole table).
+        //
+        // For now the LEGACY result drives the switch; on a debug build the
+        // per-CPU result is cross-checked against it and any divergence is
+        // recorded (`percpu::PICK_DIVERGENCES`) — the live half of the
+        // Test-648 pick-equivalence proof.  Once the cross-check has soaked,
+        // a later step promotes the per-CPU result to authoritative.  The
+        // `select_next` call publishes READY_DEPTH and drives the force
+        // backstop exactly as the inline picker did.
+        // Legacy candidate sequence: the rotated `(current_idx + i) % len` walk,
+        // as a lazy iterator — NO heap allocation on the pick hot path (the
+        // iterator is consumed in place by `select_next`).
+        let (legacy_idx, _ready_peers) =
+            select_next(&threads, cpu, (1..len).map(|i| (current_idx + i) % len), now);
 
-        for i in 1..len {
-            let idx = (current_idx + i) % len;
-            let t = &threads[idx];
-            if t.state != ThreadState::Ready {
-                continue;
-            }
-            if t.tid < 0x1000 {
-                // Non-idle Ready peer (idle threads are TID >= 0x1000); count it
-                // toward the run-queue depth before any affinity/validity skips
-                // so the metric reflects total runnable work, not just
-                // this-CPU-eligible work.
-                ready_peers += 1;
-            }
-            // Skip threads whose kernel RSP is not yet valid — another CPU is
-            // mid-way through switching them out and hasn't saved the new RSP
-            // yet.  Picking up such a thread would resume it from a stale RSP.
-            if !t.ctx_rsp_valid.load(core::sync::atomic::Ordering::Acquire) {
-                continue;
-            }
-            // Skip threads pinned to a different CPU.
-            if let Some(aff) = t.cpu_affinity {
-                if aff != cpu {
-                    continue;
-                }
-            }
-
-            // Run-queue wait age (ticks) for the anti-starvation terms.  The
-            // lazy-stamp pass above guarantees `ready_since_tick != 0` for any
-            // Ready thread by the time we get here; `saturating_sub` keeps the
-            // arithmetic safe against a non-monotone read in the unlikely event
-            // a stamp landed a tick ahead of `now`.
-            let wait_age = now.saturating_sub(t.ready_since_tick);
-            let is_idle_thread = t.tid >= 0x1000;
-
-            let mut score = (t.priority as u16) * 4;
-            if t.cpu_affinity == Some(cpu) {
-                score += 2; // Pinned to us — strong preference.
-            } else if t.last_cpu == cpu {
-                score += 1; // Ran here last — cache-warm preference.
-            }
-            // Anti-starvation aging: a Ready thread that has been passed over
-            // long enough earns an escalating, capped score bonus so it cannot
-            // be out-competed forever by continuously wake-boosted peers.  Only
-            // real (non-idle) work ages — idle threads must stay the schedule
-            // of last resort.  See `wait_age_bonus` / `STARVE_*`.
-            if !is_idle_thread {
-                score += wait_age_bonus(wait_age);
-                // Track the most-overdue real Ready peer for the hard backstop,
-                // each measured against its OWN force-deadline.  The BSP poll
-                // reactor (TID 0) gets the tighter `STARVE_FORCE_TICKS_BSP`
-                // deadline so it becomes force-eligible (and wins the most-
-                // overdue comparison) well before any worker on the coarse
-                // global ceiling.  `margin = wait_age - deadline`; positive ⇒
-                // overdue.  Comparing margins (not raw ages) means a worker that
-                // has waited longer in absolute terms does not steal the force
-                // pick from a reactor that is further past its own deadline.
-                let deadline: u64 = if t.tid == 0 {
-                    STARVE_FORCE_TICKS_BSP
-                } else {
-                    STARVE_FORCE_TICKS
-                };
-                let margin = wait_age as i64 - deadline as i64;
-                if margin > force_margin {
-                    force_margin = margin;
-                    force_age = wait_age;
-                    force_idx = Some(idx);
-                }
-            }
-
-            // AP idle threads (TID >= 0x1000 + apic_id, see
-            // arch/x86_64/apic.rs) are constructed at PRIORITY_IDLE with
-            // a per-CPU affinity pin and exist purely to give the AP a
-            // Ready thread to context-switch through when no other work
-            // is available.  Route them to the idle pool so non-idle
-            // peers always win pass 1.
-            //
-            // NB: the BSP idle thread (TID 0) is intentionally NOT in
-            // the idle pool.  TID 0 doubles as the BSP main thread that
-            // drives the kernel's polling loops (net::poll, x11::poll,
-            // gui::compositor::compose, the firefox-test heartbeat,
-            // etc.) — work that must keep advancing under load.
-            // Classifying TID 0 as idle would starve those polls when
-            // user threads saturate CPU 0, hanging the network stack and
-            // the framebuffer compositor.  Treat TID 0 as an ordinary
-            // PRIORITY_IDLE peer that loses to higher-priority workers
-            // on score alone but never falls into the schedule-of-last-
-            // resort bucket.  (`is_idle_thread` is computed once above, before
-            // the anti-starvation aging block.)
-            if is_idle_thread {
-                if score > idle_best_score || idle_best_idx.is_none() {
-                    idle_best_idx = Some(idx);
-                    idle_best_score = score;
-                }
-            } else if score > best_score || best_idx.is_none() {
-                best_idx = Some(idx);
-                best_score = score;
+        // Per-CPU pick + equivalence cross-check.  Kept on debug builds only so
+        // the release hot path pays nothing; the candidate build re-reads the
+        // runqueue (one leaf lock) and a short position map.  Note: `select_next`
+        // has already published READY_DEPTH and bumped the force counter for the
+        // legacy pass, so the cross-check must NOT call it a second time (that
+        // would double-count the force diagnostic) — instead it re-evaluates
+        // with a side-effect-free selector.
+        // The per-CPU pick omits the idle pool (the mirror excludes tid>=0x1000),
+        // which is equivalent to the legacy pick ONLY on SMP=1, where no idle
+        // thread is eligible on the BSP. Gate the cross-check on SMP=1 so it
+        // cannot false-fire on a (not-yet-supported) SMP=2 boot, and SAMPLE it
+        // (every Nth pass) so its per-sample heap allocation never dominates the
+        // pick hot path.  The authoritative legacy pick above consumes a lazy
+        // `(1..len).map(..)` iterator and allocates nothing; this sampled
+        // cross-check is the only allocating path, and only when this feature is
+        // explicitly enabled.
+        #[cfg(feature = "sched-pick-xcheck")]
+        if crate::arch::x86_64::apic::cpu_count() == 1
+            && percpu::pick_xcheck_sample_due()
+        {
+            let cand = percpu_candidate_indices(&threads, cpu as usize, current_idx);
+            let percpu_idx =
+                select_next_no_side_effects(&threads, cpu, cand.iter().copied(), now);
+            // Compare by TID (table indices differ between the two candidate
+            // orderings only when they select different threads; comparing the
+            // selected TID is the equivalence property that matters).
+            let legacy_tid = legacy_idx.map(|i| threads[i].tid);
+            let percpu_tid = percpu_idx.map(|i| threads[i].tid);
+            if legacy_tid != percpu_tid {
+                percpu::note_pick_divergence();
+                crate::serial_println!(
+                    "[SCHED/P2] PICK DIVERGENCE cpu={} legacy_tid={:?} percpu_tid={:?} \
+                     now={} current_tid={:?}",
+                    cpu, legacy_tid, percpu_tid, now,
+                    threads.get(current_idx).map(|t| t.tid),
+                );
             }
         }
 
-        // Publish the run-queue depth observed this pass (lock-free, relaxed —
-        // a diagnostic estimate, not a synchronisation point).
-        READY_DEPTH.store(ready_peers, Ordering::Relaxed);
-
-        // Pass 2 fallback: if no non-idle Ready peer is available on this
-        // CPU, fall through to the idle thread.  This preserves the
-        // existing "no work → HLT" behaviour for genuinely idle systems
-        // while honouring the invariant above when work IS available.
-        if best_idx.is_none() {
-            best_idx = idle_best_idx;
-            best_score = idle_best_score;
-        }
-
-        // Anti-starvation backstop (hard guarantee): if the most-overdue real
-        // Ready peer on this CPU is at or past its OWN force-deadline
-        // (`force_margin >= 0` ⇔ `wait_age >= deadline`), force-select it this
-        // tick regardless of score.
-        //
-        // For ordinary same-base-priority contention the widened, escalating
-        // `wait_age_bonus` (cap = full base-priority span) wins the score
-        // comparison first, so a starved worker is rescued by score-aging well
-        // before this backstop — the backstop is then a true last resort.
-        //
-        // For the `PRIORITY_IDLE` BSP poll reactor (TID 0) the split is
-        // deliberate: its score-bonus can only overtake a continuously
-        // wake-boosted `PRIORITY_NORMAL` storm after ~100 ticks of aging, so the
-        // reactor is intentionally rescued by its TIGHT per-thread deadline
-        // (`STARVE_FORCE_TICKS_BSP`, ~80 ms) — the score path is its backstop's
-        // backstop, not its primary rescue.  The tight deadline is exactly the
-        // virtual-deadline treatment a fair scheduler gives an early-yielding
-        // latency-sensitive task, bounding the net/x11/compositor pump's
-        // run-queue latency at ~80 ms instead of the ~1 s global ceiling that
-        // applies to compute-bound workers.
-        //
-        // This mirrors the balance-set-manager force-boost of starved Ready
-        // threads and the virtual-deadline guarantee that the longest-overdue
-        // runnable task eventually runs.  Only fires when the forced thread is
-        // not already the best pick (avoids a redundant override) and is
-        // non-idle (tracked that way in `force_idx`).
-        if force_margin >= 0 {
-            if let Some(fidx) = force_idx {
-                if best_idx != Some(fidx) {
-                    let n = SCHED_STARVE_FORCE_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    let deadline: u64 = if threads[fidx].tid == 0 {
-                        STARVE_FORCE_TICKS_BSP
-                    } else {
-                        STARVE_FORCE_TICKS
-                    };
-                    // Throttle the diagnostic: emit the first force-select and
-                    // then one per `STARVE_FORCE_LOG_EVERY` thereafter.  Under
-                    // sustained contention (e.g. a busy poll thread that
-                    // re-starves ~1 Hz) an unthrottled line per event would
-                    // flood the serial log; the monotone counter
-                    // (`starve_force_count()`) stays the authoritative rate
-                    // source for tooling.
-                    if n == 0 || n % STARVE_FORCE_LOG_EVERY == 0 {
-                        crate::serial_println!(
-                            "[SCHED/STARVE] force-select tid={} (waited {} ticks >= {}) on cpu={} \
-                             total={} — anti-starvation backstop",
-                            threads[fidx].tid, force_age, deadline, cpu, n + 1,
-                        );
-                    }
-                    best_idx = Some(fidx);
-                    best_score = (threads[fidx].priority as u16) * 4;
-                }
-            }
-        }
-        let _ = best_score; // suppress "unused" if later edits drop the read
+        // The legacy result is authoritative this phase; the `match` below
+        // consumes it to perform the context switch.
+        let best_idx = legacy_idx;
 
         match best_idx {
             Some(idx) => {

--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -365,6 +365,30 @@ pub fn rq_nr_running(cpu: usize) -> u32 {
     RQS[cpu].lock().nr_running()
 }
 
+/// Snapshot every Tid queued on CPU `cpu`'s runqueue, in bitmap order (highest
+/// priority level first, FIFO within a level).  Used by the phase-2b per-CPU
+/// pick to build its candidate set; the caller re-imposes the picker's rotation
+/// order on the result, so the per-level order here is not load-bearing for the
+/// selection (only membership is).  Takes the single `RQS[cpu]` leaf lock.
+#[cfg(feature = "sched-pick-xcheck")]
+pub fn rq_snapshot_tids(cpu: usize) -> alloc::vec::Vec<Tid> {
+    if cpu >= MAX_CPUS {
+        return alloc::vec::Vec::new();
+    }
+    let g = RQS[cpu].lock();
+    let mut out = alloc::vec::Vec::with_capacity(g.nr_running() as usize);
+    // Highest priority level first (mirrors `highest()`'s bitmap walk).
+    let mut bm = g.bitmap;
+    while bm != 0 {
+        let p = 31 - bm.leading_zeros() as usize;
+        for &tid in g.lists[p].iter() {
+            out.push(tid);
+        }
+        bm &= !(1u32 << p);
+    }
+    out
+}
+
 /// Decide which CPU's runqueue a Ready thread is mirrored onto.
 ///
 /// Phase-1 placement policy (mirror only): a thread is mirrored onto the CPU it
@@ -438,6 +462,43 @@ pub static MIRROR_AUDIT_FAILURES: AtomicU32 = AtomicU32::new(0);
 /// Snapshot of [`MIRROR_AUDIT_FAILURES`].
 pub fn mirror_audit_failures() -> u32 {
     MIRROR_AUDIT_FAILURES.load(Ordering::Relaxed)
+}
+
+/// Cumulative count of live scheduling passes (debug builds only) where the
+/// phase-2b per-CPU runqueue pick selected a DIFFERENT thread than the
+/// authoritative legacy table-scan pick.  Must stay zero on SMP=1: a non-zero
+/// value means the per-CPU candidate derivation or the `select_next`
+/// equivalence diverged from the legacy picker for some live ready-set the
+/// Test-648 constructed cases did not cover.  This is the live half of the
+/// pick-equivalence proof; the legacy result remains authoritative, so a
+/// divergence is observed, logged and counted but never acted on.  Monotone
+/// since boot; surfaced via [`pick_divergences`].
+pub static PICK_DIVERGENCES: AtomicU32 = AtomicU32::new(0);
+
+/// Record one live per-CPU-vs-legacy pick divergence (phase-2b cross-check).
+#[inline]
+pub fn note_pick_divergence() {
+    PICK_DIVERGENCES.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Sample gate for the live pick cross-check: returns `true` once every
+/// `PICK_XCHECK_SAMPLE` scheduling passes, so the cross-check's per-sample heap
+/// allocation and O(n) candidate rebuild never dominate the pick hot path.  The
+/// cross-check still catches a divergence within `PICK_XCHECK_SAMPLE` passes of
+/// it first arising, which is ample for a live equivalence soak.
+#[cfg(feature = "sched-pick-xcheck")]
+pub fn pick_xcheck_sample_due() -> bool {
+    /// Sample one pick in this many passes.  Power of two so the modulo is a
+    /// mask; large enough that the cross-check is a negligible amortized cost.
+    const PICK_XCHECK_SAMPLE: u32 = 256;
+    static PASS: AtomicU32 = AtomicU32::new(0);
+    let n = PASS.fetch_add(1, Ordering::Relaxed);
+    n % PICK_XCHECK_SAMPLE == 0
+}
+
+/// Snapshot of [`PICK_DIVERGENCES`].
+pub fn pick_divergences() -> u32 {
+    PICK_DIVERGENCES.load(Ordering::Relaxed)
 }
 
 /// The runqueue membership a thread SHOULD have right now: `None` if it is not a

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1310,6 +1310,8 @@ pub fn run() -> ! {
         if test_645_percpu_runqueue_scaffold() { passed += 1; }
         total += 1;
         if test_647_percpu_incremental_equiv() { passed += 1; }
+        total += 1;
+        if test_648_percpu_pick_equivalence() { passed += 1; }
     }
 
     // ── Test 105: Heap guard pages — PTE verification ─────────────────────
@@ -49249,6 +49251,264 @@ fn test_647_percpu_incremental_equiv() -> bool {
     test_println!("  incremental maintenance == full rebuild across 5 transition phases \
 (membership+placement+bitmap+nr_running); order-divergence confirmed; \
 injected-divergence detected");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 648: per-CPU pick == legacy table-scan pick (PICK-EQUIVALENCE PROOF) ─
+//
+// Perf P2 phase 2b switches the schedule() pick to read this CPU's per-CPU
+// runqueue. The mandatory safety gate is that the per-CPU pick selects the
+// IDENTICAL thread the legacy global table-scan picker would, on SMP=1. This
+// test drives BOTH selectors (via `sched::test_pick_equivalence`, which runs the
+// shared side-effect-free selection core over a legacy rotated-`1..len`
+// candidate ordering AND the per-CPU runqueue-derived ordering) over a battery
+// of constructed ready-sets and asserts they pick the same TID every time.
+//
+// The scenarios deliberately span every term the equivalence depends on:
+//   * plain priority ordering (highest priority wins),
+//   * affinity / last_cpu bonus tie-breaks within a priority level,
+//   * wait-age score-aging that flips a SMALL base-priority gap BEFORE the force
+//     deadline (the partial-inversion crossover — the case a naive base-priority
+//     bucket would miss),
+//   * the global force-deadline (STARVE_FORCE_TICKS) backstop,
+//   * the TID-0 BSP-reactor TIGHT force-deadline (STARVE_FORCE_TICKS_BSP),
+//   * a ctx_rsp_valid==false Ready thread (must be skipped by BOTH),
+//   * idle-pool-only fallback (no non-idle eligible peer),
+//   * rotation tie-break dependence on current_idx.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_648_percpu_pick_equivalence() -> bool {
+    use crate::proc::{Thread, Tid, ThreadState};
+    use crate::proc::{PRIORITY_IDLE, PRIORITY_NORMAL, PRIORITY_HIGH};
+    const NAME: &str = "[SCHED/P2] per-CPU pick == legacy pick (Test 648, equivalence proof)";
+    test_header!(NAME);
+
+    let bsp_deadline = crate::sched::bsp_force_deadline_ticks();      // 8
+    let global_deadline = crate::sched::global_force_deadline_ticks(); // 100
+
+    // Build a Ready candidate Thread on CPU `cpu_pin`/`last_cpu`, aged
+    // `now - ready_since`, optional ctx_rsp_valid.
+    fn mk(tid: Tid, prio: u8, affinity: Option<u8>, last_cpu: u8,
+          ready_since: u64, ctx_valid: bool) -> Thread {
+        let mut t = Thread::new_for_test(prio);
+        t.tid = tid;
+        t.state = ThreadState::Ready;
+        t.cpu_affinity = affinity;
+        t.last_cpu = last_cpu;
+        t.ready_since_tick = ready_since;
+        t.ctx_rsp_valid = alloc::boxed::Box::new(
+            core::sync::atomic::AtomicBool::new(ctx_valid));
+        t
+    }
+    // A non-candidate placeholder for table index 0 (the "current" thread the
+    // rotation walk starts AFTER). Blocked so it is never selectable.
+    fn cur() -> Thread {
+        let mut t = Thread::new_for_test(PRIORITY_NORMAL);
+        t.tid = 5000;
+        t.state = ThreadState::Blocked;
+        t.cpu_affinity = None;
+        t
+    }
+
+    // Run one scenario: build the table (index 0 = current), the runnable-tid
+    // list (the per-CPU runqueue membership = all Ready non-idle + idle tids on
+    // this CPU, exactly what mirror_maintain would mirror), then assert both
+    // selectors agree. `cpu`/`current_idx`/`now` parameterise the pick.
+    fn run(scenario: &str, threads: &[Thread], cpu: u8, current_idx: usize,
+           now: u64) -> Result<Option<Tid>, alloc::string::String> {
+        // Model the REAL per-CPU runqueue membership EXACTLY as the live mirror
+        // does (`percpu::is_mirrored_runnable`): a Ready thread that is NON-IDLE
+        // (`tid < 0x1000`), placed on this CPU. The mirror deliberately EXCLUDES
+        // idle-class threads (tid >= 0x1000) and includes ctx_rsp_valid==false
+        // rows (the skip is re-applied at pick time, not at mirror time). This is
+        // the candidate set `percpu_candidate_indices` derives at runtime; using
+        // it here proves the per-CPU pick == legacy pick over the ACTUAL runqueue
+        // contents, not an idealised superset.
+        //
+        // On SMP=1 this is sound because the only tid>=0x1000 threads are AP idle
+        // threads pinned to APs; none are eligible on the BSP, so the legacy
+        // idle-pool fallback selects nothing the per-CPU path (which omits idle)
+        // would miss. Scenario 7 documents this invariant explicitly.
+        let runnable: alloc::vec::Vec<Tid> = threads.iter()
+            .filter(|t| t.state == ThreadState::Ready && t.tid < 0x1000)
+            .filter(|t| t.cpu_affinity.is_none() || t.cpu_affinity == Some(cpu))
+            .map(|t| t.tid)
+            .collect();
+        let (legacy, percpu) =
+            crate::sched::test_pick_equivalence(threads, cpu, current_idx, now, &runnable);
+        if legacy != percpu {
+            return Err(alloc::format!(
+                "{}: legacy={:?} percpu={:?}", scenario, legacy, percpu));
+        }
+        Ok(legacy)
+    }
+
+    // ── Scenario 1: plain priority ordering — HIGH beats NORMAL beats IDLE. ──
+    {
+        let threads = [cur(),
+            mk(101, PRIORITY_NORMAL, None, 0, 0, true),
+            mk(102, PRIORITY_HIGH,   None, 0, 0, true),
+            mk(103, PRIORITY_IDLE,   None, 0, 0, true)];
+        match run("s1-priority", &threads, 0, 0, 0) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel != Some(102) {
+                test_fail!(NAME, "s1: selected {:?} expected Some(102) HIGH", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 2: affinity tie-break within a priority level. Two NORMAL
+    // peers; 105 is pinned to cpu0 (+2) vs 104 last_cpu=cpu0 (+1). 105 wins. ──
+    {
+        let threads = [cur(),
+            mk(104, PRIORITY_NORMAL, None, 0, 0, true),       // last_cpu match: +1
+            mk(105, PRIORITY_NORMAL, Some(0), 0, 0, true)];   // affinity pin: +2
+        match run("s2-affinity", &threads, 0, 0, 0) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel != Some(105) {
+                test_fail!(NAME, "s2: selected {:?} expected Some(105)", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 3: PARTIAL-INVERSION via score-aging BEFORE the force
+    // deadline. 106 = NORMAL+last_cpu (score 8*4+1=33). 107 = NORMAL but aged so
+    // wait_age_bonus pushes it above 106 without yet hitting the global force
+    // deadline. At age 40: bonus = (40-20)/2+1 = 11 → score 32+11 = 43 > 33,
+    // and 40 < global_deadline(100) so NO force fires — pure score-aging flip.
+    // This is the case a base-priority-only bucket would get WRONG. ──
+    {
+        let now = 40u64;
+        let threads = [cur(),
+            mk(106, PRIORITY_NORMAL, None, 0, now, true),      // age 0, score 33
+            mk(107, PRIORITY_NORMAL, None, 9, now - 40, true)];// age 40, score 43
+        // sanity: age 40 is below the global force deadline so the flip is by
+        // score-aging, not by the backstop.
+        if now >= global_deadline {
+            test_fail!(NAME, "s3 precondition: now {} >= global_deadline {}", now, global_deadline);
+            return false;
+        }
+        match run("s3-aging-crossover", &threads, 0, 0, now) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel != Some(107) {
+                test_fail!(NAME, "s3: selected {:?} expected Some(107) (aged flip)", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 4: global force-deadline backstop. A low-priority (IDLE-base
+    // but non-idle tid) worker aged past global_deadline force-wins over a fresh
+    // HIGH peer, regardless of score. ──
+    {
+        let now = global_deadline + 5;
+        let threads = [cur(),
+            mk(108, PRIORITY_HIGH, None, 9, now, true),                 // fresh, high score
+            mk(109, PRIORITY_NORMAL, None, 9, now - (global_deadline + 1), true)]; // overdue
+        match run("s4-global-force", &threads, 0, 0, now) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel != Some(109) {
+                test_fail!(NAME, "s4: selected {:?} expected Some(109) (force backstop)", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 5: TID-0 BSP reactor TIGHT deadline. TID 0 (PRIORITY_IDLE
+    // base) aged just past bsp_deadline(8) but well below global_deadline(100)
+    // force-wins over a fresh NORMAL worker — the reactor's tight deadline fires
+    // long before the worker's coarse one. ──
+    {
+        let now = bsp_deadline + 2; // 10
+        let threads = [cur(),
+            mk(110, PRIORITY_NORMAL, None, 9, now, true),       // fresh worker
+            mk(0,   PRIORITY_IDLE,   None, 0, now - (bsp_deadline + 1), true)]; // TID0 overdue vs 8
+        match run("s5-bsp-reactor-force", &threads, 0, 0, now) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel != Some(0) {
+                test_fail!(NAME, "s5: selected {:?} expected Some(0) (BSP tight deadline)", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 6: ctx_rsp_valid==false Ready thread is skipped by BOTH. The
+    // higher-priority HIGH thread is mid-switch (ctx invalid) so the NORMAL
+    // thread wins. ──
+    {
+        let threads = [cur(),
+            mk(111, PRIORITY_NORMAL, None, 0, 0, true),
+            mk(112, PRIORITY_HIGH,   None, 0, 0, false)]; // mid-switch: skipped
+        match run("s6-ctx-invalid-skip", &threads, 0, 0, 0) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel != Some(111) {
+                test_fail!(NAME, "s6: selected {:?} expected Some(111) (HIGH skipped)", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 7: SMP=1 idle invariant. On SMP=1 the only tid>=0x1000 (idle-
+    // class) threads are AP idle threads pinned to APs — NONE are eligible on
+    // the BSP (cpu 0). So a system whose only Ready peers are idle threads
+    // pinned to OTHER CPUs has an empty cpu-0 candidate set: BOTH the legacy
+    // picker (idle pool filtered by affinity!=0) and the per-CPU path (mirror
+    // excludes idle entirely) select None. This is the invariant that makes the
+    // per-CPU path's omission of the idle pool sound on SMP=1 — there is no
+    // BSP-eligible idle thread for it to miss. (Were an idle thread ever pinned
+    // to the BSP, the legacy fallback would pick it while the per-CPU path would
+    // not; that case does not arise on SMP=1, which is the supported regime.) ──
+    {
+        let threads = [cur(),
+            mk(0x1000, PRIORITY_IDLE, Some(1), 0, 0, true),   // AP-1 idle: aff!=0
+            mk(0x1001, PRIORITY_IDLE, Some(2), 0, 0, true)];  // AP-2 idle: aff!=0
+        match run("s7-idle-other-cpu", &threads, 0, 0, 0) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel.is_some() {
+                test_fail!(NAME, "s7: BSP picked an AP-pinned idle thread {:?}", sel);
+                return false;
+            }
+        }
+    }
+
+    // ── Scenario 8: rotation tie-break dependence on current_idx. Three equal
+    // NORMAL peers with NO affinity/aging differences — the winner is purely the
+    // first in rotation order from current_idx. Sweep current_idx and confirm
+    // the per-CPU ordering (rotation-distance sorted) matches the legacy walk at
+    // every starting point. ──
+    {
+        let threads = [
+            mk(200, PRIORITY_NORMAL, None, 9, 0, true),
+            mk(201, PRIORITY_NORMAL, None, 9, 0, true),
+            mk(202, PRIORITY_NORMAL, None, 9, 0, true),
+            mk(203, PRIORITY_NORMAL, None, 9, 0, true)];
+        for ci in 0..threads.len() {
+            match run("s8-rotation", &threads, 0, ci, 0) {
+                Err(e) => { test_fail!(NAME, "{} (current_idx={})", e, ci); return false; }
+                Ok(_) => {}
+            }
+        }
+    }
+
+    // ── Scenario 9: empty ready-set. No Ready peer at all → both select None. ──
+    {
+        let threads = [cur(),
+            { let mut t = Thread::new_for_test(PRIORITY_NORMAL); t.tid = 300;
+              t.state = ThreadState::Blocked; t.cpu_affinity = None; t }];
+        match run("s9-empty", &threads, 0, 0, 0) {
+            Err(e) => { test_fail!(NAME, "{}", e); return false; }
+            Ok(sel) => if sel.is_some() {
+                test_fail!(NAME, "s9: empty ready-set selected {:?}", sel);
+                return false;
+            }
+        }
+    }
+
+    test_println!("  per-CPU pick == legacy pick across 9 scenarios \
+(priority/affinity/aging-crossover/global-force/BSP-reactor-force/ctx-skip/\
+idle-fallback/rotation-sweep/empty) — equivalence proof GREEN");
     test_pass!(NAME);
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -49329,6 +49329,20 @@ fn test_648_percpu_pick_equivalence() -> bool {
         // threads pinned to APs; none are eligible on the BSP, so the legacy
         // idle-pool fallback selects nothing the per-CPU path (which omits idle)
         // would miss. Scenario 7 documents this invariant explicitly.
+        //
+        // COVERAGE NOTE (SMP=1-specific): this models per-CPU membership as
+        // *affinity-eligibility* (affinity None or Some(cpu)). The LIVE path
+        // places a thread on `RQS[target_cpu_for(affinity, last_cpu)]` =
+        // `affinity` if set else `last_cpu`. These two models coincide ONLY
+        // because on SMP=1 `last_cpu` is always 0 (no AP ever stamps a nonzero
+        // last_cpu, and no nonzero-affinity / idle-class BSP-eligible thread is
+        // ever created). When SMP=2 is promoted, an `affinity=None,
+        // last_cpu!=cpu` thread would be routed to RQS[last_cpu] (omitted from
+        // RQS[0]) while the legacy whole-table walk would still score it on
+        // cpu0 — so this test's membership model must be revisited then (the
+        // live `sched-pick-xcheck` cross-check catches any such real divergence
+        // regardless). Phase 2b's authoritative pick remains the legacy walk, so
+        // this gap is inert here.
         let runnable: alloc::vec::Vec<Tid> = threads.iter()
             .filter(|t| t.state == ThreadState::Ready && t.tid < 0x1000)
             .filter(|t| t.cpu_affinity.is_none() || t.cpu_affinity == Some(cpu))


### PR DESCRIPTION
## Perf P2 phase 2b — switch the pick onto the per-CPU runqueue (with a deterministic equivalence proof)

> **Stacked on #644 (phase 2a).** This branch includes the two 2a commits; they collapse once #644 merges. Review the top commit `c0873801` for the 2b delta.

SMP=1 stays the default and behaviour is preserved — the authoritative path is the **verbatim** legacy evaluator over the **verbatim** legacy candidate sequence.

### Design: shared verbatim evaluation, not an approximation
The legacy picker's scoring + two-pass split + force-backstop is extracted **verbatim** into a pure `select_next_core(threads, cpu, candidate-iterator, now)`. BOTH the legacy and per-CPU paths call it; they differ only in the candidate sequence:
- **legacy** — the rotated `(current_idx + i) % len` walk, passed as a **lazy iterator** (the authoritative hot path allocates nothing);
- **per-CPU** — the candidate set derived from `RQS[cpu]` (the phase-2a mirror's Ready-eligible set), re-ordered by rotation distance and with `current_idx` excluded, so the strict-max first-in-rotation tie-break matches the legacy `1..len` walk exactly.

Equivalence reduces to *"the runqueue yields the same candidate set as the table walk"*, which holds on SMP=1.

### #634 aging/force reproduced term-for-term
Because `select_next_core` **is** the original code, every #634 term is reproduced identically: `score = priority*4 + aff_bonus + wait_age_bonus(age)` (so the partial-inversion score-aging crossover that flips *before* the force deadline is exact), and the per-thread force deadline (`STARVE_FORCE_TICKS_BSP=8` for TID-0, `STARVE_FORCE_TICKS=100` otherwise) with most-overdue (`margin = age - deadline`) force-select. The `min_deadline` the design called for is this per-candidate margin; an O(1) min-of-`(ready_since+deadline)` gate to *skip* the margin scan is a pure perf refinement that doesn't change the result and is deferred to phase 3. The correctness argument here is "byte-identical evaluator", which is strictly stronger than "equivalent approximation".

### Pick-equivalence proof (mandatory gate) — Test 648
Drives BOTH selectors over **9 constructed ready-sets** and asserts identical TID: priority; affinity/last_cpu tie-break; **score-aging partial-inversion crossover before the deadline**; global force backstop; **TID-0 reactor tight deadline**; `ctx_rsp_valid==false` mid-switch skip; SMP=1 idle invariant; **rotation-tie-break sweep over every current_idx**; empty set. The rotation sweep **caught a real bug** during development (per-CPU set initially included `current_idx`, which the legacy `1..len` walk excludes) — fixed; equivalence now holds. **Test 648 PASSES.**

Optional **live cross-check** (feature `sched-pick-xcheck`, off by default, *not* in test-mode because it allocates): computes the per-CPU pick alongside the authoritative legacy pick on a sampled subset of live passes and counts divergences. A boot with it enabled ran **84s clean, 0 divergences** (force-select events firing).

### Authoritative result
The **legacy** result still drives the switch this phase; the per-CPU result is *proven equal* but not yet promoted. Promotion + the O(1) min_deadline force-gate + enqueue/wakeup-target/reschedule-IPI are phase 3.

### Guardrails
SMP=1 default + behaviour-preserving; no new lock; mm/tlb untouched; SMP=2 not enabled.

Local `test-mode` boot: 228 pass / 2 fail (645/647/648 all pass; the 2 failures are pre-existing missing-binary data-disk artifacts). Default + `firefox-test-core` builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)