### PR TITLE
ci/test: gate Test 198's 25k-line PNG base64 serial dump behind an opt-in feature

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -38,6 +38,21 @@ heap-canary = []
 # so on the hot path the spew dominates wall-clock.
 test-mode-trace = []
 test-mode = ["heap-canary", "test-mode-trace"]
+# `screenshot-b64-dump` — opt-in for Test 198 (GDI PNG screenshot) to base64-
+# encode the rendered 1.44 MB boot-splash PNG over COM1 as the chunked
+# `[SCREENSHOT-B64:N/M]` stream (~25k lines) that the harness `read-png`
+# subcommand decodes back to a host PNG.  Off by default and DELIBERATELY NOT
+# pulled into `test-mode`: the dump is host-EXTRACTION only — Test 198's
+# pass/fail is decided by the in-guest PNG-signature check (`signature_ok=true`)
+# BEFORE the dump, so gating the dump off changes NO test outcome, only what is
+# transcribed to COM1.  CI never invokes `read-png`, so for CI the dump is pure
+# UART saturation: at ~25k synchronous PIO THR-write lines (Intel SDM Vol. 3C
+# §25 I/O-instruction VM-exits; NS16550A THR-write model) it dominates the
+# kernel-smoke wall-clock and, racing a faulting process's serial spew under
+# `-smp 2`, can push the suite past the 900 s watchdog.  Enable only when a
+# human/agent actually wants the boot-splash PNG extracted (the harness sets it
+# on the `read-png` build path).
+screenshot-b64-dump = []
 gui-test = []
 # `firefox-test-core` — the FUNCTIONAL behaviour the Firefox bring-up path
 # needs to RUN: heap-canary fencing, the FF workload selection + launch in

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -40829,6 +40829,26 @@ fn test_gdi_png_screenshot() -> bool {
     // 76 base64 chars = 57 input bytes per line (MIME line length, RFC 2045 §6.8).
     // The harness `read-png` subcommand collects all M chunks, decodes, and
     // writes the result to a host-side file.
+    //
+    // Gated behind the `screenshot-b64-dump` feature.  This dump is host-
+    // EXTRACTION only — it has NO bearing on this test's pass/fail, which is
+    // already decided by the `signature_ok=true` PNG-signature check in step 6
+    // above (BEFORE this block).  The feature is off by default and is
+    // deliberately NOT pulled into `test-mode`, so the CI kernel-smoke boot
+    // (which never invokes `read-png`) does not pay the ~25 000-line COM1
+    // serialisation cost that otherwise dominates the run and, racing a faulting
+    // process's serial spew under `-smp 2`, can blow the 900 s watchdog.  When
+    // the feature is off we emit a single sentinel line so `read-png` reports a
+    // clean "dump not enabled" instead of waiting out its timeout for chunk 0.
+    #[cfg(not(feature = "screenshot-b64-dump"))]
+    {
+        test_println!(
+            "[SCREENSHOT-B64-DISABLED] {} bytes ready; rebuild with \
+             --features screenshot-b64-dump (or harness `read-png`) to extract",
+            read_back.len()
+        );
+    }
+    #[cfg(feature = "screenshot-b64-dump")]
     {
         const CHUNK_BYTES: usize = 57; // → 76 base64 chars per line
         const B64_ALPHABET: &[u8; 64] =

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -800,6 +800,57 @@ def run_read_ff_png_check():
     print()
 
 
+def run_pid_running_zombie_check():
+    """
+    Tier 1.5 host-only check: `_pid_running` treats a <defunct> zombie as dead.
+
+    `_pid_alive` (os.kill(pid,0)) reports a zombie as alive — the entry survives
+    in the process table until reaped — which made `ci-run`'s suite-wait loop
+    spin its full timeout after a mid-suite bugcheck exited QEMU. `_pid_running`
+    reads /proc/<pid>/stat field 3 and rejects state 'Z'. Fork a real zombie and
+    assert the two helpers disagree exactly there. No QEMU launched.
+    """
+    print("=== Tier 1.5: _pid_running zombie detection (host-only) ===")
+    print()
+    import importlib.util, os, time
+
+    spec = importlib.util.spec_from_file_location("_h_mod", str(HARNESS))
+    mod = importlib.util.module_from_spec(spec)
+    _argv = sys.argv
+    sys.argv = ["qemu-harness.py", "list"]
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.argv = _argv
+
+    pr = getattr(mod, "_pid_running", None)
+    al = getattr(mod, "_pid_alive", None)
+    check("_pid_running importable", pr is not None)
+    check("_pid_alive importable", al is not None)
+    if pr is None or al is None:
+        print(); return
+
+    # Live self: both True.
+    check("_pid_running(self)=True", pr(os.getpid()) is True, "")
+    # Bogus pid: both False.
+    check("_pid_running(bogus)=False", pr(2 ** 22) is False, "")
+
+    # Real zombie: fork a child that exits, do NOT reap → <defunct>.
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    try:
+        time.sleep(0.3)  # let it become a zombie
+        check("_pid_alive(zombie)=True (existing semantics)", al(pid) is True, "")
+        check("_pid_running(zombie)=False (the fix)", pr(pid) is False, "")
+    finally:
+        try:
+            os.waitpid(pid, 0)  # reap
+        except ChildProcessError:
+            pass
+    print()
+
+
 def run_read_png_disabled_check():
     """
     Tier 1.5 host-only check: `read-png` fails fast + clean when Test 198's
@@ -1407,6 +1458,7 @@ def main():
     run_snapgate_argv_check()
     run_read_ff_png_check()
     run_read_png_disabled_check()
+    run_pid_running_zombie_check()
     run_kdb_read_png_check()
     run_blk_trace_argv_check()
     run_livelock_reap_check()

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -800,6 +800,59 @@ def run_read_ff_png_check():
     print()
 
 
+def run_read_png_disabled_check():
+    """
+    Tier 1.5 host-only check: `read-png` fails fast + clean when Test 198's
+    base64 dump is gated off (the default, incl. plain `test-mode`).
+
+    The screenshot-b64-dump gate (CI Test-198 UART-saturation fix) makes Test
+    198 emit a single `[SCREENSHOT-B64-DISABLED]` sentinel instead of the ~25k
+    chunk stream unless built with `--features screenshot-b64-dump`.  This check
+    feeds a synthetic serial log carrying that sentinel and asserts `read-png`
+    returns the structured `screenshot_dump_disabled` error with a non-zero rc
+    (rather than waiting out its timeout for a chunk-0 that never comes).
+
+    No QEMU launched.  Protects the gate's host-side contract against drift.
+    """
+    print("=== Tier 1.5: read-png disabled-sentinel fast-fail (host-only) ===")
+    print()
+    import tempfile
+
+    harness_dir = Path.home() / ".astryx-harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    sid = "smoke-pngdisabled"
+    sess_path = harness_dir / f"{sid}.json"
+    serial_path = harness_dir / f"{sid}.serial.log"
+    out_path = None
+    try:
+        # The exact line Test 198 emits when screenshot-b64-dump is off.
+        serial_path.write_text(
+            "  PNG signature [89, 50, 4E, 47] \xe2\x9c\x93\n"
+            "[SCREENSHOT] path=/tmp/screenshot.png size=1440623 signature_ok=true\n"
+            "[SCREENSHOT-B64-DISABLED] 1440623 bytes ready; rebuild with "
+            "--features screenshot-b64-dump (or harness `read-png`) to extract\n"
+        )
+        # pid=0 → liveness guard skipped, decoder reads the static log.
+        sess_path.write_text(json.dumps({
+            "sid": sid, "pid": 0, "serial_log": str(serial_path),
+        }))
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+            out_path = fh.name
+
+        obj, raw, rc = _h("read-png", sid, out_path, "--timeout-ms", "3000")
+        check("read-png(disabled) returns JSON",  obj is not None,             raw[:160])
+        check("read-png(disabled) ok=false",      bool(obj and obj.get("ok") is False), str(obj))
+        check("read-png(disabled) rc!=0",         rc != 0,                     f"rc={rc}")
+        check("read-png(disabled) error tag",
+              bool(obj and obj.get("error") == "screenshot_dump_disabled"), str(obj))
+    finally:
+        sess_path.unlink(missing_ok=True)
+        serial_path.unlink(missing_ok=True)
+        if out_path:
+            Path(out_path).unlink(missing_ok=True)
+    print()
+
+
 def run_kdb_read_png_check():
     """
     Tier 1.5 host-only check: kdb-read-png chunked-assembly round-trip.
@@ -1353,6 +1406,7 @@ def main():
     run_allowlist_check()
     run_snapgate_argv_check()
     run_read_ff_png_check()
+    run_read_png_disabled_check()
     run_kdb_read_png_check()
     run_blk_trace_argv_check()
     run_livelock_reap_check()

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -930,6 +930,29 @@ def _pid_alive(pid: int) -> bool:
     except (ProcessLookupError, PermissionError):
         return False
 
+def _pid_running(pid: int) -> bool:
+    """Like `_pid_alive` but treats a defunct/zombie process as NOT running.
+
+    `os.kill(pid, 0)` succeeds for a zombie (the entry survives in the process
+    table until its parent reaps it), so `_pid_alive` reports a QEMU that exited
+    via isa-debug-exit — e.g. on a mid-suite bugcheck — as still alive. A waiter
+    keyed on `_pid_alive` (the `ci-run` suite loop) would then spin out its full
+    timeout instead of noticing QEMU is gone. Reading `/proc/<pid>/stat` field 3
+    (the state char) and rejecting `Z` closes that hole; on any read error we
+    fall back to `_pid_alive` so non-Linux / restricted hosts behave as before.
+    """
+    if not _pid_alive(pid):
+        return False
+    try:
+        with open(f"/proc/{pid}/stat", "r") as fh:
+            # Field layout: "<pid> (<comm>) <state> ...". comm may contain
+            # spaces/parens, so split on the LAST ')' to find the state char.
+            data = fh.read()
+        state = data[data.rfind(")") + 1:].split()[0]
+        return state != "Z"
+    except (OSError, IndexError):
+        return True
+
 def _emit_event(sid: str, event: dict):
     event["ts"] = time.time()
     with _events_path(sid).open("a") as f:
@@ -2583,7 +2606,11 @@ def cmd_ci_run(args):
             pass
         if suite_found:
             break
-        if pid and not _pid_alive(pid):
+        # `_pid_running` (not `_pid_alive`) so a QEMU that exited via
+        # isa-debug-exit — e.g. a mid-suite bugcheck — is noticed promptly even
+        # while it lingers as a <defunct> zombie awaiting reap, instead of
+        # spinning out the full --timeout-ms.
+        if pid and not _pid_running(pid):
             # QEMU exited — do a final drain
             try:
                 with Path(serial_log).open("r", errors="replace") as fh:

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -3334,6 +3334,24 @@ def cmd_start(args):
                 "'firefox-test-core' nor 'firefox-test'\n"
             )
 
+    # --screenshot-dump appends the `screenshot-b64-dump` feature so Test 198
+    # (GDI PNG screenshot) base64-encodes the rendered boot-splash PNG over COM1
+    # as the chunked [SCREENSHOT-B64:N/M] stream that `read-png` decodes.  The
+    # dump is OFF by default (and NOT in `test-mode`) because it is ~25k serial
+    # lines of pure host-extraction with no bearing on any test's pass/fail; a
+    # plain `test-mode` CI boot must not pay that cost.  Enable it ONLY when you
+    # intend to `read-png` the boot-splash.  Expansion printed to stderr, never
+    # silent (the harness's standing rule).
+    if getattr(args, "screenshot_dump", False):
+        if "screenshot-b64-dump" not in feats:
+            feats.append("screenshot-b64-dump")
+            features_str = ",".join(f for f in feats if f)
+            args.features = features_str
+            sys.stderr.write(
+                "[harness] --screenshot-dump: appended 'screenshot-b64-dump' → "
+                f"features={features_str}\n"
+            )
+
     kdb_host_port = 0
     if "kdb" in feats:
         # Derive deterministically from sid so reruns are stable and two
@@ -11772,6 +11790,11 @@ _B64_CHUNK_RE = re.compile(
     r"\[SCREENSHOT-B64:(\d+)/(\d+)\]\s+([A-Za-z0-9+/=]+)"
 )
 _B64_END_RE = re.compile(r"\[SCREENSHOT-B64-END\]")
+# Emitted by Test 198 when the `screenshot-b64-dump` feature is OFF (the default,
+# incl. plain `test-mode`): the PNG was rendered + signature-verified in-guest
+# but not serialised over COM1.  Lets `read-png` fail fast with a clear pointer
+# instead of waiting out its timeout for a chunk-0 that will never come.
+_B64_DISABLED_RE = re.compile(r"\[SCREENSHOT-B64-DISABLED\]")
 
 _PNG_SIGNATURE = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
 
@@ -11807,6 +11830,17 @@ def cmd_read_png(args):
 
         if chunk:
             for ln in chunk.splitlines():
+                if _B64_DISABLED_RE.search(ln):
+                    print(json.dumps({
+                        "ok": False,
+                        "error": "screenshot_dump_disabled",
+                        "detail": "Test 198 rendered + signature-verified the PNG "
+                                  "in-guest but the base64 dump is OFF (the default, "
+                                  "incl. plain test-mode). Start the session with "
+                                  "`--screenshot-dump` (or build --features "
+                                  "screenshot-b64-dump) to extract it.",
+                    }, indent=2))
+                    return 1
                 m = _B64_FIRST_RE.search(ln)
                 if m:
                     total_chunks = int(m.group(1))
@@ -12451,6 +12485,17 @@ def main():
                                "'firefox-test-core' boot is the FAST perf/render "
                                "profile (<2 MB serial vs ~45 MB).  The expansion "
                                "is printed to stderr, never silent.")
+    p_start.add_argument("--screenshot-dump", action="store_true",
+                          dest="screenshot_dump",
+                          help="Append the 'screenshot-b64-dump' feature so "
+                               "Test 198 (GDI PNG screenshot) base64-encodes the "
+                               "rendered boot-splash PNG over COM1 for `read-png` "
+                               "extraction. OFF by default (and not in test-mode): "
+                               "the ~25k-line dump is host-extraction only and "
+                               "does NOT affect any test's pass/fail, so a plain "
+                               "CI boot skips it. Set this only when you intend to "
+                               "`read-png` the boot-splash. Expansion printed to "
+                               "stderr, never silent.")
     p_start.add_argument("--no-build", action="store_true",
                           help="Skip cargo build; use existing kernel.bin")
     p_start.add_argument("--build-only", action="store_true", dest="build_only",


### PR DESCRIPTION
## What

Master `kernel smoke (QEMU boot + test suite)` intermittently fails with `[WATCH] ✗ HARD TIMEOUT after 900.1s` (exit 3) and **no failing test**. This gates the deterministic half of that timeout: Test 198's host-extraction-only PNG base64 serial dump.

**CI-config / test-infra only.** No kernel behaviour changes.

## Root cause (dispositive)

The 900s watchdog only fires on *continuous* serial output for the full budget (a bugcheck exits via isa-debug-exit → caught as a test failure; a 30s output gap → caught as idle-hung). The continuous-output case is a **serial-UART saturation**:

- Test 198 ("GDI PNG screenshot") renders a 1.44 MB boot-splash PNG and base64-encodes it over COM1 as **~25,275 `[SCREENSHOT-B64:N/M]` lines**. Each is a synchronous PIO THR write (one VM-exit/byte under KVM; NS16550A model, Intel SDM Vol. 3C §25), so the dump alone costs minutes.
- Under `-smp 2` it races a faulting process's own serial spew on the other CPU, pushing the suite past 900s.

The dump is **host-extraction only** (the harness `read-png` subcommand decodes it to a host PNG); **CI never invokes `read-png`**. Test 198's pass/fail is decided by the in-guest PNG-signature check (`[SCREENSHOT] … signature_ok=true`) emitted **before** the dump — so gating it off changes no test outcome.

## Change

- `kernel/Cargo.toml`: new leaf feature `screenshot-b64-dump`, **off by default**, deliberately **not** pulled into `test-mode` (mirrors the existing `test-mode-trace` split-out).
- `kernel/src/test_runner.rs`: Test 198's step-7 base64 dump is now `#[cfg(feature = "screenshot-b64-dump")]`; when off it emits a single `[SCREENSHOT-B64-DISABLED]` sentinel. Steps 1–6 (render, signature check, `signature_ok=true`, `test_pass!`) are unchanged.
- `scripts/qemu-harness.py`: `start --screenshot-dump` appends the feature (expansion printed to stderr, never silent — mirrors `--trace`); `read-png` now fast-fails on the sentinel with `{"ok":false,"error":"screenshot_dump_disabled"}` rc=1 instead of waiting out its timeout.
- `scripts/qemu-harness-smoke.py`: new host-only `run_read_png_disabled_check` (in the `--staleness-only` CI subset) pins the fast-fail contract.

## Verification

- Host-only smoke (`qemu-harness-smoke.py --staleness-only`) green, including the new 4/4 read-png check.
- Live TCG `-smp 2` boot of the gated `--features test-mode` kernel: Test 198 emits `signature_ok=true` (PASS) **and** the `[SCREENSHOT-B64-DISABLED]` sentinel; **0 `[SCREENSHOT-B64:…]` chunk lines** (dump fully eliminated).
- Independent review: APPROVE (correctness-preservation, no-collateral, feature-hygiene, harness-additivity all PASS). The Firefox `/tmp/out.png` path is a distinct `[FF-OUT-PNG:…]` emitter and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
