### PR TITLE
harness: provision windowed Firefox (--ff-gui) with 3072 MiB + ASTRYX_MEM_MIB override

### DIFF
--- a/scripts/astryx_qemu.py
+++ b/scripts/astryx_qemu.py
@@ -68,9 +68,18 @@ from typing import Optional
 # ── Canonical constants ──────────────────────────────────────────────────────
 
 #: Memory in MiB keyed by mode.
+#:
+#: ``gui-test`` (the windowed ``--ff-gui`` path) runs a full upstream Firefox
+#: against real web content. A heavy page (e.g. a Wikipedia article: ~7
+#: processes, libxul + per-process copy-on-write working set + page cache)
+#: needs well over 1 GiB of usable guest RAM; at 1 GiB it exhausts the page
+#: allocator mid-load and the content/parent process is torn down before the
+#: page composites. 3072 MiB gives comfortable headroom (windowed-Firefox
+#: Wikipedia content was verified to render to pixels at 2048 MiB with zero
+#: out-of-memory events; 3072 keeps margin for heavier pages).
 _MEM_MIB = {
     "test":         1024,
-    "gui-test":     1024,
+    "gui-test":     3072,
     "firefox-test": 2048,
 }
 
@@ -151,7 +160,14 @@ def _cpu_args(mode: str, kvm: bool, cpu_override: Optional[str] = None) -> list[
 
 
 def _memory_args(mode: str) -> list[str]:
-    mib = _MEM_MIB.get(mode, 1024)
+    # ASTRYX_MEM_MIB env override (mirrors ASTRYX_SMP) — lets an operator size
+    # guest RAM independent of the per-mode default for memory-pressure A/B
+    # testing without editing the per-mode table.
+    env_mib = os.environ.get("ASTRYX_MEM_MIB")
+    if env_mib:
+        mib = int(env_mib)
+    else:
+        mib = _MEM_MIB.get(mode, 1024)
     # Use M suffix so QEMU shows the value in MiB in its own logs
     return ["-m", f"{mib}M"]
 


### PR DESCRIPTION
## What

Provision the windowed-Firefox path (`--ff-gui`, mode `gui-test`) with enough guest RAM to render heavy real-web pages, and add an operator knob to size guest RAM ad hoc.

- **`gui-test` default RAM: 1024 → 3072 MiB.** Windowed Firefox runs a full upstream browser against real content; a heavy page (e.g. a Wikipedia article — ~7 processes, libxul + per-process CoW working set + page cache) has a working set well above 1 GiB. At 1024 MiB the guest page allocator is exhausted mid-load and the content/parent process is torn down before the page composites.
- **New `ASTRYX_MEM_MIB` env override** in `_memory_args` (mirrors `ASTRYX_SMP`) for memory-pressure A/B testing without editing source.

`test` and `firefox-test` (headless) defaults are unchanged. Additive + env-gated.

## Why now

Builds on #662 (SysV SHM via higher-half direct map), which removed the >1 GiB `KERNEL_PAGE_FAULT` ceiling and lets the kernel boot clean at 2/3/4 GiB.

## Verification

Windowed Firefox (musl ESR-115, GTK3), **SMP=1**, booted against `https://en.wikipedia.org/wiki/Firefox`:

- **At 2048 MiB the Wikipedia "Firefox" article rendered to verified pixels** — full article heading, body paragraphs with wikilinks, the Contents sidebar, and the infobox (Firefox fox/globe logo, screenshot, developer/release rows), plus the interactive collapsible TOC and Vector-2022 "Appearance" controls. **Zero `[OOM]` events; full 7-process e10s tree alive; zero content crashes** on the rendering boot.
- `gui-test` default is set to **3072 MiB** for additional headroom on heavier pages (3 GiB boots also showed zero OOM).

Verified-render screenshot is attached out-of-band by the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)