### PR TITLE
sched: on-CPU interlock — never dispatch a thread already live on another CPU (fixes #655 SMP double-dispatch)

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1410,6 +1410,42 @@ pub fn is_tid_on_stack_any_cpu(tid: Tid) -> bool {
     false
 }
 
+/// On-CPU dispatch interlock: returns `true` if `tid` is still live — currently
+/// dispatched (`PER_CPU_CURRENT_TID`) **or** physically executing on its kernel
+/// stack (`PER_CPU_ONSTACK_TID`) — on any logical CPU OTHER than `self_cpu`.
+///
+/// A thread that is still live on another CPU must never be dispatched/resumed
+/// here: it owns a single kernel stack, and running it on two CPUs at once lets
+/// each tear the other's saved `switch_context` frame in place (the SMP
+/// kernel-stack double-dispatch corruption).  This is the realisation, at our
+/// cooperative pick site, of the standard SMP wakeup interlock — a task carries
+/// an "on-CPU" marker held across the context switch, and a remote runqueue must
+/// not re-place the task until that marker clears.  Both signals are published
+/// with `Release` (`set_current_tid` / `set_onstack_tid`); the `Acquire` loads
+/// here pair with them so observing a CPU as no longer running/holding `tid` also
+/// observes that CPU's final stack writes for `tid` as retired.
+///
+/// `self_cpu` is excluded so a thread legitimately re-selected on the very CPU
+/// it last ran on (the common no-migration case) is never spuriously deferred.
+pub fn is_tid_live_on_other_cpu(tid: Tid, self_cpu: usize) -> bool {
+    if tid == 0 {
+        return false;
+    }
+    let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
+        .min(crate::arch::x86_64::apic::MAX_CPUS);
+    for cpu in 0..ncpus {
+        if cpu == self_cpu {
+            continue;
+        }
+        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid
+            || PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Read the currently running PID for an arbitrary CPU index.  See
 /// [`current_tid_on_cpu`].
 pub fn current_pid_on_cpu(cpu: usize) -> Pid {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -102,6 +102,48 @@ pub fn note_switch_completed() {
     crate::proc::set_onstack_tid(crate::proc::current_tid());
 }
 
+/// On-CPU dispatch-interlock counter: number of times a candidate was DEFERRED
+/// from dispatch/work-steal because it was still live (current or on-stack) on
+/// another CPU.  A non-zero value proves the #655 double-dispatch race was
+/// occurring and is now being caught.  Read via [`double_dispatch_defers`].
+static DOUBLE_DISPATCH_DEFERS: AtomicU64 = AtomicU64::new(0);
+
+/// Read the on-CPU dispatch-interlock defer counter (see
+/// [`DOUBLE_DISPATCH_DEFERS`]).
+#[inline]
+pub fn double_dispatch_defers() -> u64 {
+    DOUBLE_DISPATCH_DEFERS.load(Ordering::Relaxed)
+}
+
+/// The on-CPU dispatch interlock, applied at every dispatch/resume/work-steal
+/// site: returns `true` (and counts, rate-limited-logs) when `tid` must NOT be
+/// dispatched on `self_cpu` because it is still live on another CPU.
+///
+/// A deferred thread is NOT lost — it remains Ready/enqueued and is selected
+/// normally on a later pass once the other CPU has switched off it (both the
+/// current- and on-stack signals clear).  This is the skip-and-defer form of the
+/// SMP wakeup/migration interlock (a task is never re-placed on a runqueue while
+/// still on-CPU elsewhere); for a cooperative picker, deferring the *selection*
+/// is equivalent to — and cheaper than — spin-waiting on the marker.  Closes the
+/// #655 window in which one live thread was dispatched onto two CPUs and the two
+/// executions tore its single kernel stack's saved switch frame in place.
+#[inline]
+pub(crate) fn defer_if_live_on_other_cpu(tid: proc::Tid, self_cpu: usize) -> bool {
+    if proc::is_tid_live_on_other_cpu(tid, self_cpu) {
+        let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
+        if n <= 16 || n % 4096 == 0 {
+            crate::serial_println!(
+                "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
+                 (still live on another CPU) total_defers={}",
+                tid, self_cpu, n,
+            );
+        }
+        true
+    } else {
+        false
+    }
+}
+
 /// Read the current switch generation for `cpu` (Acquire).  Used both to
 /// snapshot at reap time and to test eligibility at pop time.
 #[inline]
@@ -2254,7 +2296,14 @@ was_emergency_4k={}",
             cpu,
             (1..len)
                 .map(|i| (current_idx + i) % len)
-                .filter(|&idx| matches!(threads[idx].mirror_slot, Some((c, _)) if c == percpu_cpu)),
+                .filter(|&idx| matches!(threads[idx].mirror_slot, Some((c, _)) if c == percpu_cpu))
+                // ── #655 on-CPU dispatch interlock (the dispatch chokepoint) ──
+                // Skip-and-defer any candidate still live (current or on-stack)
+                // on another CPU, so one thread is never dispatched onto two CPUs
+                // at once (which would tear its single kernel stack's saved
+                // switch frame in place).  Inert on SMP=1 (no other CPU) ⇒
+                // bit-for-bit unchanged.  See `defer_if_live_on_other_cpu`.
+                .filter(|&idx| !defer_if_live_on_other_cpu(threads[idx].tid, cpu as usize)),
             now,
         );
 

--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -415,6 +415,16 @@ pub fn try_steal_to(threads: &mut [proc::Thread], dst_cpu: u8, ncpus: usize) -> 
         if !t.ctx_rsp_valid.load(Ordering::Acquire) {
             continue;
         }
+        // #655 on-CPU interlock (source side): never re-home a thread still live
+        // (current or on-stack) on another CPU.  `ctx_rsp_valid` flips true the
+        // instant `switch_context_asm` saves the outgoing RSP, but the source
+        // CPU is still physically on that stack through the switch epilogue;
+        // stealing it here would let the destination CPU resume it onto the very
+        // stack the source CPU is still unwinding.  Defer until the source CPU is
+        // provably off it (both signals clear).  Inert on SMP=1.
+        if super::defer_if_live_on_other_cpu(t.tid, dst_cpu as usize) {
+            continue;
+        }
         // Respect hard affinity: never steal a thread pinned elsewhere.
         if let Some(a) = t.cpu_affinity {
             if a != dst_cpu {


### PR DESCRIPTION
## Root cause (dispositively localized)

#655 — the SMP>1 kernel-stack corruptor that has blocked dual-core — is a
**scheduler double-dispatch**: one *live* thread is concurrently selected/resumed
on two CPUs, so both execute on its single kernel stack and tear the saved
`switch_context` frame in place. Observed as a torn saved-RIP/RFLAGS →
`0xdead0006 KERNEL_PAGE_FAULT` (RIP=0) or `0x7f UNEXPECTED_KERNEL_MODE_TRAP`
(RIP=0x70xx), always on a long-lived thread (e.g. PID1's main thread) that
itself never dies — i.e. no free, no recycle, no UAF.

A discriminating probe + QMP autopsy proved it directly: at the crash, two CPUs
have RSP in one physical kstack, `PER_CPU_CURRENT_TID` is **equal on both CPUs**
(same tid), one CPU resumed in-kernel (kernel CR3) running the scheduler on the
victim's stack while the other runs the same thread in user mode.

The existing pick guards do **not** catch this: `state != Ready` is bypassed when
a still-running thread is re-readied, and `ctx_rsp_valid` flips true the instant
`switch_context_asm` saves the outgoing RSP — yet the CPU is still physically on
that stack through the switch epilogue, so a remote CPU can select or work-steal
the thread in that window.

## Fix — an on-CPU dispatch interlock

This is the cooperative-picker realization of the standard SMP wakeup/migration
invariant: a task carries an on-CPU marker held across the context switch, and a
remote runqueue must not re-place it until that marker clears (release/acquire
hand-off). For a cooperative picker, deferring the *selection* is equivalent to,
and cheaper than, spin-waiting on the marker.

- **`proc::is_tid_live_on_other_cpu(tid, self_cpu)`** — true if `tid` is current
  (`PER_CPU_CURRENT_TID`) or physically on-stack (`PER_CPU_ONSTACK_TID`) on any
  CPU *other than* `self_cpu`. `Acquire` loads pair with the `Release` publishers
  `set_current_tid` / `set_onstack_tid` (the latter from #672), so observing a
  CPU as no longer holding `tid` also observes that CPU's final stack writes for
  `tid` as retired.
- **Backstop (dispatch chokepoint):** the `schedule()` candidate iterator
  skip-and-defers any candidate live on another CPU, so the picker never
  dispatches it. The thread is **not lost** — it stays Ready/enqueued and is
  selected normally once the other CPU has switched off it.
- **Source side:** `percpu::try_steal_to` applies the same interlock so
  work-steal never re-homes a thread still unwinding its stack on a peer.
- **`DOUBLE_DISPATCH_DEFERS`** counter + a rate-limited `[SCHED/INTERLOCK]` log
  prove the race was occurring and is now caught.

**SMP=1 is inert by construction** (no other CPU ⇒ predicate always false) — the
uniprocessor scheduler is bit-for-bit unchanged. Builds on the per-CPU
current/on-stack publication from #672.

## Verification (harness-only, KVM, 2 GiB, `--ff-gui https://example.com`)

SMP=2, ×5 boots, with the double-dispatch detector armed:

| boot | class=DD | 0xdead000[67] / 0x7f | interlock defers | FF PutImage |
|------|----------|----------------------|------------------|-------------|
| 1 | 0 | 0 | 6  | yes |
| 2 | 0 | 0 | 21 | yes |
| 3 | 0 | 0 | 12 | yes |
| 4 | 0 | 0 | 17 | yes |
| 5 | 0 | 0 | 2  | (pre-paint) |

- A 300 s churn-window watch on boot 1 returned no DD hit and no bugcheck.
- The `[SCHED/INTERLOCK]` defers name the exact threads that double-dispatched
  before the fix (`tid=2`, `tid=36` "still live on another CPU") — the race is
  real, occurring, and now deferred instead of crashing.
- Before this change, SMP=2 deterministically bugchecked during this churn
  window; now it survives and FF paints via X11 (PutImage content blits).

SMP=1: no regression — boots, runs, FF paints; `interlock defers = 0` (fix inert).

## Notes
- Spec citations: Intel SDM Vol. 3A §6.14 (interrupt stack switch / per-CPU
  stacks); POSIX single-execution thread semantics.
- The diagnostic probe used to localize this is **not** in this PR (it lives on
  the verify branch); this PR is the fix only (3 files, +96/−1).
- Please do not merge yet — independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)