### PR TITLE
mm/mmap + ipc/shm: fix two SMP VMA-placement bugs spuriously failing mmap with ENOMEM

### DIFF
--- a/kernel/src/ipc/sysv_shm.rs
+++ b/kernel/src/ipc/sysv_shm.rs
@@ -174,14 +174,30 @@ pub fn shmat(shmid: u32, shmaddr: u64, _shmflg: i32) -> i64 {
         let mut procs = crate::proc::PROCESS_TABLE.lock();
         if let Some(proc) = procs.iter_mut().find(|p| p.pid == pid) {
             if let Some(vs) = proc.vm_space.as_mut() {
-                vs.areas.push(crate::mm::vma::VmArea {
+                let shm_vma = crate::mm::vma::VmArea {
                     base:    map_vaddr,
                     length:  size,
                     prot:    crate::mm::vma::PROT_READ | crate::mm::vma::PROT_WRITE,
                     flags:   crate::mm::vma::MAP_SHARED,
                     backing: crate::mm::vma::VmBacking::Device { phys_base },
                     name:    "[shm]",
-                });
+                };
+                // Insert at the sorted position rather than a raw push.  The
+                // areas list is maintained strictly ascending by base, and
+                // VmSpace::find_free_range performs a single DESCENDING pass
+                // (areas.iter().rev()) that relies on that ordering.  shmat
+                // typically attaches low in the address space (pick_vaddr ~
+                // 0x6000_0000) while the list already holds much higher VMAs
+                // (libraries, thread stacks near the top of the mmap window);
+                // a raw push left that low-base VMA at the END of the Vec, so
+                // the descending pass visited it FIRST, computed a phantom
+                // free gap spanning the whole window, and returned a base that
+                // was actually occupied — making later kernel-chosen mmap()s
+                // fail spuriously with ENOMEM (insert_vma's order-independent
+                // overlap scan then rejected the bogus placement).
+                let pos = vs.areas.iter().position(|v| v.base > shm_vma.base)
+                    .unwrap_or(vs.areas.len());
+                vs.areas.insert(pos, shm_vma);
                 // W216 H_5j-B: notify the PFH install loop of the VMA-list
                 // mutation (this site bypasses insert_vma).
                 vs.generation.fetch_add(1, core::sync::atomic::Ordering::Release);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -3427,14 +3427,11 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
         crate::mm::vmm::unmap_and_free_range_in(cr3, base, length);
     }
 
-    let vma = VmArea {
-        base,
-        length,
-        prot,
-        flags,
-        backing,
-        name,
-    };
+    // The VMA record is constructed inside Phase 3 (below) rather than here:
+    // for a non-FIXED placement the base may need to be re-chosen under the
+    // Phase 3 lock if a concurrent same-VmSpace mmap claimed the gap in the
+    // window after Phase 1 dropped the lock (the SMP TOCTOU closed below), so
+    // `backing` must remain available to clone for each insert attempt.
 
     // `[MMAP]` is verbose: every dlopen / runtime malloc / JIT page emits a
     // line, which under the demo workload runs into the thousands.  Gate it
@@ -3464,8 +3461,61 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
             None => break 'phase3 -3,
         };
 
-        match space.insert_vma(vma) {
-            Ok(()) => {
+        // Close the Phase-1/Phase-3 placement TOCTOU for kernel-chosen
+        // (non-FIXED) mappings.
+        //
+        // For a non-FIXED mmap the base was picked by find_free_range /
+        // find_free_stack_range in Phase 1 under a PROCESS_TABLE lock that was
+        // then RELEASED before this point.  On SMP a concurrent mmap into the
+        // SAME address space (sibling thread / shared CR3) can claim that gap
+        // in the window, so `insert_vma` here would fail with Overlap and we
+        // would wrongly return ENOMEM even though free address space remains —
+        // a spurious failure that POSIX mmap(2) forbids for a kernel-chosen
+        // address.  (Observed live under SMP=2: a sibling thread's memfd
+        // MAP_SHARED mmap lost this race, the userland SharedMemory map failed,
+        // and a downstream NULL dereference of the unmapped region followed.)
+        //
+        // Re-pick the gap and re-insert under the lock we now hold; with the
+        // lock held the find→insert pair is atomic, so the retry cannot itself
+        // race.  This is safe because a non-FIXED sys_mmap installs NO page
+        // table entries (frames are demand-faulted later): the chosen base
+        // lives only in the VMA record, so re-choosing it here is complete —
+        // the return value and every subsequent fault use the recorded base.
+        //
+        // MAP_FIXED placements keep the caller-supplied base unchanged (no
+        // re-pick): their Overlap is a genuine caller error and Phase 2b has
+        // already edited the page table for that exact base.
+        let mut cur_base = base;
+        let mut attempts = 0u32;
+        let installed: Option<u64> = loop {
+            let vma = VmArea {
+                base: cur_base,
+                length,
+                prot,
+                flags,
+                backing: backing.clone(),
+                name,
+            };
+            match space.insert_vma(vma) {
+                Ok(()) => break Some(cur_base),
+                Err(crate::mm::vma::VmaError::Overlap) if !is_fixed && attempts < 8 => {
+                    attempts += 1;
+                    let repick = if is_stack_alloc {
+                        space.find_free_stack_range(length)
+                    } else {
+                        space.find_free_range(length)
+                    };
+                    match repick {
+                        Some(nb) => { cur_base = nb; continue; }
+                        None => break None, // genuine address-space exhaustion
+                    }
+                }
+                Err(_) => break None,
+            }
+        };
+
+        match installed {
+            Some(b) => {
                 // Lower `mmap_hint` only when this allocation participates in the
                 // NULL-hint downward-walk regime — i.e. neither MAP_FIXED nor a
                 // MAP_STACK kernel-chosen allocation.  See
@@ -3475,20 +3525,20 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
                 // seeded by `randomised_mmap_hint()` before any NULL-hint
                 // allocation is ever issued (POSIX mmap(2), CWE-330).
                 let hint_before = space.mmap_hint;
-                space.note_mmap_placement(base, is_fixed, is_stack_alloc);
+                space.note_mmap_placement(b, is_fixed, is_stack_alloc);
                 let hint_after = space.mmap_hint;
                 #[cfg(all(feature = "firefox-test-core", feature = "firefox-trace-verbose"))]
                 crate::serial_println!(
-                    "[MMAP-HINT] pid={} base={:#x} hint_before={:#x} hint_after={:#x} is_fixed={} is_stack_alloc={}",
-                    pid, base, hint_before, hint_after, is_fixed as u8, is_stack_alloc as u8
+                    "[MMAP-HINT] pid={} base={:#x} hint_before={:#x} hint_after={:#x} is_fixed={} is_stack_alloc={} attempts={}",
+                    pid, b, hint_before, hint_after, is_fixed as u8, is_stack_alloc as u8, attempts
                 );
                 let _ = (hint_before, hint_after);
-                base as i64
+                b as i64
             }
-            Err(_) => {
+            None => {
                 crate::serial_println!(
-                    "[MMAP-ERR] pid={} insert_vma failed: base={:#x} len={:#x} flags={:#x} fd={}",
-                    pid, base, length, flags, fd as i64
+                    "[MMAP-ERR] pid={} insert_vma failed: base={:#x} len={:#x} flags={:#x} fd={} attempts={}",
+                    pid, cur_base, length, flags, fd as i64, attempts
                 );
                 -12 // ENOMEM
             }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -19763,6 +19763,59 @@ fn test_find_free_range() -> bool {
             MMAP_BASE - 0x20 * PAGE);
     }
 
+    // (7) Sort-invariant regression — a low SysV-SHM attach must not corrupt
+    //     find_free_range's single descending pass (the ipc::sysv_shm::shmat
+    //     raw-push bug).  find_free_range relies on `areas` being strictly
+    //     ascending by base.  shmat attaches low in the address space
+    //     (pick_vaddr ~ 0x6000_0000) while the list already holds high VMAs
+    //     (libraries / thread stacks near the top of the mmap window).  A raw
+    //     `areas.push()` left the low VMA at the END of the Vec, so the
+    //     descending pass visited it FIRST, computed a phantom whole-window
+    //     free gap, and returned a ceiling-flush base that actually OVERLAPPED
+    //     the high top-of-window VMA — which insert_vma's order-independent
+    //     overlap scan then rejected, failing the mmap spuriously with ENOMEM.
+    {
+        let shm_low = 0x6000_0000u64;            // MIT-SHM attach base
+        let shm_len = 0x40 * PAGE;
+        let top_len = 0x80 * PAGE;
+        let top = MMAP_BASE - top_len;           // a library/stack VMA at the top
+        let req = 0x10 * PAGE;
+
+        // (a) Correctly SORTED (the fix's behaviour): the low SHM VMA precedes
+        //     the high VMA.  find_free_range must return a NON-OVERLAPPING base
+        //     directly below the top VMA (the highest fitting gap).
+        let sorted = space_with(alloc::vec![(shm_low, shm_len), (top, top_len)]);
+        let got = sorted.find_free_range(req);
+        if got != Some(top - req) {
+            test_fail!("[VMA] find_free_range",
+                "shm-sorted: expected {:#x}, got {:?}", top - req, got);
+            return false;
+        }
+        if let Some(b) = got {
+            if sorted.areas.iter().any(|a| a.overlaps(b, req)) {
+                test_fail!("[VMA] find_free_range",
+                    "shm-sorted: returned OVERLAPPING base {:#x}", b);
+                return false;
+            }
+        }
+        test_println!("  [7a] low SHM attach kept sorted → non-overlapping {:#x} ✓",
+            top - req);
+
+        // (b) Negative control documenting the bug: with the low SHM VMA
+        //     appended out of order (the raw-push regression), the descending
+        //     pass is fooled into returning the OCCUPIED ceiling-flush slot.
+        let unsorted = space_with(alloc::vec![(top, top_len), (shm_low, shm_len)]);
+        let bad = unsorted.find_free_range(req);
+        if bad != Some(MMAP_BASE - req) {
+            test_fail!("[VMA] find_free_range",
+                "shm-unsorted control: expected buggy {:#x}, got {:?}",
+                MMAP_BASE - req, bad);
+            return false;
+        }
+        test_println!("  [7b] unsorted (raw-push) control returns occupied slot {:#x} (the bug the sorted insert prevents) ✓",
+            MMAP_BASE - req);
+    }
+
     test_pass!("[VMA] find_free_range top-down O(n) gap search (Test 308)");
     true
 }


### PR DESCRIPTION
## Summary

Under **SMP=2**, kernel-chosen (non-`MAP_FIXED`) `mmap()` could return **ENOMEM while free address space remained**. This broke Firefox's memfd/SHM mappings at the compositor stage: the userland `SharedMemory` map failed (chromium `shared_memory_posix.cc:515` "Out of memory") and a downstream **NULL dereference** (`CR2=0`) in libxul followed. Two distinct VMA-placement defects, both root-caused with live SMP=2 evidence:

### Bug 1 — `sys_mmap` find_free_range / insert_vma TOCTOU (`kernel/src/syscall/mod.rs`)

For a non-`MAP_FIXED` mapping the base is chosen by `find_free_range` in **Phase 1** under the process-table lock; the lock is **released**; then the VMA is committed by `insert_vma` in **Phase 3** under a separately re-acquired lock. On SMP a concurrent mmap into the same address space (sibling thread / shared CR3) can claim the gap in the window, so the loser's `insert_vma` fails with `Overlap` and `sys_mmap` wrongly returned ENOMEM — a spurious failure POSIX `mmap(2)` forbids for a kernel-chosen address.

**Fix:** under the Phase-3 lock, on `Overlap` for a non-`MAP_FIXED` mapping, re-pick the gap and re-insert (bounded retry). With the lock held the find→insert pair is atomic, so the retry cannot itself race. Safe because a non-`MAP_FIXED` `sys_mmap` installs no PTEs (frames are demand-faulted): the base lives only in the VMA record, so re-choosing it is complete. `MAP_FIXED` keeps the caller-supplied base.

### Bug 2 — `shmat` raw push corrupts the VMA sort invariant (`kernel/src/ipc/sysv_shm.rs`)

The `areas` list is maintained strictly ascending by base, and `find_free_range` performs a single **descending** pass that relies on that ordering. `shmat` attaches low in the address space (`pick_vaddr` ~`0x6000_0000`) while the list already holds much higher VMAs (libraries, thread stacks near the top of the mmap window) and recorded the mapping with a raw `Vec::push`, leaving the low-base VMA at the **end** of the Vec. The descending pass then visited it first, computed a phantom whole-window free gap, and returned a base that actually overlapped the high top-of-window VMA — which `insert_vma`'s order-independent overlap scan rejected, failing later `mmap()`s with ENOMEM. (MIT-SHM via `shmat` is exactly the FF/X11 compositor path.)

**Fix:** insert the shm VMA at its sorted position instead of appending.

## Evidence (SMP=2 windowed-FF, 3072 MiB)

- **Baseline:** `[MMAP-ERR] insert_vma failed ... flags=0x1 fd=76/32` (MAP_SHARED memfd, 60 KiB/452 KiB) ↔ FF `shared_memory_posix.cc:515` ENOMEM ↔ `CR2=0` SIGSEGV, perfectly 1:1:1 in the same pids, **zero PMM-exhaustion markers** (not memory exhaustion).
- **After Bug-1 fix:** memfd (`flags=0x1`) MMAP-ERR → **0**, FF SHM mmap failures → **0** — but exposed Bug 2 (anonymous mmaps flush against `MMAP_BASE` failing all retries, `attempts=8`, after `shmat → 0x60000000`).
- **After both fixes:** no mmap ENOMEM / SHM failures on the mmap path.

## Tests

`Test 308` (`find_free_range`) gains two sub-cases (both pass):
- `[7a]` a low SHM-style attach kept **sorted** → non-overlapping base.
- `[7b]` negative control: the out-of-order (raw-push) list returns the occupied top-of-window slot — the bug the sorted insert prevents.

## Scope / notes

- Base is `feat/llvmpipe-smp2-render` (carries the #674 gen-abort fix needed to reach the SMP=2 FF compositor stage). Both fixes are **independent of #674** and could be cherry-picked to master.
- This removes the **mmap ENOMEM gate** the llvmpipe-SMP=2 effort hit. Full content render under SMP=2 remains gated by a separate, pre-existing intermittent SMP scheduler wedge (`[SCHED/STARVE] runqueue wedged`, task#13/#655-SMP class) that fires before the SHM stage — out of scope here.
- **Do not merge** — independent review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)