### PR TITLE
sched: load-aware wakeup-target selection at the wake edge (Perf P2 phase 3b)

### DIFF
--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -425,15 +425,19 @@ pub fn rq_nr_running(cpu: usize) -> u32 {
     RQS[cpu].lock().nr_running()
 }
 
-/// Decide which CPU's runqueue a Ready thread is mirrored onto.
+/// Decide which CPU's runqueue a Ready thread is mirrored onto — the
+/// DETERMINISTIC placement read from the thread's stored fields.
 ///
-/// Phase-1 placement policy (mirror only): a thread is mirrored onto the CPU it
-/// would run on under the *current* picker's affinity preference — its
-/// `cpu_affinity` pin if set, else the CPU it last ran on (`last_cpu`).  This
-/// keeps the mirror's membership aligned with where the authoritative picker
-/// would place the thread, so the membership cross-check is meaningful.  The
-/// real wakeup-target selection (`select_task_rq`-equivalent, with
-/// least-loaded fallback) arrives in phase 3.
+/// A pinned thread (`cpu_affinity = Some(a)`) is always placed on its pinned
+/// CPU; an unpinned thread is placed on the CPU it last ran on (`last_cpu`).
+/// This is a pure function of stored state, so the per-CPU runqueue placement is
+/// stable across maintenance passes (it does NOT recompute a load-aware target
+/// each pass, which would thrash a thread between runqueues as load fluctuates).
+///
+/// The LOAD-AWARE wakeup-target choice (`select_task_rq`-equivalent) is made
+/// once, at the moment a thread enters the runnable set (its wake edge), by
+/// [`select_wake_target`]; the result is baked into `last_cpu` so that this
+/// deterministic placement then follows it.  See [`mirror_maintain`].
 #[inline]
 fn target_cpu_for(affinity: Option<u8>, last_cpu: u8) -> usize {
     let c = match affinity {
@@ -441,6 +445,87 @@ fn target_cpu_for(affinity: Option<u8>, last_cpu: u8) -> usize {
         None => last_cpu as usize,
     };
     if c < MAX_CPUS { c } else { 0 }
+}
+
+/// A runqueue at or above this `nr_running` is considered "overloaded" for the
+/// purpose of the cache-warm wakeup heuristic: a waking thread prefers its
+/// cache-warm `last_cpu`, but only while that CPU is not already this deep, in
+/// which case it falls back to the least-loaded runqueue.  One in-flight task
+/// plus one waking task is fine (depth 1 is not overloaded); the threshold
+/// trips when the cache-warm CPU already has a backlog the waker would queue
+/// behind.
+const RQ_OVERLOAD_THRESHOLD: u32 = 2;
+
+/// Pure wakeup-target decision (`select_task_rq`-equivalent), parameterised by a
+/// runqueue-load reader so it can run either over the live `RQS` locks (external
+/// callers) or over guards already held (the `mirror_maintain` wake edge,
+/// which must not re-lock the leaf spinlock).  `ncpus` is the number of online
+/// CPUs.  Decision order:
+///
+///   1. **Hard affinity pin** — if `affinity = Some(a)` the thread MUST run on
+///      CPU `a` (a pin is a correctness constraint, not a hint); return it.
+///   2. **Cache-warm `last_cpu`** — if that CPU's runqueue is not overloaded
+///      (`load < RQ_OVERLOAD_THRESHOLD`), keep the thread there to reuse its
+///      warm cache footprint.
+///   3. **Least-loaded runqueue** — otherwise spread the load: the CPU with the
+///      smallest load, ties broken toward the warm CPU (then the lowest index)
+///      so a tie never forces a gratuitous migration.
+///
+/// On a uniprocessor (`ncpus <= 1`) every candidate resolves to CPU 0.
+#[inline]
+fn wake_target_with_loads(
+    affinity: Option<u8>,
+    last_cpu: u8,
+    ncpus: usize,
+    load: impl Fn(usize) -> u32,
+) -> u8 {
+    // 1. Hard pin wins unconditionally.
+    if let Some(a) = affinity {
+        return if (a as usize) < MAX_CPUS { a } else { 0 };
+    }
+    if ncpus <= 1 {
+        return 0; // uniprocessor: only CPU 0 exists
+    }
+    let warm = (last_cpu as usize).min(ncpus - 1);
+    // 2. Cache-warm CPU if not overloaded.
+    let warm_load = load(warm);
+    if warm_load < RQ_OVERLOAD_THRESHOLD {
+        return warm as u8;
+    }
+    // 3. Least-loaded runqueue (prefer the warm CPU on a tie → no needless move).
+    let mut best_cpu = warm;
+    let mut best_load = warm_load;
+    for cpu in 0..ncpus {
+        let l = load(cpu);
+        if l < best_load {
+            best_load = l;
+            best_cpu = cpu;
+        }
+    }
+    best_cpu as u8
+}
+
+/// Choose the CPU a waking thread should be enqueued on
+/// (`select_task_rq`-equivalent) by reading the LIVE runqueue loads.
+///
+/// O(MAX_CPUS) and allocation-free; it briefly takes each runqueue's leaf lock
+/// to read `nr_running` (ascending index order, the documented order — and the
+/// caller must therefore NOT already hold any `RQS` lock).  On a uniprocessor
+/// (`cpu_count() == 1`) this returns 0, so the wakeup target is a no-op and
+/// SMP=1 is unchanged.  See [`wake_target_with_loads`] for the decision logic.
+pub fn select_wake_target(affinity: Option<u8>, last_cpu: u8) -> u8 {
+    let ncpus = crate::arch::x86_64::apic::cpu_count().min(MAX_CPUS as u32) as usize;
+    wake_target_with_loads(affinity, last_cpu, ncpus, |cpu| RQS[cpu].lock().nr_running())
+}
+
+/// Test-facing replica of the wakeup-target decision over caller-supplied loads
+/// (Test 650), so the >1-CPU routing can be proven without spinning real
+/// threads or touching the live `RQS`.  Identical logic to the live paths.
+#[doc(hidden)]
+pub fn test_wake_target(affinity: Option<u8>, last_cpu: u8, loads: &[u32]) -> u8 {
+    wake_target_with_loads(affinity, last_cpu, loads.len(), |cpu| {
+        loads.get(cpu).copied().unwrap_or(0)
+    })
 }
 
 /// True iff `t` belongs to the mirrored non-idle runnable pool: a `Ready`
@@ -593,11 +678,45 @@ pub fn mirror_maintain(threads: &mut [proc::Thread]) {
         guards[cpu] = Some(RQS[cpu].lock());
     }
 
-    // ── O(Δ) incremental delta ───────────────────────────────────────────────
+    // Number of online CPUs, computed once for this pass (drives the wakeup
+    // target spread below).  `cpu_count()==1` ⇒ every target is CPU 0.
+    let ncpus = crate::arch::x86_64::apic::cpu_count().min(MAX_CPUS as u32) as usize;
+
+    // ── O(Δ) incremental delta + wakeup-target selection ─────────────────────
     // For each thread, reconcile its recorded slot with its desired slot.  A
     // thread whose membership is unchanged (same cpu+prio, or still absent)
     // performs no queue mutation.
+    //
+    // WAKEUP TARGET (Perf P2 phase 3b): the moment a thread ENTERS the
+    // mirrored-runnable set — its `mirror_slot` was `None` and it is now a Ready
+    // non-idle thread — is the wake edge as the scheduler observes it (covering
+    // every Blocked/New→Ready wake site without instrumenting each one
+    // individually, the same centralisation `ready_since_tick` stamping uses).
+    // At that edge, for an UNPINNED thread, choose the load-aware target CPU
+    // (`select_task_rq`-equivalent) and bake it into `last_cpu` so the
+    // deterministic `desired_slot` placement then follows it.  A pinned thread's
+    // target is its pin, handled by `desired_slot`/`target_cpu_for` directly.
+    // The load read uses the guards already held (re-locking `RQS` here would
+    // deadlock the leaf spinlock), so the spread sees this pass's live counts.
     for t in threads.iter_mut() {
+        // Wake-edge target assignment (before computing `want`, which reads
+        // `last_cpu`).  Only on the None→runnable transition, only for unpinned
+        // threads, and only when there is more than one CPU to spread across.
+        if ncpus > 1
+            && t.mirror_slot.is_none()
+            && t.cpu_affinity.is_none()
+            && is_mirrored_runnable(t)
+        {
+            // Read loads from the guards already held (re-locking RQS here would
+            // deadlock the leaf spinlock); shares the decision with the live and
+            // test paths via `wake_target_with_loads`.
+            let target = wake_target_with_loads(
+                t.cpu_affinity, t.last_cpu, ncpus,
+                |cpu| guards[cpu].as_ref().map_or(0, |g| g.nr_running()),
+            );
+            t.last_cpu = target;
+        }
+
         let have = t.mirror_slot;
         let want = desired_slot(t);
         if have == want {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1314,6 +1314,8 @@ pub fn run() -> ! {
         if test_648_percpu_pick_equivalence() { passed += 1; }
         total += 1;
         if test_649_percpu_min_deadline_gate() { passed += 1; }
+        total += 1;
+        if test_650_percpu_wake_target() { passed += 1; }
     }
 
     // ── Test 105: Heap guard pages — PTE verification ─────────────────────
@@ -49696,6 +49698,124 @@ fn test_649_percpu_min_deadline_gate() -> bool {
     test_println!("  PerCpuRq::overdue(now) == per-candidate force gate \
 (max(wait_age-deadline)>=0) across A-empty/B-single/C-bsp-tight/D-mixed/E-late-tid0 \
 with full now-sweep — min_deadline refinement is force-decision-preserving GREEN");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 650: wakeup-target selection (select_task_rq-equivalent) ───────────
+//
+// Phase 3b adds load-aware wakeup-target routing for the >1-CPU case — the gap
+// the Phase 2b reviewer flagged: Test 648 modelled per-CPU membership as
+// affinity-ELIGIBILITY, which only coincided with the real target
+// (`affinity` else `last_cpu`) because `last_cpu ≡ 0` on SMP=1.  This test
+// exercises `percpu::test_wake_target` (the exact replica of the live decision,
+// over caller-supplied runqueue loads) for the multi-CPU routing the live path
+// takes, proving the three-tier order: hard pin → cache-warm last_cpu (unless
+// overloaded) → least-loaded fallback.
+fn test_650_percpu_wake_target() -> bool {
+    use crate::sched::percpu::test_wake_target as wt;
+    const NAME: &str = "[SCHED/P2] wakeup-target select_task_rq-equiv (Test 650)";
+    test_header!(NAME);
+
+    // Tier 1 — hard affinity pin wins regardless of load. A thread pinned to
+    // cpu 3 routes to cpu 3 even though cpu 3 is the busiest runqueue.
+    {
+        let loads = [0u32, 0, 0, 9];
+        let got = wt(Some(3), 0, &loads);
+        if got != 3 {
+            test_fail!(NAME, "tier1 pin: got cpu {} expected 3 (hard pin overrides load)", got);
+            return false;
+        }
+    }
+
+    // Tier 2 — cache-warm last_cpu kept while not overloaded (load < 2). last_cpu
+    // = 2 with load 1 → stays on 2 even though cpu 0 is emptier (warmth wins
+    // below the overload threshold, avoiding a needless migration).
+    {
+        let loads = [0u32, 5, 1, 5];
+        let got = wt(None, 2, &loads);
+        if got != 2 {
+            test_fail!(NAME, "tier2 warm: got cpu {} expected 2 (warm cpu not overloaded)", got);
+            return false;
+        }
+    }
+
+    // Tier 2/3 boundary — the warm cpu sitting at EXACTLY RQ_OVERLOAD_THRESHOLD
+    // (2) is "overloaded" (the test is `load < THRESHOLD`, strict), so it falls
+    // through to tier 3 and migrates to the strictly-emptier cpu 0. The
+    // one-below case (load 1) is the tier-2 keep above; this pins the `<` vs
+    // `<=` choice so the threshold semantics cannot silently drift.
+    {
+        let loads = [0u32, 5, 2, 5]; // warm cpu 2 at exactly the threshold
+        let got = wt(None, 2, &loads);
+        if got != 0 {
+            test_fail!(NAME, "boundary: warm at threshold got cpu {} expected 0 (migrate, not keep)", got);
+            return false;
+        }
+    }
+
+    // Tier 3 — warm cpu overloaded (load >= 2) → fall back to least-loaded. warm
+    // = cpu 1 (load 4) is overloaded; cpu 3 has the smallest load (0) → route there.
+    {
+        let loads = [3u32, 4, 2, 0];
+        let got = wt(None, 1, &loads);
+        if got != 3 {
+            test_fail!(NAME, "tier3 spread: got cpu {} expected 3 (least-loaded)", got);
+            return false;
+        }
+    }
+
+    // Tier 3 tie-break — when the warm cpu is overloaded AND is itself one of the
+    // minima after the scan, prefer it over an equal-load lower-index peer (no
+    // gratuitous migration). warm = cpu 2 (load 2, overloaded); cpus 2 and 3 tie
+    // at the minimum 2, but cpu 0 has load 2 as well — the warm cpu 2 is kept.
+    {
+        let loads = [2u32, 5, 2, 2];
+        let got = wt(None, 2, &loads);
+        if got != 2 {
+            test_fail!(NAME, "tier3 tie: got cpu {} expected 2 (warm kept on tie)", got);
+            return false;
+        }
+    }
+
+    // Tier 3 strict minimum below the warm cpu — warm cpu 3 overloaded (load 4),
+    // a strictly-smaller load exists at cpu 1 (load 1) → migrate to cpu 1.
+    {
+        let loads = [3u32, 1, 5, 4];
+        let got = wt(None, 3, &loads);
+        if got != 1 {
+            test_fail!(NAME, "tier3 strict-min: got cpu {} expected 1", got);
+            return false;
+        }
+    }
+
+    // Uniprocessor — a single CPU collapses every choice to cpu 0 (SMP=1
+    // no-op invariant: the wakeup target never changes placement on one CPU).
+    {
+        let loads = [7u32]; // ncpus == 1, even a "busy" sole CPU
+        if wt(None, 0, &loads) != 0 {
+            test_fail!(NAME, "uniproc: unpinned routed off cpu 0");
+            return false;
+        }
+        if wt(Some(0), 0, &loads) != 0 {
+            test_fail!(NAME, "uniproc: pinned routed off cpu 0");
+            return false;
+        }
+    }
+
+    // last_cpu out of range is clamped to the top CPU, not an OOB index.
+    {
+        let loads = [0u32, 0]; // 2 CPUs
+        let got = wt(None, 9, &loads); // last_cpu 9 → clamp to cpu 1
+        if got != 1 {
+            test_fail!(NAME, "clamp: got cpu {} expected 1 (last_cpu clamped to top)", got);
+            return false;
+        }
+    }
+
+    test_println!("  select_task_rq-equiv routing: hard-pin / warm-last_cpu / \
+least-loaded-fallback / warm-tie-keep / strict-min-migrate / uniproc-collapse / \
+last_cpu-clamp — >1-CPU target logic correct (closes the Phase 2b coverage nit) GREEN");
     test_pass!(NAME);
     true
 }


### PR DESCRIPTION
## Perf P2 #19 — Phase 3b (stacked on #646)

> **Base:** this PR targets the Phase 3a branch (#646), not master, so the diff shows only 3b. After #646 merges I will rebase onto master.

Adds the `select_task_rq`-equivalent wakeup-target choice and resolves the Phase 2b reviewer nit (Test 648 modelled per-CPU membership as affinity-eligibility, which only coincided with the real target because `last_cpu ≡ 0` on SMP=1).

### Target decision (`wake_target_with_loads`, three tiers)
1. **Hard affinity pin** — `cpu_affinity = Some(a)` is a correctness constraint → CPU `a`.
2. **Cache-warm `last_cpu`** — kept while that runqueue is not overloaded (`nr_running < RQ_OVERLOAD_THRESHOLD = 2`).
3. **Least-loaded runqueue** — otherwise spread; ties broken toward the warm CPU (then lowest index) so a tie never forces a gratuitous migration.

The pure decision is parameterised by a load-reader so one implementation serves three callers without duplication:
- `select_wake_target` — reads live `RQS` loads (for external wake-path callers holding no rq lock).
- `mirror_maintain`'s wake edge — reads the guards it **already holds** (re-locking the leaf spinlock would self-deadlock).
- `test_wake_target` — caller-supplied loads (Test 650).

### Driving it at the wake
Rather than instrument each of the ~18 scattered Blocked/New→Ready wake sites, the target is chosen the moment a thread ENTERS the mirrored-runnable set (`mirror_slot` was `None`, now Ready non-idle) inside `mirror_maintain` — the same centralisation `ready_since_tick` stamping uses: one auditable spot, race-free under THREAD_TABLE, impossible for a new wake site to forget. The chosen CPU is baked into `last_cpu` so the **deterministic** `desired_slot` placement follows it (it does NOT recompute a load-aware target each pass — that would thrash a thread between runqueues).

### Behaviour-preserving on SMP=1
Every tier is gated on `ncpus > 1`; on a uniprocessor the wake edge is skipped, `last_cpu` is untouched, and placement is bit-for-bit identical to Phase 3a.

### Evidence
- **Test 650** (new) exercises the >1-CPU routing: hard pin / warm-cpu-kept / least-loaded fallback / warm-on-tie / strict-min migrate / uniprocessor collapse / last_cpu clamp — closing the Phase 2b coverage nit.
- Tests 645/647/648/649 still GREEN; 3b boot: 227 pass, **0 non-allowlisted failures**, 0 bugchecks.

No new locks; lock order unchanged (THREAD_TABLE → RQS[cpu] leaf; the wake edge reads loads through guards already held in ascending order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
