### PR TITLE
harness/kdb: bank the FF-render diagnostic tooling (watch-set, cache-lookup, x11-windows, ASTRYX_MEM_MIB, ASTRYX_VNC)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -397,6 +397,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "virtio-wait-reset" => op_virtio_wait_reset(out),
         "bell-stats"       => op_bell_stats(out),
         "compose-stats"    => op_compose_stats(out),
+        "x11-windows"      => op_x11_windows(out),
         "cache-audit"      => op_cache_audit(out),
         "cache-aliasing"   => op_cache_aliasing(out),
         "cache-lookup"     => op_cache_lookup(req, out),
@@ -1378,6 +1379,34 @@ fn op_compose_stats(out: &mut String) {
         blitted, skipped, total, gate_ratio_permille
     );
 }
+// ── x11-windows ───────────────────────────────────────────────────────────────
+//
+// Live X11 window/compositor-surface introspection.  Reports, per window:
+// geometry, mapped state, the allocated pixel-buffer length, and the count of
+// non-zero (painted) pixels in the server-side source-of-truth buffer.  The
+// dispositive (b) paint-never-produced vs (c) present-dropped probe for the
+// large content surface (a mapped content window with nonzero==0 means the
+// client never wrote into the server buffer; nonzero>0 with a blank screen
+// means the compositor blit dropped it).
+fn op_x11_windows(out: &mut String) {
+    use core::fmt::Write;
+    let wins = crate::x11::window_debug_summary();
+    out.push_str(r#"{"windows":["#);
+    for (i, w) in wins.iter().enumerate() {
+        if i > 0 { out.push(','); }
+        // win/parent are emitted as quoted hex strings so the object is valid
+        // JSON (a bare 0x… literal is not JSON-parseable).
+        let _ = write!(
+            out,
+            r#"{{"fd":{},"win":"{:#x}","parent":"{:#x}","mapped":{},"w":{},"h":{},"abs_x":{},"abs_y":{},"pixels_len":{},"nonzero":{},"chrome_colored":{},"content_colored":{},"content_white":{}}}"#,
+            w.fd, w.win_id, w.parent, w.mapped, w.width, w.height,
+            w.abs_x, w.abs_y, w.pixels_len, w.nonzero,
+            w.chrome_colored, w.content_colored, w.content_white
+        );
+    }
+    let _ = write!(out, r#"],"count":{}}}"#, wins.len());
+}
+
 // ── cache-aliasing ────────────────────────────────────────────────────────────
 //
 // W215 H3a diagnostic: dump the two new counters that instrument the

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -399,6 +399,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "compose-stats"    => op_compose_stats(out),
         "cache-audit"      => op_cache_audit(out),
         "cache-aliasing"   => op_cache_aliasing(out),
+        "cache-lookup"     => op_cache_lookup(req, out),
         "fault-cache-keys" => op_fault_cache_keys(out),
         "w215-cache-residency" => op_w215_cache_residency(out),
         "tlb-stats"        => op_tlb_stats(out),
@@ -1409,6 +1410,77 @@ fn op_cache_aliasing(out: &mut String) {
     {
         out.push_str(r#"{"error":"cache-aliasing requires firefox-test feature"}"#);
     }
+}
+
+// ── cache-lookup ──────────────────────────────────────────────────────────────
+//
+// W215 in-place-writer localization helper.  Given a page-cache key
+// (mount, inode, page-aligned file offset) resolve the CURRENT backing
+// physical frame, derive the kernel direct-map (physmap) virtual address
+// (PHYS_OFF + phys, where PHYS_OFF = 0xFFFF_8000_0000_0000 — the same
+// higher-half identity map the cache/pmm zeroing paths write through), and
+// return a 16-byte content sample read from that physmap VA.
+//
+// Purpose: a GDB Z2 hardware write-watchpoint is a *linear-address* watch.
+// To catch the in-place corruptor of a live file-backed cache frame, the
+// caller must arm the watch on the kernel physmap VA of the CURRENT frame
+// (the frame's phys is per-boot and not known statically).  This op turns
+// the static, byte-proven cache key into the live (phys, kernel-VA, sample)
+// triple, so the caller can (a) confirm the frame holds REAL content (not
+// yet corrupted), then (b) arm `watch-set` on the returned kernel-VA and
+// resume — the next write through that VA is the corruptor.
+//
+// Request fields: "mount" (usize), "inode" (u64), "off" (u64, page-aligned
+// file offset).  All accept 0x-hex or decimal.  Read-only; no feature gate
+// (cache::lookup is always present).  Per Intel SDM Vol. 3A §4.10.5 the
+// direct map and the user PTE alias the same physical frame, so a write
+// through either VA mutates this content — but only a write through the
+// watched linear address fires the DR.
+fn op_cache_lookup(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    let mount = match extract_field(req, "mount").and_then(|s| parse_u64(&s)) {
+        Some(m) => m as usize,
+        None => { out.push_str(r#"{"error":"missing 'mount'"}"#); return; }
+    };
+    let inode = match extract_field(req, "inode").and_then(|s| parse_u64(&s)) {
+        Some(i) => i,
+        None => { out.push_str(r#"{"error":"missing 'inode'"}"#); return; }
+    };
+    let off = match extract_field(req, "off").and_then(|s| parse_u64(&s)) {
+        Some(o) => o & !0xFFF,
+        None => { out.push_str(r#"{"error":"missing 'off'"}"#); return; }
+    };
+    let phys = match crate::mm::cache::lookup(mount, inode, off) {
+        Some(p) => p,
+        None => {
+            out.push('{');
+            j_kv(out, "mount", &alloc::format!("{}", mount));
+            j_str(out, "inode"); out.push(':'); j_hex(out, inode); out.push(',');
+            j_str(out, "off"); out.push(':'); j_hex(out, off); out.push(',');
+            j_kv_str(out, "resident", "false");
+            j_trim_comma(out);
+            out.push('}');
+            return;
+        }
+    };
+    let kva = PHYS_OFF + phys;
+    // Sample 16 bytes from the physmap VA (the frame is RAM, always mapped).
+    let mut hex = String::with_capacity(32);
+    for i in 0..16u64 {
+        let b = unsafe { core::ptr::read_volatile((kva + i) as *const u8) };
+        let _ = write!(hex, "{:02x}", b);
+    }
+    out.push('{');
+    j_kv(out, "mount", &alloc::format!("{}", mount));
+    j_str(out, "inode"); out.push(':'); j_hex(out, inode); out.push(',');
+    j_str(out, "off"); out.push(':'); j_hex(out, off); out.push(',');
+    j_kv_str(out, "resident", "true");
+    j_str(out, "phys"); out.push(':'); j_hex(out, phys); out.push(',');
+    j_str(out, "kernel_va"); out.push(':'); j_hex(out, kva); out.push(',');
+    j_kv_str(out, "sample16", &hex);
+    j_trim_comma(out);
+    out.push('}');
 }
 
 // ── fault-cache-keys ──────────────────────────────────────────────────────────

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -527,6 +527,91 @@ pub fn get_mapped_windows() -> Vec<X11WindowSnapshot> {
     result
 }
 
+/// Live introspection of every X11 window's compositor-source surface, for the
+/// kdb `x11-windows` command.  Reports per-window geometry, mapped state, the
+/// allocated pixel-buffer length, and a count of non-zero (painted) bytes in
+/// `w.pixels`.  This is the dispositive (b)-paint-never-produced vs
+/// (c)-present-dropped probe for a large content surface: a mapped content
+/// window with `nonzero == 0` means the client never wrote pixels into the
+/// server's source-of-truth buffer (paint-never-produced); `nonzero > 0` while
+/// the screen is blank means the compositor blit dropped them (present-dropped).
+pub struct WindowDebug {
+    pub fd: u64,
+    pub win_id: u32,
+    pub parent: u32,
+    pub mapped: bool,
+    pub width: u16,
+    pub height: u16,
+    pub pixels_len: usize,
+    pub nonzero: usize,
+    pub abs_x: i32,
+    pub abs_y: i32,
+    /// Count of "real content" pixels (neither pure white 0xFFFFFF nor pure
+    /// black 0x000000) in the chrome strip (y < CHROME_STRIP_H) vs the content
+    /// region (y >= CHROME_STRIP_H).  Distinguishes a painted article (high
+    /// content-region colored count) from a blank/white-cleared content surface
+    /// (≈0 colored).  White is counted separately so a white-cleared region is
+    /// not mistaken for painted content by a bare non-zero test.
+    pub chrome_colored: usize,
+    pub content_colored: usize,
+    pub content_white: usize,
+}
+
+/// Window-local Y below which pixels are considered "chrome" (tab bar + toolbar
+/// + URL bar) rather than page content.  The Firefox toolbar block is ~85px.
+const CHROME_STRIP_H: i32 = 88;
+
+pub fn window_debug_summary() -> Vec<WindowDebug> {
+    let mut out = Vec::new();
+    if !X11_INITIALIZED.load(Ordering::Acquire) { return out; }
+    let srv = SERVER.lock();
+    for client in srv.clients.iter().filter_map(|s| s.as_ref()) {
+        for (rid, body) in client.resources.iter_all() {
+            if let resource::ResourceBody::Window(ref w) = body {
+                let mut nonzero = 0usize;
+                let mut chrome_colored = 0usize;
+                let mut content_colored = 0usize;
+                let mut content_white = 0usize;
+                let ww = w.width as usize;
+                let px = &w.pixels;
+                let npix = px.len() / 4;
+                for p in 0..npix {
+                    let o = p * 4;
+                    let b = px[o]; let g = px[o + 1]; let r = px[o + 2];
+                    if b != 0 || g != 0 || r != 0 { nonzero += 1; }
+                    let is_white = b == 0xFF && g == 0xFF && r == 0xFF;
+                    let is_black = b == 0 && g == 0 && r == 0;
+                    let y = if ww > 0 { (p / ww) as i32 } else { 0 };
+                    if y < CHROME_STRIP_H {
+                        if !is_white && !is_black { chrome_colored += 1; }
+                    } else if is_white {
+                        content_white += 1;
+                    } else if !is_black {
+                        content_colored += 1;
+                    }
+                }
+                let (ax, ay) = absolute_origin(client, rid);
+                out.push(WindowDebug {
+                    fd: client.fd,
+                    win_id: rid,
+                    parent: w.parent,
+                    mapped: w.mapped,
+                    width: w.width,
+                    height: w.height,
+                    pixels_len: w.pixels.len(),
+                    nonzero,
+                    abs_x: ax,
+                    abs_y: ay,
+                    chrome_colored,
+                    content_colored,
+                    content_white,
+                });
+            }
+        }
+    }
+    out
+}
+
 /// Test-only: read a single window-local BGRA pixel from a window's persistent
 /// pixel buffer (`w.pixels`, the compositor source of truth).  Searches every
 /// connected client for a window resource matching `win_id` (test windows use

--- a/scripts/astryx_qemu.py
+++ b/scripts/astryx_qemu.py
@@ -355,7 +355,17 @@ def _display_args(mode: str, show_window: bool) -> list[str]:
     - Headless (default): `-display none` + (for gui-test/firefox-test)
       a vmware VGA attached to VRAM so QMP `screendump` still works.
     - Windowed: shows the QEMU display for manual inspection.
+    - `ASTRYX_VNC=N` (env, opt-in): serve the vmware framebuffer over VNC on
+      127.0.0.1:(5900+N) for manual point-and-click testing on a headless host
+      (connect a VNC viewer through an SSH tunnel; QEMU routes the VNC
+      keyboard/mouse to the guest's PS/2 devices). Mirrors the ASTRYX_MEM_MIB
+      override; additive and localhost-bound. Accepts a bare display number
+      ("0") or a full host:display / :display spec.
     """
+    vnc = os.environ.get("ASTRYX_VNC")
+    if vnc:
+        spec = vnc if (":" in vnc or "." in vnc) else f"127.0.0.1:{vnc}"
+        return ["-vga", "vmware", "-vnc", spec]
     if show_window:
         # Always pick vmware VGA in windowed mode so the GUI compositor
         # has a framebuffer it understands.

--- a/scripts/astryx_qemu.py
+++ b/scripts/astryx_qemu.py
@@ -151,7 +151,14 @@ def _cpu_args(mode: str, kvm: bool, cpu_override: Optional[str] = None) -> list[
 
 
 def _memory_args(mode: str) -> list[str]:
-    mib = _MEM_MIB.get(mode, 1024)
+    # ASTRYX_MEM_MIB env override (mirrors ASTRYX_SMP) — lets an operator size
+    # guest RAM independent of the per-mode default for memory-pressure A/B
+    # testing without editing the per-mode table.
+    env_mib = os.environ.get("ASTRYX_MEM_MIB")
+    if env_mib:
+        mib = int(env_mib)
+    else:
+        mib = _MEM_MIB.get(mode, 1024)
     # Use M suffix so QEMU shows the value in MiB in its own logs
     return ["-m", f"{mib}M"]
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7168,7 +7168,7 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
-              "bell-stats", "compose-stats", "cache-audit", "cache-aliasing",
+              "bell-stats", "compose-stats", "x11-windows", "cache-audit", "cache-aliasing",
               "fault-cache-keys", "w215-cache-residency",
               "tlb-stats", "heap-stats", "w215-diag",
               # cpu-state: per-CPU scheduler/timer survey + TID-0 reactor
@@ -13147,7 +13147,7 @@ def main():
         "epoll-watch",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "uread", "trace-status",
-        "bell-stats", "compose-stats", "cache-audit", "cache-aliasing",
+        "bell-stats", "compose-stats", "x11-windows", "cache-audit", "cache-aliasing",
         "cache-lookup",
         "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -6456,13 +6456,54 @@ def cmd_watch_set(args):
                 if 0 < val < 0x10000:
                     corrupt_hit = True
                     break
+            # Enrich the catch with CR3 (names the active address space — which
+            # process's page tables were loaded when the kernel writer ran) via
+            # the QMP human monitor `info registers`, and a raw stack backtrace
+            # (best-effort): the return-address chain via the rbp frame links
+            # plus a flat dump of words at rsp.  Raw addresses only — the
+            # coordinator symbolizes against the kernel map.
+            cr3 = None
+            try:
+                hmp = _qmp_command(sess.get("qmp_sock", ""), "human-monitor-command",
+                                   {"command-line": "info registers"})
+                txt = hmp.get("return", "") if isinstance(hmp, dict) else ""
+                m = re.search(r"CR3=([0-9a-fA-F]+)", txt)
+                if m:
+                    cr3 = "0x" + m.group(1)
+            except Exception:
+                cr3 = None
+            bt_rbp = []
+            try:
+                fp = int(regs.get("rbp", "0x0"), 0)
+                for _ in range(16):
+                    if fp == 0 or fp < 0x1000:
+                        break
+                    saved_rbp = int.from_bytes(gdb.read_mem(fp, 8), "little")
+                    ret = int.from_bytes(gdb.read_mem(fp + 8, 8), "little")
+                    bt_rbp.append(hex(ret))
+                    if saved_rbp <= fp:
+                        break
+                    fp = saved_rbp
+            except Exception:
+                pass
+            stack_words = []
+            try:
+                rsp = int(regs.get("rsp", "0x0"), 0)
+                raw = gdb.read_mem(rsp, 8 * 32)
+                stack_words = [hex(int.from_bytes(raw[i*8:i*8+8], "little"))
+                               for i in range(32)]
+            except Exception:
+                pass
             fire = {
                 "fire_index": len(fires) + 1,
                 "rip": hex(rip),
                 "mode": "kernel" if is_kernel else "user",
+                "cr3": cr3,
                 "code_at_rip": code,
                 "slot_vals": slot_vals,
                 "corrupt_hit": corrupt_hit,
+                "bt_rbp_chain": bt_rbp,
+                "stack_words_at_rsp": stack_words,
                 "regs": regs,
             }
             if getattr(args, "corrupt_only", False) and not corrupt_hit:
@@ -7211,6 +7252,17 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
     if op == "proc":
         if not rest: raise ValueError("proc requires <pid>")
         return {"op": "proc", "pid": int(rest[0], 0)}
+    if op == "cache-lookup":
+        # Resolve a page-cache key (mount, inode, page-aligned file offset) to
+        # its CURRENT backing phys + kernel physmap VA + 16-byte content sample.
+        #   kdb <sid> cache-lookup <mount> <inode> <off>
+        # All accept 0x-hex or decimal.
+        if len(rest) < 3:
+            raise ValueError("cache-lookup requires <mount> <inode> <off>")
+        return {"op": "cache-lookup",
+                "mount": str(int(rest[0], 0)),
+                "inode": str(int(rest[1], 0)),
+                "off":   str(int(rest[2], 0))}
     if op == "procmaps":
         # Terse file-backed VMA map for ASLR-base / addr2line symbolication.
         # Emits one JSON object per VMA with first_page_phys via PML4 walk.
@@ -13096,6 +13148,7 @@ def main():
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "uread", "trace-status",
         "bell-stats", "compose-stats", "cache-audit", "cache-aliasing",
+        "cache-lookup",
         "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",
         "arm-phys",

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -6374,6 +6374,122 @@ def cmd_watch(args):
     })
 
 
+def cmd_watch_set(args):
+    """
+    Arm MULTIPLE hardware write watchpoints (up to 4 x86 DRs) spanning a
+    region, resume, and report the FIRST fire on ANY of them — naming the
+    writer RIP + which watched address fired + kernel/user mode.
+
+    Purpose (#655 double-map test): cover a whole saved-switch-frame region
+    with several 8-byte watches so a write through the VA cannot be missed by
+    a wrong-offset guess.  ZERO fires while the guest nonetheless corrupts the
+    frame is the dispositive proof that the corrupting store came through a
+    DIFFERENT virtual address mapping the same physical frame (a live
+    double-map) — a VA watchpoint only fires on the watched linear address.
+
+    Contract: session started with --gdb-port.  --addrs is a comma-separated
+    list of guest VAs (hex).  One-shot JSON on stdout.
+    """
+    sess = _load_session(args.sid)
+    port = _get_gdb_port(sess)
+    try:
+        addrs = [int(a, 0) for a in args.addrs.split(",") if a.strip()]
+    except ValueError:
+        _err(f"Invalid --addrs list: {args.addrs}")
+    if not addrs or len(addrs) > 4:
+        _err("watch-set: provide 1..4 comma-separated VAs (x86 has 4 DRs)")
+    length = args.length
+    timeout_s = args.timeout_ms / 1000.0
+
+    gdb = GdbClient("127.0.0.1", port)
+    if not gdb.connect():
+        _err(f"Cannot connect to GDB stub on port {port}")
+
+    armed = []
+    fires = []
+    try:
+        for a in addrs:
+            if gdb.set_watch(a, length, "write"):
+                armed.append(a)
+        if not armed:
+            _out({"ok": False, "error": "stub rejected all watchpoints (DRs exhausted?)"})
+            return
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            gdb.cont_no_wait()
+            stop = gdb.wait_for_stop(max(1.0, deadline - time.monotonic()))
+            if stop is None:
+                break  # timed out with no fire
+            try:
+                regs = gdb.read_regs()
+            except Exception:
+                regs = {}
+            rip = int(regs.get("rip", "0x0"), 0)
+            is_kernel = rip >= 0xFFFF_8000_0000_0000
+            # Identify which watched addr now differs / was hit (best-effort:
+            # report all current slot values; the writer RIP is the key datum).
+            slot_vals = {}
+            for a in armed:
+                try:
+                    slot_vals[hex(a)] = gdb.read_mem(a, length).hex()
+                except Exception:
+                    slot_vals[hex(a)] = None
+            try:
+                code = gdb.read_mem(rip, 16).hex()
+            except Exception:
+                code = None
+            # #655 corruptor discriminator: a benign live-stack write stores a
+            # real pointer (kernel VA >= 0xffff8.. or a canonical user VA); the
+            # CORRUPTING write leaves a small non-canonical value (the observed
+            # 0x7001/0x7008/0x700a garbage saved-RIP signature) in the slot.
+            # With --corrupt-only, skip fires whose slots all hold plausible
+            # pointers and only report a fire that left a small (< 0x10000)
+            # value in a watched slot — the saved-RIP-slot corruptor.
+            corrupt_hit = False
+            for hx, hv in slot_vals.items():
+                if hv is None:
+                    continue
+                try:
+                    val = int.from_bytes(bytes.fromhex(hv), "little")
+                except Exception:
+                    continue
+                if 0 < val < 0x10000:
+                    corrupt_hit = True
+                    break
+            fire = {
+                "fire_index": len(fires) + 1,
+                "rip": hex(rip),
+                "mode": "kernel" if is_kernel else "user",
+                "code_at_rip": code,
+                "slot_vals": slot_vals,
+                "corrupt_hit": corrupt_hit,
+                "regs": regs,
+            }
+            if getattr(args, "corrupt_only", False) and not corrupt_hit:
+                # benign live-stack write — keep watching for the corruptor.
+                continue
+            fires.append(fire)
+            break  # report the first (matching) fire on any watched addr
+        for a in armed:
+            try:
+                gdb.del_watch(a, length, "write")
+            except Exception:
+                pass
+    except Exception as e:
+        _err(f"GDB watch-set error: {e}")
+    finally:
+        gdb.close()
+
+    _out({
+        "ok": True,
+        "armed_addrs": [hex(a) for a in armed],
+        "length": length,
+        "fire_count": len(fires),
+        "writer": fires[0] if fires else None,
+        "all_fires": fires,
+    })
+
+
 def cmd_pause(args):
     """Pause QEMU via QMP 'stop'. Freezes all vCPUs."""
     sess     = _load_session(args.sid)
@@ -12877,6 +12993,25 @@ def main():
     p_watch.add_argument("--timeout-ms", type=int, default=120000,
                           help="Overall budget for catching the writer")
 
+    # watch-set (multi-DR region watch; #655 double-map test)
+    p_watch_set = sub.add_parser(
+        "watch-set",
+        help="[Tier2] Arm up to 4 HW write watchpoints spanning a region; "
+             "report the first fire on any. Zero fires while the frame is "
+             "nonetheless corrupted proves a double-map (write via another VA).")
+    p_watch_set.add_argument("sid")
+    p_watch_set.add_argument("--addrs", required=True,
+                             help="Comma-separated guest VAs (1..4, hex)")
+    p_watch_set.add_argument("--length", type=int, default=8,
+                             help="Watch width per addr in bytes (default 8)")
+    p_watch_set.add_argument("--timeout-ms", type=int, default=120000,
+                             help="Overall budget")
+    p_watch_set.add_argument("--corrupt-only", dest="corrupt_only",
+                             action="store_true",
+                             help="Skip benign pointer writes; report only a "
+                                  "fire that left a small (<0x10000) value in a "
+                                  "watched slot (the saved-RIP corruptor sig).")
+
     # pause
     p_pause = sub.add_parser("pause", help="[Tier2] Pause QEMU via QMP stop")
     p_pause.add_argument("sid")
@@ -13784,6 +13919,7 @@ def main():
         "step":   cmd_step,
         "cont":   cmd_cont,
         "watch":  cmd_watch,
+        "watch-set": cmd_watch_set,
         "pause":  cmd_pause,
         "resume": cmd_resume,
         "autopsy": cmd_autopsy,


### PR DESCRIPTION
Banks the reusable diagnostic tooling built during the windowed-Firefox render milestone work. All additive, opt-in, no production-path behaviour change.

## Tools
- **`qemu-harness.py watch-set --addrs A,B,C,D [--corrupt-only]`** — arm up to 4 GDB Z2 hardware write-watchpoints over a region (non-perturbing on plain builds). Used to prove the W215 page-cache corruption non-reproducing.
- **kdb `cache-lookup <mount> <inode> <off>`** — resolve a page-cache key → phys → higher-half VA → content sample (+ watch-set CR3/backtrace enrichment).
- **kdb `x11-windows`** — live window / compositor-surface introspection (per-window geometry + content-region colour diversity); a one-shot paint-never-produced vs present-dropped verdict for any render gate. (Note: judge blank-vs-painted via a cropped screendump distinct-colour count, not the `content_colored` field.)
- **`ASTRYX_MEM_MIB=<MiB>`** env override — size guest RAM for A/B (mirrors `ASTRYX_SMP`).
- **`ASTRYX_VNC=<N>`** env override — serve the framebuffer over VNC on `127.0.0.1:(5900+N)` for manual point-and-click testing on a headless host (connect via SSH tunnel or a noVNC bridge; QEMU routes VNC keyboard/mouse to the guest's PS/2 devices).

## Why
These are the instruments behind this session's results (W215 closed, the >1 GiB SHM-physmap fix, the 1 GiB OOM-ceiling root cause, and the live VNC demo). Banking them on master so they're reusable rather than living on feature branches.

Docs-/diagnostic-only; the kdb ops are `kdb`-feature-gated; the env overrides are opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)