### PR TITLE
net/unix: re-land peer-sever at teardown — stop slot-recycle cross-channel bleed (was #549)

### DIFF
--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -99,6 +99,21 @@ struct UnixSocket {
     /// the in-memory pipe.
     shut_rd:     bool,
     shut_wr:     bool,
+    /// "No more bytes will ever arrive" — set on this socket when its peer
+    /// performs `shutdown(SHUT_WR)` or fully closes.  Distinct from the local
+    /// `shut_rd` (SHUT_RD discards queued data and EOFs immediately per
+    /// IEEE 1003.1 §shutdown): with `rx_eof` the reader first DRAINS any
+    /// bytes already queued in `recv_buf` and only then observes the orderly
+    /// EOF — the recv(2) contract for a peer that performed an orderly
+    /// shutdown ("return 0 once all queued data is consumed").  Feeds the
+    /// `POLLIN`/`POLLRDHUP` readiness edges via [`read_shutdown`].
+    rx_eof:      bool,
+    /// The peer endpoint has FULLY closed (last open file description gone).
+    /// Set together with severing our `peer_id` back-pointer in [`close`], so
+    /// no code path can ever dereference the freed — and possibly RECYCLED —
+    /// peer slot through us.  Drives `POLLHUP` ([`fully_hung_up`]), the
+    /// always-writable EPIPE fast-path ([`writable`]), and write(2) → -EPIPE.
+    peer_closed: bool,
     /// Count of open file-description references to this socket slot.
     ///
     /// `socket(2)` / `socketpair(2)` initialise this to 1.  Every call that
@@ -148,6 +163,8 @@ impl UnixSocket {
             backlog_len: 0,
             shut_rd:     false,
             shut_wr:     false,
+            rx_eof:      false,
+            peer_closed: false,
             ref_count:   0,
             creator_pid: 0,
             creator_uid: 0,
@@ -169,6 +186,8 @@ impl UnixSocket {
         self.backlog_len = 0;
         self.shut_rd     = false;
         self.shut_wr     = false;
+        self.rx_eof      = false;
+        self.peer_closed = false;
         self.ref_count   = 0;
         self.creator_pid = 0;
         self.creator_uid = 0;
@@ -511,9 +530,28 @@ pub fn write(id: u64, data: &[u8]) -> i64 {
         if s.state != UnixState::Connected { return -32; }
         // SHUT_WR locally → -EPIPE per IEEE 1003.1 §shutdown.
         if s.shut_wr { return -32; }
+        // Peer fully closed → -EPIPE per POSIX write(2)/send(2) on a
+        // stream socket whose peer is gone.  (`peer_id` is severed to
+        // u64::MAX at peer teardown, so the bounds check below also
+        // catches this; the explicit flag keeps the intent readable.)
+        if s.peer_closed { return -32; }
         (s.peer_id, s.kind)
     };
     if peer_id as usize >= MAX_UNIX_SOCKETS { return -32; }
+    // Mutual-pairing gate: only deliver if the resolved peer slot still
+    // points back at US.  The socket table recycles slot indices the moment
+    // a slot's last reference is closed; a stale `peer_id` held across that
+    // recycling would otherwise inject this stream's bytes into an UNRELATED
+    // connection's receive ring (cross-channel corruption).  A connected
+    // pair is mutual by construction (socketpair(2)/connect(2)), so a
+    // mismatch can only mean "freed and possibly recycled" → the write must
+    // observe -EPIPE, exactly as if the peer had closed (POSIX send(2)).
+    {
+        let peer = &t.0[peer_id as usize];
+        if peer.state != UnixState::Connected || peer.peer_id != id {
+            return -32;
+        }
+    }
 
     if kind == SockKind::SeqPacket {
         // SEQPACKET: an entire message must fit in the receiver's ring AND
@@ -601,7 +639,14 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
     if s.kind == SockKind::SeqPacket {
         // SEQPACKET: dequeue exactly one message, truncating any tail that
         // does not fit per `man 7 unix` §SOCK_SEQPACKET.
-        if s.seq_head == s.seq_tail { return Err(-11); } // EAGAIN — no message
+        if s.seq_head == s.seq_tail {
+            // No queued message.  If the peer's write side is gone
+            // (orderly shutdown or full close), report EOF — but only
+            // AFTER the queue is empty: recv(2) requires queued data to
+            // be returned before the 0-byte orderly-shutdown indication.
+            if s.rx_eof { return Ok((0, 0)); }
+            return Err(-11); // EAGAIN — no message
+        }
         let msg_len = s.seq_lens[s.seq_head] as usize;
         s.seq_head = (s.seq_head + 1) % SEQ_QUEUE_CAP;
 
@@ -621,7 +666,13 @@ pub fn read_msg(id: u64, buf: &mut [u8]) -> Result<(usize, usize), i64> {
         result  = Ok((copied, discard));
     } else {
         // STREAM: byte-stream — copy as many bytes as fit, no boundaries.
-        if s.recv_available() == 0 { return Err(-11); }
+        if s.recv_available() == 0 {
+            // Drain-then-EOF (recv(2)): once the ring is empty AND the peer
+            // can never push more bytes (peer SHUT_WR or peer fully closed),
+            // the read observes the orderly EOF.  Queued bytes always win.
+            if s.rx_eof { return Ok((0, 0)); }
+            return Err(-11);
+        }
         let copied = s.pop(buf);
         drained = copied;
         result  = Ok((copied, 0));
@@ -660,7 +711,16 @@ pub fn shutdown(id: u64, shut_rd_flag: bool, shut_wr_flag: bool) -> i64 {
     if shut_rd_flag { s.shut_rd = true; }
     if shut_wr_flag { s.shut_wr = true; }
     if shut_wr_flag && (peer_id as usize) < MAX_UNIX_SOCKETS {
-        t.0[peer_id as usize].shut_rd = true;
+        let p = &mut t.0[peer_id as usize];
+        // Mutual-pairing gate (see `write`): never flip half-close state on
+        // a slot that no longer points back at us — after slot recycling it
+        // belongs to an UNRELATED connection, and a stale SHUT_WR here would
+        // EOF-kill that innocent stream.  Also: the peer's read direction is
+        // marked `rx_eof` (drain-then-EOF per recv(2)), NOT `shut_rd` —
+        // bytes we pushed before half-closing must remain readable.
+        if p.state == UnixState::Connected && p.peer_id == id {
+            p.rx_eof = true;
+        }
     }
     // Drop the table lock before ringing — per `man 2 shutdown` and
     // `man 7 unix`, a half-close surfaces on the peer as an orderly
@@ -704,10 +764,12 @@ pub fn inc_ref(id: u64) {
 /// "closing a file descriptor does not affect other file descriptors that
 /// refer to the same open file description".
 ///
-/// When the last reference is dropped we propagate the close as a
-/// half-shutdown to the connected peer — flipping its `shut_rd` so any
-/// subsequent local read on that peer returns 0 (orderly EOF) and any
-/// epoll/poll waiter observes `EPOLLHUP` / `POLLHUP`.  We ring
+/// When the last reference is dropped we propagate the close to the
+/// connected peer — marking it `rx_eof` (its reads drain any queued bytes,
+/// then return 0 orderly EOF per recv(2)) and `peer_closed` (its writes fail
+/// -EPIPE and any epoll/poll waiter observes `EPOLLHUP` / `POLLHUP`), and we
+/// SEVER its `peer_id` back-pointer to `u64::MAX` so no later path can
+/// dereference the slot index we are about to make recyclable.  We ring
 /// `PollBellSource::UnixShutdown` so any thread currently parked in
 /// `epoll_wait` / `poll` on the peer fd is woken in the same tick.
 pub fn close(id: u64) {
@@ -734,8 +796,24 @@ pub fn close(id: u64) {
     let mut ring = false;
     if (peer_id as usize) < MAX_UNIX_SOCKETS {
         let peer = &mut t.0[peer_id as usize];
-        if peer.state == UnixState::Connected {
-            peer.shut_rd = true;
+        // Mutual-pairing gate: only notify the peer if it still points back
+        // at the slot we just freed.  Slot indices are recycled the moment a
+        // slot's last reference drops; without this check, closing a STALE
+        // survivor (one whose own peer died earlier) would flip half-close
+        // state on whatever UNRELATED connection re-allocated the index.
+        if peer.state == UnixState::Connected && peer.peer_id == id {
+            // The peer survives us:
+            //  * `rx_eof` — its reads drain any queued bytes, then observe
+            //    the orderly EOF (recv(2): data first, then 0).
+            //  * `peer_closed` — its writes fail -EPIPE, poll reports
+            //    POLLHUP (full hang-up; POSIX poll(2)).
+            //  * SEVER its back-pointer: our slot index is about to become
+            //    recyclable, and any later dereference of it through the
+            //    survivor (write/shutdown/close/SCM enqueue) would reach an
+            //    unrelated connection.  u64::MAX fails every bounds check.
+            peer.rx_eof      = true;
+            peer.peer_closed = true;
+            peer.peer_id     = u64::MAX;
             ring = true;
         }
     }
@@ -771,9 +849,11 @@ pub fn has_data(id: u64) -> bool {
 }
 
 /// Returns true if the local read direction is at EOF — the RCV_SHUTDOWN
-/// equivalent.  This is set when the local side did `shutdown(SHUT_RD)`,
-/// the peer did `shutdown(SHUT_WR)`, or the peer `close()`d (all of which
-/// flip our `shut_rd`; see `shutdown()` / `close()` above).
+/// equivalent.  This is set when the local side did `shutdown(SHUT_RD)`
+/// (our `shut_rd`), or when the peer did `shutdown(SHUT_WR)` or fully
+/// `close()`d (our `rx_eof` — drain-then-EOF; see `shutdown()` / `close()`
+/// above).  Local SHUT_RD EOFs immediately (discarding queued data); a peer
+/// half-close/close returns queued bytes first, then the 0-byte EOF.
 ///
 /// This is a *read-direction half-close*: subsequent local `read()`s return
 /// 0 (orderly EOF) but the connection is NOT torn down and the local write
@@ -787,7 +867,11 @@ pub fn read_shutdown(id: u64) -> bool {
     let t = TABLE.lock();
     let s = &t.0[id as usize];
     if s.state == UnixState::Free { return true; }
-    s.shut_rd
+    // `rx_eof` (peer SHUT_WR or peer close) raises the same POLLIN/POLLRDHUP
+    // readiness edges as a local SHUT_RD: the read side can no longer block
+    // (queued bytes are returned, then 0).  Edge TIMING is identical to the
+    // pre-`rx_eof` behaviour, which flipped `shut_rd` directly.
+    s.shut_rd || s.rx_eof
 }
 
 /// Returns true on a *full* hang-up — the SHUTDOWN_MASK / TCP_CLOSE
@@ -798,13 +882,15 @@ pub fn read_shutdown(id: u64) -> bool {
 ///
 /// It is true when:
 ///   * our slot is `Free` (fully closed locally — TCP_CLOSE), or
-///   * the peer's slot is `Free` (peer fully closed — TCP_CLOSE), or
+///   * the peer fully closed (`peer_closed`, recorded at the peer's teardown
+///     — TCP_CLOSE; our `peer_id` back-pointer is severed to `u64::MAX` at
+///     that point, so the slot index must NOT be re-probed), or
 ///   * both directions have been shut down locally
 ///     (`shut_rd && shut_wr`, i.e. `SHUT_RDWR` — SHUTDOWN_MASK).
 ///
-/// A read-side-only half-close (peer `shutdown(SHUT_WR)`: our `shut_rd`
-/// set but `shut_wr` clear, both slots still `Connected`) is deliberately
-/// NOT a full hang-up — the write direction stays usable and only
+/// A read-side-only half-close (peer `shutdown(SHUT_WR)`: our `rx_eof` set
+/// but `shut_wr` clear, both slots still `Connected`) is deliberately NOT a
+/// full hang-up — the write direction stays usable and only
 /// [`read_shutdown`] fires.
 pub fn fully_hung_up(id: u64) -> bool {
     if id as usize >= MAX_UNIX_SOCKETS { return false; }
@@ -812,6 +898,10 @@ pub fn fully_hung_up(id: u64) -> bool {
     let s = &t.0[id as usize];
     if s.state == UnixState::Free { return true; }
     if s.shut_rd && s.shut_wr { return true; }
+    // Peer fully closed — recorded as a flag at teardown time (the peer's
+    // slot index is severed/recyclable, so probing `t.0[peer].state` would
+    // race with re-allocation and is no longer meaningful).
+    if s.peer_closed { return true; }
     let peer = s.peer_id;
     if peer == u64::MAX { return false; }
     if (peer as usize) >= MAX_UNIX_SOCKETS { return false; }
@@ -846,6 +936,7 @@ pub fn writable(id: u64) -> bool {
     if s.state == UnixState::Free { return true; }     // closed: write → EPIPE, no block
     if s.state != UnixState::Connected { return true; } // not connected: never blocks
     if s.shut_wr { return true; }                       // SHUT_WR: write → EPIPE, no block
+    if s.peer_closed { return true; }                   // peer gone: write → EPIPE, no block
     let kind = s.kind;
     let peer = s.peer_id;
     if peer == u64::MAX || (peer as usize) >= MAX_UNIX_SOCKETS { return true; }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -2475,6 +2475,27 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                 // drop-the-lock-before-ring discipline.
                                 crate::ipc::waitlist::ring_poll_bell_for(
                                     crate::ipc::waitlist::PollBellSource::UnixWrite);
+                            } else {
+                                // No receive queue to bind the batch to: the
+                                // peer is gone.  `scm_bind_peer_id` is u64::MAX
+                                // either because the fd is not a connected
+                                // AF_UNIX socket or because get_peer() was
+                                // SEVERED to u64::MAX at the peer's teardown
+                                // (net::unix::close).  The subsequent data push
+                                // returns -EPIPE, so nothing will ever deliver
+                                // or revoke this batch — release the per-object
+                                // references taken at clone time (unix inc_ref /
+                                // pipe add_writer/reader / regular-file
+                                // pin_inode) instead of dropping the cloned
+                                // descriptors on the floor.  Without this a
+                                // sendmsg(SCM_RIGHTS) racing a peer's full close
+                                // leaks a bounded ref/pin per passed fd
+                                // (CWE-772; unix(7)/recvmsg(2) SCM_RIGHTS:
+                                // undeliverable fds are dropped, mirroring
+                                // close(2) of a delivered copy).  Same release
+                                // as the revoke arms below and the receive-queue
+                                // drain in net::unix::close.
+                                crate::syscall::scm_drop_fds(sender_fds);
                             }
                         }
                     }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -803,6 +803,10 @@ pub fn run() -> ! {
     total += 1;
     if test_unix_pollout_writable_gate() { passed += 1; }
 
+    // ── AF_UNIX peer-close: sever pairing, drain-then-EOF, no recycle bleed ─
+    total += 1;
+    if test_unix_peer_close_sever_and_recycle() { passed += 1; }
+
     // ── Test 54: AF_UNIX bind/listen/connect/accept ───────────────────────
 
     total += 1;
@@ -15515,6 +15519,137 @@ fn test_writev_contiguous_prefix_on_short_write() -> bool {
     crate::syscall::dispatch_linux_kernel(3, fds[0] as u64, 0, 0, 0, 0, 0);
     crate::syscall::dispatch_linux_kernel(3, fds[1] as u64, 0, 0, 0, 0, 0);
     test_pass!("writev contiguous-prefix on AF_UNIX short write");
+    true
+}
+
+// ── AF_UNIX peer-close: sever pairing, drain-then-EOF, no recycle bleed ─────────
+//
+// Proves the slot-recycling safety contract of the global AF_UNIX socket table
+// against POSIX (recv(2), send(2), poll(2)) and `man 7 unix`:
+//   (1) Drain-then-EOF — bytes queued by the peer before it fully closed are
+//       still returned by read(); only THEN does read() report the orderly
+//       EOF (recv(2): queued data first, then 0).
+//   (2) write() on the survivor returns -EPIPE (peer gone), never "success
+//       into nowhere".
+//   (3) The survivor reports POLLHUP (fully_hung_up) + read_shutdown + writable
+//       (write can no longer block).
+//   (4) NO RECYCLE BLEED: after the dead peer's slot index is re-allocated to a
+//       brand-new pair, neither write() nor shutdown() nor close() on the stale
+//       survivor may touch the new pair — no injected bytes, no spurious EOF.
+//       (This was the live Gate-1 failure shape: a stale survivor's writes /
+//       half-close state landing on a freshly-spawned process's IPC channel.)
+fn test_unix_peer_close_sever_and_recycle() -> bool {
+    use crate::net::unix;
+    test_header!("AF_UNIX peer-close severing + slot-recycle isolation");
+    let creds = unix::PeerCreds { pid: 0, uid: 0, gid: 0 };
+
+    let (a, b) = unix::socketpair(unix::SockKind::Stream, creds);
+    if a == u64::MAX || b == u64::MAX {
+        test_fail!("unix_sever", "socketpair returned MAX");
+        return false;
+    }
+
+    // Queue 5 bytes b→a, then fully close b.  a's reads must drain the bytes
+    // FIRST and only then observe EOF.
+    let n = unix::write(b, b"HELLO");
+    if n != 5 {
+        test_fail!("unix_sever", "seed write returned {} (expected 5)", n);
+        unix::close(a); unix::close(b);
+        return false;
+    }
+    unix::close(b);
+
+    // (3) readiness edges on the survivor.
+    if !unix::read_shutdown(a) || !unix::fully_hung_up(a) || !unix::writable(a) {
+        test_fail!("unix_sever",
+            "survivor edges wrong: rdshut={} hup={} writable={}",
+            unix::read_shutdown(a), unix::fully_hung_up(a), unix::writable(a));
+        unix::close(a);
+        return false;
+    }
+    test_println!("  survivor: POLLIN/RDHUP+POLLHUP+writable edges ✓");
+
+    // (1) drain-then-EOF.
+    let mut buf = [0u8; 16];
+    let r1 = unix::read(a, &mut buf);
+    if r1 != 5 || &buf[..5] != b"HELLO" {
+        test_fail!("unix_sever",
+            "drain read returned {} (expected 5 queued bytes before EOF)", r1);
+        unix::close(a);
+        return false;
+    }
+    let r2 = unix::read(a, &mut buf);
+    if r2 != 0 {
+        test_fail!("unix_sever", "post-drain read returned {} (expected 0 EOF)", r2);
+        unix::close(a);
+        return false;
+    }
+    test_println!("  drain-then-EOF: 5 bytes then 0 ✓");
+
+    // (2) write → EPIPE.
+    let w = unix::write(a, b"X");
+    if w != -32 {
+        test_fail!("unix_sever", "write to dead peer returned {} (expected -EPIPE)", w);
+        unix::close(a);
+        return false;
+    }
+    test_println!("  write after peer close → -EPIPE ✓");
+
+    // (4) Recycle b's slot index into a fresh pair.  The allocator scans for
+    // the lowest Free slot, so one of (c, d) re-uses b's index.
+    let (c, d) = unix::socketpair(unix::SockKind::Stream, creds);
+    if c == u64::MAX || d == u64::MAX {
+        test_fail!("unix_sever", "recycle socketpair returned MAX");
+        unix::close(a);
+        return false;
+    }
+    if c != b && d != b {
+        // Environmental: another slot was free below b.  The severing already
+        // proved (get_peer == MAX); isolation cannot be exercised — pass with
+        // a note rather than fail spuriously.
+        test_println!("  note: fresh pair ({}, {}) did not re-use slot {} — \
+                       isolation leg skipped", c, d, b);
+    }
+    // Stale survivor must be fully severed: no path back to the recycled slot.
+    if unix::get_peer(a) != u64::MAX {
+        test_fail!("unix_sever", "survivor peer_id not severed: {}", unix::get_peer(a));
+        unix::close(a); unix::close(c); unix::close(d);
+        return false;
+    }
+    // Stale write must NOT inject into the new pair.
+    let _ = unix::write(a, b"INJECT");
+    if unix::bytes_available(c) != 0 || unix::bytes_available(d) != 0 {
+        test_fail!("unix_sever",
+            "stale write bled into recycled pair (avail c={} d={})",
+            unix::bytes_available(c), unix::bytes_available(d));
+        unix::close(a); unix::close(c); unix::close(d);
+        return false;
+    }
+    // Stale shutdown(SHUT_WR) and close must NOT flip EOF state on the new pair.
+    let _ = unix::shutdown(a, false, true);
+    unix::close(a);
+    if unix::read_shutdown(c) || unix::read_shutdown(d)
+        || unix::fully_hung_up(c) || unix::fully_hung_up(d)
+    {
+        test_fail!("unix_sever",
+            "stale shutdown/close bled into recycled pair (rdshut c={} d={})",
+            unix::read_shutdown(c), unix::read_shutdown(d));
+        unix::close(c); unix::close(d);
+        return false;
+    }
+    // New pair still fully functional.
+    let wn = unix::write(c, b"OK");
+    let mut nb = [0u8; 4];
+    let rn = unix::read(d, &mut nb);
+    unix::close(c); unix::close(d);
+    if wn != 2 || rn != 2 || &nb[..2] != b"OK" {
+        test_fail!("unix_sever",
+            "recycled pair round-trip broken (w={} r={})", wn, rn);
+        return false;
+    }
+    test_println!("  recycled pair isolated from stale survivor ✓");
+
+    test_pass!("AF_UNIX peer-close severing + slot-recycle isolation");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -15595,28 +15595,39 @@ fn test_unix_peer_close_sever_and_recycle() -> bool {
     }
     test_println!("  write after peer close → -EPIPE ✓");
 
-    // (4) Recycle b's slot index into a fresh pair.  The allocator scans for
-    // the lowest Free slot, so one of (c, d) re-uses b's index.
+    // (4) Recycle b's slot index into a fresh pair, DETERMINISTICALLY.  The
+    // allocator returns the two lowest Free slots, lowest first.  At the first
+    // socketpair, a and b were those two lowest-free slots (nothing free below
+    // a, nothing free between a and b); a is still occupied and nothing below b
+    // has been freed since, so after close(b) the lowest Free slot is exactly
+    // b's index.  Under the single-threaded test runner the recycle therefore
+    // MUST return c == b — we assert it rather than skip-with-note, so the
+    // isolation leg below is exercised against a genuinely recycled slot and
+    // never silently passes vacuously.
     let (c, d) = unix::socketpair(unix::SockKind::Stream, creds);
     if c == u64::MAX || d == u64::MAX {
         test_fail!("unix_sever", "recycle socketpair returned MAX");
         unix::close(a);
         return false;
     }
-    if c != b && d != b {
-        // Environmental: another slot was free below b.  The severing already
-        // proved (get_peer == MAX); isolation cannot be exercised — pass with
-        // a note rather than fail spuriously.
-        test_println!("  note: fresh pair ({}, {}) did not re-use slot {} — \
-                       isolation leg skipped", c, d, b);
+    if c != b {
+        // The recycle did not reuse b's freed index — the isolation leg would
+        // be untested (stale-survivor ops aimed at an unrelated slot).  This
+        // can only mean the slot allocator no longer returns lowest-free,
+        // which itself is worth surfacing.  Fail loudly, do not vacuously pass.
+        test_fail!("unix_sever",
+            "recycle did not reuse freed slot {}: fresh pair=({}, {})", b, c, d);
+        unix::close(a); unix::close(c); unix::close(d);
+        return false;
     }
+    test_println!("  recycled b's freed slot {} into fresh pair (c={}, d={}) ✓", b, c, d);
     // Stale survivor must be fully severed: no path back to the recycled slot.
     if unix::get_peer(a) != u64::MAX {
         test_fail!("unix_sever", "survivor peer_id not severed: {}", unix::get_peer(a));
         unix::close(a); unix::close(c); unix::close(d);
         return false;
     }
-    // Stale write must NOT inject into the new pair.
+    // Stale write must NOT inject into the new pair (c now occupies b's index).
     let _ = unix::write(a, b"INJECT");
     if unix::bytes_available(c) != 0 || unix::bytes_available(d) != 0 {
         test_fail!("unix_sever",


### PR DESCRIPTION
## Re-land — NDE

This change was originally merged as **PR #549** ("Gate-1 Finding A") on the
pre-rewrite history. The 2026-06-10 history rewrite orphaned that lineage and
this fix was never carried onto the rewritten `master`. The bug is live again
at HEAD: `kernel/src/net/unix.rs` has no `rx_eof`, no `peer_closed`, and
dereferences `peer_id` raw after teardown. This PR re-implements the fix,
reconciled with three weeks of drift (SEQPACKET slot-ring, SCM changes,
NDE-24 shutdown/backpressure work, and the ring-after-lock-drop poll-bell
discipline — all preserved). The removed kdb `unix-diag` surface is *not*
re-added (it no longer exists in the tree).

## The bug — slot-recycle cross-channel bleed

The AF_UNIX socket table recycles slot indices the instant a slot's last open
file description is closed. Teardown left the **surviving** endpoint's
`peer_id` pointing at the freed index. Once that index was re-allocated to an
unrelated connection, three things went wrong through the dangling back-pointer:

1. **`write(2)` bled into a foreign channel.** The stale survivor's writes
   pushed bytes into the *new* connection's receive ring (silent cross-channel
   stream corruption), and reported success where POSIX `send(2)`/`write(2)`
   on a peer-gone stream socket require `-EPIPE`.
2. **`shutdown(SHUT_WR)`/`close(2)` flipped EOF on a live stream.** Half-close
   state landed on the unrelated connection, delivering a spurious orderly
   hang-up that `poll(2)`/`recv(2)` observe as an EOF that never happened.
3. **Queued bytes were discarded at peer close.** The peer-close path marked
   the survivor `shut_rd`, which EOFs immediately — but `recv(2)` requires
   already-queued data to be returned *before* the 0-byte orderly-shutdown
   indication.

Under the multi-process Firefox launch this cascaded: a child holds AF_UNIX
IPC ends across a window where earlier short-lived connections close and their
indices recycle; one stale write/half-close on a fresh channel kills the
child's IPC handshake, the parent respawns, and the dead child's slots recycle
again.

## The fix (all under the existing `TABLE` lock)

- **`close()`** — mutual-pairing gate (`peer.peer_id == id`) before touching
  the peer; mark the survivor `rx_eof` + `peer_closed` and **sever** its
  `peer_id` to `u64::MAX` so no later path can dereference the recyclable index.
- **`shutdown(SHUT_WR)`** — same mutual-pairing gate; sets the peer's `rx_eof`
  (drain-then-EOF) rather than `shut_rd`.
- **`write()`** — mutual-pairing gate → `-EPIPE` on a stale/foreign peer;
  `peer_closed` → `-EPIPE` fast path.
- **`read_msg()`** — empty ring + `rx_eof` → orderly EOF, but queued bytes are
  always delivered first (`recv(2)` drain-then-EOF). Local `SHUT_RD` keeps its
  immediate-EOF semantics (IEEE 1003.1 `shutdown`).
- **`read_shutdown()`/`fully_hung_up()`/`writable()`** — `rx_eof`/`peer_closed`
  drive the `POLLIN`/`POLLRDHUP`/`POLLHUP`/`POLLOUT` edges with timing
  identical to the pre-fix peer-`Free` probes that severing makes unreachable,
  so the `PollBellSource::UnixShutdown` wake edges the poll/epoll layer depends
  on are unchanged.

## Recycle-safety invariant

Every dereference of `peer_id` is now provably safe against recycling:
severed to `u64::MAX` at teardown (fails every bounds check) **and** gated on
mutual pairing (`peer.state == Connected && peer.peer_id == id`) at each write/
shutdown/close site.

## Test (test-mode)

`test_unix_peer_close_sever_and_recycle` proves: (1) drain-then-EOF (queued
bytes then 0), (2) `-EPIPE` on write after peer close, (3) the survivor's
`POLLIN`/`POLLRDHUP` + `POLLHUP` + writable edges, and (4) recycle isolation —
after the dead peer's slot index is re-allocated to a fresh pair, a stale
`write`/`shutdown`/`close` on the survivor injects no bytes and flips no EOF
state on the new pair, which stays fully functional.

## Build

Both feature sets compile clean via `scripts/qemu-harness.py build`:
`test-mode` (`ok:true`) and `firefox-test-core` (`ok:true`). No local QEMU
booted this change — the in-kernel test suite runs under CI.

## Spec

POSIX.1-2017: `write(2)`, `send(2)`, `recv(2)`, `shutdown(2)`, `poll(2)`;
`man 7 unix`; `man 7 epoll` (`EPOLLRDHUP` vs `EPOLLHUP`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
