### PR TITLE
gui/x11/svga: damage-region compositing — repaint+present only changed rects

### DIFF
--- a/kernel/src/drivers/vmware_svga.rs
+++ b/kernel/src/drivers/vmware_svga.rs
@@ -171,10 +171,21 @@ fn fifo_reserve(svga: &VmwareSvga, bytes: u32) {
         loop {
             let next = fifo.add(SVGA_FIFO_NEXT_CMD).read_volatile();
             let stop = fifo.add(SVGA_FIFO_STOP).read_volatile();
-            let used = next.wrapping_sub(stop) % ring;
+            // `next`/`stop` are byte offsets in [min, max); `fifo_write` wraps
+            // NEXT_CMD back to `min` at `max`, so `next < stop` is a normal
+            // wrap state.  The ring size (max - min) is NOT a power of two
+            // (a 64 KiB FIFO gives ring = 0xFFC0), so `(next - stop) % ring`
+            // mis-computes `used` in the wrap case and over-reports free space
+            // — letting the producer lap the device-owned STOP.  Branch on the
+            // wrap instead (both offsets in [min,max) ⇒ stop - next < ring).
+            let used = if next >= stop { next - stop } else { ring - (stop - next) };
             let free = ring - used;
             if free >= need { return; }
             // Producer would lap the consumer: force a drain and re-check.
+            // NB: this drain spins on SVGA_REG_BUSY while SVGA.lock() is held
+            // (we are inside update_rect_async's locked region); it is only
+            // reached on the rare genuine-overrun path and is equivalent in
+            // shape to the old synchronous fifo_sync.
             write_reg(svga.io_base, SVGA_REG_SYNC, 1);
             while read_reg(svga.io_base, SVGA_REG_BUSY) != 0 {
                 core::hint::spin_loop();

--- a/kernel/src/drivers/vmware_svga.rs
+++ b/kernel/src/drivers/vmware_svga.rs
@@ -145,8 +145,49 @@ fn init_fifo(svga: &mut VmwareSvga) {
     );
 }
 
+/// Ensure at least `bytes` of free space exist in the FIFO command ring before
+/// the next write, so a producer that no longer spin-drains after every command
+/// (see [`present_kick`]) cannot lap the device-owned `SVGA_FIFO_STOP` consumer
+/// pointer and corrupt in-flight commands.
+///
+/// The VMware SVGA II FIFO is a byte ring of 32-bit words bounded by `MIN`/`MAX`;
+/// the guest advances `NEXT_CMD`, the device advances `STOP`.  Used bytes are
+/// `(NEXT_CMD - STOP) mod ring`; one word is reserved so a full ring is never
+/// indistinguishable from an empty one.  When space is short we kick the device
+/// (`SVGA_REG_SYNC`) and spin on `SVGA_REG_BUSY` to drain — the only place the
+/// present path ever blocks.  When space is available this is a few volatile
+/// reads and returns immediately, so the spin-drained callers (`update_rect`,
+/// `fill_rect`, …) are unaffected.
+fn fifo_reserve(svga: &VmwareSvga, bytes: u32) {
+    let fifo = svga.fifo_virt as *mut u32;
+    unsafe {
+        let min = fifo.add(SVGA_FIFO_MIN).read_volatile();
+        let max = fifo.add(SVGA_FIFO_MAX).read_volatile();
+        if max <= min { return; }
+        let ring = max - min;
+        // Need room for the command plus the one reserved sentinel word.
+        let need = bytes.saturating_add(4);
+        if need >= ring { return; } // command larger than the ring: best-effort
+        loop {
+            let next = fifo.add(SVGA_FIFO_NEXT_CMD).read_volatile();
+            let stop = fifo.add(SVGA_FIFO_STOP).read_volatile();
+            let used = next.wrapping_sub(stop) % ring;
+            let free = ring - used;
+            if free >= need { return; }
+            // Producer would lap the consumer: force a drain and re-check.
+            write_reg(svga.io_base, SVGA_REG_SYNC, 1);
+            while read_reg(svga.io_base, SVGA_REG_BUSY) != 0 {
+                core::hint::spin_loop();
+            }
+        }
+    }
+}
+
 /// Write a single `u32` into the FIFO ring, advancing next_cmd with wrapping.
 fn fifo_write(svga: &VmwareSvga, val: u32) {
+    // Overrun guard: never let NEXT_CMD lap the device-owned STOP pointer.
+    fifo_reserve(svga, 4);
+
     let fifo = svga.fifo_virt as *mut u32;
 
     unsafe {
@@ -157,6 +198,12 @@ fn fifo_write(svga: &VmwareSvga, val: u32) {
         // Write the value at the current next_cmd offset (byte offset → u32 index).
         let ptr = (svga.fifo_virt as *mut u8).add(next_cmd as usize) as *mut u32;
         ptr.write_volatile(val);
+
+        // The command word must be globally visible before the device can see
+        // the advanced producer pointer, or it could consume a half-written
+        // command.  On x86 (TSO) program-ordered stores to WB memory suffice;
+        // the compiler fence keeps the value store ahead of the pointer store.
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
         // Advance next_cmd, wrapping around to min if we hit max.
         next_cmd += 4;
@@ -450,6 +497,45 @@ pub fn update_rect(x: u32, y: u32, w: u32, h: u32) {
     // Explicitly drop guard before sync (sync acquires the lock too).
     drop(guard);
     fifo_sync();
+}
+
+/// Queue a targeted `SVGA_CMD_UPDATE` for a rectangle **without** spin-waiting
+/// for the device to drain.  Multiple rectangles can be queued back-to-back in
+/// one frame; a single trailing [`present_kick`] then asks the device to scan
+/// them all out.  Overrun is prevented by the per-write [`fifo_reserve`] guard
+/// (free-space check against the device `STOP` pointer), not by spinning on
+/// `SVGA_REG_BUSY` — so the common case costs only the FIFO writes, no VM-exit
+/// poll loop.  Coordinates are clamped to the active mode by the device.
+pub fn update_rect_async(x: u32, y: u32, w: u32, h: u32) {
+    if w == 0 || h == 0 { return; }
+    let guard = SVGA.lock();
+    let svga = match guard.as_ref() {
+        Some(s) if s.enabled => s,
+        _ => return,
+    };
+    fifo_write(svga, SVGA_CMD_UPDATE);
+    fifo_write(svga, x);
+    fifo_write(svga, y);
+    fifo_write(svga, w);
+    fifo_write(svga, h);
+}
+
+/// Non-blocking present: kick the device to begin draining any queued FIFO
+/// commands (e.g. the [`update_rect_async`] rectangles of this frame) and return
+/// immediately, **without** spinning on `SVGA_REG_BUSY`.  Writing
+/// `SVGA_REG_SYNC` wakes the host FIFO-processing thread; the back-pressure that
+/// keeps the guest from outrunning the device lives in [`fifo_reserve`] (it
+/// blocks only when the ring would otherwise overrun), so per-frame this is one
+/// MMIO write rather than a drain spin.
+pub fn present_kick() {
+    let guard = SVGA.lock();
+    let svga = match guard.as_ref() {
+        Some(s) if s.enabled => s,
+        _ => return,
+    };
+    // All queued FIFO command words must be visible before the host is kicked.
+    core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+    write_reg(svga.io_base, SVGA_REG_SYNC, 1);
 }
 
 /// Fill a rectangle with `color` via the FIFO (SVGA_CMD_RECT_FILL).

--- a/kernel/src/gui/compositor.rs
+++ b/kernel/src/gui/compositor.rs
@@ -22,7 +22,7 @@ pub fn is_active() -> bool {
     COMPOSITOR_ACTIVE.load(Ordering::Relaxed)
 }
 
-use core::sync::atomic::AtomicU64;
+use core::sync::atomic::{AtomicI32, AtomicU32, AtomicU64};
 
 /// Monotone damage counter.  Bumped by every accessor that changes on-screen
 /// pixel content (X11 PutImage / fill / text, window move/resize, cursor move,
@@ -65,7 +65,10 @@ const COMPOSE_MAX_IDLE_TICKS: u64 = 100;
 /// content calls this so the next [`compose_if_due`] knows a repaint is owed.
 #[inline]
 pub fn damage() {
+    DAMAGE_NOTED.fetch_add(1, Ordering::Relaxed);
     DAMAGE_SEQ.fetch_add(1, Ordering::Relaxed);
+    // Coordinate-free: force a full-surface repaint this frame.
+    DAMAGE.lock().full = true;
 }
 
 /// Rate-gated, damage-driven compositor entry point for the cooperative BSP
@@ -113,6 +116,301 @@ pub fn compose_gate_stats() -> (u64, u64) {
         COMPOSE_BLITTED.load(Ordering::Relaxed),
         COMPOSE_SKIPPED.load(Ordering::Relaxed),
     )
+}
+
+// ---------------------------------------------------------------------------
+// Damage-region tracking
+//
+// The compositor repaints and presents only the screen rectangles that
+// actually changed since the last frame, instead of regenerating + blitting
+// the whole surface.  Producers (the X11 server's draw ops, window geometry
+// changes, native GDI accessors) report changed regions as screen-space
+// rectangles via [`damage_rect`]; a coordinate-free producer (or any path we
+// have not taught fine damage) falls back to [`damage`], which forces a
+// full-surface repaint that frame.  An empty damage set is likewise treated
+// as full-surface so a direct `compose()` call (no recorded damage) still
+// refreshes everything.  See the X11 DAMAGE protocol region model and the DRM
+// dirty-fb convention (NULL/empty clips ⇒ full update).
+// ---------------------------------------------------------------------------
+
+/// Maximum number of distinct damage rectangles tracked per frame before they
+/// are collapsed into a single bounding box.  Bounds per-frame compositing work
+/// so a pathological flood of tiny rects cannot make a frame O(n) in rects.
+const MAX_DAMAGE_RECTS: usize = 16;
+
+struct DamageAccum {
+    /// Pending screen-space damage rectangles (x, y, w, h), already clipped to
+    /// the screen.  Drained by [`compose`].
+    rects: Vec<(u32, u32, u32, u32)>,
+    /// When set, the whole surface is repainted this frame and `rects` is
+    /// ignored (coarse fallback / first frame / resolution change).
+    full: bool,
+}
+
+static DAMAGE: Mutex<DamageAccum> =
+    Mutex::new(DamageAccum { rects: Vec::new(), full: true });
+
+/// Active surface dimensions, published by [`init`] so [`damage_rect`] can clip
+/// without taking the compositor lock.
+static SCREEN_W: AtomicU32 = AtomicU32::new(0);
+static SCREEN_H: AtomicU32 = AtomicU32::new(0);
+
+/// Last software-cursor position painted into the backbuffer, so a partial frame
+/// can repaint (erase) the cursor's old cell and paint its new one without a
+/// full-surface repaint.  `i32::MIN` = "no previous cursor yet".  Only used on
+/// the software-cursor path (the hardware cursor is composited by the device and
+/// leaves no framebuffer damage).
+static PREV_CURSOR_X: AtomicI32 = AtomicI32::new(i32::MIN);
+static PREV_CURSOR_Y: AtomicI32 = AtomicI32::new(i32::MIN);
+
+/// Software-cursor cell size (the arrow bitmap is 12×12).
+const CURSOR_CELL: u32 = 12;
+
+/// Counts every op that reported its own damage (fine OR a deliberate "no
+/// on-screen change", e.g. a draw to an off-screen pixmap).  The X11 dispatch
+/// snapshots this before/after a request: if it did NOT advance for a
+/// screen-changing request, the request had no fine-damage handler and the
+/// dispatch issues the coarse [`damage`] full-surface fallback.  This lets the
+/// fine-damage migration be incremental and always-correct.
+static DAMAGE_NOTED: AtomicU64 = AtomicU64::new(0);
+
+/// Read the damage-accounted counter (see [`DAMAGE_NOTED`]).
+#[inline]
+pub fn damage_noted_seq() -> u64 {
+    DAMAGE_NOTED.load(Ordering::Relaxed)
+}
+
+/// Record that the current op accounted for its own on-screen damage without
+/// necessarily changing the screen (e.g. it drew to an off-screen pixmap).
+/// Suppresses the dispatch-level coarse full-surface fallback for that op.
+#[inline]
+pub fn note_damage() {
+    DAMAGE_NOTED.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record on-screen damage for a single screen-space rectangle.  Clips to the
+/// surface; coalesces into a bounding box once the rect list exceeds
+/// [`MAX_DAMAGE_RECTS`].  Also marks the op as damage-accounted (see
+/// [`DAMAGE_NOTED`]) and advances the compose gate's [`DAMAGE_SEQ`].
+pub fn damage_rect(x: i32, y: i32, w: i32, h: i32) {
+    DAMAGE_NOTED.fetch_add(1, Ordering::Relaxed);
+    let sw = SCREEN_W.load(Ordering::Relaxed);
+    let sh = SCREEN_H.load(Ordering::Relaxed);
+    if sw == 0 || sh == 0 || w <= 0 || h <= 0 {
+        return;
+    }
+    let x0 = x.max(0) as u32;
+    let y0 = y.max(0) as u32;
+    let x1 = (x.saturating_add(w).max(0) as u32).min(sw);
+    let y1 = (y.saturating_add(h).max(0) as u32).min(sh);
+    if x1 <= x0 || y1 <= y0 {
+        return;
+    }
+    // A real on-screen change is owed: advance the compose gate.
+    DAMAGE_SEQ.fetch_add(1, Ordering::Relaxed);
+    let mut acc = DAMAGE.lock();
+    if acc.full {
+        return; // already painting everything this frame
+    }
+    acc.rects.push((x0, y0, x1 - x0, y1 - y0));
+    if acc.rects.len() > MAX_DAMAGE_RECTS {
+        let bbox = damage_bounding_box(&acc.rects);
+        acc.rects.clear();
+        acc.rects.push(bbox);
+    }
+}
+
+/// Bounding box of a non-empty rect list.
+fn damage_bounding_box(rects: &[(u32, u32, u32, u32)]) -> (u32, u32, u32, u32) {
+    let mut x0 = u32::MAX;
+    let mut y0 = u32::MAX;
+    let mut x1 = 0u32;
+    let mut y1 = 0u32;
+    for &(x, y, w, h) in rects {
+        x0 = x0.min(x);
+        y0 = y0.min(y);
+        x1 = x1.max(x + w);
+        y1 = y1.max(y + h);
+    }
+    (x0, y0, x1.saturating_sub(x0), y1.saturating_sub(y0))
+}
+
+/// Rectangle intersection in screen space, all `(x, y, w, h)`.  Returns `None`
+/// if the rectangles do not overlap.
+#[inline]
+fn rect_intersect(
+    a: (u32, u32, u32, u32),
+    b: (u32, u32, u32, u32),
+) -> Option<(u32, u32, u32, u32)> {
+    let ax2 = a.0 + a.2;
+    let ay2 = a.1 + a.3;
+    let bx2 = b.0 + b.2;
+    let by2 = b.1 + b.3;
+    let x0 = a.0.max(b.0);
+    let y0 = a.1.max(b.1);
+    let x1 = ax2.min(bx2);
+    let y1 = ay2.min(by2);
+    if x1 <= x0 || y1 <= y0 {
+        None
+    } else {
+        Some((x0, y0, x1 - x0, y1 - y0))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-compose timing/throughput instrumentation (before/after the damage-region
+// overhaul, exposed via the kdb `compose-stats` op).  All in TSC-derived µs and
+// bytes; cumulative + last-frame snapshots so a single boot quantifies the win.
+// ---------------------------------------------------------------------------
+static COMPOSE_US_TOTAL: AtomicU64 = AtomicU64::new(0);
+static COMPOSE_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static COMPOSE_DIRTY_PX_TOTAL: AtomicU64 = AtomicU64::new(0);
+static COMPOSE_FRAMES: AtomicU64 = AtomicU64::new(0);
+static COMPOSE_LAST_US: AtomicU64 = AtomicU64::new(0);
+static COMPOSE_LAST_BYTES: AtomicU64 = AtomicU64::new(0);
+static COMPOSE_LAST_DIRTY_PX: AtomicU64 = AtomicU64::new(0);
+
+/// Record one composited frame's wall time (TSC cycles), VRAM bytes moved, and
+/// dirty-pixel area, converting cycles → µs via the BSP TSC calibration.
+fn record_compose(cycles: u64, bytes: u64, dirty_px: u64) {
+    let tpt = crate::arch::x86_64::irq::TSC_PER_TICK.load(Ordering::Relaxed);
+    // TSC_PER_TICK = cycles per 10 ms tick ⇒ µs = cycles * 10_000 / TSC_PER_TICK.
+    let us = if tpt == 0 {
+        0
+    } else {
+        (cycles.saturating_mul(10_000)) / tpt
+    };
+    COMPOSE_US_TOTAL.fetch_add(us, Ordering::Relaxed);
+    COMPOSE_BYTES_TOTAL.fetch_add(bytes, Ordering::Relaxed);
+    COMPOSE_DIRTY_PX_TOTAL.fetch_add(dirty_px, Ordering::Relaxed);
+    COMPOSE_FRAMES.fetch_add(1, Ordering::Relaxed);
+    COMPOSE_LAST_US.store(us, Ordering::Relaxed);
+    COMPOSE_LAST_BYTES.store(bytes, Ordering::Relaxed);
+    COMPOSE_LAST_DIRTY_PX.store(dirty_px, Ordering::Relaxed);
+}
+
+/// Snapshot of the compose-timing instrumentation:
+/// `(frames, us_total, bytes_total, dirty_px_total, last_us, last_bytes,
+/// last_dirty_px)`.  Used by the kdb `compose-stats` op to report the
+/// before/after damage-region win.
+pub fn compose_timing_stats() -> (u64, u64, u64, u64, u64, u64, u64) {
+    (
+        COMPOSE_FRAMES.load(Ordering::Relaxed),
+        COMPOSE_US_TOTAL.load(Ordering::Relaxed),
+        COMPOSE_BYTES_TOTAL.load(Ordering::Relaxed),
+        COMPOSE_DIRTY_PX_TOTAL.load(Ordering::Relaxed),
+        COMPOSE_LAST_US.load(Ordering::Relaxed),
+        COMPOSE_LAST_BYTES.load(Ordering::Relaxed),
+        COMPOSE_LAST_DIRTY_PX.load(Ordering::Relaxed),
+    )
+}
+
+/// Self-test for the damage-region machinery (rectangle intersection, bounding-
+/// box coalescing, screen clipping, and the full-surface fallback).  Returns
+/// `true` on success.  Saves and restores the live damage accumulator so it can
+/// run against an initialised compositor without perturbing live compositing.
+/// Invoked from `test_runner::test_damage_region`.
+pub fn damage_region_selftest() -> bool {
+    // 1. rect_intersect: overlap, containment, disjoint, edge-touch.
+    if rect_intersect((0, 0, 10, 10), (5, 5, 10, 10)) != Some((5, 5, 5, 5)) {
+        return false;
+    }
+    if rect_intersect((0, 0, 100, 100), (10, 10, 20, 20)) != Some((10, 10, 20, 20)) {
+        return false;
+    }
+    if rect_intersect((0, 0, 10, 10), (20, 20, 5, 5)).is_some() {
+        return false;
+    }
+    // Edge-touch (shared boundary, zero overlap area) must be None.
+    if rect_intersect((0, 0, 10, 10), (10, 0, 10, 10)).is_some() {
+        return false;
+    }
+
+    // 2. bounding box of a disjoint pair = enclosing rect.
+    let bb = damage_bounding_box(&[(2, 3, 4, 5), (20, 30, 1, 1)]);
+    if bb != (2, 3, 19, 28) {
+        return false;
+    }
+
+    let sw = SCREEN_W.load(Ordering::Relaxed);
+    let sh = SCREEN_H.load(Ordering::Relaxed);
+    if sw == 0 || sh == 0 {
+        // Compositor not initialised — the pure-logic checks above still ran.
+        return true;
+    }
+
+    // Save the live accumulator, then exercise damage_rect in isolation.
+    let saved: (Vec<(u32, u32, u32, u32)>, bool) = {
+        let mut acc = DAMAGE.lock();
+        let r = core::mem::take(&mut acc.rects);
+        let f = acc.full;
+        acc.full = false;
+        (r, f)
+    };
+
+    let mut ok = true;
+
+    // 3. A clipped, in-bounds rect lands as one entry.
+    damage_rect(10, 10, 20, 20);
+    {
+        let acc = DAMAGE.lock();
+        if acc.full || acc.rects.len() != 1 || acc.rects[0] != (10, 10, 20, 20) {
+            ok = false;
+        }
+    }
+
+    // 4. An off-screen rect is clipped to the surface bounds.
+    {
+        let mut acc = DAMAGE.lock();
+        acc.rects.clear();
+        acc.full = false;
+    }
+    damage_rect(-5, -5, 10, 10);
+    {
+        let acc = DAMAGE.lock();
+        // (-5,-5,10,10) clips to (0,0,5,5).
+        if acc.rects.len() != 1 || acc.rects[0] != (0, 0, 5, 5) {
+            ok = false;
+        }
+    }
+
+    // 5. Flooding well past MAX_DAMAGE_RECTS stays bounded by the cap (the rect
+    //    list is collapsed to a bounding box whenever it exceeds the cap, so it
+    //    can never grow without limit).
+    {
+        let mut acc = DAMAGE.lock();
+        acc.rects.clear();
+        acc.full = false;
+    }
+    for i in 0..(MAX_DAMAGE_RECTS as u32 * 4) {
+        let x = (i % sw.max(1)) as i32;
+        damage_rect(x, 0, 1, 1);
+    }
+    {
+        let acc = DAMAGE.lock();
+        if acc.rects.len() > MAX_DAMAGE_RECTS {
+            ok = false;
+        }
+    }
+
+    // 6. Coarse damage() forces full-surface.
+    damage();
+    {
+        let acc = DAMAGE.lock();
+        if !acc.full {
+            ok = false;
+        }
+    }
+
+    // Restore the live accumulator and force a full repaint of the real frame.
+    {
+        let mut acc = DAMAGE.lock();
+        acc.rects = saved.0;
+        acc.full = true; // be conservative: full repaint next live frame
+        let _ = saved.1;
+    }
+
+    ok
 }
 
 /// Pure gating predicate for [`compose_if_due`] (extracted so it is unit
@@ -588,9 +886,6 @@ pub struct CompositorState {
     pub fb_stride: u32,
     pub backbuffer: Vec<u32>,
     pub frame_count: u64,
-    /// Bounding box of dirty region this frame: (x, y, w, h).
-    /// `None` means nothing dirty yet; `Some((0,0,sw,sh))` = full screen.
-    pub dirty_rect: Option<(u32, u32, u32, u32)>,
 }
 
 static COMPOSITOR: Mutex<Option<CompositorState>> = Mutex::new(None);
@@ -941,9 +1236,17 @@ pub fn init(fb_base: u64, width: u32, height: u32, stride: u32) {
         fb_stride: stride,
         backbuffer: vec![0u32; buf_size],
         frame_count: 0,
-        dirty_rect: Some((0, 0, width, height)), // initial frame: full dirty
     };
     *COMPOSITOR.lock() = Some(state);
+    // Publish dimensions for lock-free damage clipping, and force a full
+    // first-frame repaint.
+    SCREEN_W.store(width, Ordering::Relaxed);
+    SCREEN_H.store(height, Ordering::Relaxed);
+    {
+        let mut acc = DAMAGE.lock();
+        acc.rects.clear();
+        acc.full = true;
+    }
     crate::serial_println!(
         "[GUI] Compositor initialized ({}x{}, stride={}, fb=0x{:X})",
         width,
@@ -959,14 +1262,27 @@ pub fn init(fb_base: u64, width: u32, height: u32, stride: u32) {
 
 /// Main compositing entry point — call once per frame.
 ///
-/// 1. Fills the backbuffer with the desktop background colour.
-/// 2. Iterates over windows in z-order (back → front), collecting a snapshot
-///    of each visible, non-minimized window and drawing it.
-/// 3. Draws the mouse cursor.
-/// 4. Blits the backbuffer to the hardware framebuffer.
+/// Damage-region driven: repaints and presents only the screen rectangles that
+/// changed since the last composited frame, rather than regenerating the full
+/// backbuffer and blitting the whole surface every frame.
+///
+/// 1. Latch the pending damage region(s) (or full-surface) under the damage
+///    lock, re-arming for the next frame.
+/// 2. For each damaged region: repaint the desktop background, then the Win32
+///    windows whose bounds intersect it.
+/// 3. Composite the X11 client windows on top, copying only the damaged
+///    sub-rectangles (memcpy per row; no full-window clone).
+/// 4. Start-menu overlay + mouse cursor.
+/// 5. Blit each region to the hardware framebuffer (non-blocking
+///    `SVGA_CMD_UPDATE` per region + one trailing present kick).
+///
+/// A coordinate-free [`damage`] call (or first frame / no recorded damage)
+/// forces a full-surface frame, so direct `compose()` callers always refresh.
 pub fn compose() {
     // Mark compositor as active — disables TTY console framebuffer writes.
     COMPOSITOR_ACTIVE.store(true, Ordering::Relaxed);
+
+    let t0 = crate::arch::x86_64::irq::rdtsc();
 
     let mut guard = COMPOSITOR.lock();
     let comp = match guard.as_mut() {
@@ -978,29 +1294,57 @@ pub fn compose() {
     let sh = comp.screen_height;
     let stride = sw; // backbuffer is tightly packed
 
-    // --- 1. Desktop background (subtle gradient) ---
-    // Top: deep navy (0xFF0A0A20) → Bottom: dark teal (0xFF0D1B2A)
-    let top_r: u32 = 0x0A; let top_g: u32 = 0x0A; let top_b: u32 = 0x20;
-    let bot_r: u32 = 0x0D; let bot_g: u32 = 0x1B; let bot_b: u32 = 0x2A;
-    for y in 0..sh {
-        let r = top_r + (bot_r.wrapping_sub(top_r)) * y / sh.max(1);
-        let g = top_g + (bot_g.wrapping_sub(top_g)) * y / sh.max(1);
-        let b = top_b + (bot_b.wrapping_sub(top_b)) * y / sh.max(1);
-        let color = 0xFF000000 | (r << 16) | (g << 8) | b;
-        let row_start = (y * stride) as usize;
-        let row_end = row_start + sw as usize;
-        if row_end <= comp.backbuffer.len() {
-            comp.backbuffer[row_start..row_end].fill(color);
+    // The hardware cursor (when enabled) is composited by the SVGA device and
+    // generates no framebuffer damage.  The software-cursor fallback paints the
+    // cursor into the backbuffer; instead of forcing a full-surface frame to
+    // avoid cursor trails, it is treated as ordinary damage — the cursor's old
+    // and new cells are added to this frame's regions below (X11 DAMAGE-style
+    // accounting of the cursor's own region).
+    let hw_cursor = HARDWARE_CURSOR_ACTIVE.load(Ordering::Relaxed);
+
+    // --- 1. Latch-and-clear the damage region under the damage lock ---
+    let (mut regions, full): (Vec<(u32, u32, u32, u32)>, bool) = {
+        let mut acc = DAMAGE.lock();
+        let first = comp.frame_count == 0;
+        let full = first || acc.full || acc.rects.is_empty();
+        let regions = if full {
+            vec![(0, 0, sw, sh)]
+        } else {
+            core::mem::take(&mut acc.rects)
+        };
+        // Re-arm: any producer that runs after this point re-dirties for the
+        // next frame (the producer locks DAMAGE after us).
+        acc.rects.clear();
+        acc.full = false;
+        (regions, full)
+    };
+
+    // Software cursor: on a partial frame, repaint (erase) the cursor's previous
+    // cell and paint its new one by adding both to this frame's regions.  On a
+    // full frame the whole surface is already covered, so nothing to add.
+    let (cur_mx, cur_my) = crate::drivers::mouse::position();
+    if !hw_cursor && !full {
+        let px = PREV_CURSOR_X.load(Ordering::Relaxed);
+        let py = PREV_CURSOR_Y.load(Ordering::Relaxed);
+        for (cxp, cyp) in [(px, py), (cur_mx, cur_my)] {
+            if cxp == i32::MIN {
+                continue;
+            }
+            if let Some(r) = rect_intersect(
+                (0, 0, sw, sh),
+                (cxp.max(0) as u32, cyp.max(0) as u32, CURSOR_CELL, CURSOR_CELL),
+            ) {
+                if !regions.contains(&r) {
+                    regions.push(r);
+                }
+            }
         }
     }
-    // Full screen is dirty (background covers entire frame).
-    expand_dirty(comp, 0, 0, sw, sh);
 
-    // --- 2. Windows (back-to-front) ---
+    // --- 2. Gather Win32 window snapshots once (locks released before paint) ---
     let z_order: Vec<WindowHandle> = crate::wm::zorder::get_z_order();
-
+    let mut win32: Vec<WindowSnapshot> = Vec::new();
     for &handle in z_order.iter() {
-        // Snapshot the window data (briefly locks WINDOW_REGISTRY, then releases).
         let snap = crate::wm::window::with_window(handle, |w| WindowSnapshot {
             handle: w.handle,
             x: w.x,
@@ -1017,18 +1361,13 @@ pub fn compose() {
             style: w.style,
             state: w.state,
         });
-
         let snap = match snap {
             Some(s) => s,
             None => continue,
         };
-
-        // Skip invisible or minimized windows.
         if !snap.style.visible || snap.state == WindowState::Minimized {
             continue;
         }
-
-        // Trivial off-screen rejection.
         if snap.x + (snap.width as i32) <= 0
             || snap.y + (snap.height as i32) <= 0
             || snap.x >= sw as i32
@@ -1036,126 +1375,135 @@ pub fn compose() {
         {
             continue;
         }
-
-        draw_window(&mut comp.backbuffer, stride, &snap);
-        // Mark the window's bounding box dirty.
-        let wx = snap.x.max(0) as u32;
-        let wy = snap.y.max(0) as u32;
-        let wx2 = ((snap.x + snap.width as i32).max(0) as u32).min(sw);
-        let wy2 = ((snap.y + snap.height as i32).max(0) as u32).min(sh);
-        if wx2 > wx && wy2 > wy {
-            expand_dirty(comp, wx, wy, wx2 - wx, wy2 - wy);
-        }
+        win32.push(snap);
     }
 
-    // --- 2b. X11 client windows (on top of Win32 windows) ---
-    // Render mapped X11 windows to the backbuffer. These are from Firefox,
-    // xterm, or any other X11 client connected to our Xastryx server.
-    {
-        let x11_windows = crate::x11::get_mapped_windows();
-        for xwin in &x11_windows {
-            let wx = xwin.x as i32;
-            let wy = xwin.y as i32;
-            let ww = xwin.width as u32;
-            let wh = xwin.height as u32;
-            // Clip to screen
-            let x0 = wx.max(0) as u32;
-            let y0 = wy.max(0) as u32;
-            let x1 = ((wx + ww as i32) as u32).min(sw);
-            let y1 = ((wy + wh as i32) as u32).min(sh);
-            if x1 <= x0 || y1 <= y0 { continue; }
-            // Blit BGRA pixels to backbuffer
-            for py in y0..y1 {
-                let src_y = (py as i32 - wy) as u32;
-                let dst_off = (py * stride + x0) as usize;
-                let src_off = (src_y * ww + (x0 as i32 - wx) as u32) as usize;
-                for px in 0..(x1 - x0) as usize {
-                    let si = (src_off + px) * 4;
-                    if si + 3 >= xwin.pixels.len() { break; }
-                    let b = xwin.pixels[si] as u32;
-                    let g = xwin.pixels[si + 1] as u32;
-                    let r = xwin.pixels[si + 2] as u32;
-                    comp.backbuffer[dst_off + px] = 0xFF000000 | (r << 16) | (g << 8) | b;
-                }
+    // --- 3. Per-region repaint: background + intersecting Win32 windows ---
+    for &region in &regions {
+        paint_background_region(comp, region);
+        for snap in &win32 {
+            let wx = snap.x.max(0) as u32;
+            let wy = snap.y.max(0) as u32;
+            let wx2 = ((snap.x + snap.width as i32).max(0) as u32).min(sw);
+            let wy2 = ((snap.y + snap.height as i32).max(0) as u32).min(sh);
+            if wx2 <= wx || wy2 <= wy {
+                continue;
             }
-            expand_dirty(comp, x0, y0, x1 - x0, y1 - y0);
+            // draw_window paints its full extent into the backbuffer; only the
+            // region is presented, so an unclipped redraw of an intersecting
+            // window is correct (and the windows are few/small).
+            if rect_intersect(region, (wx, wy, wx2 - wx, wy2 - wy)).is_some() {
+                draw_window(&mut comp.backbuffer, stride, snap);
+            }
         }
     }
 
-    // --- 3. Start menu overlay (on top of all windows) ---
+    // --- 4. X11 client windows (on top of Win32), damage-bounded memcpy ---
+    // The X11 server owns the window pixel buffers; have it composite only the
+    // damaged sub-rectangles of its mapped windows directly into the backbuffer
+    // (memcpy per row under its own lock — no per-frame full-window clone, no
+    // per-pixel shuffle).  Lock order is COMPOSITOR → SERVER, as before.
+    crate::x11::blit_windows_to_backbuffer(&mut comp.backbuffer, stride, sw, sh, &regions);
+
+    // --- 5. Start-menu overlay (on top of all windows) ---
     if crate::gui::content::is_start_menu_open() {
-        crate::gui::content::render_start_menu_to_backbuffer(
-            &mut comp.backbuffer,
-            sw,
-            sh,
-        );
+        crate::gui::content::render_start_menu_to_backbuffer(&mut comp.backbuffer, sw, sh);
     }
 
-    // --- 4. Mouse cursor ---
-    let (mx, my) = crate::drivers::mouse::position();
-    if HARDWARE_CURSOR_ACTIVE.load(Ordering::Relaxed) {
-        // Hardware cursor: tell the SVGA device where to composite the cursor
-        // overlay.  This writes 3 u32s directly into FIFO bypass registers —
-        // no backbuffer modification, no MMIO blit required.
+    // --- 6. Mouse cursor (painted on top, within the regions above) ---
+    let (mx, my) = (cur_mx, cur_my);
+    if hw_cursor {
+        // Hardware cursor: position via FIFO bypass registers — no backbuffer
+        // modification, no MMIO blit.
         crate::drivers::vmware_svga::move_cursor(mx as u32, my as u32);
     } else {
-        // Software fallback: paint the cursor into the backbuffer.  The
-        // upcoming blit will copy it to VRAM along with everything else.
+        // Software cursor: the new cell is already a damage region (added at the
+        // latch on a partial frame, or covered by the full frame), so painting
+        // here lands inside a region that will be blitted below.  The old cell
+        // was repainted from the scene, erasing the previous cursor.
         draw_cursor(&mut comp.backbuffer, stride, sw, sh, mx, my);
+        PREV_CURSOR_X.store(mx, Ordering::Relaxed);
+        PREV_CURSOR_Y.store(my, Ordering::Relaxed);
     }
 
-    // --- 5. Blit to screen ---
-    blit_to_screen(comp);
+    // --- 7. Blit each region to the framebuffer, then one present kick ---
+    let mut bytes_moved: u64 = 0;
+    let mut dirty_px: u64 = 0;
+    for &region in &regions {
+        let (b, p) = blit_region(comp, region);
+        bytes_moved += b;
+        dirty_px += p;
+    }
+    crate::drivers::vmware_svga::present_kick();
 
-    // --- 6. Frame counter ---
+    // --- 8. Frame counter + timing ---
     comp.frame_count += 1;
+    let cycles = crate::arch::x86_64::irq::rdtsc().wrapping_sub(t0);
+    record_compose(cycles, bytes_moved, dirty_px);
 }
 
-/// Expand the dirty bounding box to include the given rectangle.
-#[inline]
-fn expand_dirty(comp: &mut CompositorState, x: u32, y: u32, w: u32, h: u32) {
-    let x2 = (x + w).min(comp.screen_width);
-    let y2 = (y + h).min(comp.screen_height);
-    let x = x.min(comp.screen_width);
-    let y = y.min(comp.screen_height);
-    if x2 <= x || y2 <= y { return; }
-    comp.dirty_rect = Some(match comp.dirty_rect {
-        None => (x, y, x2 - x, y2 - y),
-        Some((dx, dy, dw, dh)) => {
-            let nx = x.min(dx);
-            let ny = y.min(dy);
-            let nx2 = x2.max(dx + dw);
-            let ny2 = y2.max(dy + dh);
-            (nx, ny, nx2 - nx, ny2 - ny)
+/// Paint the desktop background gradient into one screen-space region.
+/// Top: deep navy (0xFF0A0A20) → bottom: dark teal (0xFF0D1B2A).
+fn paint_background_region(comp: &mut CompositorState, region: (u32, u32, u32, u32)) {
+    let sw = comp.screen_width;
+    let sh = comp.screen_height;
+    let stride = sw;
+    let (rx, ry, rw, rh) = region;
+    let x0 = rx.min(sw);
+    let y0 = ry.min(sh);
+    let x1 = (rx + rw).min(sw);
+    let y1 = (ry + rh).min(sh);
+    if x1 <= x0 || y1 <= y0 {
+        return;
+    }
+    let top_r: u32 = 0x0A; let top_g: u32 = 0x0A; let top_b: u32 = 0x20;
+    let bot_r: u32 = 0x0D; let bot_g: u32 = 0x1B; let bot_b: u32 = 0x2A;
+    for y in y0..y1 {
+        let r = top_r + (bot_r.wrapping_sub(top_r)) * y / sh.max(1);
+        let g = top_g + (bot_g.wrapping_sub(top_g)) * y / sh.max(1);
+        let b = top_b + (bot_b.wrapping_sub(top_b)) * y / sh.max(1);
+        let color = 0xFF000000 | (r << 16) | (g << 8) | b;
+        let row_start = (y * stride + x0) as usize;
+        let row_end = (y * stride + x1) as usize;
+        if row_end <= comp.backbuffer.len() {
+            comp.backbuffer[row_start..row_end].fill(color);
         }
-    });
+    }
 }
 
-/// Copy the backbuffer to the hardware framebuffer.
-/// Only blits the dirty region (or the full screen if dirty_rect covers it),
-/// then issues a targeted SVGA_CMD_UPDATE for that rectangle.
-fn blit_to_screen(comp: &mut CompositorState) {
-    let (dx, dy, dw, dh) = match comp.dirty_rect.take() {
-        Some(r) => r,
-        None => return, // nothing changed
-    };
-
+/// Copy one screen-space region from the backbuffer to the hardware framebuffer
+/// and queue a non-blocking `SVGA_CMD_UPDATE` for it.  Returns
+/// `(bytes_copied, pixels_copied)` for the compose-timing instrumentation.
+fn blit_region(comp: &CompositorState, region: (u32, u32, u32, u32)) -> (u64, u64) {
+    let sw = comp.screen_width;
+    let sh = comp.screen_height;
+    let (rx, ry, rw, rh) = region;
+    let x = rx.min(sw);
+    let y = ry.min(sh);
+    let x2 = (rx + rw).min(sw);
+    let y2 = (ry + rh).min(sh);
+    if x2 <= x || y2 <= y {
+        return (0, 0);
+    }
     let fb = comp.fb_base as *mut u32;
     let hw_stride = comp.fb_stride;
     let w = comp.screen_width;
-
-    // Blit only the dirty rows.
-    for row_idx in dy..(dy + dh) {
-        let src_row_start = (row_idx * w + dx) as usize;
-        let dst_row_start = (row_idx * hw_stride + dx) as usize;
-        let pixels = dw as usize;
+    let pixels = (x2 - x) as usize;
+    for row_idx in y..y2 {
+        let src_row_start = (row_idx * w + x) as usize;
+        let dst_row_start = (row_idx * hw_stride + x) as usize;
+        if src_row_start + pixels > comp.backbuffer.len() {
+            break;
+        }
         let src = &comp.backbuffer[src_row_start..src_row_start + pixels];
         unsafe {
             core::ptr::copy_nonoverlapping(src.as_ptr(), fb.add(dst_row_start), pixels);
         }
     }
-
-    crate::drivers::vmware_svga::update_rect(dx, dy, dw, dh);
+    crate::drivers::vmware_svga::update_rect_async(x, y, x2 - x, y2 - y);
+    let rows = (y2 - y) as u64;
+    let px = rows * pixels as u64;
+    (px * 4, px)
 }
 
 // ---------------------------------------------------------------------------
@@ -1167,15 +1515,7 @@ fn blit_to_screen(comp: &mut CompositorState) {
 /// Called by external code (e.g. the X11 server) when window pixel data
 /// has changed and the hardware framebuffer needs to be refreshed.
 pub fn mark_dirty(x: u32, y: u32, w: u32, h: u32) {
-    let mut guard = COMPOSITOR.lock();
-    if let Some(comp) = guard.as_mut() {
-        expand_dirty(comp, x, y, w, h);
-    }
-    // `damage()` is a single lock-free atomic; calling it under any lock is
-    // sound (it never reacquires COMPOSITOR).  Drop the guard first anyway so
-    // every damage()-bumping accessor follows the same shape.
-    drop(guard);
-    damage();
+    damage_rect(x as i32, y as i32, w as i32, h as i32);
 }
 
 /// Fill a solid rectangle in the backbuffer. `color` is 0x00RRGGBB.
@@ -1195,9 +1535,8 @@ pub fn screen_fill_rect(x: i32, y: i32, w: i32, h: i32, color: u32) {
             comp.backbuffer[ry as usize * stride + rx as usize] = color;
         }
     }
-    expand_dirty(comp, x0 as u32, y0 as u32, (x1 - x0) as u32, (y1 - y0) as u32);
     drop(guard);
-    damage();
+    damage_rect(x0, y0, x1 - x0, y1 - y0);
 }
 
 /// Blit a 32-bpp BGRA/XRGB pixel buffer into the backbuffer.
@@ -1225,11 +1564,10 @@ pub fn screen_blit_pixels(x: i32, y: i32, w: u32, h: u32, pixels: &[u8]) {
                 (r << 16) | (g << 8) | b;
         }
     }
-    let x0 = x.max(0) as u32;
-    let y0 = y.max(0) as u32;
-    expand_dirty(comp, x0, y0, w, h);
+    let x0 = x.max(0);
+    let y0 = y.max(0);
     drop(guard);
-    damage();
+    damage_rect(x0, y0, w as i32, h as i32);
 }
 
 /// Draw ASCII text using the embedded 8×16 VGA bitmap font.
@@ -1259,10 +1597,9 @@ pub fn screen_draw_text(x: i32, y: i32, text: &str, fg: u32, bg: u32) {
         }
         cx += 8;
     }
-    let tw = (text.len() as i32 * 8).max(0) as u32;
-    expand_dirty(comp, x.max(0) as u32, y.max(0) as u32, tw, 16);
+    let tw = (text.len() as i32 * 8).max(0);
     drop(guard);
-    damage();
+    damage_rect(x.max(0), y.max(0), tw, 16);
 }
 
 /// Returns `true` if the compositor has been initialised.

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1373,10 +1373,29 @@ fn op_compose_stats(out: &mut String) {
     let (blitted, skipped) = crate::gui::compositor::compose_gate_stats();
     let total = blitted.saturating_add(skipped);
     let gate_ratio_permille = if total == 0 { 0u64 } else { blitted.saturating_mul(1000) / total };
+    // Damage-region compositing throughput: per-frame µs, VRAM bytes moved, and
+    // dirty-pixel area — cumulative + last-frame.  avg_* let a single boot
+    // quantify the before/after win (idle/spinner frames drop to a tiny dirty
+    // area + µs once the page settles).
+    let (frames, us_total, bytes_total, dirty_px_total, last_us, last_bytes, last_dirty_px) =
+        crate::gui::compositor::compose_timing_stats();
+    let avg_us = if frames == 0 { 0 } else { us_total / frames };
+    let avg_bytes = if frames == 0 { 0 } else { bytes_total / frames };
+    let avg_dirty_px = if frames == 0 { 0 } else { dirty_px_total / frames };
     let _ = write!(
         out,
-        r#"{{"blitted":{},"skipped":{},"total_calls":{},"gate_ratio_permille":{}}}"#,
+        r#"{{"blitted":{},"skipped":{},"total_calls":{},"gate_ratio_permille":{},"#,
         blitted, skipped, total, gate_ratio_permille
+    );
+    let _ = write!(
+        out,
+        r#""frames":{},"avg_us":{},"avg_bytes":{},"avg_dirty_px":{},"#,
+        frames, avg_us, avg_bytes, avg_dirty_px
+    );
+    let _ = write!(
+        out,
+        r#""last_us":{},"last_bytes":{},"last_dirty_px":{},"us_total":{},"bytes_total":{}}}"#,
+        last_us, last_bytes, last_dirty_px, us_total, bytes_total
     );
 }
 // ── x11-windows ───────────────────────────────────────────────────────────────

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -647,6 +647,10 @@ pub fn run() -> ! {
     total += 1;
     if test_compositor_init() { passed += 1; }
 
+    // ── Test 39b: Damage-region compositing logic ───────────────────────
+    total += 1;
+    if test_damage_region() { passed += 1; }
+
     // ── Test 206: /proc/self/{mountinfo,cgroup,oom_score_adj} — Mozilla sandbox unblock
     //
     // Placed BEFORE Test 40 (Desktop Launch) which has pre-existing flakiness
@@ -13169,6 +13173,21 @@ fn test_compositor_init() -> bool {
     }
 
     if ok { test_pass!("Compositor Init"); }
+    ok
+}
+
+/// Damage-region compositing logic: rectangle intersection, bounding-box
+/// coalescing, screen clipping, the >MAX_DAMAGE_RECTS collapse, and the coarse
+/// full-surface fallback.  Exercises the pure machinery added by the
+/// damage-region overhaul without needing a live framebuffer/timer.
+fn test_damage_region() -> bool {
+    test_header!("Damage-region compositing");
+    let ok = crate::gui::compositor::damage_region_selftest();
+    if ok {
+        test_pass!("Damage-region compositing");
+    } else {
+        test_fail!("Damage-region", "damage_region_selftest() returned false");
+    }
     ok
 }
 

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -461,15 +461,6 @@ pub fn inject_mouse_event(rx: i16, ry: i16, buttons: u8, prev_buttons: u8) {
     }
 }
 
-/// Snapshot of an X11 window for the compositor to blit.
-pub struct X11WindowSnapshot {
-    pub x: i16,
-    pub y: i16,
-    pub width: u16,
-    pub height: u16,
-    pub pixels: Vec<u8>, // BGRA, width×height×4
-}
-
 /// Resolve a window's absolute (screen-space) origin by summing the
 /// parent-relative offsets up the window tree until the root (id 1) or an
 /// unknown parent is reached.  Window coordinates in the protocol are relative
@@ -496,35 +487,147 @@ fn absolute_origin(client: &Client, mut id: u32) -> (i32, i32) {
     (ax, ay)
 }
 
-/// Collect all mapped X11 client windows for compositor rendering.
-/// Returns a Vec of snapshots (copies pixel data to avoid holding locks).
-/// Coordinates are absolute (screen-space); child widget windows are resolved
-/// relative to their ancestors.  Resources iterate in creation order, so a
-/// parent precedes its children — i.e. children are blitted on top, matching
-/// the X11 stacking model where later-mapped children draw over their parent.
-pub fn get_mapped_windows() -> Vec<X11WindowSnapshot> {
-    if !X11_INITIALIZED.load(Ordering::Acquire) { return Vec::new(); }
+/// Screen-space rectangle intersection, all `(x, y, w, h)`; `None` if disjoint.
+#[inline]
+fn rect_intersect_u(
+    a: (u32, u32, u32, u32),
+    b: (u32, u32, u32, u32),
+) -> Option<(u32, u32, u32, u32)> {
+    let x0 = a.0.max(b.0);
+    let y0 = a.1.max(b.1);
+    let x1 = (a.0 + a.2).min(b.0 + b.2);
+    let y1 = (a.1 + a.3).min(b.1 + b.3);
+    if x1 <= x0 || y1 <= y0 { None } else { Some((x0, y0, x1 - x0, y1 - y0)) }
+}
+
+/// Composite the mapped X11 client windows on top of the compositor backbuffer,
+/// copying only the parts that fall inside the supplied damage `regions`.
+///
+/// Replaces the previous "deep-clone every mapped window's pixel buffer per
+/// frame, then per-pixel BGRA→XRGB shuffle the whole window" path.  For each
+/// mapped window we compute its screen-space bounds (child widgets resolved via
+/// their ancestors' offsets), intersect with each damage region, and `memcpy`
+/// only the intersected rows directly from the window's persistent `pixels`
+/// buffer into the backbuffer.  The window surface is BGRA and the backbuffer
+/// is little-endian XRGB8888 (memory order B,G,R,X); the colour bytes coincide
+/// and the alpha/X byte is ignored by the SVGA scanout, so a raw row `memcpy`
+/// is correct and avoids both the clone and the per-pixel arithmetic.
+///
+/// Called by the compositor holding the `COMPOSITOR` lock; this takes the X11
+/// `SERVER` lock — the established COMPOSITOR → SERVER order.  Resources iterate
+/// in creation order, so a parent precedes its children (children composite on
+/// top), matching the X11 stacking model.
+pub fn blit_windows_to_backbuffer(
+    backbuffer: &mut [u32],
+    stride: u32,
+    screen_w: u32,
+    screen_h: u32,
+    regions: &[(u32, u32, u32, u32)],
+) {
+    if !X11_INITIALIZED.load(Ordering::Acquire) || regions.is_empty() { return; }
     let srv = SERVER.lock();
-    let mut result = Vec::new();
     for slot in srv.clients.iter() {
-        if let Some(client) = slot {
-            for (rid, body) in client.resources.iter_all() {
-                if let resource::ResourceBody::Window(ref w) = body {
-                    if w.mapped && !w.pixels.is_empty() && w.width > 0 && w.height > 0 {
-                        let (ax, ay) = absolute_origin(client, rid);
-                        result.push(X11WindowSnapshot {
-                            x: ax as i16,
-                            y: ay as i16,
-                            width: w.width,
-                            height: w.height,
-                            pixels: w.pixels.clone(),
-                        });
+        let client = match slot { Some(c) => c, None => continue };
+        for (rid, body) in client.resources.iter_all() {
+            let w = match body {
+                resource::ResourceBody::Window(ref w) => w,
+                _ => continue,
+            };
+            if !(w.mapped && !w.pixels.is_empty() && w.width > 0 && w.height > 0) {
+                continue;
+            }
+            let (ax, ay) = absolute_origin(client, rid);
+            let ww = w.width as u32;
+            let wh = w.height as u32;
+            // Window screen bounds clipped to the surface.
+            let wsx0 = ax.max(0) as u32;
+            let wsy0 = ay.max(0) as u32;
+            let wsx1 = ((ax + ww as i32).max(0) as u32).min(screen_w);
+            let wsy1 = ((ay + wh as i32).max(0) as u32).min(screen_h);
+            if wsx1 <= wsx0 || wsy1 <= wsy0 { continue; }
+            let win_rect = (wsx0, wsy0, wsx1 - wsx0, wsy1 - wsy0);
+            for &region in regions {
+                let (ix, iy, iw, ih) = match rect_intersect_u(win_rect, region) {
+                    Some(r) => r,
+                    None => continue,
+                };
+                let npix = iw as usize;
+                for sy in iy..(iy + ih) {
+                    let local_x = (ix as i32 - ax) as u32;
+                    let local_y = (sy as i32 - ay) as u32;
+                    let src_byte = ((local_y * ww + local_x) * 4) as usize;
+                    let dst_idx = (sy * stride + ix) as usize;
+                    if src_byte + npix * 4 > w.pixels.len() { continue; }
+                    if dst_idx + npix > backbuffer.len() { continue; }
+                    // SAFETY: bounds checked above; disjoint src (Vec<u8>) and
+                    // dst (backbuffer slice) regions.
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(
+                            w.pixels.as_ptr().add(src_byte),
+                            backbuffer.as_mut_ptr().add(dst_idx) as *mut u8,
+                            npix * 4,
+                        );
                     }
                 }
             }
         }
     }
-    result
+}
+
+/// Report on-screen damage for a window-local rectangle that was drawn into a
+/// window's persistent surface, converting it to screen space via the window's
+/// absolute origin and forwarding it to the compositor.  Always marks the op as
+/// damage-accounted (suppressing the dispatch's coarse full-surface fallback),
+/// but pushes a damage rectangle only when `win_id` is a *mapped window*: a draw
+/// into an off-screen pixmap (or an unmapped window) changes nothing visible.
+fn mark_window_damage(fd: u64, win_id: u32, lx: i32, ly: i32, lw: i32, lh: i32) {
+    crate::gui::compositor::note_damage();
+    if lw <= 0 || lh <= 0 { return; }
+    let rect = {
+        let srv = SERVER.lock();
+        srv.clients.iter().filter_map(|s| s.as_ref()).find(|c| c.fd == fd)
+            .and_then(|c| {
+                let mapped_window = c.resources.entries.iter().filter_map(|s| s.as_ref())
+                    .find(|r| r.id == win_id)
+                    .map(|r| matches!(r.body, resource::ResourceBody::Window(ref w) if w.mapped))
+                    .unwrap_or(false);
+                if !mapped_window { return None; }
+                let (ax, ay) = absolute_origin(c, win_id);
+                Some((ax + lx, ay + ly, lw, lh))
+            })
+    };
+    if let Some((sx, sy, w, h)) = rect {
+        crate::gui::compositor::damage_rect(sx, sy, w, h);
+    }
+}
+
+/// Report whole-window on-screen damage for `win_id` (used by draw paths whose
+/// exact sub-rectangle is not available, e.g. the generic software rasteriser).
+/// Always marks the op damage-accounted; pushes a rectangle only for a mapped
+/// window.
+fn mark_window_damage_full(fd: u64, win_id: u32) {
+    crate::gui::compositor::note_damage();
+    let dims = {
+        let srv = SERVER.lock();
+        srv.clients.iter().filter_map(|s| s.as_ref()).find(|c| c.fd == fd)
+            .and_then(|c| {
+                c.resources.entries.iter().filter_map(|s| s.as_ref())
+                    .find(|r| r.id == win_id)
+                    .and_then(|r| match r.body {
+                        resource::ResourceBody::Window(ref w) if w.mapped => {
+                            Some((w.width as i32, w.height as i32))
+                        }
+                        _ => None,
+                    })
+                    .map(|(ww, wh)| {
+                        let (ax, ay) = absolute_origin(c, win_id);
+                        (ax, ay, ww, wh)
+                    })
+            })
+    };
+    if let Some((sx, sy, w, h)) = dims {
+        crate::gui::compositor::damage_rect(sx, sy, w, h);
+    }
 }
 
 /// Live introspection of every X11 window's compositor-source surface, for the
@@ -1018,6 +1121,12 @@ fn handle_request(fd: u64, data: &[u8]) {
     let seq = { let mut srv = SERVER.lock();
         match srv.clients.iter_mut().filter_map(|s| s.as_mut()).find(|c| c.fd == fd) {
             Some(c) => c.next_seq(), None => return } };
+    // Snapshot the compositor's damage-accounted counter: a handler that reports
+    // fine per-rectangle damage (via `mark_window_damage`) advances it, which
+    // suppresses the coarse full-surface fallback below.  Handlers we have not
+    // yet taught fine damage leave it unchanged and so still fall back to a
+    // correct (if conservative) full-surface repaint.
+    let pre_noted = crate::gui::compositor::damage_noted_seq();
     match opcode {
         proto::OP_CREATE_WINDOW         => op_create_window(fd, data, seq),
         proto::OP_CHANGE_WINDOW_ATTRS   => op_change_win_attrs(fd, data),
@@ -1124,15 +1233,18 @@ fn handle_request(fd: u64, data: &[u8]) {
 
     // Signal the rate-gated compositor that on-screen content may have changed.
     // The X11 server's window pixel buffers (`WindowData::pixels`) are the
-    // compositor's source of truth (it re-blits them each frame), but unlike
+    // compositor's source of truth (it composites them each frame), but unlike
     // the native GDI accessors the X11 draw path does not go through
-    // `compositor::screen_*`, so nothing else bumps the damage counter.  Bump
-    // it here for every request that can alter a mapped window's contents or
-    // geometry — including the extension draw paths (RENDER / SHM PutImage /
-    // COMPOSITE) — so `compose_if_due()` repaints promptly.  A non-drawing
-    // request (reply-only, property, atom) leaves the desktop quiescent and
-    // costs zero framebuffer MMIO.
-    if x11_op_changes_screen(opcode) {
+    // `compositor::screen_*`, so nothing else reports damage.  Drawing handlers
+    // that have been taught fine damage call `mark_window_damage` (advancing the
+    // accounted counter), so the compositor repaints only the changed
+    // rectangles.  For any screen-changing request whose handler reported no
+    // fine damage, fall back here to a coarse full-surface repaint so the result
+    // is always correct.  A non-drawing request (reply-only, property, atom)
+    // leaves the desktop quiescent and costs zero framebuffer MMIO.
+    if x11_op_changes_screen(opcode)
+        && crate::gui::compositor::damage_noted_seq() == pre_noted
+    {
         crate::gui::compositor::damage();
     }
 }
@@ -1195,6 +1307,9 @@ fn window_fill_pixels(fd: u64, win_id: u32, x: i32, y: i32, w: i32, h: i32, bgra
             }
         }
     });
+    // Solid-fill path (RenderFillRectangles / ClearArea / viewable background):
+    // report the filled rectangle as on-screen damage.
+    mark_window_damage(fd, win_id, x, y, w, h);
 }
 
 /// Paint a window-local region to the window's background, honouring the X core
@@ -1340,6 +1455,8 @@ fn window_draw_text_pixels(fd: u64, win_id: u32, tx: i32, ty: i32, text: &str, f
             }
         }
     });
+    // Report the text run's bounding box as on-screen damage (8×16 cells).
+    mark_window_damage(fd, win_id, tx, ty, text.len() as i32 * FW, 16);
 }
 
 /// Composite a window-local BGRA source rectangle into `w.pixels`.
@@ -1392,6 +1509,12 @@ fn window_composite_pixels(
             }
         }
     });
+    // The window's persistent surface changed: report the composited rectangle
+    // as on-screen damage (screen-space conversion + the mapped-window gate live
+    // in `mark_window_damage`).  This helper funnels both core PutImage(window)
+    // and MIT-SHM ShmPutImage — the windowed-Firefox content paint path — so a
+    // small present (spinner, caret) damages a small rectangle, not the screen.
+    mark_window_damage(fd, win_id, dx, dy, rw, rh);
 }
 
 // ── CreateWindow (1) ──────────────────────────────────────────────────────────
@@ -1756,6 +1879,9 @@ fn op_map_window(fd: u64, data: &[u8], seq: u16) {
     for &pwid in &to_paint {
         paint_window_background(fd, pwid, 0, 0, 0, 0, true);
     }
+    // A newly-mapped window is a geometry change: damage its whole screen rect
+    // so the compositor paints it (and any newly-viewable area) this frame.
+    mark_window_damage_full(fd, wid);
 }
 
 // ── MapSubwindows (9) ─────────────────────────────────────────────────────────
@@ -1830,14 +1956,32 @@ fn op_map_subwindows(fd: u64, data: &[u8], seq: u16) {
 fn op_unmap_window(fd: u64, data: &[u8], seq: u16) {
     if data.len() < 8 { return; }
     let wid = r32(data, 4);
+    // The region the window vacates is now exposed (background or lower windows)
+    // and must be repainted.  Capture its last screen-space rect *before*
+    // clearing the mapped flag (after which it no longer contributes pixels).
+    let mut vacated: Option<(i32, i32, i32, i32)> = None;
     with_client(fd, |c| {
+        let info = c.resources.get_window_mut(wid)
+            .map(|w| (w.width as i32, w.height as i32, w.mapped));
+        let (ww, wh, was_mapped) = match info { Some(v) => v, None => return };
+        if was_mapped {
+            // dims already copied out, so this immutable walk does not overlap
+            // the mutable window borrow.
+            let (ax, ay) = absolute_origin(c, wid);
+            vacated = Some((ax, ay, ww, wh));
+        }
         if let Some(w) = c.resources.get_window_mut(wid) {
             w.mapped = false;
-            if w.event_mask & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
+            let em = w.event_mask;
+            if em & proto::EVENT_MASK_STRUCTURE_NOTIFY != 0 {
                 c.send(&event::encode_unmap_notify(seq, wid));
             }
         }
     });
+    crate::gui::compositor::note_damage();
+    if let Some((x, y, w, h)) = vacated {
+        crate::gui::compositor::damage_rect(x, y, w, h);
+    }
 }
 
 // ── ConfigureWindow (12) ──────────────────────────────────────────────────────
@@ -1846,7 +1990,25 @@ fn op_configure_window(fd: u64, data: &[u8], seq: u16) {
     if data.len() < 12 { return; }
     let wid  = r32(data, 4);
     let mask = r16(data, 8);
+    // A geometry change damages both the old and the new screen rect (the old
+    // rect exposes whatever was beneath; the new rect must be repainted).
+    let mut old_rect: Option<(i32, i32, i32, i32)> = None;
+    let mut new_rect: Option<(i32, i32, i32, i32)> = None;
     with_client(fd, |c| {
+        // Old screen rect (only if currently mapped — else nothing was shown).
+        let old = c.resources.get_window_mut(wid)
+            .map(|w| (w.width as i32, w.height as i32, w.mapped));
+        let mapped = match old {
+            Some((ow, oh, m)) => {
+                if m {
+                    let (ax, ay) = absolute_origin(c, wid);
+                    old_rect = Some((ax, ay, ow, oh));
+                }
+                m
+            }
+            None => return,
+        };
+        // Apply the requested geometry.
         if let Some(w) = c.resources.get_window_mut(wid) {
             let mut vi = 12usize;
             if mask & proto::CW_X      != 0 { w.x = r16(data, vi) as i16; vi += 4; }
@@ -1858,7 +2020,19 @@ fn op_configure_window(fd: u64, data: &[u8], seq: u16) {
                 c.send(&event::encode_configure_notify(seq, wid, x, y, width, height, bw));
             }
         }
+        // New screen rect.
+        if mapped {
+            let new = c.resources.get_window_mut(wid)
+                .map(|w| (w.width as i32, w.height as i32));
+            if let Some((nw, nh)) = new {
+                let (ax, ay) = absolute_origin(c, wid);
+                new_rect = Some((ax, ay, nw, nh));
+            }
+        }
     });
+    crate::gui::compositor::note_damage();
+    if let Some((x, y, w, h)) = old_rect { crate::gui::compositor::damage_rect(x, y, w, h); }
+    if let Some((x, y, w, h)) = new_rect { crate::gui::compositor::damage_rect(x, y, w, h); }
 }
 
 // ── GetGeometry (14) ──────────────────────────────────────────────────────────
@@ -2714,6 +2888,11 @@ fn op_copy_area(fd: u64, data: &[u8]) {
     let height  = r16(data, 26) as i32;
     if width <= 0 || height <= 0 { return; }
 
+    // A window destination reports a precise rect via `window_composite_pixels`;
+    // a pixmap destination changes nothing on-screen.  Either way the op is
+    // accounted, so it must not trip the dispatch's coarse full-surface fallback.
+    crate::gui::compositor::note_damage();
+
     // Determine src and dst drawable types
     let (src_is_pixmap, dst_is_pixmap) = {
         let srv = SERVER.lock();
@@ -2911,7 +3090,9 @@ fn op_poly_fill_rect(fd: u64, data: &[u8]) {
     };
 
     if is_pixmap {
-        // Draw rectangles into the pixmap's pixel buffer
+        // Draw rectangles into the pixmap's pixel buffer (off-screen: accounted
+        // but no on-screen damage).
+        crate::gui::compositor::note_damage();
         let color = 0xFF000000 | (fg & 0x00FFFFFF); // set full alpha
         let mut i = 12usize;
         while i + 8 <= data.len() {
@@ -2953,6 +3134,8 @@ fn op_poly_fill_rect(fd: u64, data: &[u8]) {
                     }
                 }
             });
+            // Report the filled rectangle as on-screen damage.
+            mark_window_damage(fd, draw, rx, ry, rw, rh);
         }
     }
 }
@@ -2994,6 +3177,15 @@ fn with_drawable_pixels<F: FnMut(&mut [u8], i32, i32)>(fd: u64, draw: u32, is_pi
             f(&mut w.pixels, ww, wh);
         }
     });
+    // Generic raster path (PolyFill/PolyLine/PolyArc/PolyPoint/ImageText/…): the
+    // exact sub-rectangle is not threaded through here, so report whole-window
+    // damage when the target is a window.  Off-screen pixmap draws change
+    // nothing visible but are still accounted (suppressing the coarse fallback).
+    if is_pix {
+        crate::gui::compositor::note_damage();
+    } else {
+        mark_window_damage_full(fd, draw);
+    }
 }
 
 // PolyFillArc (71): list of ARC {x:i16,y:i16,w:u16,h:u16,a1:i16,a2:i16} (12 B).
@@ -3137,6 +3329,11 @@ fn op_put_image(fd: u64, data: &[u8]) {
     if fmt != proto::IMAGE_FORMAT_ZPIXMAP || depth < 24 { return; }
     let px_len = (width * height * 4) as usize;
     if data.len() < 24 + px_len { return; }
+
+    // Account for this op's damage: the window branch reports a precise rect via
+    // `window_composite_pixels`; the pixmap branch changes nothing on-screen but
+    // must still suppress the dispatch's coarse full-surface fallback.
+    crate::gui::compositor::note_damage();
 
     // Determine if target is a pixmap or a window
     let is_pixmap = {
@@ -3546,6 +3743,11 @@ fn op_render_composite(fd: u64, data: &[u8]) {
     let width  = r16(data, 32) as i32;
     let height = r16(data, 34) as i32;
     if width <= 0 || height <= 0 { return; }
+
+    // A window destination reports a precise rect via `window_composite_pixels`;
+    // a pixmap (off-screen Picture) destination changes nothing on-screen.
+    // Account for the op either way so it does not trip the coarse fallback.
+    crate::gui::compositor::note_damage();
 
     // Resolve picture → drawable IDs
     let (src_draw, dst_draw) = {
@@ -4887,6 +5089,10 @@ fn op_render_free_glyphs(fd: u64, data: &[u8]) {
 // GlyphSetElt: 0xFF(1)  pad(3) new_gsid(4)
 fn op_render_composite_glyphs(fd: u64, data: &[u8], elem_size: u8) {
     if data.len() < 28 { return; }
+    // The final window write funnels through `window_composite_pixels` (precise
+    // per-run damage); account here so an off-screen (pixmap) glyph target does
+    // not trip the dispatch's coarse full-surface fallback.
+    crate::gui::compositor::note_damage();
     let op     = data[4];
     let src_id = r32(data, 8);
     let dst_id = r32(data, 12);


### PR DESCRIPTION
## Summary

The windowed-display pipeline (in-kernel compositor + VMware SVGA II driver)
regenerated and re-presented the **entire screen every composited frame**, even
for a single changed pixel — the dominant cause of UI slowness. This PR makes
the compositor **repaint and present only the screen rectangles that actually
changed** (damage-region compositing), eliminates the per-frame full-window
clone and per-pixel BGRA→XRGB shuffle, and switches the present path to a
non-blocking FIFO kick.

**Do not merge — for coordinator review.**

## What changed (file:line scope)

**`kernel/src/gui/compositor.rs`**
- Damage accumulator + API: `damage_rect`/`note_damage` (fine, screen-space,
  coalesced to a bbox past a 16-rect cap) alongside the existing coarse
  `damage()` full-surface fallback. Empty/coordinate-free damage ⇒ full frame,
  so direct `compose()` callers still refresh.
- `compose()` rewritten: latch-and-clear regions under the damage lock
  (re-arming for the next frame), per-region background + intersecting-window
  repaint, X11 layer composited damage-bounded, per-region VRAM blit. Background
  gradient painted only into damaged regions (no per-frame 8 MB refill);
  backbuffer persists.
- Software cursor participates in damage (old + new cell added to the frame's
  regions) instead of forcing a full repaint, so the win holds while the HW
  cursor is disabled. **HW cursor path untouched** (owned by kmd-engineer).
- Per-frame instrumentation (µs / bytes-moved / dirty-px, cumulative +
  last-frame) via the kdb `compose-stats` op.

**`kernel/src/x11/mod.rs`**
- `get_mapped_windows` (full per-frame clone of every window) → removed,
  replaced by `blit_windows_to_backbuffer`, which copies only the damaged
  sub-rects with a per-row `copy_nonoverlapping` (BGRA window surface vs
  little-endian XRGB8888 framebuffer: colour bytes coincide, X byte ignored by
  scanout — raw row copy is correct).
- Draw handlers report fine damage (PutImage / ShmPutImage / CopyArea / RENDER
  Composite via the shared `window_composite_pixels`; PolyFillRectangle / fills
  / text / generic raster). Map/Unmap/Configure damage the affected screen rect
  (incl. the rect a window **vacates**). Unconverted ops fall back to a correct
  full-surface repaint — the migration is incremental and always correct.

**`kernel/src/drivers/vmware_svga.rs`**
- `update_rect_async` + `present_kick`: queue per-region `SVGA_CMD_UPDATE`s and
  kick once per frame without spin-waiting on `SVGA_REG_BUSY`.
- `fifo_reserve`: FIFO free-space check against the device-owned
  `SVGA_FIFO_STOP` consumer pointer so the non-blocking present cannot lap the
  consumer (VMware SVGA II FIFO model); a compiler fence orders each command
  word ahead of the `NEXT_CMD` advance.

**Tests**: `test_runner.rs` test 39b (`test_damage_region`) — rect
intersection, bbox coalescing, screen clipping, the rect-cap collapse, and the
full-surface fallback.

## Quantified win

Old `compose()` did, **every** composited frame: an ~8.3 MB VRAM blit of the
full 1920×1080 surface + an ~8.3 MB gradient regen + an ~5 MB clone of the
1280×972 browser window + a ~1.24 M-iteration per-pixel shuffle.

After (windowed Firefox / example.com, SMP=1, from the kdb `compose-stats` op):
- The largest presented frame is bounded to **`last_dirty_px = 1,244,304`** =
  exactly the 1280×972 browser window — **never the full 2,073,600-px screen**.
  The desktop background outside the browser window is presented **once**, not
  every frame.
- `avg_bytes ≈ 6.1 MB`/frame **even during page load** (dominated by full-window
  content presents) vs the old unconditional 8.3 MB **floor** — and the old
  path additionally paid the 8.3 MB gradient + 5 MB clone + shuffle on top,
  which are now gone entirely.
- At true idle (static page) the rate gate skips composing (0 bytes/frame); a
  small element update (spinner/caret) damages only its rectangle (e.g. a 30×30
  throbber ≈ 3.6 KB vs 8.3 MB ≈ ~2,300×).

## Render-intact proof

Compared screendumps to the known-good reference
(`p2-example.com-…png`, 1920×1080):
- **Settled render = byte-identical to the reference: 0 differing pixels**
  (`mean_abs_diff=0.0, max_diff=0`).
- **Three independent boots are pixel-identical to each other** (`max_diff=0`) —
  deterministic, no random stale regions.
- **Partial-update test**: two screendumps of the same live boot at different
  times are identical (`max_diff=0`) — repeated partial-update frames leave no
  stale pixels.
- No tearing, no garbage regions, `n_diff_gt32 = 0`.

## Notes / scope

- Hardware cursor re-enable + input are intentionally **out of scope** (owned by
  kmd-engineer); the SW-cursor damage handling here is forward-compatible with
  either.
- The intermittent content-proc crashes seen on some boots (#GP under SMP=2;
  STACK_CANARY_CORRUPT under SMP=1) are the pre-existing parked content-init /
  kstack-recycle saga in pid≥3 (clone/anon-fault/kstack path) — unrelated to
  this PR's compositor/X11/SVGA code; the real-binary boots used for the
  verification above were SMP=1 and crash-free.

References: VMware SVGA II device register + FIFO model; X11 protocol
region/damage semantics; Intel SDM Vol. 3 (MMIO/VM-exit cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
