### PR TITLE
perf(boot): front-load Firefox start-up DSO closure + widen ext2 read-coalescing cap

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1275,6 +1275,79 @@ pub unsafe extern "C" fn _start(boot_info: *const BootInfo) -> ! {
                 "/disk/opt/firefox/libxul.so",              // 157 MB — glibc variant
                 "/disk/usr/lib/firefox-esr/libxul.so",      // 130 MB — musl variant (firefox-esr 115.x)
                 "/disk/usr/lib/firefox/libxul.so",          // 130 MB — musl variant (firefox 132.x)
+
+                // ── Firefox start-up shared-library closure ──────────────
+                // After libxul, ld-musl demand-pages the REST of Firefox's
+                // DSO closure as the browser initialises XPCOM, the GTK
+                // widget toolkit, PSM/crypto and the GPU-feature probe.
+                // Without pre-loading, each object is faulted in piecemeal —
+                // thousands of single-page readahead misses, every one a
+                // busy-polled virtio round-trip (no MSI-X) — adding seconds
+                // before the first window maps.  Pre-loading them here turns
+                // that scatter into one sequential precache burst.
+                //
+                // Each entry is a SONAME symlink that resolves to the
+                // versioned object on the ext2 data disk; an absent path
+                // returns 0 pages benignly (prepopulate_file -> resolve Err),
+                // so the list is safe to ship for both the firefox-esr (115.x)
+                // and firefox (132.x) staging variants.  The bulk read is
+                // bounded by prepopulate_file's PMM low-water guard, so a
+                // tight-memory boot sheds the TAIL of this list rather than
+                // starving the kernel — hence the ordering: most load-bearing
+                // objects first, the largest/most-optional last.
+                //
+                // GTK3 widget toolkit + GLib object/IO core
+                "/disk/usr/lib/libgtk-3.so.0",              // 8.1 MB
+                "/disk/usr/lib/libgdk-3.so.0",              // 938 KB
+                "/disk/usr/lib/libgio-2.0.so.0",            // 1.9 MB
+                "/disk/usr/lib/libglib-2.0.so.0",           // 1.3 MB
+                "/disk/usr/lib/libgobject-2.0.so.0",        // 378 KB
+                // ICU (Unicode/intl tables, pulled in by XPCOM init)
+                "/disk/usr/lib/libicui18n.so.74",           // 2.6 MB
+                "/disk/usr/lib/libicuuc.so.74",             // 1.6 MB
+                // NSS / NSPR (PSM crypto + TLS handshake init)
+                "/disk/usr/lib/libnss3.so",                 // 1.2 MB
+                "/disk/usr/lib/libnspr4.so",                // 236 KB
+                "/disk/usr/lib/libssl3.so",                 // 406 KB
+                "/disk/usr/lib/libsmime3.so",               // 166 KB
+                "/disk/usr/lib/libnssutil3.so",             // 174 KB
+                "/disk/usr/lib/libsoftokn3.so",             // 337 KB
+                "/disk/usr/lib/libfreeblpriv3.so",          // 914 KB
+                // C++ runtime + compression/parse base libs
+                "/disk/usr/lib/libstdc++.so.6",             // 2.6 MB
+                "/disk/usr/lib/libgcc_s.so.1",              // 138 KB
+                "/disk/lib/libz.so.1",                      // 102 KB
+                "/disk/usr/lib/libexpat.so.1",              // 134 KB
+                "/disk/usr/lib/libbrotlidec.so.1",          // 54 KB
+                // 2D text/graphics: cairo, pango, harfbuzz, freetype,
+                // fontconfig, pixman, pixbuf, png
+                "/disk/usr/lib/libcairo.so.2",              // 935 KB
+                "/disk/usr/lib/libpango-1.0.so.0",          // 335 KB
+                "/disk/usr/lib/libpangocairo-1.0.so.0",     // 54 KB
+                "/disk/usr/lib/libpangoft2-1.0.so.0",       // 82 KB
+                "/disk/usr/lib/libharfbuzz.so.0",           // 1.1 MB
+                "/disk/usr/lib/libfreetype.so.6",           // 650 KB
+                "/disk/usr/lib/libfontconfig.so.1",         // 250 KB
+                "/disk/usr/lib/libpixman-1.so.0",           // 566 KB
+                "/disk/usr/lib/libgdk_pixbuf-2.0.so.0",     // 150 KB
+                "/disk/usr/lib/libpng16.so.16",             // 182 KB
+                "/disk/usr/lib/libgraphite2.so.3",          // 122 KB
+                // Mozilla support DSOs (dependentlibs.list closure)
+                "/disk/usr/lib/firefox-esr/libmozsqlite3.so",       // 1.3 MB
+                "/disk/usr/lib/firefox-esr/libmozsandbox.so",       // 162 KB
+                "/disk/usr/lib/firefox-esr/liblgpllibs.so",         // 36 KB
+                "/disk/usr/lib/firefox-esr/libipcclientcerts.so",   // 375 KB
+                // Mesa GL client + dispatch (glxtest GPU-feature probe)
+                "/disk/usr/lib/libGL.so.1",                 // 614 KB
+                "/disk/usr/lib/libglapi.so.0",              // 226 KB
+                "/disk/usr/lib/libEGL.so.1",                // 275 KB
+                // Mesa software rasteriser (llvmpipe/gallium) — the largest
+                // single object; demand-faulted by the glxtest probe and the
+                // GL compositor path.  Listed LAST so the PMM low-water guard
+                // sheds it first on a tight-memory boot.  All three driver
+                // SONAMEs (libgallium_dri/swrast_dri/kms_swrast_dri) are
+                // symlinks to this one inode, so caching it covers them all.
+                "/disk/usr/lib/xorg/modules/dri/libgallium_dri.so", // 34 MB
             ] {
                 let t0 = arch::x86_64::irq::get_ticks();
                 let pages = mm::cache::prepopulate_file(path);

--- a/kernel/src/vfs/ext2.rs
+++ b/kernel/src/vfs/ext2.rs
@@ -888,10 +888,18 @@ impl Ext2Fs {
             // first hole, the first non-contiguous block, or end-of-request.
             if off_in_block == 0 && (to_read - read_total) >= self.block_size {
                 // Cap the coalesced run so the sector count fits the device
-                // request ABI (u16 sectors) with margin: 512 sectors = 256 KiB
-                // at 1 KiB blocks, comfortably larger than the 128 KiB
-                // demand-fault readahead window while staying well inside u16.
-                const MAX_RUN_SECTORS: usize = 512;
+                // request ABI (u16 sectors) with margin.  4096 sectors =
+                // 2 MiB, which matches the page-cache prepopulate burst size
+                // (mm::cache::prepopulate_file reads in 2 MiB chunks): a
+                // disk-contiguous chunk now coalesces into ONE ext2 run, and
+                // the virtio-blk layer splits that single run into its 1 MiB
+                // (2048-sector) request batches — so a 2 MiB read costs two
+                // device round-trips instead of eight.  Even at the maximum
+                // 4 KiB block size the resulting sector_count is 4096, well
+                // inside u16 (65535).  The dst slice is a sub-slice of the
+                // caller's buffer, so the contiguity requirement is unchanged
+                // from the prior 256 KiB cap — only the run length grows.
+                const MAX_RUN_SECTORS: usize = 4096;
                 let sectors_per_block_usz = (self.block_size / 512).max(1);
                 let max_run_by_sectors = MAX_RUN_SECTORS / sectors_per_block_usz;
                 let max_whole_blocks =


### PR DESCRIPTION
## Summary

Two low-risk, measurement-anchored start-up wins for the windowed-Firefox boot path. Both land on the **ext2 data disk** (`/disk`, confirmed ext2 magic `0x53ef`) that backs the browser's shared-library closure. **Do not merge — independent review pending.**

### P1 — Extend the boot precache to the full FF start-up DSO closure (`kernel/src/main.rs`)
Today the FFTEST precache only loads libxul + ld-musl + firefox-bin. After libxul, ld-musl demand-pages the **rest** of Firefox's start-up closure piecemeal — thousands of single-page readahead misses, each a busy-polled virtio round-trip (no MSI-X) — stalling the path to the first mapped window. This extends the list to the genuinely-hot, large objects:

- **GTK3 + GLib** (libgtk-3/libgdk-3/libgio/libglib/libgobject)
- **ICU** (libicui18n/libicuuc)
- **NSS/NSPR** (libnss3/libnspr4/libssl3/libsmime3/libnssutil3/libsoftokn3/libfreeblpriv3)
- **C++/compression base** (libstdc++/libgcc_s/libz/libexpat/libbrotlidec)
- **2D text/graphics** (cairo/pango/harfbuzz/freetype/fontconfig/pixman/gdk_pixbuf/png16/graphite2)
- **Mozilla support DSOs** (libmozsqlite3/libmozsandbox/liblgpllibs/libipcclientcerts — the `dependentlibs.list` closure)
- **Mesa GL** (libGL/libglapi/libEGL + the 34 MB llvmpipe/gallium rasteriser the glxtest probe loads)

The list is **bounded and safe**: each entry is a SONAME symlink that resolves on the data disk; an absent path caches 0 pages benignly (so it ships for both firefox-esr 115.x and firefox 132.x variants); it is ordered most-load-bearing-first and the bulk read is bounded by `prepopulate_file`'s existing PMM low-water guard, so a tight-memory boot sheds the tail (the 34 MB gallium first) rather than starving the kernel.

### P2 — Raise the ext2 read-coalescing cap `MAX_RUN_SECTORS` 512 → 4096 (`kernel/src/vfs/ext2.rs`)
256 KiB → 2 MiB per coalesced run, matching the 2 MiB page-cache prepopulate chunk. A disk-contiguous chunk now coalesces into a single ext2 run that virtio-blk splits into its 1 MiB (2048-sector) batches — 2 device round-trips instead of 8 per 2 MiB. At the 4 KiB block size the resulting `sector_count` is 4096, well inside the u16 request ABI. The destination is a sub-slice of the caller's already-contiguous buffer, so the physical-contiguity requirement is unchanged from the prior cap.

## Measurement (harness, SMP=1, Wikipedia, `ASTRYX_MEM_MIB=2048`, KVM)

Clean A/B, identical flags (`firefox-test-core,kdb --ff-gui --ff-url https://en.wikipedia.org/wiki/Firefox --smp 1`). md5-verified staged kernels (BEFORE `bb54e0ad…`, AFTER `48cc4150…`).

| Run | libxul precache | page-cache pages | post-launch → window | total → window |
|---|---|---|---|---|
| BEFORE (master) | 689 t | 32369 | ~5559 t (~55.6 s) | ~63 s |
| AFTER #1 | 647 t | **48391** | ~4813 t (~48.1 s) | ~57.7 s |
| AFTER #2 | 689 t | **48391** | ~4713 t (~47.1 s) | ~56.7 s |

(ticks = 100 Hz, since FF launch.)

- **P1 is the win:** the full closure now precaches (32369 → 48391 pages, +16022 pages in a ~2.2 s sequential burst), and the window maps **~7.5-8.5 s sooner post-launch** (consistent across both AFTER runs), netting **~5-6 s faster end-to-end** despite the +2.2 s extra precache.
- **P2 is non-regressive but modest here:** libxul precache (647-689 t) is within run-to-run noise on both sides — the precache is **transfer-rate-bound (~20 MB/s)**, not request-overhead-bound, under KVM. P2 still cuts the virtio request count ~4× on contiguous reads (fewer doorbell VM-exits / IRQs) and will matter more on slower/no-KVM transports. The task's predicted 4× precache speedup does not materialise because the bottleneck is the transfer rate, not the request count.
- No boot regression observed; both AFTER runs reach the FF browser window.

## Risk / correctness
- `/disk` is ext2 (verified), so P2 applies to the FF closure.
- P2 buffer-contiguity: `submit_request` builds one descriptor as `phys = virt - PHYS_OFFSET`, valid for the kernel-linear-mapped (heap) buffers used by `prepopulate_file`; raising the cap only lengthens the run within an already-contiguous buffer. The partition wrapper forwards `count` cleanly to virtio do_io (1 MiB batching is the binding downstream limit).
- `sector_count` max = 4096 ≪ u16 65535.

Refs: ext2 on-disk format; VIRTIO 1.2 §5.2 (block device); POSIX `read(2)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)