### PR TITLE
NDE-29: net RX/TX throughput in the FFTEST heartbeat (net-vs-CPU tail observability)

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1729,8 +1729,21 @@ user_pref("security.sandbox.content.level", 0);
                                     crate::proc::ThreadState::Dead => p1_dead += 1,
                                 }
                             }
-                            serial_println!("[FFTEST] tick={} sc={} pf={} total_th={} p1:{}(run={},blk={},dead={})",
-                                elapsed, sc, pf, total, p1_total, p1_run, p1_blk, p1_dead);
+                            // Net throughput counters alongside the sc/pf
+                            // heartbeat: a network-bound load tail shows rx_b
+                            // climbing while sc is flat; a CPU-serialization
+                            // tail shows the inverse (rx_b plateaued, sc
+                            // exploding).  Sizing that split was previously
+                            // impossible from this line — the only net
+                            // visibility was per-event [TCP]/[UDP] markers,
+                            // which miss data carried on already-open
+                            // connections.  rx_ovr surfaces e1000 RX-ring
+                            // drops (MPC); it reads 0 on the virtio-net path.
+                            let (nrx, ntx, brx, btx) = crate::net::stats();
+                            let nov = crate::net::rx_overruns();
+                            serial_println!("[FFTEST] tick={} sc={} pf={} total_th={} p1:{}(run={},blk={},dead={}) net:rx_pkt={} tx_pkt={} rx_b={} tx_b={} rx_ovr={}",
+                                elapsed, sc, pf, total, p1_total, p1_run, p1_blk, p1_dead,
+                                nrx, ntx, brx, btx, nov);
                         }
                         None => {
                             serial_println!("[FFTEST] tick={} sc={} pf={} THREAD_TABLE busy, skipping",


### PR DESCRIPTION
## What

Appends cumulative network counters to the periodic `[FFTEST]` heartbeat
line in `kernel/src/main.rs`:

```
[FFTEST] tick=.. sc=.. pf=.. total_th=.. p1:..(run=..,blk=..,dead=..) \
    net:rx_pkt=.. tx_pkt=.. rx_b=.. tx_b=.. rx_ovr=..
```

Sourced from `net::stats()` (packets/bytes RX+TX) and `net::rx_overruns()`
(e1000 MPC ring-overrun count; reads 0 on the virtio-net fallback).

## Why

Investigating *"Firefox takes too long to load"* on SMP=1, the load phase
could not be split into **network-latency** vs **single-core CPU
serialization** from the serial log alone. The only net visibility was
the per-event `[TCP]`/`[UDP]` markers, which fire on connection
state-transitions and per-datagram — they **miss bulk data carried on
already-open TCP connections**, exactly where a "resources trickle for
minutes" hypothesis would live.

This counter line makes the split legible at a glance: a network-bound
tail shows `rx_b` climbing while `sc` is flat; a CPU-bound tail shows
`rx_b` plateaued while `sc` explodes.

### Measurement it produced (SMP=1, en.wikipedia.org/wiki/Firefox)

| tick (~100 Hz) | sc | rx_b (cumulative RX) |
|---|---|---|
| 4020 | 38,693 | 0 |
| 7000 (~70 s, first paint) | 1,077,981 | **2,040,728** |
| 10000 | 3,670,534 | 2,040,728 (frozen) |
| 20110 (~201 s, render+PNG) | 12,088,067 | 2,110,006 (+70 KB) |

The entire ~2 MB page downloads by ~tick 7000; the post-paint tail adds
**+70 KB of RX while burning +11 M syscalls on one core**. The tail is
single-core CPU serialization, not network latency.

## Safety

Additive only — the `[FFTEST] tick=… sc=… pf=…` prefix is unchanged, so
the harness FFTEST grep / wedge-detector keeps matching. Net fields are
appended after the existing fields.

## Posture

**Do NOT merge yet — independent review pending.** Observability-only;
no behavioural change to the net stack or scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)