### PR TITLE
sched/proc: don't reap a thread's kernel stack while it runs on another CPU

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1052,8 +1052,15 @@ pub fn current_tid() -> Tid {
 }
 
 /// Set the currently running thread's TID (per-CPU).
+///
+/// Published with `Release` so a cross-CPU `Acquire` reader
+/// ([`is_tid_current_on_any_cpu`]) observes this CPU's current TID coherently:
+/// the reaper relies on this to never free the kernel stack of a thread that
+/// is still executing on another core.  The companion `current_tid()` /
+/// `current_tid_on_cpu()` fast readers stay `Relaxed`/`Acquire` as before — a
+/// CPU reading *its own* slot needs no barrier.
 pub fn set_current_tid(tid: Tid) {
-    PER_CPU_CURRENT_TID[cpu_index()].store(tid, Ordering::Relaxed);
+    PER_CPU_CURRENT_TID[cpu_index()].store(tid, Ordering::Release);
 }
 
 /// Read the currently running TID for an arbitrary CPU index (not necessarily
@@ -1066,6 +1073,41 @@ pub fn current_tid_on_cpu(cpu: usize) -> Tid {
     } else {
         0
     }
+}
+
+/// Returns `true` if `tid` is the thread currently executing on **any** logical
+/// processor — including a CPU other than the caller's.
+///
+/// This is the cross-CPU analogue of comparing against [`current_tid`]: where
+/// `current_tid()` only answers "is `tid` running on *my* CPU", this surveys
+/// every CPU's per-CPU current-TID slot.  It is the kernel equivalent of the
+/// `task_on_cpu()` predicate other SMP kernels gate teardown on: a thread's
+/// kernel stack (or any other execution-state resource) must never be freed,
+/// recycled, or zero-filled while the thread is still on a CPU, even if a
+/// different CPU marked it Dead out-of-band (e.g. `exit_group` marking a
+/// sibling Dead while that sibling is mid-syscall on another core).
+///
+/// `tid == 0` is the per-CPU idle/bootstrap sentinel and is never a reapable
+/// user thread, so a zero query short-circuits to `false`.
+///
+/// Ordering: each slot is read with `Acquire` so the result synchronises-with
+/// the `Release` publish performed by `set_current_tid`/the context-switch
+/// path when a CPU adopts a thread as current.  A `false` result therefore
+/// means no CPU had `tid` published as current at a point no earlier than this
+/// call observed each slot — sufficient for the reaper, which re-checks under
+/// the THREAD_TABLE lock that the thread is still Dead.
+pub fn is_tid_current_on_any_cpu(tid: Tid) -> bool {
+    if tid == 0 {
+        return false;
+    }
+    let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
+        .min(crate::arch::x86_64::apic::MAX_CPUS);
+    for cpu in 0..ncpus {
+        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid {
+            return true;
+        }
+    }
+    false
 }
 
 /// Read the currently running PID for an arbitrary CPU index.  See
@@ -2361,15 +2403,31 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // grow large enough that the linear scan becomes a latency concern,
     // consider an atomic per-process Running-thread counter as a fast
     // pre-check before taking the lock.
-    let any_sibling_running = {
-        let threads = THREAD_TABLE.lock();
-        threads.iter().any(|t| {
-            t.pid == pid
-            && (calling_tid == 0 || t.tid != calling_tid)
-            && t.state == ThreadState::Running
+    //
+    // CROSS-CPU detection: the `state == Running` test that used to live here
+    // was defeated by this function's own earlier pass, which forced every
+    // sibling to `Dead` (so none read as Running and the guard always fell
+    // through to an immediate free).  A sibling marked Dead can still be
+    // physically executing on another CPU mid-syscall; freeing the user page
+    // tables out from under it lets its SYSRETQ land on a now-unmapped user VA
+    // (Intel SDM Vol. 3A §4.10).  Detect "still on a CPU" via the per-CPU
+    // current-PID slots — the address-space analogue of the reaper's
+    // `is_tid_current_on_any_cpu` kstack guard.
+    let any_sibling_on_cpu = {
+        let calling_cpu_tid = current_tid();
+        let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
+            .min(crate::arch::x86_64::apic::MAX_CPUS);
+        (0..ncpus).any(|c| {
+            let ctid = current_tid_on_cpu(c);
+            current_pid_on_cpu(c) == pid
+                && ctid != 0
+                // Exclude the exit_group caller itself (it is mid-teardown on
+                // its own stack; it frees the rest after it yields).
+                && !(calling_tid != 0 && ctid == calling_tid)
+                && ctid != calling_cpu_tid
         })
     };
-    if !any_sibling_running {
+    if !any_sibling_on_cpu {
         free_process_memory(pid);
     }
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -709,17 +709,33 @@ fn reap_dead_threads_sched() {
     // Collect (stack_base, stack_pages, last_cpu) for each reapable thread,
     // removing them from THREAD_TABLE in the same pass.  `last_cpu` feeds the
     // per-CPU switch-generation quiescence gate (see `CPU_SWITCH_GEN`).
-    let stacks: alloc::vec::Vec<(u64, usize, usize)> = {
+    let stacks = {
         let mut threads = THREAD_TABLE.lock();
         // A Dead thread is safe to reap only when ctx_rsp_valid == true, which
         // switch_context_asm sets AFTER saving the thread's RSP (meaning the CPU
         // has left or is about to leave the thread's kernel stack).  Exit paths
         // (exit_thread/exit_group) set ctx_rsp_valid=false before calling schedule(),
         // preventing the AP from freeing the stack while the BSP is still on it.
+        //
+        // CROSS-CPU GUARD (SMP=2 exit_group race): `current_tid` only names the
+        // thread running on THIS CPU.  `exit_group_inner` marks every sibling of
+        // the dying group Dead out-of-band (proc/mod.rs) while a sibling may be
+        // mid-syscall and physically executing on ANOTHER CPU.  Such a sibling
+        // still has ctx_rsp_valid == true (it was set true when the sibling was
+        // switched IN, not when it switched out), so the ctx_rsp_valid gate alone
+        // does NOT exclude it.  Reaping it would push its kernel stack to the
+        // dead-stack cache (which zero-fills the stack) or free it to the PMM
+        // while that stack is live on the other CPU — the sibling's next
+        // `ret`/`iretq` then loads a zeroed/recycled return slot and transfers
+        // control to RIP=0 (#PF IFETCH) or a torn low address (#GP).  Gate on
+        // `is_tid_current_on_any_cpu` — the kernel analogue of `task_on_cpu()` —
+        // so a Dead-but-still-executing thread is skipped until it actually
+        // leaves its CPU (and publishes ctx_rsp_valid via switch_context_asm).
         let dead_indices: alloc::vec::Vec<usize> = threads.iter().enumerate()
             .filter(|(_, t)| {
                 t.is_reapable()
                     && t.tid != current_tid
+                    && !crate::proc::is_tid_current_on_any_cpu(t.tid)
                     && t.ctx_rsp_valid.load(core::sync::atomic::Ordering::Acquire)
             })
             .map(|(i, _)| i)
@@ -1770,6 +1786,17 @@ was_emergency_4k={}",
                     if cur.state == ThreadState::Running {
                         cur.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
                         cur.state = ThreadState::Ready;
+                    } else {
+                        // Outgoing thread is NOT Running — it Blocked/Slept, or was
+                        // marked Dead out-of-band by a sibling's `exit_group` while
+                        // executing here.  We are still on its kernel stack until
+                        // `switch_context_asm` below saves RSP, but `set_current_tid`
+                        // (a few lines down) will stop publishing this tid as current.
+                        // Clear ctx_rsp_valid so the cross-CPU reaper's gate
+                        // (`Dead && !current_on_any_cpu && ctx_rsp_valid`) cannot free
+                        // this still-in-use stack during the publish→switch window.
+                        // `switch_context_asm` re-sets it true after saving RSP.
+                        cur.ctx_rsp_valid.store(false, core::sync::atomic::Ordering::Release);
                     }
                     // Decay priority boost here (outgoing thread, lock already held)
                     // rather than in the timer ISR to avoid 100 Hz try_lock overhead.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1318,6 +1318,8 @@ pub fn run() -> ! {
         if test_650_percpu_wake_target() { passed += 1; }
         total += 1;
         if test_652_percpu_audit_image_off_stack() { passed += 1; }
+        total += 1;
+        if test_653_reaper_skips_thread_on_other_cpu() { passed += 1; }
     }
 
     // ── Test 105: Heap guard pages — PTE verification ─────────────────────
@@ -49906,6 +49908,68 @@ fn test_652_percpu_audit_image_off_stack() -> bool {
 
     test_println!("  [PerCpuRq; MAX_CPUS] audit image dwarfs the emergency kstack \
 tier → must stay heap-allocated (closes the switch_context popf #DB) GREEN");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 653: reaper cross-CPU guard — never reap a thread on another CPU ────
+//
+// Regression for the SMP=2 content-init crash race: `exit_group_inner` marks
+// every sibling of a dying thread group Dead out-of-band while a sibling may be
+// physically executing on another CPU.  Such a sibling keeps `ctx_rsp_valid ==
+// true` (set true when it was switched IN), so the reaper's `ctx_rsp_valid`
+// gate alone does NOT exclude it.  Reaping it would push its kernel stack to
+// the dead-stack cache (which zero-fills it) or free it to the PMM while the
+// stack is live on the other CPU — the sibling's next `ret`/`iretq` then loads
+// a zeroed/recycled return slot and jumps to RIP=0 (#PF IFETCH) or a torn low
+// address such as 0x700a (#GP).
+//
+// The fix gates the reaper on `proc::is_tid_current_on_any_cpu(tid)` — the
+// kernel analogue of `task_on_cpu()`.  This test pins that predicate's core
+// invariants (it is the load-bearing primitive of the reaper gate):
+//   1. The calling thread's own TID IS current on this CPU → predicate true.
+//      (A reaper running on any CPU must therefore never select the thread
+//      executing on that CPU, even if it has been marked Dead out-of-band.)
+//   2. A TID that no CPU has ever adopted as current → predicate false.
+//   3. The idle/bootstrap sentinel TID 0 → predicate false (never a reapable
+//      user thread).
+fn test_653_reaper_skips_thread_on_other_cpu() -> bool {
+    const NAME: &str = "[SCHED/SMP] reaper cross-CPU guard (Test 653)";
+    test_header!(NAME);
+
+    let my_tid = crate::proc::current_tid();
+
+    // (1) The thread currently executing on this CPU must report as current on
+    //     "some" CPU — this is exactly what stops a concurrent reaper on the
+    //     other core from freeing this stack out from under us.
+    if my_tid != 0 && !crate::proc::is_tid_current_on_any_cpu(my_tid) {
+        test_fail!(NAME,
+            "current tid {} not reported running on any CPU — reaper would be \
+             free to recycle a live kernel stack", my_tid);
+        return false;
+    }
+
+    // (2) A TID no CPU runs must be reported absent.  u64::MAX is never a real
+    //     allocated TID (allocation is monotonic from a small base), so it can
+    //     never be published in a PER_CPU_CURRENT_TID slot.
+    let phantom_tid: u64 = u64::MAX;
+    if crate::proc::is_tid_current_on_any_cpu(phantom_tid) {
+        test_fail!(NAME,
+            "phantom tid {:#x} falsely reported running — reaper would defer \
+             forever / mis-gate", phantom_tid);
+        return false;
+    }
+
+    // (3) TID 0 short-circuits to false (per-CPU idle/bootstrap sentinel).
+    if crate::proc::is_tid_current_on_any_cpu(0) {
+        test_fail!(NAME, "sentinel tid 0 reported running — must be false");
+        return false;
+    }
+
+    test_println!(
+        "  current_tid={} on_any_cpu={} phantom_absent=true sentinel0_absent=true",
+        my_tid, crate::proc::is_tid_current_on_any_cpu(my_tid)
+    );
     test_pass!(NAME);
     true
 }


### PR DESCRIPTION
## Summary

Closes the SMP use-after-free where the dead-thread reaper frees a thread's kernel stack while that thread is **still executing on another CPU**.

`exit_group_inner` marks every sibling of a dying thread group `Dead` out-of-band. On SMP a sibling can be mid-syscall and physically executing on another core at that instant. `reap_dead_threads_sched`'s gate was `is_reapable() && tid != current_tid && ctx_rsp_valid`:
- `current_tid` names only the *reaping* CPU's current thread.
- A switched-in (Running) thread carries `ctx_rsp_valid == true` — that flag proves a context was saved at some point, **not** that the thread has left its CPU.

So a sibling marked Dead while running on the other core passed all three gates and had its kernel stack pushed to the dead-stack cache (which zero-fills it) or returned to the PMM while still live. Its next `ret`/`iretq` then loaded a zeroed/recycled return slot and jumped to **RIP=0** (kernel instruction-fetch #PF) or a torn low address (#GP).

### Evidence (GDB autopsy, SMP=2 windowed Firefox)
- Faulting boot: `[PROC] PID 1 exit_group(11) caller_tid=20` → all siblings CLEARTID'd → `[PROC] PID 1 memory freed` → kernel #PF, **RIP=0, CS=0x08, CR2=0x0, "not-present READ KERNEL IFETCH", TID 2 (the dying process's main thread)**.
- The faulting thread's kernel stack read **all-zero above RSP** — a freshly recycled/zeroed stack.

## Fix
- Add `proc::is_tid_current_on_any_cpu(tid)` — surveys every CPU's per-CPU current-TID slot (cross-CPU analogue of `current_tid()`). `set_current_tid` now publishes with `Release` so the `Acquire` survey is coherent across cores.
- Gate the reaper on `!is_tid_current_on_any_cpu(t.tid)` so a Dead-but-still-executing thread is skipped until it leaves its CPU and re-publishes `ctx_rsp_valid` via `switch_context_asm`.
- In `schedule()`, clear the outgoing thread's `ctx_rsp_valid` for the Dead/Blocked case too (previously only Running), closing the narrow publish→switch window.
- Replace `exit_group_inner`'s `state == Running` deferred-free guard (defeated by its own earlier Dead-marking) with a per-CPU current-PID survey, so `free_process_memory` is correctly deferred to the last sibling's syscall-exit drain while a sibling is still on another CPU (Intel SDM Vol. 3A §4.10).

SMP=1 reduces the survey to the existing `tid != current_tid` compare → behaviour-preserving.

## Verification
- **SMP=2 windowed Firefox**: the RIP=0 / all-zero-stack crash class no longer reproduces; boots reach `MapWindow` and render.
- **SMP=1 windowed Firefox**: clean, renders (no regression).
- **Test 653** (`[SCHED/SMP] reaper cross-CPU guard`) PASSES; placed ahead of the Firefox launch oracle.
- Independent reviewer pass (SMP/reaper = high blast radius): APPROVE-WITH-NITS — memory ordering, the Blocked-outgoing `ctx_rsp_valid` clear, lock discipline, and SMP=1 no-op all confirmed sound.

## Scope / not in this PR
This closes the **reaper-frees-running-thread** UAF (the RIP=0 / all-zero-stack class). A **separate** teardown-time corruption that restores a torn `switch_context` frame (a low `0x70xx` RIP/RSP, *not* a zeroed slot; observed RSP in a recurring physical range) is a distinct mechanism and remains open — it lives in the switch-frame-recycle area, not the stack-free area this PR fixes. The `SCHED/STARVE Dead/reaped` runqueue-livelock (the scheduler-starvation half of the same workload) is also out of scope.

## Test plan
- [x] `test-mode` SMP=2 boot: Test 653 PASS (plus 650/652).
- [x] `firefox-test-core` SMP=2 GUI boots: RIP=0 class gone, render reached.
- [x] `firefox-test-core` SMP=1 GUI boot: clean render.

> Note for the merge gate: the kernel-smoke check is the chronically-flaky parked-W215 lane; confirm its failure is that known flake rather than blocking on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
