### PR TITLE
mm/ipc: access SysV SHM backing via the higher-half direct map (fix >1 GiB KERNEL_PAGE_FAULT)

### DIFF
--- a/kernel/src/ipc/sysv_shm.rs
+++ b/kernel/src/ipc/sysv_shm.rs
@@ -88,9 +88,20 @@ pub fn shmget(key: i32, size: u64, flags: i32) -> i64 {
         None => return -12, // ENOMEM
     };
 
-    // Zero the backing memory
+    // Zero the backing memory through the higher-half physical map.
+    //
+    // `alloc_pages` returns a *physical* base.  The CPU must reach it through
+    // a mapped virtual address: the kernel's higher-half direct map at
+    // `PHYS_OFF + phys` covers every physical frame (0 .. 4 GiB), whereas the
+    // low identity map (virtual == physical) only covers the first 1 GiB of
+    // RAM.  Dereferencing the bare physical address therefore faults the
+    // instant `alloc_pages` hands back a frame above 1 GiB — exactly what a
+    // large MIT-SHM segment triggers on a >1 GiB guest.  See Intel SDM Vol. 3A
+    // §4.5 (4-level paging): a linear address is translated only if every
+    // paging-structure entry on its walk is present; the identity range past
+    // 1 GiB has no such entries, so the access is a not-present #PF.
     unsafe {
-        core::ptr::write_bytes(phys_base as *mut u8, 0, size_aligned as usize);
+        core::ptr::write_bytes(phys_to_kvirt(phys_base), 0, size_aligned as usize);
     }
 
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
@@ -288,19 +299,47 @@ pub fn shmctl(shmid: u32, cmd: i32, buf: u64) -> i64 {
     }
 }
 
-/// Look up a segment by its shmid and return its `(phys_base, size)`.
+/// Look up a segment by its shmid and return its raw `(phys_base, size)`.
 ///
-/// The backing pages are physically contiguous and reside in the kernel's
-/// identity-mapped low memory, so the returned `phys_base` is directly readable
-/// by the kernel (the same property `shmget`'s `write_bytes(phys_base ...)` zero
-/// relies on).  Used by the X server's MIT-SHM ShmPutImage to read client pixel
-/// data straight from the segment without a per-frame copy through the request
-/// body.  Returns `None` if no in-use segment has that id.
+/// The backing pages are physically contiguous.  The returned value is a
+/// *physical* address — suitable for installing a page-table entry, but NOT
+/// for direct CPU dereference (the low identity map only covers the first
+/// 1 GiB of RAM).  Callers that need to read or write the segment bytes from
+/// kernel mode must use [`segment_kvirt`], which returns a higher-half virtual
+/// base valid for any frame.  Returns `None` if no in-use segment has that id.
 pub fn segment_phys(shmid: u32) -> Option<(u64, u64)> {
     let segs = SEGMENTS.lock();
     segs.iter()
         .find(|s| s.in_use && s.id == shmid)
         .map(|s| (s.phys_base, s.size))
+}
+
+/// Look up a segment by its shmid and return its kernel-readable
+/// `(virt_base, size)`.
+///
+/// `virt_base` is the segment's physical base mapped through the kernel's
+/// higher-half direct map (`PHYS_OFF + phys`), so it is dereferenceable from
+/// kernel mode regardless of where the frame lives in physical memory.  Used
+/// by the in-kernel X server's MIT-SHM `ShmPutImage` / `CopyArea` paths to read
+/// client pixel data straight from the segment without a per-frame copy.
+/// Returns `None` if no in-use segment has that id.
+///
+/// Per Intel SDM Vol. 3A §4.5, the higher-half direct map is the only mapping
+/// guaranteed present for physical addresses above the 1 GiB identity range, so
+/// the raw `phys_base` must never be dereferenced directly.
+pub fn segment_kvirt(shmid: u32) -> Option<(u64, u64)> {
+    let segs = SEGMENTS.lock();
+    segs.iter()
+        .find(|s| s.in_use && s.id == shmid)
+        .map(|s| (phys_to_kvirt(s.phys_base) as u64, s.size))
+}
+
+/// Convert a physical frame base into a kernel-dereferenceable pointer via the
+/// higher-half direct map.  The map covers physical 0 .. 4 GiB (`PHYS_OFF`),
+/// unlike the low identity map which stops at 1 GiB.
+#[inline]
+fn phys_to_kvirt(phys: u64) -> *mut u8 {
+    (crate::mm::vmm::PHYS_OFF + phys) as *mut u8
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1024,6 +1024,10 @@ pub fn run() -> ! {
     total += 1;
     if test_sysv_shm() { passed += 1; }
 
+    // ── SHM higher-half direct-map invariant (>1 GiB zero-fill regression) ──
+    total += 1;
+    if test_shm_phys_map_invariant() { passed += 1; }
+
     // ── Test 79: syscall completeness — fcntl FD_CLOEXEC, fsync, fd table ────
 
     total += 1;
@@ -20247,7 +20251,8 @@ fn test_x11_glx_handshake() -> bool {
 // real SysV shared-memory segment, fills it with a known pixel pattern, attaches
 // it via MIT-SHM ShmAttach, issues ShmPutImage into a mapped window, and verifies
 // the pixel was composited into the window surface — i.e. the server read the
-// pixel data straight from the segment's physical backing (sysv_shm::segment_phys).
+// pixel data straight from the segment's backing via the higher-half direct
+// map (sysv_shm::segment_kvirt).
 fn test_x11_shm_put_image() -> bool {
     test_header!("X11 MIT-SHM ShmPutImage (real shared-memory present)");
 
@@ -20287,16 +20292,16 @@ fn test_x11_shm_put_image() -> bool {
     let shmid = shmid as u32;
     // Write a known BGRA pattern (0x11,0x22,0x33,0xFF) directly into the segment's
     // physical backing — the same memory the X server will read on ShmPutImage.
-    let (phys_base, _size) = match crate::ipc::sysv_shm::segment_phys(shmid) {
+    let (virt_base, _size) = match crate::ipc::sysv_shm::segment_kvirt(shmid) {
         Some(v) => v,
         None => {
-            test_fail!("x11_shm", "segment_phys({}) returned None", shmid);
+            test_fail!("x11_shm", "segment_kvirt({}) returned None", shmid);
             crate::net::unix::close(client); return false;
         }
     };
-    // SAFETY: phys_base is the identity-mapped base of the just-allocated segment.
+    // SAFETY: virt_base is the higher-half direct-map base of the just-allocated segment.
     unsafe {
-        let p = phys_base as *mut u8;
+        let p = virt_base as *mut u8;
         for i in 0..(W * H) as usize {
             *p.add(i * 4)     = 0x11;
             *p.add(i * 4 + 1) = 0x22;
@@ -20437,18 +20442,18 @@ fn test_x11_shm_create_pixmap() -> bool {
         crate::net::unix::close(client); return false;
     }
     let shmid = shmid as u32;
-    let (phys_base, _size) = match crate::ipc::sysv_shm::segment_phys(shmid) {
+    let (virt_base, _size) = match crate::ipc::sysv_shm::segment_kvirt(shmid) {
         Some(v) => v,
         None => {
-            test_fail!("x11_shmpix", "segment_phys({}) returned None", shmid);
+            test_fail!("x11_shmpix", "segment_kvirt({}) returned None", shmid);
             crate::ipc::sysv_shm::shmctl(shmid, crate::ipc::sysv_shm::IPC_RMID, 0);
             crate::net::unix::close(client); return false;
         }
     };
     // Initial pattern (will be OVERWRITTEN after CreatePixmap to prove live read).
-    // SAFETY: phys_base is the identity-mapped base of the just-allocated segment.
+    // SAFETY: virt_base is the higher-half direct-map base of the just-allocated segment.
     unsafe {
-        let p = phys_base as *mut u8;
+        let p = virt_base as *mut u8;
         for i in 0..(W * H) as usize {
             *p.add(i * 4) = 0x00; *p.add(i * 4 + 1) = 0x00;
             *p.add(i * 4 + 2) = 0x00; *p.add(i * 4 + 3) = 0xFF;
@@ -20507,9 +20512,9 @@ fn test_x11_shm_create_pixmap() -> bool {
 
     // Now CHANGE the segment AFTER the pixmap exists — CopyArea must see THIS,
     // proving the pixmap reads live segment contents (not a create-time snapshot).
-    // SAFETY: same identity-mapped segment base, still allocated.
+    // SAFETY: same higher-half direct-map segment base, still allocated.
     unsafe {
-        let p = phys_base as *mut u8;
+        let p = virt_base as *mut u8;
         for i in 0..(W * H) as usize {
             *p.add(i * 4) = 0x44; *p.add(i * 4 + 1) = 0x55;
             *p.add(i * 4 + 2) = 0x66; *p.add(i * 4 + 3) = 0xFF;
@@ -22423,6 +22428,86 @@ fn test_sysv_shm() -> bool {
     }
 
     if ok { test_pass!("SysV SHM — shmget / shmat / shmdt / shmctl"); }
+    ok
+}
+
+/// Regression guard for the >1 GiB SHM-zero bugcheck (KERNEL_PAGE_FAULT at
+/// `memset` from `shmget`).  A SysV segment's physical backing may live above
+/// the 1 GiB low identity map; the kernel must therefore reach the bytes only
+/// through the higher-half direct map (`PHYS_OFF + phys`), never through the
+/// bare physical address.  This test pins that invariant: `segment_kvirt` must
+/// return exactly `PHYS_OFF + phys`, a higher-half address, and a write/read
+/// through it must round-trip.  The old code dereferenced the raw physical base
+/// returned by `segment_phys`, which faults the instant a frame lands >1 GiB.
+fn test_shm_phys_map_invariant() -> bool {
+    test_header!("SHM higher-half direct-map invariant (>1 GiB zero-fill guard)");
+    let mut ok = true;
+
+    let shmid = crate::ipc::sysv_shm::shmget(
+        crate::ipc::sysv_shm::IPC_PRIVATE,
+        16384,
+        crate::ipc::sysv_shm::IPC_CREAT | 0o666,
+    );
+    if shmid < 0 {
+        test_fail!("shm_physmap", "shmget returned {}", shmid);
+        return false;
+    }
+    let shmid = shmid as u32;
+
+    let raw = crate::ipc::sysv_shm::segment_phys(shmid);
+    let kv  = crate::ipc::sysv_shm::segment_kvirt(shmid);
+    match (raw, kv) {
+        (Some((phys, psize)), Some((virt, vsize))) => {
+            // Invariant: kvirt == PHYS_OFF + phys (the direct map), and the
+            // returned address is in the higher half — never a bare phys.
+            let expect = crate::mm::vmm::PHYS_OFF + phys;
+            if virt != expect {
+                test_fail!("shm_physmap",
+                    "segment_kvirt={:#x} != PHYS_OFF+phys={:#x}", virt, expect);
+                ok = false;
+            }
+            if virt < crate::mm::vmm::PHYS_OFF {
+                test_fail!("shm_physmap",
+                    "segment_kvirt={:#x} is not higher-half (bare phys?)", virt);
+                ok = false;
+            }
+            if psize != vsize {
+                test_fail!("shm_physmap", "size mismatch {} != {}", psize, vsize);
+                ok = false;
+            }
+            // shmget already zero-filled through the direct map; a non-faulting
+            // read here proves the mapping is live for the whole segment.
+            unsafe {
+                let p = virt as *const u8;
+                let first = *p;
+                let last  = *p.add((vsize - 1) as usize);
+                if first != 0 || last != 0 {
+                    test_fail!("shm_physmap",
+                        "segment not zero-filled: first={:#x} last={:#x}", first, last);
+                    ok = false;
+                }
+                // Round-trip a byte through the direct map.
+                let pw = virt as *mut u8;
+                *pw.add((vsize - 1) as usize) = 0xA5;
+                if *p.add((vsize - 1) as usize) != 0xA5 {
+                    test_fail!("shm_physmap", "direct-map write did not round-trip");
+                    ok = false;
+                }
+            }
+            if ok {
+                test_println!(
+                    "  segment_kvirt={:#x} = PHYS_OFF+{:#x}, size={} ✓", virt, phys, vsize);
+            }
+        }
+        _ => {
+            test_fail!("shm_physmap", "segment_phys/kvirt returned None");
+            ok = false;
+        }
+    }
+
+    crate::ipc::sysv_shm::shmctl(shmid, crate::ipc::sysv_shm::IPC_RMID, 0);
+
+    if ok { test_pass!("SHM higher-half direct-map invariant (>1 GiB zero-fill guard)"); }
     ok
 }
 

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -185,8 +185,9 @@ static SERVER: Mutex<Server> = Mutex::new(Server::new());
 // MIT-SHM ShmAttach binds an X resource id (`shmseg`) to a previously-created
 // SysV shared-memory segment (the integer `shmid` the client got from
 // `shmget`).  ShmPutImage then references the `shmseg`; the server resolves it
-// to the `shmid`, looks up the segment's physical backing via
-// `sysv_shm::segment_phys`, and reads pixel data directly.  Attachments are
+// to the `shmid`, looks up the segment's kernel-readable base via
+// `sysv_shm::segment_kvirt` (higher-half direct map), and reads pixel data
+// directly.  Attachments are
 // few (a compositor uses a handful of back-buffers), so a small fixed table
 // shared across all clients is sufficient.
 const MAX_SHM_ATTACH: usize = 32;
@@ -2725,13 +2726,14 @@ fn op_copy_area(fd: u64, data: &[u8]) {
                         let rh = (y1 - y0).max(0) as usize;
                         let mut buf = alloc::vec![0u8; rw * rh * 4];
                         let ok = if p.is_shm_backed() {
-                            // Resolve the segment's kernel-readable physical base
-                            // and copy the clipped rectangle from it.  Row stride
-                            // is the SHM image stride (scanline-padded), not sw*4.
-                            match crate::ipc::sysv_shm::segment_phys(p.shm_shmid) {
-                                Some((phys_base, seg_size)) => {
+                            // Resolve the segment's kernel-readable virtual base
+                            // (higher-half direct map) and copy the clipped
+                            // rectangle from it.  Row stride is the SHM image
+                            // stride (scanline-padded), not sw*4.
+                            match crate::ipc::sysv_shm::segment_kvirt(p.shm_shmid) {
+                                Some((virt_base, seg_size)) => {
                                     let stride = p.shm_stride as usize;
-                                    let base = phys_base as usize + p.shm_offset as usize;
+                                    let base = virt_base as usize + p.shm_offset as usize;
                                     // Last byte the loop touches must lie inside the
                                     // segment (guards against a truncated/detached
                                     // segment between CreatePixmap and CopyArea).
@@ -2741,11 +2743,11 @@ fn op_copy_area(fd: u64, data: &[u8]) {
                                         || (p.shm_offset as u64 + last as u64) > seg_size {
                                         false
                                     } else {
-                                        // SAFETY: `phys_base` is the identity-mapped,
-                                        // kernel-readable base of a physically
+                                        // SAFETY: `virt_base` is the higher-half
+                                        // direct-map address of a physically
                                         // contiguous SysV segment (see
-                                        // sysv_shm::shmget); the bound check above
-                                        // keeps every read inside the segment.
+                                        // sysv_shm::segment_kvirt); the bound check
+                                        // above keeps every read inside the segment.
                                         for row in 0..rh {
                                             for col in 0..rw {
                                                 let so = base
@@ -3807,7 +3809,7 @@ fn op_shm_put_image(fd: u64, data: &[u8]) {
     if total_w <= 0 || total_h <= 0 || src_w <= 0 || src_h <= 0 { return; }
 
     let shmid = match shm_lookup(fd, shmseg) { Some(id) => id, None => return };
-    let (phys_base, seg_size) = match crate::ipc::sysv_shm::segment_phys(shmid) {
+    let (virt_base, seg_size) = match crate::ipc::sysv_shm::segment_kvirt(shmid) {
         Some(v) => v, None => return,
     };
 
@@ -3821,13 +3823,13 @@ fn op_shm_put_image(fd: u64, data: &[u8]) {
     if src_x < 0 || src_y < 0
         || src_x + src_w > total_w || src_y + src_h > total_h { return; }
 
-    // SAFETY: `phys_base` is the identity-mapped, kernel-readable base of a
-    // physically-contiguous SysV segment (see sysv_shm::shmget).  The bounds
-    // checks above guarantee `[offset, offset+img_len)` is within the segment,
-    // so the slice never reads past the backing pages.
+    // SAFETY: `virt_base` is the higher-half direct-map address of a
+    // physically-contiguous SysV segment (see sysv_shm::segment_kvirt).  The
+    // bounds checks above guarantee `[offset, offset+img_len)` is within the
+    // segment, so the slice never reads past the backing pages.
     let src: &[u8] = unsafe {
         core::slice::from_raw_parts(
-            (phys_base + offset) as *const u8,
+            (virt_base + offset) as *const u8,
             img_len as usize,
         )
     };


### PR DESCRIPTION
## Summary

Boot-critical mm fix: the kernel deterministically bugchecked
`0xdead0006 KERNEL_PAGE_FAULT` whenever the guest had **more than ~1 GiB of
RAM** and Firefox/X11 reached windowed compositing. This blocked provisioning
the RAM needed for heavy pages (the Wikipedia content-paint gate was
root-caused to a 1 GiB ceiling).

## Root cause (GDB autopsy)

`shmget()` zero-filled a freshly allocated SysV SHM segment by dereferencing
the **bare physical** base returned by `alloc_pages()`:

```rust
write_bytes(phys_base as *mut u8, 0, size_aligned)   // bare phys → identity map
```

The low identity map (virtual == physical) only covers the first **1 GiB** of
RAM. On a >1 GiB guest, a large MIT-SHM framebuffer segment (e.g. 4.86 MiB for
a 1280×972 window) is allocated above 1 GiB; the `memset` then writes an
unmapped linear address → not-present supervisor write #PF → bugcheck.

Autopsy at `ke_bugcheck` (3 GiB guest):
- P3 / faulting RIP = `memset`
- return slot at the faulting RSP (P4) → **`sysv_shm::shmget`**
- P1 / CR2 = `0x626b9000` (a bare physical address ≈1.54 GiB, no higher-half bits)
- P2 = `0x2` (kernel WRITE, not-present)

## Fix

Route all kernel-mode access to SHM segment bytes through the **higher-half
direct map** (`PHYS_OFF + phys`), which covers all physical RAM (0–4 GiB) — the
same mapping every other hot frame-zeroing path already uses. Per Intel SDM
Vol. 3A §4.5, a linear address is only translated when every paging-structure
entry on its walk is present; the identity range past 1 GiB has none.

- `shmget()` zeroes via `PHYS_OFF + phys`.
- New `segment_kvirt()` returns the higher-half base; `segment_phys()` now
  documents that its raw result is for page-table installation only and must
  not be dereferenced.
- The in-kernel X server's MIT-SHM `ShmPutImage` / `CopyArea` pixel reads and
  the `x11_shm` / `x11_shmpix` tests use `segment_kvirt()`, so **no bare-phys
  SHM dereference remains**.
- `shmat()` PTE installation is unchanged — it correctly consumes a physical
  address. The <1 MiB AP-startup trampoline identity mapping is untouched.

## Regression test

`test_shm_phys_map_invariant` pins `segment_kvirt() == PHYS_OFF + phys`,
asserts a higher-half result, and round-trips a byte through the direct map —
a future bare-phys regression fails the suite.

## Verification (`ASTRYX_MEM_MIB` A/B, SMP=1, `--ff-gui`)

| Guest RAM | Before | After |
|---|---|---|
| 3 GiB | `KERNEL_PAGE_FAULT` (CR2 ≈ 2.04 GiB) | SHM segment at **phys 0x82999000 (~2.05 GiB)** zeroed + 425 ShmPutImage composites, **0 bugchecks** |
| 4 GiB | `KERNEL_PAGE_FAULT` | clean boot, **0 bugchecks** |
| ≤1 GiB | OK | OK (no regression) |

(The separate FF content-init crash gate and the OOM-kill behaviour below the
SHM path are pre-existing and out of scope for this fix.)

Do not merge — for coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
