### PR TITLE
arch/sched: self-heal the SMP dead-CPU LAPIC-timer wedge (de-facto single core)

### DIFF
--- a/kernel/src/arch/x86_64/apic.rs
+++ b/kernel/src/arch/x86_64/apic.rs
@@ -409,11 +409,22 @@ pub fn lapic_eoi() {
 /// a single core there is no sibling, so the BSP idle path calls this to keep
 /// the timer — and therefore the scheduler tick and `TICK_COUNT` — alive.
 ///
-/// Writing the initial-count register restarts the down-counter (Intel SDM
-/// Vol. 3A §11.5.4), so a wedged periodic timer begins firing again. The LVT
-/// rewrite is belt-and-suspenders in case the vector/mode bits were lost.
-/// Safe to call from any context: it touches only this CPU's LAPIC MMIO and
-/// the value written is the immutable boot-time calibration. No-op before
+/// Re-programs the timer with the FULL from-scratch sequence rather than just
+/// rewriting the initial count: the divide-configuration register, then a fresh
+/// (masked → unmasked) LVT, then the initial count. This mirrors the boot-time
+/// `init_timer` path exactly. A minimal re-arm that rewrites only the LVT and
+/// initial-count register was observed NOT to resume injection on a wedged KVM
+/// LAPIC (the timer-ISR counter stayed frozen): per Intel SDM Vol. 3A §11.5.1
+/// the down-counter is derived through the divide-configuration register, and a
+/// counter wedged with a stale/indeterminate divisor latch does not re-latch on
+/// a bare initial-count write. The order is mandated by §11.5.4 — the LVT mode
+/// and divide configuration must be established *before* the initial-count write
+/// that (re)starts the count. The mask→unmask of LVT bit 16 forces the hardware
+/// to re-evaluate the timer LVT from a known-masked state so the subsequent
+/// initial-count write re-latches cleanly.
+///
+/// Safe to call from any context: it touches only this CPU's LAPIC MMIO and the
+/// values written are the immutable boot-time calibration. No-op before
 /// calibration (period == 0) or if the APIC is disabled.
 pub fn rearm_timer() {
     if !is_enabled() {
@@ -423,7 +434,18 @@ pub fn rearm_timer() {
     if period == 0 {
         return;
     }
-    lapic_write(LAPIC_TIMER_LVT, 0x20000 | 32); // periodic | vector 32
+    // Stop the counter and mask the timer LVT first, so the re-program starts
+    // from a known-quiescent state (Intel SDM Vol. 3A §11.5.4: an initial-count
+    // write of 0 stops the timer).
+    lapic_write(LAPIC_TIMER_INIT, 0);
+    lapic_write(LAPIC_TIMER_LVT, 0x10000 | 32); // masked (bit 16) | vector 32
+    // Re-establish the divide configuration (divide by 16) — the step a bare
+    // LVT+init re-arm omitted (§11.5.1: the count is clocked through this
+    // register; a stale divisor latch prevents a wedged counter from resuming).
+    lapic_write(LAPIC_TIMER_DIVIDE, 0x03);
+    // Fresh periodic, unmasked LVT, then start the counter with the calibrated
+    // period — order per §11.5.4 (mode/divide before the count that starts it).
+    lapic_write(LAPIC_TIMER_LVT, 0x20000 | 32); // periodic (bit 17) | vector 32
     lapic_write(LAPIC_TIMER_INIT, period);
 }
 
@@ -1202,19 +1224,22 @@ pub extern "C" fn ap_rust_entry() -> ! {
     #[cfg(feature = "w215-diag")]
     crate::arch::x86_64::debug_reg::apply_pending_to_this_cpu();
 
-    // Enable interrupts and enter scheduling loop.
-    // After each timer interrupt wakes this AP from HLT, check if a reschedule
-    // is needed and switch to any ready thread.  check_reschedule() is safe
-    // here because the idle thread holds no locks.
-    unsafe { core::arch::asm!("sti", options(nomem, nostack)); }
-
+    // Enter the scheduling loop.  Each iteration waits one quantum, then checks
+    // for a pending reschedule and switches to any ready thread.
+    // check_reschedule() is safe here because the idle thread holds no locks.
     loop {
-        // HLT until next timer interrupt.
-        unsafe { core::arch::asm!("hlt", options(nomem, nostack)); }
+        // Wait one quantum.  `sched_wait_quantum` halts (`sti; hlt; cli`) while
+        // this AP's LAPIC timer is delivering, but if this AP's own periodic
+        // timer wedges (KVM injection suppression) it re-arms the local LAPIC
+        // and spins (`sti; pause; cli`) instead — so an idle AP whose timer dies
+        // re-arms ITSELF rather than depending solely on a sibling's cross-CPU
+        // poke to limp it along (Intel SDM Vol. 3A §11.5.4).  This keeps the
+        // dead-timer self-heal symmetric between the BSP reactor and idle APs.
+        crate::arch::x86_64::irq::sched_wait_quantum();
         // Reset watchdog: the AP idle thread is alive and responding to interrupts.
         // Without this, the watchdog fires on idle CPUs with no threads to schedule.
         crate::arch::x86_64::irq::reset_watchdog_counter();
-        // Check for pending reschedule after being woken by the timer ISR.
+        // Check for pending reschedule after waking.
         crate::sched::check_reschedule();
     }
 }

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -189,6 +189,17 @@ pub fn init() {
             #[cfg(feature = "w215-diag")]
             IDT[0xF1].set_handler(fix(super::irq::irq_w215_dr_sync_handler as *const () as u64), kernel_cs, 0, 0);
 
+            // Cross-CPU timer-wake IPI (vector 0xF3).  A CPU whose LAPIC timer
+            // is delivering sends this to a sibling whose timer ISR went stale
+            // (its LAPIC periodic timer wedged — Intel SDM Vol. 3A §11.5.4) so
+            // the sibling cannot sleep through a dead timer.  Production SMP
+            // self-heal (not diagnostic), so it is always wired.  Vector 0xF2 is
+            // reserved for the reschedule IPI (Perf P2 phase 3c); this poke uses
+            // 0xF3 so the two cross-CPU paths stay independent.  The handler
+            // records the poke, drives a scheduler tick and EOIs; the wake is
+            // effected by the interrupt itself resuming the target from `hlt`.
+            IDT[0xF3].set_handler(fix(super::irq::irq_timer_wake_handler as *const () as u64), kernel_cs, 0, 0);
+
             // Syscall interrupt (vector 0x80) — for int 0x80 style syscalls
             IDT[0x80].set_handler(fix(isr_syscall_int80 as *const () as u64), kernel_cs, 0, 3);
 

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -37,6 +37,18 @@ pub fn reset_watchdog_counter() {
     WATCHDOG_COUNTER[cpu as usize].store(0, Ordering::Relaxed);
 }
 
+/// Read the watchdog counter of an arbitrary CPU (diagnostic-only).  A high
+/// value means that CPU has gone many ticks without a context switch (its
+/// current thread is CPU-bound or it is wedged); a low value means it is
+/// switching threads regularly.  Out-of-range index returns 0.
+pub fn watchdog_counter(cpu: usize) -> u32 {
+    if cpu < MAX_CPUS {
+        WATCHDOG_COUNTER[cpu].load(Ordering::Relaxed)
+    } else {
+        0
+    }
+}
+
 /// PIC I/O ports.
 const PIC1_COMMAND: u16 = 0x20;
 const PIC1_DATA: u16 = 0x21;
@@ -320,6 +332,241 @@ pub static TIMER_REARM_COUNT: AtomicU64 = AtomicU64::new(0);
 /// tick. Used to rate-limit the software tick to ~`TICK_HZ`.
 static LAST_SOFT_TICK: AtomicU64 = AtomicU64::new(0);
 
+/// Per-CPU LAPIC-timer liveness snapshot for [`cpu_timer_live`].  Element
+/// `[cpu]` stores `(last_seen_isr_count, tsc_at_observation)`: the value of
+/// `TIMER_ISR_PER_CPU[cpu]` the last time this CPU checked its own liveness,
+/// and the TSC at that check.  A check whose ISR count has not advanced AND
+/// whose TSC has moved more than the liveness window ⇒ this CPU's own periodic
+/// timer has wedged (KVM LAPIC-injection suppression, Intel SDM Vol. 3A
+/// §11.5.4 — a wedged periodic counter does not spontaneously resume).
+///
+/// Why per-CPU and not the global `TICK_COUNT`: `TICK_COUNT` is TSC-derived and
+/// CAS-published by *whichever* online CPU's timer ISR runs (see `timer_tick`),
+/// so on SMP a single healthy sibling keeps the GLOBAL clock fresh and masks a
+/// LOCALLY dead timer.  A CPU whose own LAPIC has stopped delivering would see
+/// `TICK_COUNT` tracking the TSC perfectly (the sibling maintains it) and wrongly
+/// conclude its timer is healthy — then `hlt` into a sleep its own dead timer
+/// never wakes.  This per-CPU ISR-advancement check is immune to that masking.
+static CPU_TIMER_SEEN: [(AtomicU64, AtomicU64); super::apic::MAX_CPUS] =
+    [const { (AtomicU64::new(0), AtomicU64::new(0)) }; super::apic::MAX_CPUS];
+
+/// Per-CPU sticky "this CPU's LAPIC periodic timer is currently dead" flag.
+///
+/// Set the moment [`cpu_timer_live`] first declares the local timer wedged;
+/// cleared only when the local `TIMER_ISR_PER_CPU` count is observed to advance
+/// (a real recovery — the timer started delivering again).  It is sticky on
+/// purpose: a wedged KVM LAPIC does not reliably resume after a re-arm (Intel
+/// SDM Vol. 3A §11.5.4 restarts the *counter*, but KVM may keep suppressing
+/// *injection*), so without stickiness `cpu_timer_live` would optimistically
+/// report "healthy" again as soon as it re-anchored the TSC inside the liveness
+/// window — and the caller would `hlt` straight back into the dead-timer trap,
+/// only to be woken ~one window later by the sibling poke (a low-duty-cycle
+/// limp at ~1/window Hz instead of a CPU that keeps running).  Sticky-dead makes
+/// a CPU with a wedged timer SPIN continuously (self-clocked off the TSC) until
+/// the hardware timer genuinely recovers.
+static CPU_TIMER_DEAD: [core::sync::atomic::AtomicBool; super::apic::MAX_CPUS] =
+    [const { core::sync::atomic::AtomicBool::new(false) }; super::apic::MAX_CPUS];
+
+/// True iff `cpu`'s LAPIC periodic timer has been declared dead and not yet
+/// recovered.  Diagnostic accessor for the kdb `cpu-state` survey.
+pub fn cpu_timer_dead(cpu: usize) -> bool {
+    if cpu < super::apic::MAX_CPUS {
+        CPU_TIMER_DEAD[cpu].load(Ordering::Relaxed)
+    } else {
+        false
+    }
+}
+
+/// Count of per-CPU LAPIC re-arms triggered by [`cpu_timer_live`] detecting a
+/// locally-wedged timer.  Diagnostic-only; a non-zero value on the BSP under
+/// SMP is the signature of the dead-CPU0-LAPIC self-heal firing.
+pub static PERCPU_TIMER_REARM_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Snapshot of [`PERCPU_TIMER_REARM_COUNT`].
+pub fn percpu_timer_rearm_count() -> u64 {
+    PERCPU_TIMER_REARM_COUNT.load(Ordering::Relaxed)
+}
+
+/// IPI vector for the cross-CPU timer-wake poke (see `timer_wake_interrupt`).
+/// 0xF0 = TLB shootdown, 0xF1 = W215 DR-sync, 0xF2 reserved for the reschedule
+/// IPI (Perf P2 phase 3c), 0xF3 = timer-wake.  A distinct vector per IPI class
+/// keeps each handler body independent (Intel SDM Vol. 3A §10.6.1).
+pub const TIMER_WAKE_VECTOR: u8 = 0xF3;
+
+/// Number of timer-wake IPIs SENT (a live CPU poked a sibling whose timer ISR
+/// went stale) and RECEIVED.  Diagnostic-only; a non-zero `sent` under SMP is
+/// the signature of the dead-sibling-LAPIC self-heal driving the poke.
+pub static TIMER_WAKE_IPI_SENT: AtomicU64 = AtomicU64::new(0);
+pub static TIMER_WAKE_IPI_RECEIVED: AtomicU64 = AtomicU64::new(0);
+
+/// Per-CPU `(last_seen_isr, tsc_at_observation)` used by the timer-ISR sender to
+/// detect a sibling whose own timer ISR has gone stale.  Distinct from
+/// `CPU_TIMER_SEEN` (which the SELF-check in `cpu_timer_live` owns) so the two
+/// liveness observers never clobber each other's anchors.
+static SIBLING_TIMER_SEEN: [(AtomicU64, AtomicU64); super::apic::MAX_CPUS] =
+    [const { (AtomicU64::new(0), AtomicU64::new(0)) }; super::apic::MAX_CPUS];
+
+/// Snapshots of the timer-wake IPI counters.
+pub fn timer_wake_ipi_sent() -> u64 { TIMER_WAKE_IPI_SENT.load(Ordering::Relaxed) }
+pub fn timer_wake_ipi_received() -> u64 { TIMER_WAKE_IPI_RECEIVED.load(Ordering::Relaxed) }
+
+/// From a LIVE CPU's timer ISR, poke any sibling whose own timer ISR has gone
+/// stale (its LAPIC periodic timer wedged) so it cannot sleep through a dead
+/// timer.  Called once per local tick by `timer_tick`; cheap (a handful of
+/// atomic reads, an IPI only when a sibling is actually found stale).
+///
+/// "Stale" = the sibling's `TIMER_ISR_PER_CPU` count has not advanced across a
+/// `STALE_WINDOW`-tick wall-clock window (TSC-measured against our own publish
+/// rate).  We re-anchor the observation whenever the sibling advances OR we
+/// poke it, so a single sibling is poked at most ~once per window rather than
+/// every tick — enough to keep it awake and re-arming without an IPI storm.
+fn poke_stale_siblings(this_cpu: usize, tsc_now: u64, tsc_per_tick: u64) {
+    /// Wall-clock window (100 Hz ticks) a sibling's timer may be silent before
+    /// we consider it wedged and poke it.  ~20 ticks (≈200 ms) is well clear of
+    /// normal ISR jitter yet keeps the reactor's worst-case stall short.
+    const STALE_WINDOW: u64 = 20;
+    if tsc_per_tick == 0 {
+        return;
+    }
+    let ncpus = (super::apic::cpu_count() as usize).min(super::apic::MAX_CPUS);
+    for cpu in 0..ncpus {
+        if cpu == this_cpu {
+            continue;
+        }
+        let isr_now = TIMER_ISR_PER_CPU[cpu].load(Ordering::Relaxed);
+        let seen_isr = SIBLING_TIMER_SEEN[cpu].0.load(Ordering::Relaxed);
+        let seen_tsc = SIBLING_TIMER_SEEN[cpu].1.load(Ordering::Relaxed);
+
+        // First observation, or the sibling's timer advanced: it is alive.
+        // Re-anchor and move on.
+        if seen_tsc == 0 || isr_now != seen_isr {
+            SIBLING_TIMER_SEEN[cpu].0.store(isr_now, Ordering::Relaxed);
+            SIBLING_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+            continue;
+        }
+
+        // Sibling's timer ISR has not advanced since our last observation.  How
+        // long (wall-clock) has it been silent?
+        let silent = tsc_now.wrapping_sub(seen_tsc) / tsc_per_tick;
+        if silent < STALE_WINDOW {
+            continue;
+        }
+
+        // Wedged sibling: poke it.  Any interrupt resumes it from `hlt`; its own
+        // idle/wait path then re-arms its LAPIC (cpu_timer_live).  Re-anchor the
+        // TSC (keep the stale ISR count) so we re-poke at most once per window.
+        super::apic::send_ipi(cpu as u8, TIMER_WAKE_VECTOR);
+        TIMER_WAKE_IPI_SENT.fetch_add(1, Ordering::Relaxed);
+        SIBLING_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+    }
+}
+
+/// Check whether the CALLING CPU's own LAPIC periodic timer is still
+/// delivering interrupts, and re-arm it if it has wedged.
+///
+/// Returns `true` if this CPU's `TIMER_ISR_PER_CPU` count has advanced since the
+/// previous check (or the liveness window has not yet elapsed) — i.e. the local
+/// timer is delivering.  Returns `false` if the local timer has gone silent for
+/// more than `window_ticks` of wall-clock (TSC-measured) while this CPU was
+/// active; in that case it has already issued a `rearm_timer()` for the local
+/// LAPIC (Intel SDM Vol. 3A §11.5.4 — rewriting the LVT + initial-count restarts
+/// a wedged periodic counter) so the caller MUST NOT `hlt` (a dead timer offers
+/// no wakeup) but should spin and re-drive cooperative work.
+///
+/// Unlike the global `TICK_COUNT`-vs-TSC check this is per-CPU and so detects a
+/// locally-dead timer even when a healthy sibling keeps the global clock fresh
+/// (the SMP "de-facto single core" failure mode).  Cheap: two atomic reads, an
+/// `rdtsc`, and — only when wedged — a re-arm.  `window_ticks` is in 100 Hz
+/// ticks; ~10 (≈100 ms) tolerates normal ISR jitter without false re-arms.
+pub fn cpu_timer_live(window_ticks: u64) -> bool {
+    let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        return true; // pre-calibration — the timer is not expected yet
+    }
+    let cpu = super::apic::cpu_index();
+    if cpu >= super::apic::MAX_CPUS {
+        return true;
+    }
+    let isr_now = TIMER_ISR_PER_CPU[cpu].load(Ordering::Relaxed);
+    let tsc_now = rdtsc();
+    let seen_isr = CPU_TIMER_SEEN[cpu].0.load(Ordering::Relaxed);
+    let seen_tsc = CPU_TIMER_SEEN[cpu].1.load(Ordering::Relaxed);
+
+    // First observation for this CPU, or the local timer advanced since the
+    // last check: it is alive.  Record the new snapshot, CLEAR any sticky-dead
+    // flag (a real recovery), and report healthy.
+    if seen_tsc == 0 || isr_now != seen_isr {
+        CPU_TIMER_SEEN[cpu].0.store(isr_now, Ordering::Relaxed);
+        CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+        CPU_TIMER_DEAD[cpu].store(false, Ordering::Relaxed);
+        return true;
+    }
+
+    // ISR count unchanged since the last check.  If this CPU's timer was already
+    // declared dead, it STAYS dead until the ISR actually advances (handled
+    // above) — report unhealthy without re-arming again, so the caller keeps
+    // spinning (self-clocked) rather than oscillating hlt↔wake at ~1/window Hz.
+    if CPU_TIMER_DEAD[cpu].load(Ordering::Relaxed) {
+        return false;
+    }
+
+    // Not yet declared dead: how long has the local timer been silent (in
+    // wall-clock ticks)?
+    let silent_ticks = tsc_now.wrapping_sub(seen_tsc) / tsc_per_tick;
+    if silent_ticks < window_ticks {
+        return true; // within tolerance — not yet considered wedged
+    }
+
+    // The local LAPIC periodic timer has been silent for > window_ticks while
+    // this CPU is active: declare it wedged (sticky).  Re-arm it once (rewrites
+    // LVT + initial-count — harmless and revives a merely-masked timer) and
+    // report unhealthy so the caller spins rather than hlt-ing into a sleep the
+    // dead timer cannot end.  The sticky flag keeps it false on every subsequent
+    // call until the ISR genuinely advances.
+    CPU_TIMER_DEAD[cpu].store(true, Ordering::Relaxed);
+    super::apic::rearm_timer();
+    PERCPU_TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
+    CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+    false
+}
+
+/// Idle-wait one quantum from a scheduler wait-path: sleep until the next wake,
+/// but never sleep into a dead-timer trap.
+///
+/// The scheduler's "no Ready peer" wait paths classically execute
+/// `sti; hlt; cli`, relying on this CPU's periodic LAPIC timer to wake it ~10 ms
+/// later so it can re-run the picker.  On SMP a CPU whose LAPIC periodic timer
+/// has wedged (KVM injection suppression — see [`cpu_timer_live`]) has no such
+/// wakeup: a blind `hlt` there sleeps until an unrelated asynchronous IRQ
+/// happens to land on the CPU, which under a single-vCPU-affine IRQ routing is
+/// effectively never — the CPU drops out of scheduling entirely (the
+/// "de-facto single core" failure mode).
+///
+/// This helper makes the wait timer-fault-tolerant:
+///   * **Timer live** → `sti; hlt; cli` as before (cheap; the timer wakes us).
+///   * **Timer wedged** → [`cpu_timer_live`] has already re-armed the local
+///     LAPIC; drive a software scheduler tick from the TSC and spin briefly
+///     (`sti; pause; cli`) WITHOUT halting, so the CPU re-enters the picker on
+///     its own clock and any peer that becomes Ready is picked up promptly.
+///
+/// The `sti` window in both arms lets a pending IRQ/IPI (including a TLB
+/// shootdown IPI, #643, or a future reschedule IPI, #648) land before the CPU
+/// blocks/spins, so this composes with the cross-CPU IPI paths unchanged.
+#[inline]
+pub fn sched_wait_quantum() {
+    if cpu_timer_live(10) {
+        // Healthy local timer: halt until the next tick (or any wake).  The
+        // STI shadow guarantees `hlt` executes before any pending interrupt,
+        // so this is race-free.
+        unsafe { core::arch::asm!("sti; hlt; cli", options(nomem, nostack)); }
+    } else {
+        // Local timer wedged (already re-armed by cpu_timer_live).  Keep the
+        // run queue moving on the TSC clock and spin instead of halting.
+        crate::sched::timer_tick_schedule();
+        unsafe { core::arch::asm!("sti; pause; cli", options(nomem, nostack)); }
+    }
+}
+
 /// Cooperative idle step for the BSP polling/soak loop.
 ///
 /// Returns `true` if the LAPIC timer is healthy (the caller may safely `hlt`
@@ -365,8 +612,25 @@ pub fn idle_tick(slack: u64) -> bool {
     let tsc_floor = elapsed / tsc_per_tick;
 
     // Timer healthy: the ISR is keeping TICK_COUNT within `slack` of the TSC.
+    //
+    // On SMP this GLOBAL check is necessary but not sufficient: `TICK_COUNT` is
+    // maintained by whichever online CPU's timer ISR runs, so a healthy sibling
+    // keeps it fresh and masks a LOCALLY-dead timer on the calling CPU (the
+    // "de-facto single core" failure mode where one CPU's LAPIC periodic timer
+    // wedges under KVM and the other carries the whole clock).  So even when the
+    // global clock looks healthy, gate the `hlt` on this CPU's OWN timer being
+    // live — `cpu_timer_live` re-arms a locally-wedged LAPIC and returns false,
+    // and a CPU whose own timer is dead must spin (not `hlt` into a sleep its
+    // timer can never end).  Window ~10 ticks (≈100 ms) tolerates ISR jitter.
     if tsc_floor <= published.wrapping_add(slack) {
-        return true;
+        if cpu_timer_live(10) {
+            return true;
+        }
+        // Global clock fine but the local timer just wedged: keep the run queue
+        // moving with a software tick before reporting unhealthy so the caller
+        // spins instead of hlt-ing.
+        crate::sched::timer_tick_schedule();
+        return false;
     }
 
     // Timer starved. Try to revive it (harmless if it's just masked), then
@@ -570,6 +834,23 @@ extern "C" fn timer_tick() {
     let is_bsp = cpu == 0;
     if cpu < super::apic::MAX_CPUS {
         TIMER_ISR_PER_CPU[cpu].fetch_add(1, Ordering::Relaxed);
+    }
+
+    // ── Cross-CPU dead-timer wake (SMP self-heal) ───────────────────────────
+    // Our own LAPIC timer is clearly delivering (we are inside its ISR).  Poke
+    // any SIBLING whose own timer ISR has gone stale — a CPU whose LAPIC
+    // periodic timer wedged (KVM injection suppression) and that may have
+    // halted on the assumption its timer would wake it.  Without this a healthy
+    // CPU keeps the global clock alive while a wedged sibling sleeps forever,
+    // carrying the whole machine alone (the SMP "de-facto single core" failure
+    // mode).  Cheap and self-rate-limited (one poke per sibling per ~200 ms);
+    // a uniprocessor finds no siblings and does nothing.  See
+    // `poke_stale_siblings` + `timer_wake_interrupt`.
+    {
+        let tpt = TSC_PER_TICK.load(Ordering::Acquire);
+        if tpt != 0 && cpu < super::apic::MAX_CPUS {
+            poke_stale_siblings(cpu, rdtsc(), tpt);
+        }
     }
 
     // Compute the wall-clock-correct TICK_COUNT from the TSC delta.  Any
@@ -778,8 +1059,32 @@ irq_stub!(irq_e1000_handler, e1000_interrupt);
 irq_stub!(irq_virtio_blk_handler, virtio_blk_interrupt);
 irq_stub!(irq_virtio_serial_handler, virtio_serial_interrupt);
 irq_stub!(irq_tlb_shootdown_handler, tlb_shootdown_interrupt);
+irq_stub!(irq_timer_wake_handler, timer_wake_interrupt);
 #[cfg(feature = "w215-diag")]
 irq_stub!(irq_w215_dr_sync_handler, w215_dr_sync_interrupt);
+
+/// Cross-CPU timer-wake IPI body (vector 0xF3).
+///
+/// Sent by a CPU whose own LAPIC timer is delivering to a SIBLING whose
+/// per-CPU timer-ISR count has gone stale — i.e. a CPU whose LAPIC periodic
+/// timer has wedged (KVM injection suppression; Intel SDM Vol. 3A §11.5.4 — a
+/// wedged periodic counter does not spontaneously resume).  A CPU that has
+/// halted (`hlt`) on the assumption its timer will wake it would otherwise
+/// sleep until an unrelated asynchronous IRQ happens to land on it; under
+/// single-vCPU-affine IRQ routing that is effectively never, so the CPU drops
+/// out of scheduling entirely (the SMP "de-facto single core" failure mode).
+///
+/// The IPI itself is the cure: delivering ANY interrupt resumes the target
+/// from `hlt`, after which its idle/wait path re-runs `cpu_timer_live`, detects
+/// the locally-dead timer, re-arms its own LAPIC and drives a software tick.
+/// This handler therefore only needs to record the poke and EOI; it also drives
+/// a scheduler tick so a freshly-Ready peer is picked up immediately on the
+/// woken CPU rather than waiting for the next loop iteration.
+extern "C" fn timer_wake_interrupt() {
+    TIMER_WAKE_IPI_RECEIVED.fetch_add(1, Ordering::Relaxed);
+    crate::sched::timer_tick_schedule();
+    if super::apic::is_enabled() { super::apic::lapic_eoi(); }
+}
 
 /// W215 Arm-1 DR0/DR7 sync IPI body.  Programs this CPU's DR0/DR7 from
 /// the values published by `arch::x86_64::debug_reg::arm_write_watchpoint`.

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -367,6 +367,24 @@ static CPU_TIMER_SEEN: [(AtomicU64, AtomicU64); super::apic::MAX_CPUS] =
 static CPU_TIMER_DEAD: [core::sync::atomic::AtomicBool; super::apic::MAX_CPUS] =
     [const { core::sync::atomic::AtomicBool::new(false) }; super::apic::MAX_CPUS];
 
+/// Per-CPU count of consecutive futile re-arms since this CPU's timer was last
+/// declared dead.  Reset to 0 whenever the ISR advances (recovery).  Once it
+/// reaches [`MAX_FUTILE_REARMS`] the periodic re-arm retry STOPS for this CPU
+/// (the host — typically KVM — is permanently suppressing injection on this
+/// vCPU; no amount of re-programming the guest LAPIC will revive it) and the
+/// CPU relies purely on the TSC-clocked spin + cross-CPU poke to stay scheduled.
+/// This bounds futile LAPIC-MMIO writes on a permanently-dead timer while still
+/// giving a transiently-wedged timer many chances to resume.
+static CPU_TIMER_DEAD_REARMS: [AtomicU64; super::apic::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; super::apic::MAX_CPUS];
+
+/// Cap on consecutive periodic re-arms of a dead timer before giving up on
+/// re-programming it (≈ a few seconds of retries at one re-arm per liveness
+/// window).  A genuinely transient wedge resumes well within this; a
+/// host-suppressed timer never will, so stop churning LAPIC MMIO and let the
+/// spin + cross-CPU poke carry the CPU.
+const MAX_FUTILE_REARMS: u64 = 32;
+
 /// True iff `cpu`'s LAPIC periodic timer has been declared dead and not yet
 /// recovered.  Diagnostic accessor for the kdb `cpu-state` survey.
 pub fn cpu_timer_dead(cpu: usize) -> bool {
@@ -499,33 +517,56 @@ pub fn cpu_timer_live(window_ticks: u64) -> bool {
         CPU_TIMER_SEEN[cpu].0.store(isr_now, Ordering::Relaxed);
         CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
         CPU_TIMER_DEAD[cpu].store(false, Ordering::Relaxed);
+        CPU_TIMER_DEAD_REARMS[cpu].store(0, Ordering::Relaxed);
         return true;
     }
 
-    // ISR count unchanged since the last check.  If this CPU's timer was already
-    // declared dead, it STAYS dead until the ISR actually advances (handled
-    // above) — report unhealthy without re-arming again, so the caller keeps
-    // spinning (self-clocked) rather than oscillating hlt↔wake at ~1/window Hz.
+    // ISR count unchanged since the last check.  How long (wall-clock) has the
+    // local timer been silent since we last re-anchored?
+    let silent_ticks = tsc_now.wrapping_sub(seen_tsc) / tsc_per_tick;
+
+    // Already declared dead: stay dead (the caller keeps spinning, self-clocked)
+    // but RE-ARM PERIODICALLY — once per window of continued silence — rather
+    // than only once at declaration.  A wedged KVM LAPIC may not resume on the
+    // first re-arm if injection is still being suppressed (e.g. an MMIO VM-exit
+    // storm has not yet subsided); retrying every window gives the full
+    // from-scratch re-program (see `apic::rearm_timer`) repeated chances to
+    // re-latch the counter once the host stops suppressing.  Bounded to one
+    // re-arm per window, so it is cheap and never an IPI/MMIO storm.  Recovery
+    // (ISR advancing) is detected by the first branch above, which clears the
+    // sticky flag.
     if CPU_TIMER_DEAD[cpu].load(Ordering::Relaxed) {
+        if silent_ticks >= window_ticks
+            && CPU_TIMER_DEAD_REARMS[cpu].load(Ordering::Relaxed) < MAX_FUTILE_REARMS
+        {
+            super::apic::rearm_timer();
+            PERCPU_TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
+            CPU_TIMER_DEAD_REARMS[cpu].fetch_add(1, Ordering::Relaxed);
+            CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+        }
+        // Past the cap (host is permanently suppressing injection) we stop
+        // re-arming and rely on the TSC-clocked spin + cross-CPU poke; still
+        // re-anchor occasionally so `silent_ticks` does not overflow the divide.
+        else if silent_ticks >= window_ticks {
+            CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+        }
         return false;
     }
 
-    // Not yet declared dead: how long has the local timer been silent (in
-    // wall-clock ticks)?
-    let silent_ticks = tsc_now.wrapping_sub(seen_tsc) / tsc_per_tick;
     if silent_ticks < window_ticks {
         return true; // within tolerance — not yet considered wedged
     }
 
     // The local LAPIC periodic timer has been silent for > window_ticks while
-    // this CPU is active: declare it wedged (sticky).  Re-arm it once (rewrites
-    // LVT + initial-count — harmless and revives a merely-masked timer) and
-    // report unhealthy so the caller spins rather than hlt-ing into a sleep the
-    // dead timer cannot end.  The sticky flag keeps it false on every subsequent
-    // call until the ISR genuinely advances.
+    // this CPU is active: declare it wedged (sticky).  Re-arm it (full
+    // from-scratch re-program; see `apic::rearm_timer`) and report unhealthy so
+    // the caller spins rather than hlt-ing into a sleep the dead timer cannot
+    // end.  The sticky flag keeps it false on every subsequent call (with a
+    // periodic re-arm retry, above) until the ISR genuinely advances.
     CPU_TIMER_DEAD[cpu].store(true, Ordering::Relaxed);
     super::apic::rearm_timer();
     PERCPU_TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
+    CPU_TIMER_DEAD_REARMS[cpu].store(1, Ordering::Relaxed);
     CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
     false
 }

--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -496,6 +496,67 @@ fn poke_stale_siblings(this_cpu: usize, tsc_now: u64, tsc_per_tick: u64) {
 /// (the SMP "de-facto single core" failure mode).  Cheap: two atomic reads, an
 /// `rdtsc`, and — only when wedged — a re-arm.  `window_ticks` is in 100 Hz
 /// ticks; ~10 (≈100 ms) tolerates normal ISR jitter without false re-arms.
+///
+/// The pure decision logic is factored into [`timer_live_decision`] so it can be
+/// unit-tested without LAPIC hardware; `cpu_timer_live` is the thin per-CPU shell
+/// that gathers the inputs (atomics, `rdtsc`, `cpu_index`) and applies the side
+/// effects (re-arm, counter updates) the decision asks for.
+
+/// Outcome of the per-CPU timer-liveness decision (the hardware-free core of
+/// [`cpu_timer_live`]).  Lets the state machine be exercised in `test_runner`
+/// without a real LAPIC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimerLiveDecision {
+    /// Timer is delivering (ISR advanced, or still within the tolerance window).
+    /// `clear_dead` is true when a previously-dead timer has genuinely recovered.
+    Live { clear_dead: bool },
+    /// Timer is wedged: report unhealthy (caller must spin, not `hlt`).
+    /// `rearm` is true when the caller should issue a from-scratch LAPIC re-arm
+    /// this call (bounded by the futile-re-arm cap once already dead).
+    Dead { rearm: bool },
+}
+
+/// Pure liveness decision shared by [`cpu_timer_live`] and its unit test.
+///
+/// Inputs (all caller-gathered):
+///   * `isr_advanced` — did `TIMER_ISR_PER_CPU[cpu]` change since the last anchor?
+///   * `first_obs`    — is this the first observation for this CPU (no anchor yet)?
+///   * `silent_ticks` — wall-clock ticks since the anchor TSC (0 if `isr_advanced`).
+///   * `window_ticks` — tolerance window before declaring a silent timer wedged.
+///   * `already_dead` — is the sticky dead flag currently set?
+///   * `rearms_so_far`— consecutive futile re-arms since this CPU went dead.
+///   * `max_rearms`   — the futile-re-arm cap ([`MAX_FUTILE_REARMS`]).
+///
+/// The decision is total and side-effect-free; the caller maps it onto the
+/// atomics + the `rearm_timer()` MMIO.
+pub fn timer_live_decision(
+    isr_advanced: bool,
+    first_obs: bool,
+    silent_ticks: u64,
+    window_ticks: u64,
+    already_dead: bool,
+    rearms_so_far: u64,
+    max_rearms: u64,
+) -> TimerLiveDecision {
+    // ISR advanced (or first observation): alive; clear sticky-dead on recovery.
+    if first_obs || isr_advanced {
+        return TimerLiveDecision::Live { clear_dead: already_dead };
+    }
+    // Already declared dead: stay dead, but re-arm once per window until the
+    // futile-re-arm cap, then stop churning LAPIC MMIO and rely on spin + poke.
+    if already_dead {
+        let rearm = silent_ticks >= window_ticks && rearms_so_far < max_rearms;
+        return TimerLiveDecision::Dead { rearm };
+    }
+    // Not yet dead: within tolerance ⇒ still live; past the window ⇒ declare dead
+    // and re-arm now.
+    if silent_ticks < window_ticks {
+        TimerLiveDecision::Live { clear_dead: false }
+    } else {
+        TimerLiveDecision::Dead { rearm: true }
+    }
+}
+
 pub fn cpu_timer_live(window_ticks: u64) -> bool {
     let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
     if tsc_per_tick == 0 {
@@ -509,66 +570,55 @@ pub fn cpu_timer_live(window_ticks: u64) -> bool {
     let tsc_now = rdtsc();
     let seen_isr = CPU_TIMER_SEEN[cpu].0.load(Ordering::Relaxed);
     let seen_tsc = CPU_TIMER_SEEN[cpu].1.load(Ordering::Relaxed);
+    let already_dead = CPU_TIMER_DEAD[cpu].load(Ordering::Relaxed);
+    let rearms = CPU_TIMER_DEAD_REARMS[cpu].load(Ordering::Relaxed);
 
-    // First observation for this CPU, or the local timer advanced since the
-    // last check: it is alive.  Record the new snapshot, CLEAR any sticky-dead
-    // flag (a real recovery), and report healthy.
-    if seen_tsc == 0 || isr_now != seen_isr {
-        CPU_TIMER_SEEN[cpu].0.store(isr_now, Ordering::Relaxed);
-        CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
-        CPU_TIMER_DEAD[cpu].store(false, Ordering::Relaxed);
-        CPU_TIMER_DEAD_REARMS[cpu].store(0, Ordering::Relaxed);
-        return true;
-    }
-
-    // ISR count unchanged since the last check.  How long (wall-clock) has the
-    // local timer been silent since we last re-anchored?
+    let first_obs = seen_tsc == 0;
+    let isr_advanced = isr_now != seen_isr;
+    // `silent_ticks` is meaningful only when the ISR has NOT advanced; the
+    // decision ignores it on the advanced/first-obs path.
     let silent_ticks = tsc_now.wrapping_sub(seen_tsc) / tsc_per_tick;
 
-    // Already declared dead: stay dead (the caller keeps spinning, self-clocked)
-    // but RE-ARM PERIODICALLY — once per window of continued silence — rather
-    // than only once at declaration.  A wedged KVM LAPIC may not resume on the
-    // first re-arm if injection is still being suppressed (e.g. an MMIO VM-exit
-    // storm has not yet subsided); retrying every window gives the full
-    // from-scratch re-program (see `apic::rearm_timer`) repeated chances to
-    // re-latch the counter once the host stops suppressing.  Bounded to one
-    // re-arm per window, so it is cheap and never an IPI/MMIO storm.  Recovery
-    // (ISR advancing) is detected by the first branch above, which clears the
-    // sticky flag.
-    if CPU_TIMER_DEAD[cpu].load(Ordering::Relaxed) {
-        if silent_ticks >= window_ticks
-            && CPU_TIMER_DEAD_REARMS[cpu].load(Ordering::Relaxed) < MAX_FUTILE_REARMS
-        {
-            super::apic::rearm_timer();
-            PERCPU_TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
-            CPU_TIMER_DEAD_REARMS[cpu].fetch_add(1, Ordering::Relaxed);
+    match timer_live_decision(
+        isr_advanced, first_obs, silent_ticks, window_ticks,
+        already_dead, rearms, MAX_FUTILE_REARMS,
+    ) {
+        TimerLiveDecision::Live { clear_dead } => {
+            // Record the fresh anchor and, on a genuine recovery, clear the
+            // sticky-dead flag + futile-re-arm counter.
+            CPU_TIMER_SEEN[cpu].0.store(isr_now, Ordering::Relaxed);
             CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+            if clear_dead {
+                CPU_TIMER_DEAD[cpu].store(false, Ordering::Relaxed);
+                CPU_TIMER_DEAD_REARMS[cpu].store(0, Ordering::Relaxed);
+            }
+            true
         }
-        // Past the cap (host is permanently suppressing injection) we stop
-        // re-arming and rely on the TSC-clocked spin + cross-CPU poke; still
-        // re-anchor occasionally so `silent_ticks` does not overflow the divide.
-        else if silent_ticks >= window_ticks {
-            CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+        TimerLiveDecision::Dead { rearm } => {
+            // Declare dead (idempotent) and, if the decision asked for it, issue
+            // the full from-scratch re-arm and bump the bounded retry counter.
+            if !already_dead {
+                CPU_TIMER_DEAD[cpu].store(true, Ordering::Relaxed);
+            }
+            if rearm {
+                super::apic::rearm_timer();
+                PERCPU_TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
+                // First re-arm at declaration seeds the counter at 1; subsequent
+                // periodic retries increment it toward the cap.
+                if already_dead {
+                    CPU_TIMER_DEAD_REARMS[cpu].fetch_add(1, Ordering::Relaxed);
+                } else {
+                    CPU_TIMER_DEAD_REARMS[cpu].store(1, Ordering::Relaxed);
+                }
+                CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+            } else if silent_ticks >= window_ticks {
+                // Past the cap: stop re-arming but re-anchor so a long-dead
+                // timer's `silent_ticks` divide never overflows.
+                CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
+            }
+            false
         }
-        return false;
     }
-
-    if silent_ticks < window_ticks {
-        return true; // within tolerance — not yet considered wedged
-    }
-
-    // The local LAPIC periodic timer has been silent for > window_ticks while
-    // this CPU is active: declare it wedged (sticky).  Re-arm it (full
-    // from-scratch re-program; see `apic::rearm_timer`) and report unhealthy so
-    // the caller spins rather than hlt-ing into a sleep the dead timer cannot
-    // end.  The sticky flag keeps it false on every subsequent call (with a
-    // periodic re-arm retry, above) until the ISR genuinely advances.
-    CPU_TIMER_DEAD[cpu].store(true, Ordering::Relaxed);
-    super::apic::rearm_timer();
-    PERCPU_TIMER_REARM_COUNT.fetch_add(1, Ordering::Relaxed);
-    CPU_TIMER_DEAD_REARMS[cpu].store(1, Ordering::Relaxed);
-    CPU_TIMER_SEEN[cpu].1.store(tsc_now, Ordering::Relaxed);
-    false
 }
 
 /// Idle-wait one quantum from a scheduler wait-path: sleep until the next wake,

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -402,6 +402,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "fault-cache-keys" => op_fault_cache_keys(out),
         "w215-cache-residency" => op_w215_cache_residency(out),
         "tlb-stats"        => op_tlb_stats(out),
+        "cpu-state"        => op_cpu_state(out),
         "heap-stats"       => op_heap_stats(out),
         "w215-diag"        => op_w215_diag(out),
         "arm-phys"         => op_arm_phys(req, out),
@@ -1610,6 +1611,89 @@ fn op_arm_phys(req: &str, out: &mut String) {
         let _ = req;
         out.push_str(r#"{"armed":false,"error":"requires_w215_diag"}"#);
     }
+}
+
+// ── cpu-state ───────────────────────────────────────────────────────────────
+//
+// Per-CPU scheduler/timer survey for diagnosing SMP imbalance — specifically
+// "de-facto single core" symptoms where one CPU carries all scheduled load and
+// the other idles.  For each online CPU it reports:
+//
+//   * `timer_isr`       — cumulative LAPIC timer-ISR entries on that CPU.  A
+//                         frozen/near-zero count vs a peer means that CPU's
+//                         periodic timer is not delivering (timer-dead).
+//   * `current_tid`/`current_pid` — what is running on that CPU right now.
+//   * `watchdog`        — ticks since that CPU last context-switched (high ⇒
+//                         CPU-bound or wedged; low ⇒ switching regularly).
+//   * `nr_running`      — depth of that CPU's per-CPU runqueue mirror.
+//
+// Plus a `tid0` block describing the BSP poll reactor (the latency-critical
+// net/x11/compositor thread): its `last_cpu`, `affinity`, `mirror_slot` (which
+// runqueue it is enqueued on) and `state`.  Together these distinguish
+// "cpu0 timer dead" (timer_isr frozen on cpu0) from "reactor steered to cpu1"
+// (cpu0 timer alive but tid0.mirror_slot pinned to cpu1).
+fn op_cpu_state(out: &mut String) {
+    use core::fmt::Write;
+    use crate::arch::x86_64::apic::MAX_CPUS;
+
+    let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize).min(MAX_CPUS);
+    let tick = crate::arch::x86_64::irq::get_ticks();
+
+    out.push('{');
+    let _ = write!(out, r#""tick":{},"ncpus":{},"cpus":["#, tick, ncpus);
+    for cpu in 0..ncpus {
+        if cpu > 0 { out.push(','); }
+        let timer = crate::arch::x86_64::irq::TIMER_ISR_PER_CPU[cpu]
+            .load(core::sync::atomic::Ordering::Relaxed);
+        let cur_tid = crate::proc::current_tid_on_cpu(cpu);
+        let cur_pid = crate::proc::current_pid_on_cpu(cpu);
+        let wd = crate::arch::x86_64::irq::watchdog_counter(cpu);
+        let nr = crate::sched::percpu::rq_nr_running(cpu);
+        let dead = crate::arch::x86_64::irq::cpu_timer_dead(cpu);
+        let _ = write!(
+            out,
+            r#"{{"cpu":{},"timer_isr":{},"timer_dead":{},"current_tid":{},"current_pid":{},"watchdog":{},"nr_running":{}}}"#,
+            cpu, timer, dead, cur_tid, cur_pid, wd, nr);
+    }
+    out.push(']');
+
+    // Self-heal telemetry: sibling timer-wake IPIs sent/received + per-CPU LAPIC
+    // re-arms.  Non-zero `wake_ipi_sent` under SMP = the dead-sibling-LAPIC
+    // self-heal is driving the cross-CPU poke.
+    let _ = write!(
+        out,
+        r#","wake_ipi_sent":{},"wake_ipi_received":{},"percpu_timer_rearm":{}"#,
+        crate::arch::x86_64::irq::timer_wake_ipi_sent(),
+        crate::arch::x86_64::irq::timer_wake_ipi_received(),
+        crate::arch::x86_64::irq::percpu_timer_rearm_count());
+
+    // TID-0 (BSP poll reactor) placement.  Best-effort under a brief try_lock;
+    // emit a `busy` marker rather than block the kdb listener if THREAD_TABLE
+    // is held by an in-flight syscall.
+    match try_lock_brief(&THREAD_TABLE) {
+        Some(tt) => {
+            if let Some(t) = tt.iter().find(|t| t.tid == 0) {
+                let aff = match t.cpu_affinity {
+                    Some(a) => a as i32,
+                    None => -1,
+                };
+                let (ms_cpu, ms_prio): (i32, i32) = match t.mirror_slot {
+                    Some((c, p)) => (c as i32, p as i32),
+                    None => (-1, -1),
+                };
+                let _ = write!(
+                    out,
+                    r#","tid0":{{"last_cpu":{},"affinity":{},"mirror_cpu":{},"mirror_prio":{},"state":"{:?}","priority":{}}}"#,
+                    t.last_cpu, aff, ms_cpu, ms_prio, t.state, t.priority);
+            } else {
+                out.push_str(r#","tid0":null"#);
+            }
+        }
+        None => {
+            out.push_str(r#","tid0":"THREAD_TABLE held""#);
+        }
+    }
+    out.push('}');
 }
 
 fn op_tlb_stats(out: &mut String) {

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1056,6 +1056,28 @@ pub fn set_current_tid(tid: Tid) {
     PER_CPU_CURRENT_TID[cpu_index()].store(tid, Ordering::Relaxed);
 }
 
+/// Read the currently running TID for an arbitrary CPU index (not necessarily
+/// the calling CPU).  Used by diagnostics that survey every CPU's state from a
+/// single thread (e.g. the kdb `cpu-state` op).  Returns 0 for an
+/// out-of-range index.
+pub fn current_tid_on_cpu(cpu: usize) -> Tid {
+    if cpu < crate::arch::x86_64::apic::MAX_CPUS {
+        PER_CPU_CURRENT_TID[cpu].load(Ordering::Relaxed)
+    } else {
+        0
+    }
+}
+
+/// Read the currently running PID for an arbitrary CPU index.  See
+/// [`current_tid_on_cpu`].
+pub fn current_pid_on_cpu(cpu: usize) -> Pid {
+    if cpu < crate::arch::x86_64::apic::MAX_CPUS {
+        PER_CPU_CURRENT_PID[cpu].load(Ordering::Relaxed)
+    } else {
+        0
+    }
+}
+
 /// Set the currently running process's PID (per-CPU).
 ///
 /// Must be called from every `set_current_tid` call site that knows the

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1597,9 +1597,7 @@ was_emergency_4k={}",
                     // sti; hlt; cli — the STI shadow guarantees the next
                     // instruction (hlt) is executed before any pending
                     // interrupt fires, so this sequence is race-free.
-                    unsafe {
-                        core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
-                    }
+                    crate::arch::x86_64::irq::sched_wait_quantum();
                     // Re-check SCHEDULER_ACTIVE after waking from hlt.
                     // If another CPU called sched::disable() while we were
                     // halted, timer_tick_schedule() now short-circuits and
@@ -1635,9 +1633,7 @@ was_emergency_4k={}",
                             current_tid, STARVATION_BURST_THRESHOLD,
                         );
                     }
-                    unsafe {
-                        core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
-                    }
+                    crate::arch::x86_64::irq::sched_wait_quantum();
                     // See is_active() recheck rationale above.
                     if !is_active() {
                         crate::hal::enable_interrupts();
@@ -1880,9 +1876,7 @@ was_emergency_4k={}",
                                 current_tid, STARVATION_BURST_THRESHOLD,
                             );
                         }
-                        unsafe {
-                            core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
-                        }
+                        crate::arch::x86_64::irq::sched_wait_quantum();
                         // Re-check SCHEDULER_ACTIVE after waking from hlt.
                         // sched::disable() on another CPU silently disarms
                         // timer_tick_schedule()'s wake hooks, so without
@@ -1905,9 +1899,7 @@ was_emergency_4k={}",
                                 current_tid, STARVATION_BURST_THRESHOLD,
                             );
                         }
-                        unsafe {
-                            core::arch::asm!("sti; hlt; cli", options(nomem, nostack));
-                        }
+                        crate::arch::x86_64::irq::sched_wait_quantum();
                         // See is_active() recheck rationale above.
                         if !is_active() {
                             crate::hal::enable_interrupts();

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2236,6 +2236,12 @@ pub fn run() -> ! {
     total += 1;
     if test_646_tlb_timeout_force_flush() { passed += 1; }
 
+    // ── Test 651: per-CPU LAPIC-timer liveness decision state machine ──
+    // The hardware-free core of the SMP dead-CPU-timer self-heal: ISR-advance
+    // recovery, tolerance window, sticky-dead, bounded futile re-arm cap.
+    total += 1;
+    if test_651_cpu_timer_live_decision() { passed += 1; }
+
     // ── Test 217: /proc/<N>/maps returns target PID's VMA table (W216) ──
     // Verifies three properties:
     //   1. open(/proc/<target>/maps) from a different caller PID succeeds
@@ -49900,6 +49906,68 @@ fn test_652_percpu_audit_image_off_stack() -> bool {
 
     test_println!("  [PerCpuRq; MAX_CPUS] audit image dwarfs the emergency kstack \
 tier → must stay heap-allocated (closes the switch_context popf #DB) GREEN");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 651: per-CPU LAPIC-timer liveness decision state machine ───────────
+//
+// Exercises the hardware-free core of the SMP dead-CPU-timer self-heal
+// (`irq::timer_live_decision`) so the state machine is covered without a real
+// LAPIC: ISR-advance recovery (incl. clearing sticky-dead), the tolerance
+// window, the dead→re-arm declaration, periodic re-arm while dead, and the
+// bounded futile-re-arm cap that stops churning LAPIC MMIO on a permanently
+// host-suppressed (KVM) timer.  The same function drives `cpu_timer_live`, so
+// these cases pin the production behaviour.
+fn test_651_cpu_timer_live_decision() -> bool {
+    use crate::arch::x86_64::irq::{timer_live_decision, TimerLiveDecision as D};
+    const NAME: &str = "[ARCH/SMP] per-CPU timer-liveness decision (Test 651)";
+    test_header!(NAME);
+    const W: u64 = 10;   // window_ticks
+    const CAP: u64 = 32; // MAX_FUTILE_REARMS
+
+    // First observation → live, nothing to clear.
+    if timer_live_decision(false, true, 0, W, false, 0, CAP) != (D::Live { clear_dead: false }) {
+        test_fail!(NAME, "first observation not Live"); return false;
+    }
+    // ISR advanced while healthy → live, nothing to clear.
+    if timer_live_decision(true, false, 0, W, false, 0, CAP) != (D::Live { clear_dead: false }) {
+        test_fail!(NAME, "isr-advanced healthy not Live"); return false;
+    }
+    // ISR advanced while previously dead → live AND clear sticky-dead (recovery).
+    if timer_live_decision(true, false, 0, W, true, 5, CAP) != (D::Live { clear_dead: true }) {
+        test_fail!(NAME, "recovery did not clear sticky-dead"); return false;
+    }
+    // Silent but within the tolerance window → still live, no clear.
+    if timer_live_decision(false, false, W - 1, W, false, 0, CAP) != (D::Live { clear_dead: false }) {
+        test_fail!(NAME, "within-window silence not tolerated as Live"); return false;
+    }
+    // Silent past the window, not yet dead → declare dead AND re-arm now.
+    if timer_live_decision(false, false, W, W, false, 0, CAP) != (D::Dead { rearm: true }) {
+        test_fail!(NAME, "wedge declaration did not re-arm"); return false;
+    }
+    // Already dead, a full window of continued silence, under the cap → re-arm.
+    if timer_live_decision(false, false, W, W, true, 5, CAP) != (D::Dead { rearm: true }) {
+        test_fail!(NAME, "periodic retry under cap did not re-arm"); return false;
+    }
+    // Already dead, silence NOT yet a full window → stay dead, do NOT re-arm
+    // (avoids an MMIO storm faster than once per window).
+    if timer_live_decision(false, false, W - 1, W, true, 5, CAP) != (D::Dead { rearm: false }) {
+        test_fail!(NAME, "sub-window dead re-armed too eagerly"); return false;
+    }
+    // Already dead, AT the futile-re-arm cap → stay dead, STOP re-arming
+    // (permanently host-suppressed timer; rely on spin + cross-CPU poke).
+    if timer_live_decision(false, false, W * 5, W, true, CAP, CAP) != (D::Dead { rearm: false }) {
+        test_fail!(NAME, "re-armed past the futile cap (would churn LAPIC MMIO)"); return false;
+    }
+    // One below the cap still re-arms (boundary is strict `<`).
+    if timer_live_decision(false, false, W, W, true, CAP - 1, CAP) != (D::Dead { rearm: true }) {
+        test_fail!(NAME, "cap boundary off-by-one: one-below-cap should still re-arm"); return false;
+    }
+
+    test_println!("  decision: first-obs / isr-advance-recovery(+clear) / within-window-tolerate / \
+wedge-declare(+rearm) / periodic-retry-under-cap / sub-window-no-rearm / at-cap-stop / \
+cap-boundary-strict — dead-CPU-timer self-heal state machine GREEN");
     test_pass!(NAME);
     true
 }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7014,6 +7014,9 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
               "bell-stats", "compose-stats", "cache-audit", "cache-aliasing",
               "fault-cache-keys", "w215-cache-residency",
               "tlb-stats", "heap-stats", "w215-diag",
+              # cpu-state: per-CPU scheduler/timer survey + TID-0 reactor
+              # placement.  Diagnoses SMP "de-facto single core" imbalance.
+              "cpu-state",
               "coverage-flush", "proc-metrics",
               "futex-stats",
               # blk-trace: out-of-band drain of the virtio-blk LBA ring.
@@ -12958,6 +12961,11 @@ def main():
         "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
         "arm-phys",
+        # cpu-state: per-CPU scheduler/timer survey (timer_isr, current_tid,
+        # watchdog, nr_running) + the TID-0 poll-reactor placement (last_cpu,
+        # affinity, mirror_slot).  Diagnoses SMP "de-facto single core"
+        # imbalance.  See kdb::op_cpu_state.
+        "cpu-state",
         # blk-trace: drain the virtio-blk LBA ring (JSON) / re-emit `[BLK]`
         # serial lines for the heatmap. Also exposed as the `blk-trace`
         # top-level subcommand below (drain|flush).


### PR DESCRIPTION
## Problem

On SMP=2 the TID-0 BSP poll reactor logged all heartbeats on `cpu=1` and zero on `cpu=0` — SMP=2 was de-facto single core, a residual after the earlier CPU0-LAPIC-death bringup fix.

## Root cause (byte-proven, dispositive differential)

Under **KVM**, the BSP's LAPIC **periodic timer stops delivering interrupts** post-bringup (host-side injection suppression). GDB autopsy of an SMP=2 boot: `TIMER_ISR_PER_CPU[0]` is frozen at 122 for the entire run while `[1]` advances at ~100 Hz.

The differential is dispositive: the **same kernel under TCG** (no KVM) delivers the BSP timer normally — `TIMER_ISR_PER_CPU` is balanced across both CPUs (4369 vs 4405), heartbeats land on **both** cpu0 and cpu1, and the self-heal added here **never fires**. So the guest kernel is correct; the wedge is a host (KVM) artifact on the BSP vCPU.

Why the existing self-heal missed it: `irq::idle_tick` checked the **global** `TICK_COUNT` vs the TSC. `TICK_COUNT` is TSC-derived and CAS-published by *whichever* online CPU's timer ISR runs, so a single healthy sibling keeps the global clock fresh and **masks** a locally-dead timer. The afflicted CPU saw `TICK_COUNT` tracking the TSC, concluded its timer was healthy, and `hlt`'d into a sleep its own dead timer could never end.

## Fix

Two complementary **per-CPU** mechanisms (`arch/x86_64/irq.rs`):

1. **Self-check** (`cpu_timer_live`): each CPU tracks its *own* `TIMER_ISR_PER_CPU` advancement vs the TSC. On a wedge it sets a sticky dead flag, re-arms the local LAPIC, and reports unhealthy so the scheduler wait path **spins** (self-clocked off the TSC) instead of halting. Immune to the sibling-masking that defeats the global check. The pure decision logic is factored into `timer_live_decision` (unit-tested, Test 651). The re-arm retry is bounded by `MAX_FUTILE_REARMS=32`: a host that permanently suppresses injection on a vCPU will never resume no matter how the guest re-programs its LAPIC, so past the cap the CPU stops churning LAPIC MMIO and relies purely on the TSC-clocked spin + cross-CPU poke that already keeps it scheduled.

2. **Cross-CPU poke** (`poke_stale_siblings` + timer-wake IPI, **vector 0xF3**): from a live CPU's timer ISR, poke any sibling whose ISR count has gone stale so it cannot sleep through a dead timer. Self-rate-limited (≤ one poke per sibling per ~200 ms); a uniprocessor finds no siblings and does nothing.

`idle_tick` now gates its `hlt` on `cpu_timer_live` even when the global clock looks fresh; the scheduler's three `sti;hlt;cli` wait sites and the AP idle loop now use a timer-fault-tolerant `sched_wait_quantum`.

`apic::rearm_timer` was also hardened: it previously rewrote only the LVT + initial-count, which was observed **not** to resume injection on a wedged timer. It now re-programs from scratch — stop, mask, re-write the **divide-configuration** register, fresh periodic unmasked LVT, then the initial count — matching the boot-time init path. Per Intel SDM Vol. 3A §11.5.1 the counter is clocked through the divide-configuration register, and §11.5.4 mandates the mode/divide be established before the initial-count write that (re)starts the count.

## Verification

- **KVM SMP=2** (×4 boots): zero bugchecks; cpu0 schedules real work for the whole run (per-CPU current-TID advancing, watchdog 0) via the spin + cross-CPU poke, with the self-heal telemetry firing (timer-wake IPIs sent/received, re-arm count reaching the cap).
- **TCG SMP=2**: heartbeats on **both** cpu0 and cpu1, balanced per-CPU ISR counts, self-heal never fires (zero false positives).
- **SMP=1**: with a healthy timer, byte-identical to baseline (the self-heal only diverges when a timer is actually wedged).
- **test-mode**: pass/fail counts identical to `master` (the two fails are the allow-listed `tcc`/`busybox` env-gap fixtures). New Test 651 covers the decision state machine.

## Diagnostics added

kdb `cpu-state` op (per-CPU `timer_isr`/`timer_dead`/`current_tid`/`watchdog`/`nr_running` + TID-0 reactor placement + self-heal telemetry), wired through the harness allowlist; `proc::current_tid_on_cpu`/`current_pid_on_cpu` and `irq::watchdog_counter` accessors.

## Notes for the coordinator (cross-cutting)

- The timer-wake IPI uses **vector 0xF3** specifically to avoid colliding with the reschedule IPI (0xF2) on the in-flight Perf P2 phase-3c/3d branches.
- **Separate pre-existing issue, not in scope here:** SMP=1 GUI-Firefox crashes deterministically with a `#DB` at `switch_context_asm`'s `popf` (a torn `RFLAGS` with `TF=1` restored off a recycled kernel stack). This **reproduces on a clean `origin/master` build with none of this PR's changes** (bisect-confirmed) — it is the kstack-recycle / stack-canary saga and needs its own owner.
- This PR does **not** flip the SMP=2 default — that stays a separate, coordinator-sequenced change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
