### PR TITLE
drivers: Wave-1 safe subset (partition flush-forward, virtio-net RX-drain/deferred-TX, e1000 MMIO atomic, keyboard atomics)

### DIFF
--- a/kernel/src/drivers/keyboard.rs
+++ b/kernel/src/drivers/keyboard.rs
@@ -71,13 +71,23 @@ pub enum KeyEvent {
     FKey(u8),
 }
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 /// Modifier key state tracked across scancodes.
-static mut SHIFT_PRESSED: bool = false;
-static mut CTRL_PRESSED: bool = false;
-static mut ALT_PRESSED: bool = false;
-static mut CAPS_LOCK: bool = false;
+///
+/// These are read/written from `process_scancode`, which runs in the IRQ1
+/// (PS/2 keyboard) handler context, and could also be observed from other
+/// CPUs.  `AtomicBool` is used instead of `static mut` to avoid undefined
+/// behaviour and the data race a plain `static mut` would create under SMP
+/// (a torn modifier update would leave a "stuck" Shift/Ctrl/Alt).  Each flag
+/// is independent, so per-flag `Relaxed` atomics are sufficient — there is no
+/// cross-flag invariant to enforce.
+static SHIFT_PRESSED: AtomicBool = AtomicBool::new(false);
+static CTRL_PRESSED: AtomicBool = AtomicBool::new(false);
+static ALT_PRESSED: AtomicBool = AtomicBool::new(false);
+static CAPS_LOCK: AtomicBool = AtomicBool::new(false);
 /// Extended scancode prefix (0xE0) was received.
-static mut EXTENDED_PREFIX: bool = false;
+static EXTENDED_PREFIX: AtomicBool = AtomicBool::new(false);
 
 // ── i8042 low-level helpers ─────────────────────────────────────────────────
 
@@ -247,31 +257,29 @@ pub fn scancode_to_ascii(scancode: u8) -> Option<char> {
 ///
 /// Handles extended prefix (0xE0), modifier tracking, and CapsLock toggle.
 pub fn process_scancode(scancode: u8) -> Option<KeyEvent> {
-    // SAFETY: Single-threaded keyboard handling (interrupts serialize access).
-    unsafe {
+    {
         // Extended scancode prefix
         if scancode == 0xE0 {
-            EXTENDED_PREFIX = true;
+            EXTENDED_PREFIX.store(true, Ordering::Relaxed);
             return None;
         }
 
-        let is_extended = EXTENDED_PREFIX;
-        EXTENDED_PREFIX = false;
+        let is_extended = EXTENDED_PREFIX.swap(false, Ordering::Relaxed);
 
         // Key release (bit 7 set)
         if scancode & 0x80 != 0 {
             let released = scancode & 0x7F;
             if is_extended {
                 match released {
-                    0x38 => ALT_PRESSED = false,  // Right Alt release
-                    0x1D => CTRL_PRESSED = false,  // Right Ctrl release
+                    0x38 => ALT_PRESSED.store(false, Ordering::Relaxed),  // Right Alt release
+                    0x1D => CTRL_PRESSED.store(false, Ordering::Relaxed),  // Right Ctrl release
                     _ => {}
                 }
             } else {
                 match released {
-                    0x2A | 0x36 => SHIFT_PRESSED = false,
-                    0x1D => CTRL_PRESSED = false,
-                    0x38 => ALT_PRESSED = false,
+                    0x2A | 0x36 => SHIFT_PRESSED.store(false, Ordering::Relaxed),
+                    0x1D => CTRL_PRESSED.store(false, Ordering::Relaxed),
+                    0x38 => ALT_PRESSED.store(false, Ordering::Relaxed),
                     _ => {}
                 }
             }
@@ -291,25 +299,25 @@ pub fn process_scancode(scancode: u8) -> Option<KeyEvent> {
                 0x52 => Some(KeyEvent::Insert),
                 0x49 => Some(KeyEvent::PageUp),
                 0x51 => Some(KeyEvent::PageDown),
-                0x1D => { CTRL_PRESSED = true; None }  // Right Ctrl
-                0x38 => { ALT_PRESSED = true; None }   // Right Alt
+                0x1D => { CTRL_PRESSED.store(true, Ordering::Relaxed); None }  // Right Ctrl
+                0x38 => { ALT_PRESSED.store(true, Ordering::Relaxed); None }   // Right Alt
                 _ => None,
             };
         }
 
         // Modifier key presses
         match scancode {
-            0x2A | 0x36 => { SHIFT_PRESSED = true; return None; }
-            0x1D => { CTRL_PRESSED = true; return None; }
-            0x38 => { ALT_PRESSED = true; return None; }
-            0x3A => { CAPS_LOCK = !CAPS_LOCK; return None; }
+            0x2A | 0x36 => { SHIFT_PRESSED.store(true, Ordering::Relaxed); return None; }
+            0x1D => { CTRL_PRESSED.store(true, Ordering::Relaxed); return None; }
+            0x38 => { ALT_PRESSED.store(true, Ordering::Relaxed); return None; }
+            0x3A => { CAPS_LOCK.fetch_xor(true, Ordering::Relaxed); return None; }
             _ => {}
         }
 
-        let shift = SHIFT_PRESSED;
-        let ctrl = CTRL_PRESSED;
-        let alt = ALT_PRESSED;
-        let caps = CAPS_LOCK;
+        let shift = SHIFT_PRESSED.load(Ordering::Relaxed);
+        let ctrl = CTRL_PRESSED.load(Ordering::Relaxed);
+        let alt = ALT_PRESSED.load(Ordering::Relaxed);
+        let caps = CAPS_LOCK.load(Ordering::Relaxed);
 
         // Special keys
         match scancode {

--- a/kernel/src/drivers/partition.rs
+++ b/kernel/src/drivers/partition.rs
@@ -380,6 +380,31 @@ impl BlockDevice for PartitionBlockDevice {
         }
         self.inner.write_sectors(self.start_lba + lba, count, data)
     }
+
+    // The wrapper MUST forward cache/geometry queries to the underlying
+    // device.  Falling back to the `BlockDevice` defaults here would make
+    // `fsync(2)` through a partition a silent no-op (FLUSH never reaches the
+    // drive) and would let a read-only device be mounted read-write because
+    // `is_readonly()` would report `false`.  See block.rs for the per-method
+    // wire/semantics references.
+
+    /// Forward FLUSH to the underlying device so partition-scoped `fsync(2)`
+    /// actually commits the drive's write-back cache to media.
+    fn flush(&self) -> Result<(), BlockError> {
+        self.inner.flush()
+    }
+
+    /// Inherit the underlying device's read-only status so filesystems refuse
+    /// an RW mount of a write-protected device at mount time.
+    fn is_readonly(&self) -> bool {
+        self.inner.is_readonly()
+    }
+
+    /// Inherit the underlying device's logical block size (the partition does
+    /// not change the device's addressing granularity).
+    fn logical_block_size(&self) -> u32 {
+        self.inner.logical_block_size()
+    }
 }
 
 /// Create a `PartitionBlockDevice` wrapping an inner device at the given LBA

--- a/kernel/src/net/e1000.rs
+++ b/kernel/src/net/e1000.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use spin::Mutex;
 
 // ── PCI constants ───────────────────────────────────────────────────────────
@@ -124,7 +124,12 @@ struct TxDesc {
 // ── Static driver state ─────────────────────────────────────────────────────
 
 /// MMIO base address for the e1000 registers.
-static MMIO_BASE: Mutex<u64> = Mutex::new(0);
+///
+/// Written exactly once, from `init_device()`, before the NIC is marked
+/// `AVAILABLE`; read on every register access (the RX/TX hot paths).  An
+/// `AtomicU64` removes the per-access `spin::Mutex` lock/unlock round-trip
+/// that the previous `Mutex<u64>` imposed on `mmio_read`/`mmio_write`.
+static MMIO_BASE: AtomicU64 = AtomicU64::new(0);
 
 /// Whether the e1000 NIC has been initialized.
 static AVAILABLE: AtomicBool = AtomicBool::new(false);
@@ -249,7 +254,7 @@ fn rx_flush_nudge() {
 /// is the user's VMA mapping.  See the per-process page-table layout note
 /// at `mm/vmm.rs:31-35` for the deeper rationale.
 fn mmio_read(reg: u32) -> u32 {
-    let base = *MMIO_BASE.lock();
+    let base = MMIO_BASE.load(Ordering::Relaxed);
     unsafe {
         let ptr = phys_to_virt(base + reg as u64) as *const u32;
         core::ptr::read_volatile(ptr)
@@ -259,7 +264,7 @@ fn mmio_read(reg: u32) -> u32 {
 /// Write a 32-bit register in MMIO space.  See `mmio_read` for the
 /// physical-vs-virtual rationale.
 fn mmio_write(reg: u32, val: u32) {
-    let base = *MMIO_BASE.lock();
+    let base = MMIO_BASE.load(Ordering::Relaxed);
     unsafe {
         let ptr = phys_to_virt(base + reg as u64) as *mut u32;
         core::ptr::write_volatile(ptr, val);
@@ -328,7 +333,9 @@ fn init_device(bus: u8, dev: u8) -> bool {
         mmio_base
     };
 
-    *MMIO_BASE.lock() = mmio_base;
+    // Write-once: store the base before any register access (and before the
+    // NIC is marked AVAILABLE), so every subsequent mmio_read/mmio_write sees it.
+    MMIO_BASE.store(mmio_base, Ordering::Relaxed);
     crate::serial_println!("[E1000] MMIO base: {:#X}", mmio_base);
 
     // 2) Enable PCI bus mastering + memory space access

--- a/kernel/src/net/virtio_net.rs
+++ b/kernel/src/net/virtio_net.rs
@@ -47,7 +47,7 @@
 
 extern crate alloc;
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use spin::Mutex;
 use crate::hal;
 use crate::mm::pmm;
@@ -159,8 +159,6 @@ struct VirtioNetDevice {
     tx_bufs_phys: u64,
     /// Last seen used ring index for RX queue.
     rxq_last_used: u16,
-    /// Last seen used ring index for TX queue.
-    txq_last_used: u16,
     /// Next descriptor index to use for available ring in RX queue.
     rxq_avail_idx: u16,
     /// Next TX slot (wraps at NUM_TX_SLOTS).
@@ -169,6 +167,17 @@ struct VirtioNetDevice {
 
 static VIRTIO_NET: Mutex<Option<VirtioNetDevice>> = Mutex::new(None);
 static VIRTIO_NET_AVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// Count of RX used-ring entries discarded as malformed (length <= the
+/// virtio_net_hdr, or an out-of-range descriptor id).  Such entries still have
+/// their descriptor re-posted so the device never starves for RX buffers; this
+/// counter exists only for observability of burst/overflow loss.
+static RX_DROPS: AtomicU64 = AtomicU64::new(0);
+
+/// Read the running count of dropped (malformed) RX frames.
+pub fn rx_drops() -> u64 {
+    RX_DROPS.load(Ordering::Relaxed)
+}
 
 // ── Initialization ──────────────────────────────────────────────────────────
 
@@ -384,7 +393,6 @@ pub fn init() -> bool {
             rx_bufs_phys,
             tx_bufs_phys,
             rxq_last_used: 0,
-            txq_last_used: 0,
             rxq_avail_idx: rx_use, // we already posted rx_use descriptors
             tx_slot: 0,
         });
@@ -422,11 +430,14 @@ fn find_virtio_net_pci() -> Option<crate::drivers::pci::PciDevice> {
 /// Send a raw Ethernet frame via virtio-net.
 ///
 /// The caller passes the raw frame (no virtio_net_hdr).  This function:
-/// 1. Copies the frame into a driver-owned TX buffer slot.
-/// 2. Prepends a zeroed virtio_net_hdr (no offloads).
-/// 3. Posts a 2-descriptor chain (hdr + frame) onto the TX virtqueue.
-/// 4. Kicks the notification register.
-/// 5. Spin-polls the used ring for completion before returning.
+/// 1. Lazily reclaims TX descriptors completed since the previous call.
+/// 2. Copies the frame into a driver-owned TX buffer slot.
+/// 3. Prepends a zeroed virtio_net_hdr (no offloads).
+/// 4. Posts a 2-descriptor chain (hdr + frame) onto the TX virtqueue.
+/// 5. Kicks the notification register and returns *without* spin-waiting for
+///    completion.  The descriptor/buffer for this send is reclaimed on a later
+///    call; back-pressure (a brief bounded spin) is applied only when every TX
+///    slot is still in flight.
 pub fn send_packet(data: &[u8]) {
     if !VIRTIO_NET_AVAILABLE.load(Ordering::Acquire) { return; }
     if data.is_empty() || data.len() > (RX_BUF_SIZE - VIRTIO_NET_HDR_SIZE) { return; }
@@ -440,10 +451,61 @@ pub fn send_packet(data: &[u8]) {
     let io_base    = dev.io_base;
     let qs         = dev.txq_size;
     let txq_base   = phys_to_virt::<u8>(dev.txq_phys);
+    let tx_slots   = core::cmp::min(qs / 2, NUM_TX_SLOTS as u16) as usize;
 
-    // Pick the next TX slot (wraps at NUM_TX_SLOTS).
+    // ── Deferred TX reclaim + back-pressure ──────────────────────────────────
+    // Previously this function spun on the used ring (~5M iterations) after
+    // every kick, holding the device mutex the whole time — serialising the
+    // whole TX path on device completion latency.  Instead, reclaim lazily:
+    // read the used-ring index (= count of completed chains) and treat any TX
+    // slot whose chain has completed as free.  Only when *all* tx_slots are
+    // still outstanding must we wait — and then only briefly, bounded — before
+    // reusing a slot whose buffer the device may still be reading.
+    //
+    // SAFETY: the used/avail ring live in PMM memory we own; the device only
+    // writes the used ring and reads the avail ring/descriptors.
+    unsafe {
+        let used_idx_ptr  = txq_base.add(used_ring_offset(qs)).add(2) as *const u16;
+        let avail_idx_ptr = txq_base.add(avail_ring_offset(qs)).add(2) as *const u16;
+
+        // Reclaim everything the device has completed so far: the used-ring
+        // index *is* the count of completed chains, so no per-slot bookkeeping
+        // is needed — a slot is free once `posted - used >= tx_slots` no longer
+        // holds for it.
+        let used_now = used_idx_ptr.read_volatile();
+
+        // Outstanding = posted (avail idx) − completed (used idx).
+        let posted = avail_idx_ptr.read_volatile();
+        let mut outstanding = posted.wrapping_sub(used_now) as usize;
+
+        if outstanding >= tx_slots {
+            // Queue full: wait (bounded) for at least one completion so the
+            // slot we are about to reuse is no longer device-owned.
+            let mut timeout = 5_000_000u32;
+            loop {
+                let used_cur = used_idx_ptr.read_volatile();
+                outstanding = posted.wrapping_sub(used_cur) as usize;
+                if outstanding < tx_slots {
+                    break;
+                }
+                timeout = match timeout.checked_sub(1) {
+                    Some(v) => v,
+                    None => {
+                        crate::serial_println!(
+                            "[VIRTIO-NET] TX queue full — dropping frame (device not draining)"
+                        );
+                        return;
+                    }
+                };
+                core::hint::spin_loop();
+            }
+        }
+    }
+
+    // Pick the next TX slot (wraps at tx_slots).  The back-pressure check above
+    // guarantees this slot's previous chain has completed, so reusing its
+    // descriptors/buffer cannot race the device.
     let slot = dev.tx_slot as usize;
-    let tx_slots = core::cmp::min(qs / 2, NUM_TX_SLOTS as u16) as usize;
     dev.tx_slot = ((slot + 1) % tx_slots) as u16;
 
     // Each slot occupies RX_BUF_SIZE bytes: first VIRTIO_NET_HDR_SIZE bytes
@@ -507,26 +569,11 @@ pub fn send_packet(data: &[u8]) {
         // Kick the device: writing queue 1 to QUEUE_NOTIFY triggers TX.
         hal::outw(io_base + VIRTIO_REG_QUEUE_NOTIFY, QUEUE_TX);
 
-        // Spin-poll the used ring until the device marks completion.
-        // The used ring layout: flags(u16), idx(u16), ring[qs]({id,len} each 8 bytes).
-        let used_base = txq_base.add(used_ring_offset(qs));
-        let used_idx_ptr = used_base.add(2) as *const u16;
-        let expected = dev.txq_last_used.wrapping_add(1);
-
-        let mut timeout = 5_000_000u32;
-        loop {
-            let current = used_idx_ptr.read_volatile();
-            if current == expected { break; }
-            timeout = match timeout.checked_sub(1) {
-                Some(v) => v,
-                None => {
-                    crate::serial_println!("[VIRTIO-NET] TX timeout waiting for used ring");
-                    break;
-                }
-            };
-            core::hint::spin_loop();
-        }
-        dev.txq_last_used = expected;
+        // Return immediately — completion is reclaimed lazily on a later
+        // send_packet() call (see the deferred-reclaim block above).  The TX
+        // buffer for this slot is not reused until tx_slots further sends have
+        // occurred, by which point the back-pressure guard has confirmed the
+        // device finished reading it.
     }
 }
 
@@ -546,62 +593,89 @@ pub fn send_packet(data: &[u8]) {
 pub fn poll_rx() {
     if !VIRTIO_NET_AVAILABLE.load(Ordering::Acquire) { return; }
 
-    // Process one completed RX descriptor per call.  If the caller wants to
-    // drain the queue it should call poll_rx() in a loop.
-    let mut frame_buf = [0u8; RX_BUF_SIZE];
-    let mut frame_len = 0usize;
-    let mut desc_id_to_repost: Option<u16> = None;
-
-    {
-        let mut guard = VIRTIO_NET.lock();
-        let dev = match guard.as_mut() {
-            Some(d) => d,
+    // Drain the RX used ring: process *every* completed descriptor, not just
+    // one per call.  Processing a single descriptor per poll meant that under
+    // a receive burst the device-side ring filled faster than we consumed it
+    // and frames were dropped.  Per iteration we copy the frame out while
+    // holding the device lock, re-post the descriptor, release the lock, and
+    // deliver lock-free (the stack may re-enter send_packet, which also takes
+    // VIRTIO_NET — so we must not hold it across handle_rx_packet).
+    //
+    // The loop is bounded by the RX queue size: at most that many descriptors
+    // can be outstanding, so a misbehaving device cannot wedge us in an
+    // unbounded loop.  Any frames that arrive after the bound are picked up by
+    // the next poll_rx() call.
+    let max_iters = {
+        let guard = VIRTIO_NET.lock();
+        match guard.as_ref() {
+            Some(d) => d.rxq_size as u32,
             None => return,
-        };
-
-        let io_base = dev.io_base;
-        let qs      = dev.rxq_size;
-
-        // SAFETY: All accesses below are to PMM-allocated memory we own.
-        // The device owns only descriptors in the available ring; used-ring
-        // entries are returned to us.
-        unsafe {
-            let rxq_virt  = phys_to_virt::<u8>(dev.rxq_phys);
-            let used_base = rxq_virt.add(used_ring_offset(qs));
-            let used_idx  = (used_base.add(2) as *const u16).read_volatile();
-
-            if used_idx == dev.rxq_last_used {
-                return; // nothing received
-            }
-
-            // Read the used-ring entry for our current position.
-            let entry_off   = 4 + ((dev.rxq_last_used % qs) as usize) * 8;
-            let desc_id     = (used_base.add(entry_off)     as *const u32).read_volatile() as usize;
-            let total_len   = (used_base.add(entry_off + 4) as *const u32).read_volatile() as usize;
-
-            dev.rxq_last_used = dev.rxq_last_used.wrapping_add(1);
-
-            if total_len > VIRTIO_NET_HDR_SIZE && desc_id < qs as usize {
-                let flen    = total_len - VIRTIO_NET_HDR_SIZE;
-                let buf_phys = dev.rx_bufs_phys + (desc_id * RX_BUF_SIZE) as u64;
-                let src     = phys_to_virt::<u8>(buf_phys + VIRTIO_NET_HDR_SIZE as u64);
-                let copy_len = core::cmp::min(flen, RX_BUF_SIZE - VIRTIO_NET_HDR_SIZE);
-                core::ptr::copy_nonoverlapping(src, frame_buf.as_mut_ptr(), copy_len);
-                frame_len = copy_len;
-            }
-
-            // Re-post the descriptor regardless of frame validity so the
-            // device never runs out of RX buffers.
-            let rxq_virt_repost = phys_to_virt::<u8>(dev.rxq_phys);
-            re_post_rx_desc(rxq_virt_repost, qs, dev, desc_id as u16, io_base);
-            desc_id_to_repost = Some(desc_id as u16);
         }
-    } // mutex released here
+    };
 
-    // Now call up into the stack with no locks held.
-    let _ = desc_id_to_repost; // already re-posted inside the lock
-    if frame_len > 0 {
-        super::handle_rx_packet(&frame_buf[..frame_len]);
+    for _ in 0..max_iters {
+        let mut frame_buf = [0u8; RX_BUF_SIZE];
+        let mut frame_len = 0usize;
+        let mut malformed = false;
+
+        {
+            let mut guard = VIRTIO_NET.lock();
+            let dev = match guard.as_mut() {
+                Some(d) => d,
+                None => return,
+            };
+
+            let io_base = dev.io_base;
+            let qs      = dev.rxq_size;
+
+            // SAFETY: All accesses below are to PMM-allocated memory we own.
+            // The device owns only descriptors in the available ring; used-ring
+            // entries are returned to us.
+            unsafe {
+                let rxq_virt  = phys_to_virt::<u8>(dev.rxq_phys);
+                let used_base = rxq_virt.add(used_ring_offset(qs));
+                let used_idx  = (used_base.add(2) as *const u16).read_volatile();
+
+                if used_idx == dev.rxq_last_used {
+                    return; // ring fully drained
+                }
+
+                // Read the used-ring entry for our current position.
+                let entry_off   = 4 + ((dev.rxq_last_used % qs) as usize) * 8;
+                let desc_id     = (used_base.add(entry_off)     as *const u32).read_volatile() as usize;
+                let total_len   = (used_base.add(entry_off + 4) as *const u32).read_volatile() as usize;
+
+                dev.rxq_last_used = dev.rxq_last_used.wrapping_add(1);
+
+                if total_len > VIRTIO_NET_HDR_SIZE && desc_id < qs as usize {
+                    let flen    = total_len - VIRTIO_NET_HDR_SIZE;
+                    let buf_phys = dev.rx_bufs_phys + (desc_id * RX_BUF_SIZE) as u64;
+                    let src     = phys_to_virt::<u8>(buf_phys + VIRTIO_NET_HDR_SIZE as u64);
+                    let copy_len = core::cmp::min(flen, RX_BUF_SIZE - VIRTIO_NET_HDR_SIZE);
+                    core::ptr::copy_nonoverlapping(src, frame_buf.as_mut_ptr(), copy_len);
+                    frame_len = copy_len;
+                } else {
+                    // Malformed used entry (runt or out-of-range desc id): the
+                    // descriptor is still re-posted below so the device never
+                    // starves for RX buffers; just record the loss.
+                    malformed = true;
+                }
+
+                // Re-post the descriptor regardless of frame validity so the
+                // device never runs out of RX buffers.
+                let rxq_virt_repost = phys_to_virt::<u8>(dev.rxq_phys);
+                re_post_rx_desc(rxq_virt_repost, qs, dev, desc_id as u16, io_base);
+            }
+        } // mutex released here
+
+        if malformed {
+            RX_DROPS.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Now call up into the stack with no locks held.
+        if frame_len > 0 {
+            super::handle_rx_packet(&frame_buf[..frame_len]);
+        }
     }
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -323,6 +323,14 @@ pub fn run() -> ! {
     total += 1;
     if test_ahci_per_port_mutex() { passed += 1; }
 
+    // ── Test 0g: PartitionBlockDevice forwards flush/RO/blksize ──────────
+    total += 1;
+    if test_partition_forwards_flush_ro_blksize() { passed += 1; }
+
+    // ── Test 0h: PS/2 keyboard modifier flags (atomics, no stuck mod) ────
+    total += 1;
+    if test_keyboard_modifier_state() { passed += 1; }
+
     // ── Test 1: Network Configuration ───────────────────────────────────
 
     total += 1;
@@ -3375,6 +3383,149 @@ fn kdb_runtime_loop(exit_code: u32) -> ! {
 }
 
 // ── Individual Tests ────────────────────────────────────────────────────────
+
+/// Number of `flush()` calls observed by the partition-forwarding probe device.
+static PART_PROBE_FLUSH_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Mock `BlockDevice` whose flush/RO/blksize answers are observable, so we can
+/// assert that `PartitionBlockDevice` forwards them to its inner device rather
+/// than silently using the `BlockDevice` trait defaults (which would make
+/// partition-scoped `fsync(2)` a no-op and report a write-protected device as
+/// writable).
+struct PartProbeDevice {
+    ro: bool,
+    blk: u32,
+}
+
+impl crate::drivers::block::BlockDevice for PartProbeDevice {
+    fn sector_count(&self) -> u64 {
+        4096
+    }
+    fn read_sectors(
+        &self,
+        _lba: u64,
+        count: u32,
+        buf: &mut [u8],
+    ) -> Result<(), crate::drivers::block::BlockError> {
+        let len = (count as usize) * crate::drivers::block::SECTOR_SIZE;
+        if buf.len() < len {
+            return Err(crate::drivers::block::BlockError::BufferTooSmall);
+        }
+        for b in buf[..len].iter_mut() {
+            *b = 0;
+        }
+        Ok(())
+    }
+    fn write_sectors(
+        &self,
+        _lba: u64,
+        _count: u32,
+        _data: &[u8],
+    ) -> Result<(), crate::drivers::block::BlockError> {
+        Ok(())
+    }
+    fn flush(&self) -> Result<(), crate::drivers::block::BlockError> {
+        PART_PROBE_FLUSH_CALLS.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn is_readonly(&self) -> bool {
+        self.ro
+    }
+    fn logical_block_size(&self) -> u32 {
+        self.blk
+    }
+}
+
+/// Regression: `PartitionBlockDevice` must forward `flush()`, `is_readonly()`,
+/// and `logical_block_size()` to the underlying device.  See block.rs for the
+/// FLUSH (virtio-blk T_FLUSH / ATA FLUSH CACHE) and RO/blksize semantics.
+fn test_partition_forwards_flush_ro_blksize() -> bool {
+    test_header!("Partition forwards flush/RO/blksize");
+    use crate::drivers::block::BlockDevice;
+
+    PART_PROBE_FLUSH_CALLS.store(0, Ordering::Relaxed);
+
+    let inner = Box::new(PartProbeDevice { ro: true, blk: 4096 });
+    let part = crate::drivers::partition::create_partition_device(inner, 64, 1024);
+
+    // (1) flush() must reach the inner device (not the no-op default).
+    let _ = part.flush();
+    let calls = PART_PROBE_FLUSH_CALLS.load(Ordering::Relaxed);
+    if calls != 1 {
+        test_fail!(
+            "partition_flush_forward",
+            "inner flush() called {} times, expected 1 (fsync-through-partition would be a silent no-op)",
+            calls
+        );
+        return false;
+    }
+
+    // (2) is_readonly() must reflect the inner device, not default false.
+    if !part.is_readonly() {
+        test_fail!(
+            "partition_ro_forward",
+            "PartitionBlockDevice reported writable for a read-only inner device — an RO device could be mounted RW"
+        );
+        return false;
+    }
+
+    // (3) logical_block_size() must reflect the inner device, not default 512.
+    let lbs = part.logical_block_size();
+    if lbs != 4096 {
+        test_fail!(
+            "partition_blksize_forward",
+            "logical_block_size() = {}, expected inner 4096",
+            lbs
+        );
+        return false;
+    }
+
+    test_pass!("Partition forwards flush/RO/blksize");
+    true
+}
+
+/// Regression: PS/2 keyboard modifier state (now `AtomicBool`, was `static mut`)
+/// must apply Shift/Ctrl and clear cleanly on key-release (no stuck modifier).
+/// Scancodes are PS/2 Set 1 (after i8042 translation).
+fn test_keyboard_modifier_state() -> bool {
+    test_header!("Keyboard modifier flags (atomics)");
+    use crate::drivers::keyboard::{process_scancode, KeyEvent};
+
+    // 0x1E = 'a' make code; 0x2A = Left Shift make; 0xAA = Left Shift break;
+    // 0x1D = Left Ctrl make; 0x9D = Left Ctrl break.
+
+    // Plain 'a' -> lowercase 'a'.
+    if process_scancode(0x1E) != Some(KeyEvent::Char('a')) {
+        test_fail!("keyboard_modifiers", "plain 0x1E did not yield 'a'");
+        return false;
+    }
+
+    // Shift held -> 'A'.
+    let _ = process_scancode(0x2A);
+    if process_scancode(0x1E) != Some(KeyEvent::Char('A')) {
+        test_fail!("keyboard_modifiers", "Shift+0x1E did not yield 'A'");
+        return false;
+    }
+
+    // Shift released -> back to 'a' (no stuck Shift).
+    let _ = process_scancode(0xAA);
+    if process_scancode(0x1E) != Some(KeyEvent::Char('a')) {
+        test_fail!("keyboard_modifiers", "Shift release left a stuck modifier (got non-'a')");
+        return false;
+    }
+
+    // Ctrl held -> Ctrl('a'); then release so we leave clean state.
+    let _ = process_scancode(0x1D);
+    let ctrl = process_scancode(0x1E);
+    let _ = process_scancode(0x9D);
+    if ctrl != Some(KeyEvent::Ctrl('a')) {
+        test_fail!("keyboard_modifiers", "Ctrl+0x1E did not yield Ctrl('a')");
+        return false;
+    }
+
+    test_pass!("Keyboard modifier flags (atomics)");
+    true
+}
 
 fn test_network_config() -> bool {
     test_header!("Network Configuration (ip)");


### PR DESCRIPTION
## Summary

The safe, dependency-free subset of driver-overhaul **Wave 1** — five contained correctness/perf wins with no dependency on the parked kstack-recycle work and no interrupt-routing changes (MSI-X infra + IRQ-vector allocator remain a separate, gated effort). SMP-independent throughout.

| Item | File | Fixes |
|---|---|---|
| **W1-3** | `drivers/partition.rs` | `PartitionBlockDevice` now forwards `flush()` / `is_readonly()` / `logical_block_size()` to its inner device. Was inheriting trait defaults → **`fsync(2)` through a partition was a silent no-op** (device FLUSH never issued) and a **read-only device reported writable** (RW mount of RO media). |
| **W1-4** | `net/virtio_net.rs` | `poll_rx()` drains the **whole RX used ring** per call (copy/deliver/repost per descriptor, lock dropped before delivery), bounded by RX queue size. One-descriptor-per-poll dropped frames under burst. Adds an `RX_DROPS` malformed-frame counter. |
| **W1-6** | `net/virtio_net.rs` | `send_packet()` no longer spins the used ring (~5M iters) under the device mutex after every kick. TX is reclaimed **lazily on the next send** via the used-ring index; a bounded back-pressure spin applies only when all TX slots are in flight. Drops the now-redundant `txq_last_used` field. |
| **W1-5** | `net/e1000.rs` | Write-once MMIO base → `AtomicU64` (was `spin::Mutex<u64>`), removing a per-register lock round-trip on the RX/TX hot path. This is the **active NIC under Firefox**. |
| **W1-7** | `drivers/keyboard.rs` | Modifier flags (Shift/Ctrl/Alt/CapsLock/extended-prefix) → `AtomicBool` (was `static mut`): removes UB + the SMP data race that could leave a **stuck modifier**. Drops the stale "single-threaded" comment. |

`mouse.rs` / cursor input, `compositor.rs`, and `vmware_svga.rs` were deliberately **not touched** (owned by sibling agents). MSI-X / IRQ-allocator work is out of scope.

## Tests

Two regressions added to `test_runner.rs`, matching existing style:
- **Test 0g** — `PartitionBlockDevice` forwards flush/RO/blksize to a probe device (asserts inner `flush()` is actually called, RO propagates, 4096 block size propagates).
- **Test 0h** — PS/2 keyboard modifier application + clean release (Shift→`A`, release→`a` with no stuck modifier, Ctrl→`Ctrl('a')`).

## Verification

- `cargo check` clean (default + `test-mode`); no new warnings on the changed lines.
- Full `test-mode` boot (SMP=1, KVM): **263 pass**. Both new tests pass. The driver-relevant suite is green:
  - **E1000 driver / ARP resolution / Ping gateway / DHCP** all pass → W1-5 e1000 MMIO-via-AtomicU64 fetches over the network end-to-end.
  - **virtio-blk features + flush / wait-modes / quarantine** all pass.
- The suite's final **Firefox ESR launch oracle** (Test 139, which launches real headless Firefox and is documented as "Firefox is expected to crash") hit the known intermittent SMP=1 Firefox content-init crash (userspace fault, `CR2=0x4000a2` in FF's own ELF). This is unrelated to this PR's kernel-driver changes (FF loads a local `file://`, not the network path); a clean `origin/master` baseline confirms the same FF-oracle behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
