### PR TITLE
gui/input: per-cell cursor damage on move (perf) + PS/2 mouse init hardening & diagnostics

### DIFF
--- a/kernel/src/drivers/mouse.rs
+++ b/kernel/src/drivers/mouse.rs
@@ -68,15 +68,25 @@ pub fn init(width: u32, height: u32) {
     wait_input();
     unsafe { crate::hal::outb(COMMAND_PORT, 0xA8); } // Enable auxiliary device
 
-    // Enable IRQ12
+    // Configure the controller command byte (CCB) for the mouse:
+    //   * bit 1 (0x02) — enable the mouse/aux IRQ12.
+    //   * bit 5 (0x20) — mouse-clock DISABLE: must be CLEARED or the controller
+    //     gates the aux clock and the device never streams movement packets
+    //     (so no IRQ12 ever fires).  The keyboard's CCB write leaves bit 5 set
+    //     ("keep mouse bits as-is"), and although the `0xA8` enable-aux command
+    //     is specified to clear it, we must not depend on that side effect —
+    //     clear bit 5 explicitly here so the aux clock is unconditionally on.
+    // Reference: IBM PS/2 / 8042 keyboard-controller command-byte definition;
+    // PC/AT keyboard controller specification (command byte bits 1 and 5).
     wait_input();
     unsafe { crate::hal::outb(COMMAND_PORT, 0x20); } // Read controller config byte
     wait_output();
     let config = unsafe { crate::hal::inb(DATA_PORT) };
+    let new_config = (config | 0x02) & !0x20; // enable IRQ12, clear mouse-clock-disable
     wait_input();
     unsafe { crate::hal::outb(COMMAND_PORT, 0x60); } // Write controller config byte
     wait_input();
-    unsafe { crate::hal::outb(DATA_PORT, config | 0x02); } // Enable IRQ12
+    unsafe { crate::hal::outb(DATA_PORT, new_config); }
 
     // Reset mouse
     mouse_write(0xFF);
@@ -182,4 +192,36 @@ pub fn warp(x: i32, y: i32) {
 /// Check if mouse is initialized.
 pub fn is_initialized() -> bool {
     MOUSE_INITIALIZED.load(Ordering::Relaxed)
+}
+
+/// Best-effort read of the live i8042 controller command byte (CCB), for the
+/// `mouse-state` kdb diagnostic.
+///
+/// Issues the `0x20` (read-config) controller command and returns the byte.
+/// Bit 1 (0x02) = mouse IRQ enabled; bit 5 (0x20) = mouse-clock disabled (must
+/// be 0 for the mouse to stream).  Returns `None` if the controller already has
+/// an unread output byte on entry (a device packet in flight): issuing `0x20`
+/// then would read that data byte instead of the config and could desync the
+/// packet assembler, so we decline rather than corrupt the stream.  Interrupts
+/// are masked across the command/read so the IRQ12 handler cannot race the read.
+/// Reference: PC/AT 8042 keyboard-controller command byte; status-register OBF
+/// (bit 0) / AUX (bit 5) flags.
+pub fn read_ccb() -> Option<u8> {
+    let mut flags: u64;
+    // Save RFLAGS then mask interrupts so the IRQ12 handler cannot consume the
+    // output byte between our `0x20` command and the `0x60` read.  Restoring the
+    // saved RFLAGS re-enables interrupts only if they were enabled on entry.
+    unsafe { core::arch::asm!("pushfq; pop {}; cli", out(reg) flags, options(nomem)); }
+    // Decline if an output byte is already pending (OBF, status bit 0): consuming
+    // it would steal a device packet byte and report garbage.
+    let ccb = if unsafe { crate::hal::inb(STATUS_PORT) } & 0x01 != 0 {
+        None
+    } else {
+        wait_input();
+        unsafe { crate::hal::outb(COMMAND_PORT, 0x20); }
+        wait_output();
+        Some(unsafe { crate::hal::inb(DATA_PORT) })
+    };
+    unsafe { core::arch::asm!("push {}; popfq", in(reg) flags, options(nomem)); }
+    ccb
 }

--- a/kernel/src/gui/input.rs
+++ b/kernel/src/gui/input.rs
@@ -81,6 +81,14 @@ const SC_LALT: u8     = 0x38;
 // Break-code flag
 const SC_RELEASE: u8  = 0x80;
 
+// ── Cursor cell size ────────────────────────────────────────────────────────
+
+/// Software-cursor cell size in pixels (the arrow bitmap is 12×12).  Matches the
+/// compositor's cursor cell; used to report *fine* cursor damage on a pointer
+/// move so the move costs a ~KB partial frame rather than a full-surface
+/// recomposite.
+const CURSOR_CELL: i32 = 12;
+
 // ── Input state ────────────────────────────────────────────────────────────
 
 /// Tracks previous-frame state so we can detect deltas.
@@ -139,10 +147,22 @@ pub fn pump_input() {
 
     if mouse_moved || buttons_changed {
         // On-screen cursor position changed → owe a recomposite so the
-        // damage-driven compositor repaints the cursor.  `damage()` is a
-        // lock-free atomic (it never takes COMPOSITOR), so bumping it while
-        // INPUT_STATE is held is sound.
-        crate::gui::compositor::damage();
+        // damage-driven compositor repaints the cursor.  Report *fine* damage
+        // for just the cursor's old and new 12×12 cells (the PR #666 per-cell
+        // cursor path) rather than the coarse full-surface `damage()`, which
+        // forced an ~8 MB full-frame recomposite on every pointer move.
+        // Recording fine rects makes the next `compose()` a partial frame; on a
+        // partial frame compose() itself erases the previously-painted cursor
+        // cell and paints the new one within these regions (no trail).  Cursor
+        // damage is owed only on an actual move — a pure button change does not
+        // alter on-screen pixels, and any resulting redraw reports its own
+        // damage.  `damage_rect` takes only the lock-free DAMAGE accumulator
+        // (never COMPOSITOR), so calling it while INPUT_STATE is held is sound.
+        if mouse_moved {
+            crate::gui::compositor::damage_rect(
+                state.prev_mouse_x, state.prev_mouse_y, CURSOR_CELL, CURSOR_CELL);
+            crate::gui::compositor::damage_rect(mx, my, CURSOR_CELL, CURSOR_CELL);
+        }
         process_mouse(&state, mx, my, buttons);
 
         // ── X11 mouse forwarding ───────────────────────────────────────

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -397,6 +397,7 @@ pub fn dispatch(req: &str, out: &mut String) {
         "virtio-wait-reset" => op_virtio_wait_reset(out),
         "bell-stats"       => op_bell_stats(out),
         "compose-stats"    => op_compose_stats(out),
+        "mouse-state"      => op_mouse_state(out),
         "x11-windows"      => op_x11_windows(out),
         "cache-audit"      => op_cache_audit(out),
         "cache-aliasing"   => op_cache_aliasing(out),
@@ -1396,6 +1397,42 @@ fn op_compose_stats(out: &mut String) {
         out,
         r#""last_us":{},"last_bytes":{},"last_dirty_px":{},"us_total":{},"bytes_total":{}}}"#,
         last_us, last_bytes, last_dirty_px, us_total, bytes_total
+    );
+}
+// ── mouse-state ─────────────────────────────────────────────────────────────
+//
+// Per-link evidence for the PS/2 mouse → input-pump → X11-pointer chain.
+//   irq12_count    : IRQ12 (vector 44) fires recorded by perf — proves the
+//                    QEMU PS/2 device → IOAPIC → ISR link is live.
+//   initialized    : mouse::init completed (data reporting enabled).
+//   x,y,buttons    : decoded pointer state from mouse.rs — advances iff
+//                    handle_irq successfully assembled+decoded packets.
+//   x11_*          : whether the X11 server would deliver MotionNotify to its
+//                    focused window (focus_selects_motion=false ⇒ events are
+//                    dropped at the server even though the sprite tracks).
+fn op_mouse_state(out: &mut String) {
+    use core::fmt::Write;
+    let irq12 = crate::perf::interrupt_count(44);
+    let irq1 = crate::perf::interrupt_count(33);
+    let (mx, my) = crate::drivers::mouse::position();
+    let buttons = crate::drivers::mouse::buttons();
+    let initialized = crate::drivers::mouse::is_initialized();
+    // CCB is best-effort: None when a device byte is in flight (see read_ccb).
+    let ccb = crate::drivers::mouse::read_ccb();
+    let ccb_val = ccb.map(|c| c as i32).unwrap_or(-1);
+    let mouse_irq_enabled = ccb.map(|c| c & 0x02 != 0).unwrap_or(false); // CCB bit 1
+    let mouse_clock_on = ccb.map(|c| c & 0x20 == 0).unwrap_or(false);    // bit 5 clear = clock on
+    let (x11_init, x11_clients, x11_focus, x11_motion) =
+        crate::x11::debug_pointer_state();
+    let _ = write!(
+        out,
+        r#"{{"irq12_count":{},"irq1_count":{},"initialized":{},"x":{},"y":{},"buttons":{},"ccb":{},"mouse_irq_enabled":{},"mouse_clock_on":{},"#,
+        irq12, irq1, initialized, mx, my, buttons, ccb_val, mouse_irq_enabled, mouse_clock_on
+    );
+    let _ = write!(
+        out,
+        r#""x11_initialized":{},"x11_clients":{},"x11_focus_window":{},"x11_focus_selects_motion":{}}}"#,
+        x11_init, x11_clients, x11_focus, x11_motion
     );
 }
 // ── x11-windows ───────────────────────────────────────────────────────────────

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -413,6 +413,35 @@ pub fn inject_key_event(keycode: u8, pressed: bool) {
     }
 }
 
+/// Debug snapshot of the server pointer-routing state, for the kdb `mouse-state`
+/// op.  Returns `(initialized, client_count, focus_window,
+/// focus_selects_pointer_motion)` — i.e. whether [`inject_mouse_event`] would
+/// actually deliver a MotionNotify to the focused window (it only does so when
+/// that window's event mask includes `PointerMotion`).
+pub fn debug_pointer_state() -> (bool, u32, u32, bool) {
+    let srv = SERVER.lock();
+    if !srv.initialized {
+        return (false, 0, 0, false);
+    }
+    let fw = srv.focus_window;
+    let mut clients = 0u32;
+    let mut motion = false;
+    for slot in srv.clients.iter() {
+        if let Some(c) = slot {
+            clients += 1;
+            let entries = &c.resources.entries;
+            if let Some(r) = entries.iter().filter_map(|s| s.as_ref()).find(|r| r.id == fw) {
+                if let resource::ResourceBody::Window(ref w) = r.body {
+                    if w.event_mask & proto::EVENT_MASK_POINTER_MOTION != 0 {
+                        motion = true;
+                    }
+                }
+            }
+        }
+    }
+    (true, clients, fw, motion)
+}
+
 /// Inject a mouse motion / button event to X11 clients.
 ///
 /// `rx`/`ry` are root-space coordinates.  `buttons` is a button-state bitmask

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7168,7 +7168,7 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
         qemu-harness.py kdb <sid> syscall-trend 10 4
     """
     if op in ("ping", "proc-list", "vfs-mounts", "trace-status",
-              "bell-stats", "compose-stats", "x11-windows", "cache-audit", "cache-aliasing",
+              "bell-stats", "compose-stats", "mouse-state", "x11-windows", "cache-audit", "cache-aliasing",
               "fault-cache-keys", "w215-cache-residency",
               "tlb-stats", "heap-stats", "w215-diag",
               # cpu-state: per-CPU scheduler/timer survey + TID-0 reactor
@@ -13147,7 +13147,7 @@ def main():
         "epoll-watch",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "uread", "trace-status",
-        "bell-stats", "compose-stats", "x11-windows", "cache-audit", "cache-aliasing",
+        "bell-stats", "compose-stats", "mouse-state", "x11-windows", "cache-audit", "cache-aliasing",
         "cache-lookup",
         "fault-cache-keys",
         "w215-cache-residency", "tlb-stats", "heap-stats", "w215-diag",


### PR DESCRIPTION
## Summary

Two independent input-path changes (one perf fix, one PS/2 hardening) plus a kdb diagnostic for the mouse-delivery chain. **Do not merge yet — for review.**

### Task 2 (perf, primary deliverable): cursor-move is no longer a full-screen recomposite
`gui/input.rs:145` called the coarse `compositor::damage()` on every pointer move, which forces a full-surface frame (~8 MB backbuffer→VRAM blit + full SVGA UPDATE) — defeating the per-cell cursor damage the damage-region compositor (#666) already implements. Now we report **fine** damage for the cursor's old and new 12×12 cells via `compositor::damage_rect()`. The next `compose()` becomes a partial frame; on a partial frame `compose()` itself erases the previously-painted cursor cell and paints the new one inside those regions (no trail — the #666 software-cursor path at compositor.rs handles erase/paint). A pointer move now costs a ~KB partial frame instead of ~8 MB. Cursor damage is owed only on an actual move; a pure button transition changes no on-screen pixels.

### Task 1 (PS/2 mouse delivery): hardening + precise diagnosis
The reported symptom is "guest cursor doesn't move over VNC." This change:
- **Hardens i8042 mouse init** (`drivers/mouse.rs`): the CCB write only OR'd in the mouse-IRQ-enable bit and relied on `0xA8` to clear the mouse-clock-disable bit (0x20). Per the PC/AT 8042 spec the aux clock must be enabled (bit 5 clear) for the mouse to stream; the keyboard's CCB write leaves bit 5 set. We now clear bit 5 explicitly (correct on real hardware; benign where `0xA8` already clears it).
- **Adds diagnostics**: `kdb mouse-state` (irq12/irq1 counts, decoded position/buttons, live CCB enable/clock bits, X11 focus pointer-motion routing), `mouse::read_ccb()`, `x11::debug_pointer_state()`, and harness registration of the op.

### Diagnosis findings (see PR thread / agent report for detail)
- Per-link test via QMP `input-send-event` on a live FF-gui boot showed `irq12_count` frozen at 1 and `mouse::position()` unchanged after `move-rel`.
- **Control experiment:** QMP **keyboard** injection also left `irq1_count` frozen at 1. Since the keyboard works over VNC in the live session, this shows QMP `input-send-event` does **not** reach the i8042 under the harness's `-display none` headless config — so the headless-QMP method cannot exercise the PS/2 path. End-to-end cursor verification needs a VNC-capable boot.
- `move-abs` → QMP "Input handler not found for event type abs", confirming no absolute pointing device (the usb-tablet path is precluded by the dead USB-HID stack). Over VNC, absolute pointer events have no device to land on; the PS/2-only path depends on QEMU's VNC→relative fallback + a streaming guest mouse.

## Testing
- Builds clean (`firefox-test-core,kdb`).
- The new `kdb mouse-state` op responded with its new fields on a live boot, proving the booted kernel contained these changes.
- Cursor-move → small-frame and click-navigates could **not** be verified headless due to the QMP-input-delivery limitation above; recommend VNC-based verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)