### PR TITLE
kernel: de-gate per-syscall trace instrumentation out of the firefox-test-core fast profile

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -73,8 +73,12 @@ firefox-test-core = ["heap-canary"]
 # diagnostic — no correctness role.  Depends on `firefox-test-core` because the
 # trace emitters reuse core-only diagnostic plumbing (e.g. the syscall-ring
 # `dump_futex_wait_stack` rbp-chain walker) — trace is a strict superset of the
-# functional core, never a standalone.
-firefox-test-trace = ["firefox-test-core"]
+# functional core, never a standalone.  Also pulls `syscall-trace` so the heavy
+# per-syscall ring (heap-alloc Entry + user-stack-walk caller-RIP) and the kdb
+# syscall-trend producer stay ON for full-trace debugging boots — they were
+# moved OFF the fast `firefox-test-core` functional profile (a ~10^5 syscalls/s
+# fast-path tax) and behind the explicit `syscall-trace` opt-in.
+firefox-test-trace = ["firefox-test-core", "syscall-trace"]
 # Backward-compatible super-feature: `--features firefox-test` enables both the
 # functional core and the full diagnostic trace, so existing debugging
 # invocations are byte-identical to before this split.  Perf/render/CI boots

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1063,11 +1063,20 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
         crate::proc::proc_metrics::enter_syscall(_metrics_pid, num, tick);
     }
 
-    // ── Per-process syscall ring buffer (firefox-test only) ──────────────────
+    // ── Per-process syscall ring buffer (syscall-trace opt-in) ───────────────
     // Record the call at entry so that the path/return-value hooks inside
     // sys_read_linux / sys_open_linux can attach extra context before we
     // patch the return value after the match dispatch completes.
-    #[cfg(feature = "firefox-test-core")]
+    //
+    // This per-syscall entry HEAP-ALLOCATES a ring Entry (String + Vec) and
+    // reads the caller's return address via a user-stack walk
+    // (`get_user_caller_rip`) on every syscall — a heavy fast-path tax at a
+    // busy process's ~10^5 syscalls/sec.  It is diagnostic only, so gate it
+    // behind the explicit `syscall-trace` opt-in rather than the fast
+    // `firefox-test-core` functional profile.  `firefox-test`/`--trace` pull
+    // `syscall-trace` (see Cargo.toml), so full-trace debugging boots are
+    // unaffected; a bare `firefox-test-core` perf boot stays lean.
+    #[cfg(feature = "syscall-trace")]
     let ring_entry_idx = {
         let pid = crate::proc::current_pid_lockless();
         // Auto-track every user-process PID >= 1 that makes a Linux syscall —
@@ -1087,7 +1096,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
             None
         }
     };
-    #[cfg(not(feature = "firefox-test-core"))]
+    #[cfg(not(feature = "syscall-trace"))]
     let _ring_entry_idx: Option<usize> = None;
 
     // ── Transient debug trace: log Linux syscalls from user processes ─────────
@@ -1139,7 +1148,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     // sys_open_linux can attach path / read-content context to the pending
     // entry without needing to thread it through every syscall signature.
     // Syscalls are serialised per CPU, so a single atomic per CPU is safe.
-    #[cfg(feature = "firefox-test-core")]
+    #[cfg(feature = "syscall-trace")]
     crate::subsys::linux::syscall_ring::set_current_entry(ring_entry_idx);
 
     // Route through dispatch_body() so an early `return` inside any match
@@ -1148,7 +1157,7 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
     let ret: i64 = dispatch_body(num, arg1, arg2, arg3, arg4, arg5, arg6);
 
     // ── Close out the ring entry with the syscall's return value ─────────────
-    #[cfg(feature = "firefox-test-core")]
+    #[cfg(feature = "syscall-trace")]
     {
         let pid = crate::proc::current_pid_lockless();
         crate::syscall::ring::end(pid, ring_entry_idx, ret);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1022,8 +1022,13 @@ pub fn dispatch(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64,
 
     // kdb syscall-trend ring: append (tick, pid, nr) so the kdb
     // `syscall-trend` op can produce a per-PID histogram of recent activity.
-    // Wait-free; no allocation; produces zero overhead in non-kdb builds.
-    #[cfg(feature = "kdb")]
+    // Wait-free; no allocation — but the producer reads `get_ticks()`
+    // (rdtsc + a 64-bit divide) on EVERY syscall, which at a busy process's
+    // ~10^5 syscalls/sec is a measurable fast-path tax.  Gate it behind the
+    // explicit `syscall-trace` opt-in (in addition to `kdb`, which owns the
+    // ring storage) so a plain `kdb` boot — the common fast profiling build —
+    // pays nothing.  `kdb syscall-trend` therefore requires `syscall-trace`.
+    #[cfg(all(feature = "kdb", feature = "syscall-trace"))]
     {
         let pid = crate::proc::current_pid_lockless();
         crate::perf::record_syscall_event(pid, num);


### PR DESCRIPTION
## Problem
The `firefox-test-core[,kdb]` "fast" perf profile still paid heavy **per-syscall** trace instrumentation, firing at the measured Firefox busy-poll rate of **125–169 K syscalls/s**:
- the per-process syscall **ring** heap-allocates an Entry (String + Vec) *and* walks the user stack via `get_user_caller_rip` on every syscall, and
- the kdb **syscall-trend** producer calls `get_ticks()` (rdtsc + 64-bit divide) per syscall.

This is a #622-class mis-gate (debug instrumentation leaking into the fast profile). It burned ~6–9% of the core on pure instrumentation and inflated our own profiling numbers.

## Change (surgical, cfg-gating only — no ABI/behaviour/pixel change)
Move the heavy per-syscall instrumentation behind the explicit `syscall-trace` opt-in:
- `kernel/src/subsys/linux/syscall.rs` — the per-process ring (`ring_entry_idx`/`set_current_entry`/`ring::end`) re-gated `firefox-test-core` → `syscall-trace`.
- `kernel/src/syscall/mod.rs` — the kdb syscall-trend producer `record_syscall_event` re-gated `kdb` → `all(kdb, syscall-trace)`.
- `kernel/Cargo.toml` — `firefox-test-trace` / `--trace` / `firefox-test` now pull `syscall-trace`, so full-trace debugging is unchanged; only a bare `firefox-test-core[,kdb]` perf boot goes lean.

**Kept on the fast path** (mission-essential, cheap): `perf::record_syscall` (2 atomics), `proc::sample::record_syscall` (4 relaxed stores — feeds the silent-thread detector), `proc_metrics::enter_syscall`.

## Verification
- Both profiles compile (lean + trace). Lean kernel boots; kdb `proc-metrics` / `cpu-state` / `ff-progress` verified working; Firefox launched, connected X11, downloaded the page, ran clean.
- Measured reclaim: ~6–9% of the core (get_ticks 6%→~2% via 3 calls/syscall → 1; per-syscall ring heap-alloc + `get_user_caller_rip` gone from the hot set).
- Diagnostic-only; the busy-poll storm sc-rate is unchanged (167K vs 169K) — this does not change any observable Firefox behaviour, only removes profiling overhead from the fast profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)