### PR TITLE
mm/heap: make the heap-canary corruption handler fault-immune (un-mask the real [HEAP CORRUPT] report)

### DIFF
--- a/kernel/src/mm/heap.rs
+++ b/kernel/src/mm/heap.rs
@@ -351,18 +351,45 @@ fn heap_corrupt_canary(
 /// `[rbp + 8]` per the System V AMD64 ABI §3.4.1 frame-pointer convention.
 ///
 /// This is a *hint* only — the kernel is built with `-fomit-frame-pointer` in
-/// some translation units, so the value may not be a true return address.  We
-/// only ever format it (never dereference it), so a garbage read is harmless,
-/// and on the common path (`heap_corrupt` keeps a frame pointer) it points at
-/// the alloc/dealloc call site that tripped the corruption check.
+/// some translation units, so `rbp` is a general scratch register there and
+/// may hold a non-pointer value.  Therefore we must **not** dereference `rbp`
+/// unconditionally: a `mov rax, [rbp+8]` on a garbage `rbp` page-faults, and
+/// because this helper runs inside the corruption *panic* path that fault
+/// replaces the located, greppable `[HEAP CORRUPT]` report with an opaque
+/// `KERNEL_PAGE_FAULT` bugcheck (observed under SMP=2 heavy render: `rbp` held
+/// `0x0000_0000_017a_f600`, so `[rbp+8]` faulted at CR2 `0x017a_f608`).
+///
+/// We therefore validate `rbp` as a canonical, 8-aligned higher-half kernel
+/// stack address before the load — the same guard `mm::cache::caller_rip`
+/// already applies (System V AMD64 ABI §3.2.2 stack alignment; the kernel
+/// higher-half begins at `0xFFFF_8000_0000_0000`).  If `rbp` is implausible
+/// the hint is simply unavailable and we return `0`, never faulting, so the
+/// `[HEAP CORRUPT]` panic always prints.
 #[inline(always)]
 fn caller_return_address() -> usize {
-    let ra: usize;
-    // SAFETY: read-only load through RBP; the value is only formatted into the
-    // panic string, never used as a pointer.  No memory is written.
+    let rbp: usize;
+    // SAFETY: reads the frame-pointer register only; no memory access.
     unsafe {
         core::arch::asm!(
-            "mov {ra}, [rbp + 8]",
+            "mov {rbp}, rbp",
+            rbp = out(reg) rbp,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    // A valid saved frame pointer on a kernel stack is non-null, 8-aligned and
+    // in the higher half.  Anything else is an `-fomit-frame-pointer` leftover
+    // — do not dereference it (return the "unavailable" sentinel 0).
+    if rbp == 0 || (rbp & 0x7) != 0 || rbp < 0xFFFF_8000_0000_0000 {
+        return 0;
+    }
+    let ra: usize;
+    // SAFETY: read-only load through a validated higher-half, 8-aligned RBP;
+    // the value is only formatted into the panic string, never used as a
+    // pointer.  No memory is written.
+    unsafe {
+        core::arch::asm!(
+            "mov {ra}, [{rbp} + 8]",
+            rbp = in(reg) rbp,
             ra = out(reg) ra,
             options(nostack, readonly, preserves_flags),
         );

--- a/scripts/autopsy/presets.yaml
+++ b/scripts/autopsy/presets.yaml
@@ -353,3 +353,54 @@ presets:
         reg: rsp
         offset: 0
         len: 256
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # heap-canary
+  # ───────────────────────────────────────────────────────────────────────────
+  # Break at heap::heap_corrupt_canary ENTRY (the kernel-heap red-zone
+  # corruption handler).  This handler is reached the instant a live
+  # allocation's front or rear canary is found clobbered on free; capturing
+  # it at ENTRY recovers the full corruption picture BEFORE the handler's own
+  # caller_return_address() read (mov [rbp+8]) can fault on an omit-frame-
+  # pointer rbp and mask the signal with a KERNEL_PAGE_FAULT.
+  #
+  # heap_corrupt_canary(reason: &str, block_start: usize, data_ptr: usize,
+  #                     found: u64, expected: u64, user_size: usize).
+  # By sysV AMD64 ABI §3.2.3 the args land in:
+  #   rdi = reason.ptr, rsi = reason.len, rdx = block_start, rcx = data_ptr,
+  #   r8  = found, r9 = expected; the 7th arg (user_size) is the first stacked
+  #   arg, at [rsp+8] at entry ([rsp] = return address of the dealloc caller).
+  # The AllocHeader (heap-canary build) is 32 B {block_start, block_size,
+  # user_size, front_canary} and sits immediately below data_ptr, so the
+  # front canary is at data_ptr-8.  Reading rcx-32..rcx+224 captures the whole
+  # header plus the start of the user region; r8 (found) is the clobber value
+  # and r9 (expected) names which edge (CANARY_FRONT vs CANARY_REAR).
+  heap-canary:
+    description: |
+      heap::heap_corrupt_canary entry.  rdx=block_start, rcx=data_ptr,
+      r8=found(clobber value), r9=expected(edge magic), [rsp]=dealloc caller
+      return addr, [rsp+8]=user_size.  Captures the AllocHeader + user-region
+      start at rcx, the reason string at rdi, and the FreeBlock origin at rdx.
+    steps:
+      - name: regs
+        kind: regs
+      - name: reason_str
+        kind: mem_via_reg
+        reg: rdi
+        offset: 0
+        len: 64
+      - name: alloc_header_and_data
+        kind: mem_via_reg
+        reg: rcx
+        offset: -32
+        len: 256
+      - name: block_origin
+        kind: mem_via_reg
+        reg: rdx
+        offset: -16
+        len: 96
+      - name: caller_and_usersize
+        kind: mem_via_reg
+        reg: rsp
+        offset: 0
+        len: 32


### PR DESCRIPTION
## Problem
Under SMP=2 heavy render (Firefox/Wikipedia), a kernel page fault was observed at `RIP=heap_corrupt_canary+0x24`, `CR2=0x017af608`, `error_code=0x0`, `Code=0xdead0006 (KERNEL_PAGE_FAULT)`, cascading into a re-entrant `RIP=0` bugcheck.

Root cause: the crash is the heap's **own corruption handler faulting**, not the corruptor. `heap_corrupt_canary` (the red-zone corruption reporter) calls `caller_return_address()` for a best-effort `caller_ret=` hint, which did `mov rax, [rbp+8]` **unconditionally**. The kernel is built with `-fomit-frame-pointer` in some translation units, so `rbp` is a general scratch register there and may hold a non-pointer value (observed `rbp = 0x0000_0000_017a_f600`). Dereferencing it page-faults — and because it runs inside the corruption *panic* path, that fault **replaces** the located, greppable `[HEAP CORRUPT] found=…/expected=…/block=…` report with an opaque `KERNEL_PAGE_FAULT`, discarding exactly the diagnostic needed to localize the writer.

## Fix
Validate `rbp` as a canonical, 8-aligned, higher-half kernel-stack address before the load — the same guard `mm::cache::caller_rip` already applies. If `rbp` is implausible the hint is simply unavailable (returns `0`), never faulting, so the `[HEAP CORRUPT]` panic always prints.

This is a **diagnostic-robustness** fix: it does not change the corruption itself, it makes the next occurrence self-diagnosing (a located `[HEAP CORRUPT]` line naming the victim block) instead of an opaque double-fault. Default builds are unaffected.

Also adds a `heap-canary` GDB-autopsy preset (`scripts/autopsy/presets.yaml`) capturing the handler's arguments at entry.

## Verification
- Disassembly-confirmed: the `+0x24` region no longer emits a bare `[rbp+8]` load (now `mov %rbp,%rax` + higher-half/align guard).
- 5× SMP=2 boots produced zero `0xdead0006`.

## Spec references
System V AMD64 ABI §3.2.2 / §3.4.1 (stack alignment / frame-pointer convention); Intel SDM Vol. 3A §6.12 (#PF semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)