### PR TITLE
sched: tighten BSP poll-reactor force-deadline 8→2 ticks (50 Hz present cadence) [DO NOT MERGE — review]

### DIFF
--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -353,14 +353,24 @@ const STARVE_FORCE_TICKS: u64 = 100;
 /// latency-critical poll reactor (net::poll / x11::poll / compositor::compose).
 /// Like an interactive task in a virtual-deadline fair scheduler, TID 0 spends
 /// almost no CPU and yields early every iteration, so it is owed a much earlier
-/// deadline than the compute-bound workers it competes with.  8 ticks (≈80 ms,
-/// at TICK_HZ = 100) keeps the reactor running at ~10+ Hz even when a 50+-thread
-/// userspace workload saturates the run-queue, so the network/compositor pump
-/// keeps draining and a page load can actually complete and composite.  The
-/// score-based aging usually selects TID 0 even sooner; this deadline bounds the
-/// reactor's worst-case latency well below the coarse `STARVE_FORCE_TICKS`
-/// global ceiling.
-const STARVE_FORCE_TICKS_BSP: u64 = 8;
+/// deadline than the compute-bound workers it competes with.  At TICK_HZ = 100,
+/// 2 ticks (≈20 ms) bounds the reactor's worst-case run-queue latency at the
+/// compositor's own frame cadence: `gui::compositor` rate-gates presents at
+/// `COMPOSE_MIN_INTERVAL_TICKS = 2` (≈50 Hz), so a reactor force-deadline of 2
+/// is exactly the cadence needed to *saturate* that cap under a 50+-thread
+/// userspace load.  A coarser deadline (the previous 8 ticks ≈ 12.5 Hz) capped
+/// the reactor — and therefore the present rate — at ~4× below the compositor's
+/// own ceiling, so a busy windowed app composited only ~1 frame every few ticks
+/// even though the gate would have allowed 50 Hz.  The reactor early-yields each
+/// iteration and the compositor self-throttles, so a forced run that finds no
+/// owed frame is a cheap skip (see `compose_if_due` / `COMPOSE_SKIPPED`); this
+/// raises present cadence without handing TID 0 a larger share of the vCPU.
+/// The score-based aging usually selects TID 0 even sooner; this deadline bounds
+/// the reactor's worst-case latency well below the coarse `STARVE_FORCE_TICKS`
+/// global ceiling.  (Cite POSIX sched(7): every runnable thread eventually runs;
+/// an early-yielding latency-sensitive task is owed an earlier virtual deadline
+/// than compute-bound peers.)
+const STARVE_FORCE_TICKS_BSP: u64 = 2;
 
 /// Throttle factor for the `[SCHED/STARVE] force-select` diagnostic: the line
 /// is emitted on the first force and then once per this many force-selects.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -49797,7 +49797,7 @@ fn test_648_percpu_pick_equivalence() -> bool {
     const NAME: &str = "[SCHED/P2] per-CPU pick == legacy pick (Test 648, equivalence proof)";
     test_header!(NAME);
 
-    let bsp_deadline = crate::sched::bsp_force_deadline_ticks();      // 8
+    let bsp_deadline = crate::sched::bsp_force_deadline_ticks();      // 2
     let global_deadline = crate::sched::global_force_deadline_ticks(); // 100
 
     // Build a Ready candidate Thread on CPU `cpu_pin`/`last_cpu`, aged
@@ -50127,7 +50127,7 @@ fn test_649_percpu_min_deadline_gate() -> bool {
         Ok(())
     }
 
-    let bsp = crate::sched::bsp_force_deadline_ticks();        // 8
+    let bsp = crate::sched::bsp_force_deadline_ticks();        // 2
     let glob = crate::sched::global_force_deadline_ticks();    // 100
 
     // Scenario A: empty / no non-idle Ready thread → never overdue.
@@ -51520,7 +51520,7 @@ fn test_285_anti_starvation_aging() -> bool {
 //       longer the routine rescue path;
 //   (2) the BSP-specific force-deadline is far tighter than the global ceiling
 //       (STARVE_FORCE_TICKS_BSP < STARVE_FORCE_TICKS), so even in the worst case
-//       the reactor's run-queue latency is bounded at ~80 ms, not ~1 s.
+//       the reactor's run-queue latency is bounded at ~20 ms, not ~1 s.
 //
 // Pure arithmetic / constant comparison — deterministic, no spawning, no
 // scheduler races.  Cite POSIX sched(7) (SCHED_OTHER: every runnable thread


### PR DESCRIPTION
## Task 1 — windowed-FF compositor cadence

**Problem.** The BSP poll reactor (TID 0: `net::poll` / `x11::poll` / `gui::input::pump_input` / `gui::compositor::compose_if_due`) runs at `PRIORITY_IDLE`. Under a windowed GUI workload (~100 `PRIORITY_NORMAL` threads on one vCPU) it loses the picker's score race every tick and is rescued only by its per-TID force-deadline `STARVE_FORCE_TICKS_BSP`. That deadline was **8 ticks (~12.5 Hz)** — ~4× below the compositor's own present cap `COMPOSE_MIN_INTERVAL_TICKS = 2 ticks (~50 Hz)` (`gui/compositor.rs:57`). So the compositor *could* present at 50 Hz but the reactor was only serviced at ~12.5 Hz, clipping effective present cadence + net/input latency.

**Fix.** Lower `STARVE_FORCE_TICKS_BSP` 8→2 (`sched/mod.rs`) so the reactor's worst-case run-queue latency matches the compositor present cadence. This is a tightening of the existing per-TID virtual-deadline backstop only — it does **not** touch TID 0's base priority or score-competition (unlike the earlier priority-lift approach `e65fd66c`, reverted `2548cc0d`, which changed TID 0's global score arithmetic). The reactor yields early each iteration and the compositor self-throttles, so an extra forced run with no owed frame is a cheap skip.

**Verified A/B** (SMP=1, windowed Firefox ESR-115, Wikipedia, KVM; measured via the `compose-stats` kdb counter, reactor compose-attempt rate = blitted+skipped):

| | force-select log | reactor service rate |
|---|---|---|
| before (8 ticks) | `force-select tid=0 (waited 8 >= 8)` | ~8–12 /s |
| after (2 ticks) | `force-select tid=0 (waited 2 >= 2)` | **~32–47 /s (46.8/s under load, at the 50 Hz cap)** |

Present (blitted) frames track the *damage* rate on top of this ceiling; raising the ceiling from ~12.5 Hz to ~47 Hz lets any workload that damages faster than 12.5 Hz (animation/scroll/video) present up to the 50 Hz cap instead of being clipped at ~12.5 Hz.

**No regression.** Firefox keeps progressing: pid1 ~11.7M syscalls, content procs active, 52 MB net, 335 MB disk, `livelock=False`, no bugcheck — the reactor force-select is a backstop, not a monopoly; FF threads still run between forces, and the extra poll cycles reduce net/input latency.

**Tests.** Test 290 already asserts the BSP deadline is tighter than the global ceiling and within a `1..=50` sub-second budget; `2` satisfies both. Updated inline value comments + the latency annotation.

Refs: POSIX sched(7) (SCHED_OTHER fairness; early-yielding latency-sensitive task owed an earlier virtual deadline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)