### PR TITLE
mm/pmm: reserve the UEFI bootstrap stack so the allocator can't recycle TID 0's live stack

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1644,6 +1644,19 @@ user_pref("security.sandbox.content.level", 0);
             // once; emit_out_png() re-reads and streams the bytes (see below).
             let mut out_png_emitted = false;
             let mut last_png_probe_tick: u64 = 0;
+
+            // Backstop for the bootstrap-stack reservation (mm/pmm.rs): we are
+            // at the deepest point of `kernel_main`-phase bring-up on the BSP
+            // (TID 0) bootstrap stack, just before settling into the steady-
+            // state poll loop.  Assert the live RSP still lies inside the span
+            // `pmm::init` reserved against the page allocator; if a late init
+            // phase descended below the reserved floor, that frame is a free
+            // bootstrap-stack page the allocator could recycle out from under
+            // TID 0's saved switch_context frame — turn that silent residual
+            // into a loud bugcheck here rather than an intermittent torn-frame
+            // fault later.
+            crate::mm::pmm::bootstrap_stack_assert_rsp_reserved();
+
             loop {
                 gui::input::pump_input();
                 crate::net::poll();

--- a/kernel/src/mm/pmm.rs
+++ b/kernel/src/mm/pmm.rs
@@ -91,6 +91,15 @@ const BITMAP_SIZE: usize = MAX_PAGES / 8;
 /// 0 = free, 1 = used/reserved.
 static mut BITMAP: [u8; BITMAP_SIZE] = [0xFF; BITMAP_SIZE]; // Start all as used
 
+/// Physical span (inclusive page bounds, byte addresses) reserved for the
+/// UEFI bootstrap stack at `init`.  Zero until `init` runs (or when the live
+/// stack is already higher-half, e.g. under the test harness).  Exposed via
+/// [`bootstrap_stack_phys_span`] for the regression test and diagnostics.
+static BOOTSTRAP_STACK_PHYS_FIRST: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+static BOOTSTRAP_STACK_PHYS_LAST: core::sync::atomic::AtomicU64 =
+    core::sync::atomic::AtomicU64::new(0);
+
 /// Lock for bitmap operations.
 static PMM_LOCK: Mutex<()> = Mutex::new(());
 
@@ -203,6 +212,60 @@ pub fn boot_info_phys_page_span() -> (usize, usize, u64) {
     let last = ((astryx_shared::BOOT_INFO_PHYS_BASE + bytes.saturating_sub(1))
         / PAGE_SIZE as u64) as usize;
     (first, last, bytes)
+}
+
+/// Inclusive `(first_phys, last_phys)` byte-address span reserved for the UEFI
+/// bootstrap stack at `init`, or `(0, 0)` if no firmware stack was reserved
+/// (the live stack was already higher-half — e.g. under the test harness).
+///
+/// The BSP idle thread (TID 0) executes on this stack for the lifetime of the
+/// system (the bootloader never installs a fresh stack and `proc::init` never
+/// migrates TID 0 off it), so every page in this span MUST stay reserved
+/// against the page allocator — handing one out lets its new owner overwrite
+/// TID 0's saved `switch_context` frame and tear the next resume.
+pub fn bootstrap_stack_phys_span() -> (u64, u64) {
+    (
+        BOOTSTRAP_STACK_PHYS_FIRST.load(Ordering::Relaxed),
+        BOOTSTRAP_STACK_PHYS_LAST.load(Ordering::Relaxed),
+    )
+}
+
+/// Runtime backstop for the bootstrap-stack reservation: verify the live RSP
+/// still lies within the reserved span.
+///
+/// The reservation in [`init`] picks a fixed downward window below the RSP it
+/// observed at PMM-init time.  Every later boot phase grows the BSP stack
+/// *below* that point; if any descends past the reserved floor, that frame is a
+/// FREE bootstrap-stack page the allocator could recycle — silently
+/// re-introducing the torn-`switch_context`-frame fault.  Call this at the
+/// deepest init point (the bottom of `kernel_main`-phase bring-up) so any
+/// shortfall is a loud bugcheck rather than an intermittent recycle months
+/// later.  No-op when no firmware-stack span was recorded (higher-half live
+/// stack, e.g. the test harness) or when the live stack is already higher-half.
+#[inline(never)]
+pub fn bootstrap_stack_assert_rsp_reserved() {
+    let (first, last) = bootstrap_stack_phys_span();
+    if first == 0 && last == 0 {
+        return; // no firmware stack reserved — nothing to police
+    }
+    let rsp: u64;
+    // SAFETY: reading the stack pointer has no side effects.
+    unsafe { core::arch::asm!("mov {}, rsp", out(reg) rsp, options(nomem, nostack, preserves_flags)); }
+    if rsp == 0 || rsp >= astryx_shared::KERNEL_VIRT_BASE {
+        return; // live stack is higher-half (already PMM-reserved by construction)
+    }
+    // `last` is the first byte of the last reserved page; admit the whole page.
+    let lo = first;
+    let hi = last + (PAGE_SIZE as u64 - 1);
+    if rsp < lo || rsp > hi {
+        crate::ke::bugcheck::ke_bugcheck(
+            crate::ke::bugcheck::BUGCHECK_BAD_KERNEL_RSP,
+            rsp,
+            lo,
+            hi,
+            0,
+        );
+    }
 }
 
 /// True if the page index is currently marked used in the PMM bitmap.
@@ -381,6 +444,87 @@ pub fn init(boot_info: &BootInfo) {
         // SAFETY: We hold the PMM lock and page is in bounds.
         unsafe {
             mark_page_used(page);
+        }
+    }
+
+    // Reserve the UEFI bootstrap stack against the PMM (torn-switch-frame fix).
+    //
+    // The bootloader `jmp`s to the kernel WITHOUT installing a fresh stack, so
+    // the kernel — and forever after the BSP idle thread (TID 0) — executes on
+    // the firmware-provided stack (UEFI §2.3.4: the boot-time stack lives in
+    // EfiBootServicesData / EfiConventionalMemory).  Our memory-map converter
+    // reports that region as `Available`, so the loop above just marked the
+    // bootstrap-stack pages FREE.  Under heavy allocation pressure the PMM then
+    // hands one of those physical frames to a user/heap allocation whose owner
+    // overwrites it — while TID 0's saved `switch_context` frame still lives on
+    // that very stack.  The next resume of TID 0 restores a torn frame
+    // (garbage RSP/RIP) and faults.  By design TID 0 never migrates off this
+    // stack (see `proc::init` / `main`), so the frames must be reserved.
+    //
+    // We are executing on the bootstrap stack right now, so the live RSP names
+    // a page inside it.  Reserve a generous window: a few pages above the
+    // current frame (the firmware's own callers, already unwound but still part
+    // of the allocation) and the full kernel-stack span below it — every later
+    // boot phase (`syscall::init`, `vfs::init`, the scheduler bring-up, …) grows
+    // the stack *below* this point, and all of those frames belong to TID 0's
+    // permanent stack and must stay reserved.  The window is bounded and one-
+    // shot; over-reserving a handful of conventional pages is harmless.
+    //
+    // Only meaningful when the live stack is identity-mapped (RSP < the
+    // higher-half base): in `test-mode` the harness may already be on a
+    // higher-half kernel stack, in which case there is no firmware stack to
+    // reserve and we skip — the reservation is purely additive and SMP-count
+    // independent, so it is a behaviour-preserving no-op there and on SMP=1.
+    {
+        let rsp: u64;
+        // SAFETY: reading the stack pointer has no side effects.
+        unsafe { core::arch::asm!("mov {}, rsp", out(reg) rsp, options(nomem, nostack, preserves_flags)); }
+        if rsp != 0 && rsp < astryx_shared::KERNEL_VIRT_BASE {
+            // Pages above the current frame (firmware callers) + a generous
+            // span below it.  The BSP never leaves this stack, and every later
+            // boot phase (`syscall::init`, `vfs::init`, the GUI/X11 bring-up
+            // with on-stack page buffers, …) descends *below* this frame, so
+            // the downward reservation must comfortably exceed the deepest
+            // `kernel_main` frame.  128 pages (512 KiB) is twice the kernel's
+            // own per-thread kernel-stack budget (`proc::KERNEL_STACK_PAGES`
+            // = 64 pages / 256 KiB), which already bounds the deepest call
+            // chain any single thread is allowed to reach — so a frame below
+            // this floor would be a stack-overflow bug in its own right.
+            // `bootstrap_stack_contains_rsp` provides a loud runtime backstop
+            // at the deepest init point so any shortfall is a bugcheck, never
+            // a silent recycle.  4 pages above covers the firmware's residual
+            // (already-unwound) frames.
+            const ABOVE_PAGES: u64 = 4;
+            const BELOW_PAGES: u64 = 128;
+            let cur_page = rsp / PAGE_SIZE as u64;
+            let first = cur_page.saturating_sub(BELOW_PAGES);
+            let last = cur_page.saturating_add(ABOVE_PAGES);
+            let mut reserved = 0u64;
+            for page in first..=last {
+                let p = page as usize;
+                if p == 0 || p >= MAX_PAGES {
+                    continue;
+                }
+                // SAFETY: lock held, index bounds-checked above.
+                unsafe {
+                    if !is_page_used_locked(p) {
+                        mark_page_used(p);
+                        reserved += 1;
+                        if total_available > 0 {
+                            total_available -= 1;
+                        }
+                    }
+                }
+            }
+            BOOTSTRAP_STACK_PHYS_FIRST.store(first * PAGE_SIZE as u64, Ordering::Relaxed);
+            BOOTSTRAP_STACK_PHYS_LAST.store(last * PAGE_SIZE as u64, Ordering::Relaxed);
+            crate::serial_println!(
+                "[PMM] Bootstrap stack reserved: rsp={:#x} phys=[{:#x}..={:#x}] newly_reserved={} (torn-frame fix)",
+                rsp,
+                first * PAGE_SIZE as u64,
+                last * PAGE_SIZE as u64,
+                reserved,
+            );
         }
     }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1320,6 +1320,8 @@ pub fn run() -> ! {
         if test_652_percpu_audit_image_off_stack() { passed += 1; }
         total += 1;
         if test_653_reaper_skips_thread_on_other_cpu() { passed += 1; }
+        total += 1;
+        if test_654_bootstrap_stack_reserved() { passed += 1; }
     }
 
     // ── Test 105: Heap guard pages — PTE verification ─────────────────────
@@ -49969,6 +49971,61 @@ fn test_653_reaper_skips_thread_on_other_cpu() -> bool {
     test_println!(
         "  current_tid={} on_any_cpu={} phantom_absent=true sentinel0_absent=true",
         my_tid, crate::proc::is_tid_current_on_any_cpu(my_tid)
+    );
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 654: UEFI bootstrap stack reserved against the PMM ──────────────────
+//
+// Regression for the SMP=2 torn-`switch_context`-frame bugcheck (TID 0 idle
+// resumed with a bare-physical RSP in the recurring 0x3fe7b__ range, RIP in the
+// 0x70xx cluster).  Root cause: the bootloader `jmp`s to the kernel without
+// installing a fresh stack, so the BSP idle thread (TID 0) runs forever on the
+// firmware-provided stack, whose physical pages the UEFI memory map reports as
+// `Available` — the page allocator was free to hand one out under load, letting
+// the new owner overwrite TID 0's live saved frame.  `pmm::init` now reserves
+// that span.  This test asserts every page in the reserved span is marked used,
+// so the allocator can never re-issue it.
+fn test_654_bootstrap_stack_reserved() -> bool {
+    const NAME: &str = "[MM/PMM] bootstrap stack reserved (Test 654)";
+    test_header!(NAME);
+
+    let (first, last) = crate::mm::pmm::bootstrap_stack_phys_span();
+
+    // Under the test harness the live stack may already be higher-half (the
+    // firmware stack was replaced before this test runs), in which case
+    // `init` recorded no span.  That is a valid no-op outcome — there is no
+    // firmware stack to protect — so the test passes vacuously.
+    if first == 0 && last == 0 {
+        test_println!("  no firmware-stack span recorded (higher-half live stack) — vacuous pass");
+        test_pass!(NAME);
+        return true;
+    }
+
+    if last < first {
+        test_fail!(NAME, "inverted span first={:#x} last={:#x}", first, last);
+        return false;
+    }
+
+    // Every page in [first, last] (inclusive byte addresses) must be reserved.
+    let first_page = (first / 4096) as usize;
+    let last_page = (last / 4096) as usize;
+    let mut checked = 0usize;
+    for page in first_page..=last_page {
+        if !crate::mm::pmm::is_page_used_for_test(page) {
+            test_fail!(NAME,
+                "bootstrap-stack page {:#x} (phys {:#x}) is FREE — allocator could \
+                 hand it out and tear TID 0's switch frame",
+                page, page * 4096);
+            return false;
+        }
+        checked += 1;
+    }
+
+    test_println!(
+        "  span=[{:#x}..={:#x}] pages={} all_reserved=true",
+        first, last, checked
     );
     test_pass!(NAME);
     true


### PR DESCRIPTION
## Summary

Fixes the **bootstrap-stack variant** of the residual SMP=2 torn-`switch_context`-frame bugcheck (TID 0 resumed with a bare-physical RSP in the recurring `0x3fe7b___` range, RIP in the `0x70xx` cluster).

## Root cause (live-proven via GDB)

The bootloader transfers to the kernel with a bare `jmp` and never installs a fresh stack, so the kernel — and from then on the **BSP idle thread (TID 0)** — runs for the lifetime of the system on the **firmware-provided stack** (physical ~`0x3fe7b000`, identity-mapped via PML4[0]). The UEFI memory map reports that region as `EfiBootServicesData`/`EfiConventionalMemory`, which our converter maps to `Available`, so `pmm::init` left those frames **free**. By design TID 0 never migrates off this stack (it keeps a higher-half kernel stack only for `TSS.RSP[0]`).

Under heavy allocation pressure (the Firefox SMP=2 clone / `exit_group` storm) the page allocator handed one of those physical frames to a heap/user allocation whose new owner overwrote it — while TID 0's saved `switch_context` restore frame still lived on that stack. TID 0's next resume restored a **torn frame**: `switch_context_asm`'s `mov rsp, rsi` loaded a bare-physical RSP, the pops read the new owner's bytes, and `ret` transferred to a low garbage RIP → kernel `#PF`/`#GP` on CPU 0 / TID 0. This was distinct from the dead-stack-cache zero recycle (frame overwritten in place, not zero-filled; the frame was never a tracked kernel stack, hence free-shadow-clean).

**Live evidence:** at `schedule()` on a running boot, TID 0's RSP = `0x3fe7d2a0` (bare physical, `0x3fe7_xxxx`), CS=`0x08` — exactly the crash range (`RSP=0x3fe7b758`, `RSP-bp=0x3fe7b028`). The reserved span (`phys 0x3fdfd000..0x3fe81000`, 133 pages) was entirely free before this change (`newly_reserved=133`), i.e. the allocator **would** have handed those frames out.

## The fix

- `pmm::init` reads the live RSP (we run on the bootstrap stack during init) and, when the stack is identity-mapped, reserves a generous window against the page allocator — 512 KiB below the current frame (twice the kernel's per-thread stack budget, which already bounds the deepest call chain any thread may reach) plus a few pages above for firmware residual frames. Only currently-free pages are taken; bounded, one-shot; a no-op when the live stack is already higher-half.
- `bootstrap_stack_assert_rsp_reserved()` is called at the deepest point of `kernel_main` bring-up and bugchecks loudly if the live RSP ever escapes the reserved span — converting any future shortfall from a silent recycle into a catchable assert.
- **Test 654** asserts every page in the reserved span is marked used.

The reservation is correct independent of CPU count (TID 0 always runs here); **SMP=1 is behaviour-preserving**.

## Scope

This closes the **bootstrap-stack variant** (TID 0, bare-physical `0x3fe7b___` RSP). A separate torn-frame on **regular higher-half kernel stacks** (recycled dead-stack reissue, observed as TID *N>0* on `0xffff8000…` stacks) is a different mechanism and is **not** addressed here.

## Verification

- Across SMP=2 windowed-Firefox boots the bootstrap-stack signature (bare-physical RSP / TID 0) **no longer reproduces** (0 occurrences vs a ~33% baseline bugcheck rate); the remaining intermittent crashes are the separate higher-half-kstack variant.
- The reserved span covers every observed crash address; the RSP backstop never false-fires.
- SMP=1 windowed-Firefox renders with no regression.
- Test 654 passes; `cargo check` clean (`test-mode` + `firefox-test-core`).

Independent SMP/PMM-blast-radius review: APPROVE-WITH-NITS (all six correctness dimensions — lock discipline, page accounting, the identity-vs-higher-half classifier, over-reservation safety, the SMP=1 no-op, and the inline-asm — refuted as concerns); the sole substantive nit (span sufficiency under late-phase stack growth) is addressed by the widened window + the runtime backstop assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
