### PR TITLE
NDE-27: recvfrom(2) reports orderly EOF (0) not EAGAIN on a peer-FINned TCP socket (SMP=1 FF vCPU-monopoly hang)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -429,6 +429,13 @@ pub fn dispatch(req: &str, out: &mut String) {
         // net-ipver: read or toggle the runtime IPv4/IPv6 address-family
         // enable flags (net::ipver).  One-shot, structured JSON output.
         "net-ipver"     => op_net_ipver(req, out),
+        // socket-poll: per-AF_INET-socket poll-readiness divergence report.
+        // For each socket dumps the readiness poll_revents would compute plus
+        // the TCB state resolved by local-port-only vs the exact 4-tuple; a
+        // mismatch (`divergent`) means a sibling TCB on the same local port is
+        // being mis-attributed (spurious POLLIN/EOF → busy-poll livelock).
+        // Emits a [SOCKPOLL] serial mirror so it survives a vCPU monopoly.
+        "socket-poll"   => op_socket_poll(out),
         _ => {
             out.push_str(r#"{"error":"unknown op: "#);
             for c in op.chars().take(64) {
@@ -4067,6 +4074,80 @@ fn op_net_ipver(req: &str, out: &mut String) {
         if v4 { "true" } else { "false" },
         if v6 { "true" } else { "false" },
     );
+}
+
+// ── socket-poll ─────────────────────────────────────────────────────────────
+//
+// Per-AF_INET-socket poll-readiness divergence report.  Names, per socket,
+// the readiness `poll_revents` computes AND the TCB state resolved by
+// local-port-only vs the exact 4-tuple; `divergent` flags the sticky-POLLIN
+// / spurious-EOF condition (a sibling TCB on the same local port being
+// mis-attributed).  A [SOCKPOLL] serial mirror is emitted so the result
+// survives a vCPU-monopoly busy-poll livelock (kdb starved).
+fn op_socket_poll(out: &mut String) {
+    use core::fmt::Write;
+    fn st_name(s: Option<crate::net::tcp::TcpState>) -> &'static str {
+        use crate::net::tcp::TcpState::*;
+        match s {
+            Some(Closed) => "CLOSED", Some(Listen) => "LISTEN",
+            Some(SynSent) => "SYN_SENT", Some(SynReceived) => "SYN_RCVD",
+            Some(Established) => "ESTABLISHED", Some(FinWait1) => "FIN_WAIT_1",
+            Some(FinWait2) => "FIN_WAIT_2", Some(CloseWait) => "CLOSE_WAIT",
+            Some(LastAck) => "LAST_ACK", Some(TimeWait) => "TIME_WAIT",
+            None => "NONE",
+        }
+    }
+    let diag = crate::net::socket::snapshot_poll_diag();
+    let mut divergent = 0usize;
+    let mut sticky_in = 0usize;
+    out.push('{');
+    let _ = write!(out, r#""count":{},"sockets":["#, diag.len());
+    for (i, d) in diag.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        out.push('{');
+        j_kv(out, "id", &alloc::format!("{}", d.id));
+        j_kv_str(out, "type", if d.is_tcp { "tcp" } else { "udp" });
+        j_kv(out, "local_port", &alloc::format!("{}", d.local_port));
+        j_kv_str(out, "remote", &alloc::format!("{}.{}.{}.{}:{}",
+            d.remote_ip[0], d.remote_ip[1], d.remote_ip[2], d.remote_ip[3],
+            d.remote_port));
+        j_kv(out, "connected", if d.connected { "true" } else { "false" });
+        j_kv(out, "bound", if d.bound { "true" } else { "false" });
+        j_kv(out, "read_ready", if d.read_ready { "true" } else { "false" });
+        j_kv(out, "write_ready", if d.write_ready { "true" } else { "false" });
+        j_kv(out, "rdhup", if d.rdhup { "true" } else { "false" });
+        j_kv(out, "hup", if d.hup { "true" } else { "false" });
+        j_kv(out, "recv_len", &alloc::format!("{}", d.recv_len));
+        j_kv(out, "send_len", &alloc::format!("{}", d.send_len));
+        j_kv_str(out, "port_state", st_name(d.port_state));
+        j_kv_str(out, "tuple_state", st_name(d.tuple_state));
+        j_kv(out, "siblings_on_port", &alloc::format!("{}", d.siblings_on_port));
+        j_kv(out, "divergent", if d.divergent { "true" } else { "false" });
+        j_trim_comma(out);
+        out.push('}');
+        if d.divergent {
+            divergent += 1;
+            // Sticky POLLIN: poll reports readable but the exact-flow TCB has
+            // no buffered data and is not at a genuine EOF — recv can't drain.
+            if d.read_ready && d.recv_len == 0
+               && matches!(d.tuple_state, Some(crate::net::tcp::TcpState::Established)) {
+                sticky_in += 1;
+            }
+            crate::serial_println!(
+                "[SOCKPOLL] DIVERGENT id={} lport={} remote={}.{}.{}.{}:{} \
+                 port_state={} tuple_state={} read_ready={} recv_len={} \
+                 siblings={}",
+                d.id, d.local_port,
+                d.remote_ip[0], d.remote_ip[1], d.remote_ip[2], d.remote_ip[3],
+                d.remote_port, st_name(d.port_state), st_name(d.tuple_state),
+                d.read_ready, d.recv_len, d.siblings_on_port);
+        }
+    }
+    let _ = write!(out, r#"],"divergent":{},"sticky_pollin":{}}}"#,
+                   divergent, sticky_in);
+    crate::serial_println!(
+        "[SOCKPOLL] summary sockets={} divergent={} sticky_pollin={}",
+        diag.len(), divergent, sticky_in);
 }
 
 // ── procmaps ──────────────────────────────────────────────────────────────────

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -506,16 +506,33 @@ pub fn socket_recv_status(id: u64, max_len: usize) -> Result<RecvOutcome, &'stat
             // CloseWait (or has progressed to LastAck/Closed/TimeWait); with
             // no buffered data that is an orderly EOF (RFC 793 §3.5).  An
             // Established (or still-handshaking) connection with an empty
-            // buffer is would-block.
-            let peer_closed = match super::tcp::get_state(sock.local_port) {
-                Some(st) => matches!(st,
-                    super::tcp::TcpState::CloseWait
-                    | super::tcp::TcpState::LastAck
-                    | super::tcp::TcpState::TimeWait
-                    | super::tcp::TcpState::Closed),
-                // No TCB found for this port: the flow is gone — treat as EOF
-                // so a reader drains to completion rather than spinning.
-                None => true,
+            // buffer is would-block.  Resolved by the full 4-tuple
+            // (`get_state_for`), not the local port alone, so a sibling
+            // session on the same port (RFC 9293 §3.4) cannot induce a
+            // spurious EOF on this connected socket.
+            let peer_closed = if sock.connected && sock.remote_port != 0 {
+                match super::tcp::get_state_for(sock.local_port,
+                                                sock.remote_ip,
+                                                sock.remote_port) {
+                    Some(st) => matches!(st,
+                        super::tcp::TcpState::CloseWait
+                        | super::tcp::TcpState::LastAck
+                        | super::tcp::TcpState::TimeWait
+                        | super::tcp::TcpState::Closed),
+                    // No TCB for this 4-tuple: the flow is gone — EOF so a
+                    // reader drains to completion rather than spinning.
+                    None => true,
+                }
+            } else {
+                // Legacy single-peer / unconnected fallback: port-only.
+                match super::tcp::get_state(sock.local_port) {
+                    Some(st) => matches!(st,
+                        super::tcp::TcpState::CloseWait
+                        | super::tcp::TcpState::LastAck
+                        | super::tcp::TcpState::TimeWait
+                        | super::tcp::TcpState::Closed),
+                    None => true,
+                }
             };
             if peer_closed { Ok(RecvOutcome::Eof) } else { Ok(RecvOutcome::WouldBlock) }
         }
@@ -628,11 +645,22 @@ pub fn socket_recvfrom(id: u64, max_len: usize) -> Result<(Vec<u8>, Ipv4Address,
             // the connected peer (RFC 793 + IEEE 1003.1).  An unconnected
             // listener wouldn't have any in-band data to read here, so a
             // zero peer in that edge case is harmless.
-            let peer_ip   = sock.remote_ip;
-            let peer_port = sock.remote_port;
+            let peer_ip    = sock.remote_ip;
+            let peer_port  = sock.remote_port;
             let local_port = sock.local_port;
+            let connected  = sock.connected;
             drop(sockets);
-            let data = super::tcp::read(local_port, max_len);
+            // Per-connection drain keyed on the full 4-tuple for a
+            // connect(2)ed / accept(2)-side socket (RFC 793 §3.8
+            // demultiplexing), matching `socket_recv` — the port-only drain
+            // could otherwise touch a sibling session sharing the local
+            // port.  Falls back to the port-only drain for the legacy
+            // single-peer case.
+            let data = if connected && peer_port != 0 {
+                super::tcp::read_from(local_port, peer_ip, peer_port, max_len)
+            } else {
+                super::tcp::read(local_port, max_len)
+            };
             Ok((data, peer_ip, peer_port))
         }
     };
@@ -736,8 +764,13 @@ pub fn socket_read_ready(id: u64) -> bool {
                 // CloseWait (or has progressed past it); with no buffered
                 // data that is an orderly EOF.  A vanished TCB is also EOF
                 // (the flow is gone — a reader must drain to completion
-                // rather than spin).
-                match super::tcp::get_state(sock.local_port) {
+                // rather than spin).  Keyed on the full 4-tuple
+                // (`get_state_for`), not the local port alone: a sibling
+                // session sharing the port (RFC 9293 §3.4 demultiplexing)
+                // must not make this flow report a spurious EOF.
+                match super::tcp::get_state_for(sock.local_port,
+                                                sock.remote_ip,
+                                                sock.remote_port) {
                     Some(st) => matches!(st,
                         super::tcp::TcpState::CloseWait
                         | super::tcp::TcpState::LastAck
@@ -835,6 +868,64 @@ pub fn socket_write_ready(id: u64) -> bool {
                 // Not connected (listener / fresh socket): a send() does
                 // not block; report writable so the eventual error surfaces.
                 true
+            }
+        }
+    }
+}
+
+/// True when a `recv(2)`/`recvfrom(2)` on this socket would return `0`
+/// (an orderly end-of-stream) rather than block — i.e. the read side is
+/// at EOF with no buffered data left to drain.  Strictly **non-destructive**
+/// (state inspection only): it is the EOF half of the [`socket_read_ready`]
+/// readability gate, used by the `recvfrom(2)` handler to map an *empty*
+/// drain to `0` (EOF) instead of `-EAGAIN`.
+///
+/// Without this distinction a peer-FINned connection (CLOSE-WAIT with an
+/// empty buffer) reads as `poll(2)`-readable (the next recv "won't block")
+/// yet `recvfrom` returns `-EAGAIN`, so a level-triggered event loop spins
+/// `poll → recvfrom → EAGAIN → poll …` forever and never observes the
+/// orderly close to deregister the fd (RFC 9293 §3.5; `man 2 recv`:
+/// "a return value of 0 means the peer has performed an orderly shutdown").
+/// EOF is keyed on the exact 4-tuple ([`super::tcp::get_state_for`]); a
+/// datagram (UDP) socket has no EOF concept and always reports `false`.
+pub fn socket_recv_would_eof(id: u64) -> bool {
+    let sockets = SOCKETS.lock();
+    let sock = match sockets.iter().find(|s| s.id == id) {
+        Some(s) => s,
+        None => return false,
+    };
+    // shutdown(SHUT_RD): every subsequent recv returns 0 (EOF).
+    if sock.shut_rd { return true; }
+    if !sock.bound { return false; }
+    match sock.socket_type {
+        // UDP is connectionless: an empty queue is "no datagram yet"
+        // (would-block), never an orderly EOF.
+        SocketType::Udp => false,
+        SocketType::Tcp => {
+            if sock.connected && sock.remote_port != 0 {
+                // Buffered bytes remain ⇒ not at EOF (a recv returns data).
+                if super::tcp::has_data_for(sock.local_port,
+                                            sock.remote_ip,
+                                            sock.remote_port) {
+                    return false;
+                }
+                // Empty buffer: EOF iff the peer half-closed (CloseWait or
+                // beyond) or the TCB has vanished — keyed on this exact
+                // 4-tuple so a sibling session sharing the local port
+                // cannot induce a spurious EOF (RFC 9293 §3.4).
+                match super::tcp::get_state_for(sock.local_port,
+                                                sock.remote_ip,
+                                                sock.remote_port) {
+                    Some(st) => matches!(st,
+                        super::tcp::TcpState::CloseWait
+                        | super::tcp::TcpState::LastAck
+                        | super::tcp::TcpState::TimeWait
+                        | super::tcp::TcpState::Closed),
+                    None => true,
+                }
+            } else {
+                // Listener / unconnected: no peer, no EOF.
+                false
             }
         }
     }
@@ -1017,4 +1108,94 @@ pub fn socket_connect(id: u64, remote_ip: Ipv4Address, remote_port: u16) -> Resu
         }
     }
     Ok(())
+}
+
+// ── kdb poll-divergence diagnostic ────────────────────────────────────────────
+
+/// Per-socket poll-readiness diagnostic snapshot.  Captures, for each
+/// AF_INET socket, both the readiness `poll(2)`/`epoll(7)` would compute
+/// (`read_ready`/`write_ready`/`rdhup`/`hup`) AND the underlying TCB state
+/// resolved two ways: by local port alone (`port_state`, what the legacy
+/// `get_state` helper returns) versus by the exact 4-tuple (`tuple_state`).
+/// When those disagree, the port-only resolver is reporting a *sibling*
+/// connection's state for this flow — the exact condition that makes a
+/// live ESTABLISHED socket spuriously report POLLIN/EOF, which a consumer
+/// cannot drain (busy-poll livelock).  Diagnostic-only; `kdb`-gated.
+#[cfg(feature = "kdb")]
+#[derive(Clone, Copy)]
+pub struct SockPollDiag {
+    pub id:          u64,
+    pub is_tcp:      bool,
+    pub local_port:  u16,
+    pub remote_ip:   Ipv4Address,
+    pub remote_port: u16,
+    pub connected:   bool,
+    pub bound:       bool,
+    pub read_ready:  bool,
+    pub write_ready: bool,
+    pub rdhup:       bool,
+    pub hup:         bool,
+    pub recv_len:    usize,
+    pub send_len:    usize,
+    /// `get_state(local_port)` — the port-only resolver.
+    pub port_state:  Option<super::tcp::TcpState>,
+    /// `get_state_for(4-tuple)` — the exact-flow resolver.
+    pub tuple_state: Option<super::tcp::TcpState>,
+    /// Number of TCBs sharing this `local_port` (>1 ⇒ collision risk).
+    pub siblings_on_port: usize,
+    /// True when `port_state != tuple_state` for a connected socket — the
+    /// port-only resolver is mis-attributing a sibling TCB's state.
+    pub divergent:   bool,
+}
+
+/// Snapshot every AF_INET socket with its poll readiness + dual-resolver
+/// TCB state, for the kdb `socket-poll` op.  Locks SOCKETS only to copy
+/// the flat tuple set, then resolves each socket's readiness via the
+/// normal public predicates (which re-lock briefly) — so it observes
+/// exactly what `poll_revents` observes.
+#[cfg(feature = "kdb")]
+pub fn snapshot_poll_diag() -> alloc::vec::Vec<SockPollDiag> {
+    // 1. Flat copy of the socket tuples (drop SOCKETS before reaching tcp).
+    struct Flat { id: u64, is_tcp: bool, lp: u16, rip: Ipv4Address, rp: u16,
+                  connected: bool, bound: bool }
+    let flats: alloc::vec::Vec<Flat> = {
+        let sockets = SOCKETS.lock();
+        sockets.iter().map(|s| Flat {
+            id: s.id,
+            is_tcp: s.socket_type == SocketType::Tcp,
+            lp: s.local_port,
+            rip: s.remote_ip,
+            rp: s.remote_port,
+            connected: s.connected,
+            bound: s.bound,
+        }).collect()
+    };
+    // 2. One TCB-table snapshot for sibling-count + buffer depths.
+    let conns = super::tcp::snapshot_connections();
+    flats.into_iter().map(|f| {
+        let (rdhup, hup) = socket_hangup_status(f.id);
+        let port_state  = if f.is_tcp { super::tcp::get_state(f.lp) } else { None };
+        let tuple_state = if f.is_tcp && f.connected && f.rp != 0 {
+            super::tcp::get_state_for(f.lp, f.rip, f.rp)
+        } else { None };
+        let siblings_on_port = if f.is_tcp {
+            conns.iter().filter(|c| c.local_port == f.lp).count()
+        } else { 0 };
+        let (recv_len, send_len) = conns.iter()
+            .find(|c| c.local_port == f.lp && c.remote_ip == f.rip
+                      && c.remote_port == f.rp)
+            .map(|c| (c.recv_len, c.send_len))
+            .unwrap_or((0, 0));
+        let divergent = f.is_tcp && f.connected && f.rp != 0
+            && port_state != tuple_state;
+        SockPollDiag {
+            id: f.id, is_tcp: f.is_tcp, local_port: f.lp,
+            remote_ip: f.rip, remote_port: f.rp,
+            connected: f.connected, bound: f.bound,
+            read_ready:  socket_read_ready(f.id),
+            write_ready: socket_write_ready(f.id),
+            rdhup, hup, recv_len, send_len,
+            port_state, tuple_state, siblings_on_port, divergent,
+        }
+    }).collect()
 }

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -1419,6 +1419,10 @@ pub struct ConnSnap {
     pub remote_ip:   Ipv4Address,
     pub remote_port: u16,
     pub state:       TcpState,
+    /// Bytes queued in the receive buffer (awaiting recv(2)).
+    pub recv_len:    usize,
+    /// Bytes queued in the send buffer (not yet on the wire).
+    pub send_len:    usize,
 }
 
 /// Return a snapshot of every connection in the TCP table.  Caller-owned
@@ -1431,6 +1435,8 @@ pub fn snapshot_connections() -> alloc::vec::Vec<ConnSnap> {
         remote_ip:   c.remote_ip,
         remote_port: c.remote_port,
         state:       c.state,
+        recv_len:    c.recv_buffer.len(),
+        send_len:    c.send_buffer.len(),
     }).collect()
 }
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2155,13 +2155,26 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 // excess of an oversized datagram).
                 match crate::net::socket::socket_recvfrom(socket_id, len) {
                     Ok((data, src_ip, src_port)) => {
-                        // Empty result on a non-blocking socket = EAGAIN
-                        // per IEEE 1003.1 §recvfrom.  We can only hit
-                        // this branch when blocking==false (the wait
-                        // loop above guarantees data on the blocking
-                        // path) so the userspace contract holds.
+                        // An empty drain is either an orderly end-of-stream
+                        // or a transient would-block, and recvfrom(2) MUST
+                        // distinguish them: a peer-FINned TCP connection
+                        // (CLOSE-WAIT, empty buffer) returns 0 ("the peer
+                        // has performed an orderly shutdown", man 2 recv /
+                        // RFC 9293 §3.5), while an ESTABLISHED socket with
+                        // no data yet returns -EAGAIN (IEEE 1003.1 §recvfrom).
+                        //
+                        // Returning -EAGAIN for the EOF case is the bug that
+                        // wedges a level-triggered event loop: poll() reports
+                        // the CLOSE-WAIT fd readable (the next recv "won't
+                        // block"), the app recvfrom()s, gets -EAGAIN instead
+                        // of the 0 that would let it close the fd, and spins
+                        // poll → recvfrom → EAGAIN forever — monopolising the
+                        // CPU and never observing the orderly close.
                         if data.is_empty() {
-                            return -11; // EAGAIN
+                            if crate::net::socket::socket_recv_would_eof(socket_id) {
+                                return 0; // orderly EOF
+                            }
+                            return -11; // EAGAIN (would-block)
                         }
                         let n = data.len().min(len);
                         if n > 0 {

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2041,6 +2041,9 @@ pub fn run() -> ! {
     total += 1;
     if test_recvfrom_truncated_addrlen() { passed += 1; }
 
+    total += 1;
+    if test_recvfrom_closewait_reports_eof() { passed += 1; }
+
     // ── Tests 195–199: shutdown(2) half-close (Phase NDE-4) ──────────────
 
     total += 1;
@@ -36601,6 +36604,99 @@ fn test_recvfrom_truncated_addrlen() -> bool {
 
     test_println!("  cap=8 → 8 bytes copied, *addrlen=16, tail untouched ✓");
     test_pass!("recvfrom — sockaddr truncation honours addrlen in/out");
+    true
+}
+
+/// recvfrom(2) on a peer-FINned (CLOSE-WAIT) TCP connection with an empty
+/// receive buffer must report an orderly end-of-stream — the syscall path
+/// returns `0`, not `-EAGAIN`.
+///
+/// Regression guard for the single-vCPU busy-poll livelock: poll(2) reports
+/// a CLOSE-WAIT fd readable (the next recv "won't block"); if recvfrom then
+/// returns `-EAGAIN` instead of `0`, a level-triggered event loop spins
+/// `poll → recvfrom → EAGAIN` forever and never observes the orderly close
+/// to deregister the fd (RFC 9293 §3.5; `man 2 recv`: 0 = orderly shutdown).
+/// The recvfrom(2) handler maps an empty drain to `0` exactly when
+/// `socket_recv_would_eof` is true, so we assert that predicate (which the
+/// handler consults) plus the empty drain — the two facts that compose the
+/// handler's return.
+#[cfg(feature = "kdb")]
+fn test_recvfrom_closewait_reports_eof() -> bool {
+    test_header!("recvfrom — CLOSE-WAIT empty buffer reports EOF, not EAGAIN");
+
+    use crate::net::socket;
+    use crate::net::tcp;
+
+    const LPORT: u16 = 50071;
+    const RIP:   [u8; 4] = [10, 9, 9, 9];
+    const RPORT: u16 = 8443;
+
+    // Synthetic connected socket + its Established TCB (no SLIRP 3WHS).
+    let id = socket::socket_create_accepted(LPORT, RIP, RPORT);
+    if let Err(e) = tcp::test_inject_established(LPORT, RIP, RPORT, &[]) {
+        socket::socket_close(id);
+        test_fail!("recvfrom_cw", "inject established failed: {}", e);
+        return false;
+    }
+
+    // Control: ESTABLISHED + empty buffer is would-block, NOT EOF.
+    if socket::socket_recv_would_eof(id) {
+        socket::socket_close(id);
+        test_fail!("recvfrom_cw", "ESTABLISHED empty falsely reported EOF");
+        return false;
+    }
+
+    // Deliver the peer's FIN at the in-order sequence → CLOSE-WAIT.
+    let seq = match tcp::test_recv_next(LPORT, RIP, RPORT) {
+        Some(s) => s,
+        None => { socket::socket_close(id); test_fail!("recvfrom_cw", "no recv_next"); return false; }
+    };
+    match tcp::test_feed_segment(LPORT, RIP, RPORT, seq, &[], true) {
+        Some((st, buflen)) => {
+            if st != tcp::TcpState::CloseWait || buflen != 0 {
+                socket::socket_close(id);
+                test_fail!("recvfrom_cw", "expected CLOSE_WAIT empty, got {:?} buflen={}", st, buflen);
+                return false;
+            }
+        }
+        None => { socket::socket_close(id); test_fail!("recvfrom_cw", "feed FIN: no TCB"); return false; }
+    }
+
+    // poll(2) reports the fd readable (the recv won't block) …
+    if !socket::socket_read_ready(id) {
+        socket::socket_close(id);
+        test_fail!("recvfrom_cw", "CLOSE-WAIT not poll-readable");
+        return false;
+    }
+    // … the drain yields no bytes …
+    let drained = match socket::socket_recvfrom(id, 4096) {
+        Ok((d, _, _)) => d,
+        Err(e) => { socket::socket_close(id); test_fail!("recvfrom_cw", "recvfrom err: {}", e); return false; }
+    };
+    if !drained.is_empty() {
+        socket::socket_close(id);
+        test_fail!("recvfrom_cw", "expected empty drain, got {} bytes", drained.len());
+        return false;
+    }
+    // … and the handler-consulted EOF predicate is true → recvfrom returns 0.
+    if !socket::socket_recv_would_eof(id) {
+        socket::socket_close(id);
+        test_fail!("recvfrom_cw",
+            "CLOSE-WAIT empty drain reported would-block (EAGAIN) instead of EOF — \
+             the busy-poll livelock regression");
+        return false;
+    }
+
+    socket::socket_close(id);
+    test_println!("  CLOSE-WAIT empty: read_ready=1, drain=0B, would_eof=1 → recvfrom returns 0 ✓");
+    test_pass!("recvfrom — CLOSE-WAIT empty buffer reports EOF, not EAGAIN");
+    true
+}
+
+#[cfg(not(feature = "kdb"))]
+fn test_recvfrom_closewait_reports_eof() -> bool {
+    test_header!("recvfrom — CLOSE-WAIT EOF (kdb-only)");
+    test_pass!("recvfrom — CLOSE-WAIT EOF (kdb-only stub)");
     true
 }
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7018,6 +7018,9 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
               # placement.  Diagnoses SMP "de-facto single core" imbalance.
               "cpu-state",
               "coverage-flush", "proc-metrics",
+              # socket-poll: per-AF_INET-socket poll-readiness divergence report
+              # (sticky-POLLIN / spurious-EOF busy-poll localizer).
+              "socket-poll",
               "futex-stats",
               # blk-trace: out-of-band drain of the virtio-blk LBA ring.
               "blk-trace", "blk-trace-flush",
@@ -12971,6 +12974,10 @@ def main():
         # top-level subcommand below (drain|flush).
         "blk-trace", "blk-trace-flush",
         "coverage-flush", "proc-metrics", "thread-park-audit",
+        # socket-poll: per-AF_INET-socket poll-readiness divergence report
+        # (sticky-POLLIN / spurious-EOF busy-poll localizer). [SOCKPOLL]
+        # serial mirror survives a vCPU monopoly. See kdb::op_socket_poll.
+        "socket-poll",
         "rip-trace",
         "futex-ghost-hist",
         # One-shot musl pthread_cond/mutex wake-target-vs-wait-addr report:


### PR DESCRIPTION
## Problem
On SMP=1 windowed Firefox loading a real HTTPS site, the single vCPU was monopolised and the machine hung: a connected TCP socket reached **CLOSE-WAIT with an empty receive buffer**, and a level-triggered event loop (`poll`/`epoll` + `recvfrom`) spun forever.

## Root cause
- `poll(2)` correctly reports the fd readable (the next recv won't block — it will return the orderly EOF), via `socket_read_ready` (CLOSE-WAIT/peer-FIN + empty buffer ⇒ POLLIN), per `man 2 poll` and RFC 9293 §3.5.
- But `recvfrom(2)` drained nothing and the handler mapped the empty drain to **`-EAGAIN` unconditionally** — never the **`0`** that `man 2 recv` defines for an orderly peer shutdown.
- The app therefore never observed the close to deregister the fd, and spun `poll → recvfrom(EAGAIN) → poll …` forever, pinning the CPU and starving every other thread.

`socket_recvfrom` returned an empty `Vec` for *both* would-block and EOF with no way to distinguish them. The `recvmsg(47)` TCP path already handled this correctly (`socket_recv_status`: Eof⇒0, WouldBlock⇒-EAGAIN); **`recvfrom(45)` was the straggler.**

## Fix
- `socket_recv_would_eof()` — a non-destructive 4-tuple EOF predicate; the `recvfrom(45)` handler maps an empty drain to `0` when true, `-EAGAIN` otherwise.
- `socket_recvfrom` drains per the full 4-tuple (`tcp::read_from`) for a connected socket, matching `socket_recv` (RFC 793 §3.8 demultiplexing).
- `socket_read_ready` / `socket_recv_status` resolve peer-FIN/EOF by the exact 4-tuple (`tcp::get_state_for`) rather than local port alone, so a sibling session sharing the local port (RFC 9293 §3.4) cannot induce a spurious EOF.

## Verification
- A/B on SMP=1 windowed FF (en.wikipedia.org), 3/3 boots: the vCPU monopoly is **gone** — unfixed: serial frozen, kdb 100% unresponsive 10+ min (socket id 29 = CLOSE-WAIT to :443, empty buffer, `recvfrom` looping <0.2s); fixed: kdb responsive (`pong`), serial advancing, no sticky-POLLIN.
- Regression test `test_recvfrom_closewait_reports_eof` (test_runner.rs).

Note: this fixes the machine-hang (one gate). Wikipedia *content paint* remains blocked by a separate, regime-independent gate — tracked separately; **no render claim here**.

## Diagnostics (reusable, additive)
kdb `socket-poll` op + harness subcommand: per-AF_INET-socket poll readiness vs dual-resolver TCB state, with a `[SOCKPOLL]` serial mirror — localises sticky-POLLIN / spurious-EOF busy-poll livelocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)