### PR TITLE
ipc/eventfd: per-open-file-description refcount across fork/dup/SCM (re-land Fix A of #545)

### DIFF
--- a/kernel/src/ipc/eventfd.rs
+++ b/kernel/src/ipc/eventfd.rs
@@ -56,6 +56,15 @@ struct EventFdEntry {
     counter: u64,
     flags:   u32,
     in_use:  bool,
+    /// Open-file-description reference count.  One reference per
+    /// `FileDescriptor` (in any process's fd table) that names this slot,
+    /// plus one per in-flight SCM_RIGHTS copy.  Per POSIX.1-2017 §2.14,
+    /// `fork(2)`, and `dup(2)`: duplicated descriptors refer to the SAME
+    /// open file description, and per `close(2)` the underlying object is
+    /// released only when the LAST descriptor referring to it is closed.
+    /// `create()` starts this at 1; `inc_ref()` bumps it on fork/dup/
+    /// SCM-enqueue; `close()` decrements and frees the slot only at zero.
+    refs:    u32,
     /// Monotonic readiness-rise generation.  Bumped on every counter
     /// `0 → non-zero` transition (a fresh not-ready→ready edge per
     /// `eventfd(2)` + `epoll(7)`), and never on a write that only grows an
@@ -72,7 +81,7 @@ struct EventFdEntry {
 
 impl EventFdEntry {
     const fn empty() -> Self {
-        Self { counter: 0, flags: 0, in_use: false, rise_seq: 0 }
+        Self { counter: 0, flags: 0, in_use: false, refs: 0, rise_seq: 0 }
     }
 }
 
@@ -104,10 +113,29 @@ pub fn create(initval: u64, flags: u32) -> u64 {
             slot.in_use  = true;
             slot.counter = initval;
             slot.flags   = flags;
+            slot.refs    = 1; // the creating fd's open-file-description ref
             return i as u64;
         }
     }
     u64::MAX // No free slot
+}
+
+/// Add one open-file-description reference to a live slot.
+///
+/// Call sites mirror the unix-socket / pipe refcount discipline:
+/// `fork(2)`/`clone(2)`-without-CLONE_FILES fd-table duplication,
+/// `dup(2)`/`dup2(2)`/`fcntl(F_DUPFD)`, and SCM_RIGHTS enqueue.  Per
+/// POSIX.1-2017 §2.14 the duplicate descriptor refers to the same open
+/// file description; without this bump the FIRST `close(2)` from either
+/// holder would free the shared counter slot, leaving the survivor with
+/// a dangling id that fails EBADF — or worse, lands on a recycled slot.
+pub fn inc_ref(id: u64) {
+    let mut table = TABLE.lock();
+    if let Some(slot) = table.get_mut(id as usize) {
+        if slot.in_use {
+            slot.refs = slot.refs.saturating_add(1);
+        }
+    }
 }
 
 /// Non-blocking read from eventfd.  Returns the current counter as a u64
@@ -218,17 +246,38 @@ pub fn write(id: u64, val: u64) -> Result<(), i64> {
     Ok(())
 }
 
-/// Free an eventfd slot.  Wakes every reader parked on the slot so they
+/// Drop one open-file-description reference; free the slot only when the
+/// LAST reference is released.  Per POSIX `close(2)`: "If fildes is the
+/// last file descriptor referring to the open file description, the
+/// resources associated with the open file description shall be
+/// released."  An eventfd inherited across `fork(2)` (or duplicated via
+/// `dup(2)`/SCM_RIGHTS) is one shared object with multiple references —
+/// a child's close (e.g. a pre-`execve(2)` close-on-exec scrub) must NOT
+/// destroy the counter the parent is still writing to.
+///
+/// On the final free, wakes every reader parked on the slot so they
 /// observe EBADF on the next try_read call rather than blocking
 /// indefinitely against a counter that nobody can ever post to.
 pub fn close(id: u64) {
-    {
+    let freed = {
         let mut table = TABLE.lock();
-        if let Some(slot) = table.get_mut(id as usize) {
-            *slot = EventFdEntry::empty();
+        match table.get_mut(id as usize) {
+            Some(slot) if slot.in_use => {
+                if slot.refs > 1 {
+                    slot.refs -= 1;
+                    false
+                } else {
+                    *slot = EventFdEntry::empty();
+                    true
+                }
+            }
+            // Not in use: double-close or stale id — nothing to drop.
+            _ => false,
         }
+    };
+    if freed {
+        wake_readers_all(id);
     }
-    wake_readers_all(id);
 }
 
 /// Check if counter > 0 (used by `poll` / `select`).
@@ -317,4 +366,13 @@ pub fn waiter_cleanup(efd_id: u64, tid: u64) {
 pub fn debug_reader_waiter_count(efd_id: u64) -> usize {
     let waiters = EVENTFD_READ_WAITERS.lock();
     waiters.get(&efd_id).map(|l| l.len()).unwrap_or(0)
+}
+
+/// Test-only diagnostic: returns the open-file-description reference
+/// count for `efd_id` (0 when the slot is free).
+pub fn debug_ref_count(efd_id: u64) -> u32 {
+    let table = TABLE.lock();
+    table.get(efd_id as usize)
+        .map(|s| if s.in_use { s.refs } else { 0 })
+        .unwrap_or(0)
 }

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2555,9 +2555,14 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // promptly.  Iterate a snapshot to avoid holding PROCESS_TABLE while calling
     // into PIPE_TABLE / unix socket TABLE (lock ordering: resource table before
     // PROCESS_TABLE).
-    let (pipe_ends, socket_ids): (alloc::vec::Vec<(u64, bool)>, alloc::vec::Vec<u64>) = {
+    let (pipe_ends, socket_ids, eventfd_ids): (
+        alloc::vec::Vec<(u64, bool)>,
+        alloc::vec::Vec<u64>,
+        alloc::vec::Vec<u64>,
+    ) = {
         let procs = PROCESS_TABLE.lock();
-        let (mut pipes, mut sockets) = (alloc::vec::Vec::new(), alloc::vec::Vec::new());
+        let (mut pipes, mut sockets, mut eventfds) =
+            (alloc::vec::Vec::new(), alloc::vec::Vec::new(), alloc::vec::Vec::new());
         if let Some(p) = procs.iter().find(|p| p.pid == pid) {
             for f in p.file_descriptors.iter().filter_map(|f| f.as_ref()) {
                 if f.file_type == crate::vfs::FileType::Pipe
@@ -2569,10 +2574,12 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
                     && f.flags & crate::syscall::UNIX_SOCKET_FLAG != 0
                 {
                     sockets.push(f.inode);
+                } else if f.file_type == crate::vfs::FileType::EventFd {
+                    eventfds.push(f.inode);
                 }
             }
         }
-        (pipes, sockets)
+        (pipes, sockets, eventfds)
     };
     for (pipe_id, is_write) in pipe_ends {
         if is_write {
@@ -2585,6 +2592,13 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // close tears the slot down and notifies the peer.
     for socket_id in socket_ids {
         crate::net::unix::close(socket_id);
+    }
+    // Drop the exiting process's eventfd open-file-description refs; the
+    // slot is freed only when the last reference (e.g. a parent's fd in
+    // the inherited case) goes away — per POSIX close(2) last-reference
+    // semantics, mirroring the socket/pipe handling above.
+    for efd_id in eventfd_ids {
+        crate::ipc::eventfd::close(efd_id);
     }
 
     // Release POSIX file locks held by this process (C1).
@@ -3215,6 +3229,24 @@ fn inc_pipe_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
     }
 }
 
+/// Bump the eventfd open-file-description refcount for every eventfd fd
+/// the child inherits via fork/vfork/clone-without-`CLONE_FILES`.  Same
+/// rationale as `inc_socket_refs_for_fork` / `inc_pipe_refs_for_fork`:
+/// per POSIX.1-2017 §2.14 and `fork(2)`, the duplicated descriptors refer
+/// to the same open file description, so each inherited eventfd fd must
+/// count as one more reference.  Without this bump, the child's
+/// close-on-exec scrub (a plain `close(2)` loop before `execve(2)`) frees
+/// the parent's live counter slot — the parent's next `write(2)` to its
+/// own fd then fails EBADF, and a later `eventfd2(2)` recycles the slot
+/// out from under the stale id (CWE-416 class via slot reuse).
+fn inc_eventfd_refs_for_fork(fds: &[Option<crate::vfs::FileDescriptor>]) {
+    for fd in fds.iter().filter_map(|f| f.as_ref()) {
+        if fd.file_type == crate::vfs::FileType::EventFd {
+            crate::ipc::eventfd::inc_ref(fd.inode);
+        }
+    }
+}
+
 /// Drop the pipe-end refcount associated with a single `FileDescriptor`
 /// that is about to be cleared (e.g. by `close(2)`, by `execve(2)`'s
 /// `FD_CLOEXEC` purge, or by `dup2(2)` overwriting an existing slot).
@@ -3301,6 +3333,9 @@ pub fn fork_process(parent_pid: Pid, _parent_tid: Tid, parent_regs: &ForkUserReg
     // purges its CLOEXEC fd, so parent's `read` would see premature EOF
     // (or worse, refcount underflow on the second close).
     inc_pipe_refs_for_fork(&fds);
+    // And eventfd slots — the child's pre-exec close-on-exec scrub must
+    // not free a counter the parent still posts to (AudioIPC waker case).
+    inc_eventfd_refs_for_fork(&fds);
 
     // Enforce RLIMIT_NPROC: count non-zombie processes.
     {
@@ -3568,6 +3603,8 @@ pub fn fork_process_share_vm(
     // (and any other inherited pipe end) survives until BOTH the parent's
     // copy AND the child's copy are closed.  See `inc_pipe_refs_for_fork`.
     inc_pipe_refs_for_fork(&fds);
+    // And eventfd open-file-description refs (see `inc_eventfd_refs_for_fork`).
+    inc_eventfd_refs_for_fork(&fds);
 
     // RLIMIT_NPROC.
     {
@@ -4275,6 +4312,8 @@ pub fn vfork_process(parent_pid: Pid, parent_tid: Tid, parent_regs: &ForkUserReg
     inc_socket_refs_for_fork(&fds);
     // And pipe fd refcounts.
     inc_pipe_refs_for_fork(&fds);
+    // And eventfd open-file-description refs (see `inc_eventfd_refs_for_fork`).
+    inc_eventfd_refs_for_fork(&fds);
 
     // Get parent's TLS base from thread struct.
     let parent_tls = {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -1289,7 +1289,12 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let socket_id = crate::syscall::get_socket_id(pid, fd);
                 crate::net::socket::socket_close(socket_id);
             }
-            // If it's an eventfd, free the counter slot.
+            // If it's an eventfd, drop one open-file-description reference.
+            // The counter slot is freed only when the LAST reference goes
+            // away (POSIX close(2)) — an eventfd inherited across fork(2)
+            // or duplicated via dup(2)/SCM_RIGHTS is one shared object, so
+            // a child's pre-execve close-on-exec scrub must not destroy
+            // the counter the parent still writes to.
             if crate::syscall::is_eventfd_fd(pid, fd) {
                 let efd_id = crate::syscall::get_eventfd_id(pid, fd);
                 crate::ipc::eventfd::close(efd_id);
@@ -2414,6 +2419,17 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                                                 // on drain (scm_drop_fds path).
                                                 crate::vfs::pin_inode(
                                                     fdesc.mount_idx, fdesc.inode);
+                                            } else if fdesc.file_type
+                                                == crate::vfs::FileType::EventFd
+                                            {
+                                                // The in-flight copy is one more
+                                                // reference to the same open file
+                                                // description (unix(7) SCM_RIGHTS);
+                                                // balanced by the receiver's later
+                                                // close(2), or by scm_drop_fds if
+                                                // the batch is never received.
+                                                crate::ipc::eventfd::inc_ref(
+                                                    fdesc.inode);
                                             }
                                         }
                                         cloned

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -666,7 +666,9 @@ pub fn scm_drain_receiver(receiver_id: u64) -> Vec<crate::vfs::FileDescriptor> {
 ///     (`vfs::pin_inode`); when that was the last reference to a deferred-
 ///     deleted (unlinked) memfd, the inode is freed by `unpin_inode`.  Without
 ///     this the pin (and thus the inode) would leak forever.
-///   * eventfd / other sentinel fds → no per-object refcount to balance.
+///   * eventfd → drop one open-file-description reference
+///     (`ipc::eventfd::close`); the counter slot is freed on the last drop.
+///   * other sentinel fds → no per-object refcount to balance.
 ///
 /// MUST be called with no unix `TABLE` / `PENDING_SCM` lock held — it re-enters
 /// `net::unix::close`, which takes the unix TABLE lock.
@@ -689,8 +691,11 @@ pub fn scm_drop_fds(fds: Vec<crate::vfs::FileDescriptor>) {
             && fd.mount_idx != usize::MAX
         {
             crate::vfs::unpin_inode(fd.mount_idx, fd.inode);
+        } else if fd.file_type == crate::vfs::FileType::EventFd {
+            // Balance the inc_ref taken at SCM enqueue time.
+            crate::ipc::eventfd::close(fd.inode);
         }
-        // eventfds / other sentinel fds: no per-object refcount to drop.
+        // Other sentinel fds: no per-object refcount to drop.
     }
 }
 
@@ -1726,6 +1731,14 @@ pub(crate) fn sys_exec(path_ptr: u64, path_len: u64, argv_ptr: u64, envp_ptr: u6
                             && f.flags & crate::syscall::UNIX_SOCKET_FLAG != 0
                         {
                             crate::net::unix::close(f.inode);
+                        }
+                        // Drop the eventfd open-file-description ref too —
+                        // the slot is freed only on the LAST reference
+                        // (POSIX close(2)), so a CLOEXEC-marked eventfd
+                        // inherited from the parent does not destroy the
+                        // counter the parent still posts to.
+                        if f.file_type == crate::vfs::FileType::EventFd {
+                            crate::ipc::eventfd::close(f.inode);
                         }
                     }
                 }
@@ -4095,6 +4108,12 @@ pub(crate) fn sys_dup(old_fd: usize) -> i64 {
             crate::ipc::pipe::pipe_add_reader(fd_clone.inode);
         }
     }
+    // And eventfd slots — the duplicate is one more reference to the same
+    // open file description (POSIX.1-2017 §2.14 / dup(2)); close(2) frees
+    // the counter slot only when the last reference drops.
+    if fd_clone.file_type == crate::vfs::FileType::EventFd {
+        crate::ipc::eventfd::inc_ref(fd_clone.inode);
+    }
 
     // Find lowest free fd
     for i in 0..proc.file_descriptors.len() {
@@ -4156,6 +4175,10 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
             crate::ipc::pipe::pipe_add_reader(fd_clone.inode);
         }
     }
+    // And eventfd slots (same open-file-description rule as sys_dup).
+    if fd_clone.file_type == crate::vfs::FileType::EventFd {
+        crate::ipc::eventfd::inc_ref(fd_clone.inode);
+    }
 
     // Grow the table if needed
     while proc.file_descriptors.len() <= new_fd {
@@ -4173,6 +4196,10 @@ pub(crate) fn sys_dup2(old_fd: usize, new_fd: usize) -> i64 {
             && prev.flags & UNIX_SOCKET_FLAG != 0
         {
             crate::net::unix::close(prev.inode);
+        }
+        // A displaced eventfd loses one open-file-description ref too.
+        if prev.file_type == crate::vfs::FileType::EventFd {
+            crate::ipc::eventfd::close(prev.inode);
         }
     }
     proc.file_descriptors[new_fd] = Some(fd_clone);

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1514,6 +1514,19 @@ pub fn run() -> ! {
         if test_295b_proc_fd_sentinel_reopen_no_uaf() { passed += 1; }
     }
 
+    // ── Test 297: eventfd open-file-description refcount across fork/dup ───
+    // Per POSIX.1-2017 §2.14, fork(2), and dup(2): duplicate descriptors
+    // refer to the SAME open file description, and per close(2) the object
+    // is released only when the LAST reference is closed.  An eventfd
+    // inherited across fork is one shared counter with two references; the
+    // child's pre-execve close-on-exec scrub must NOT free the slot the
+    // parent still writes to.  Refs: close(2), fork(2), dup(2), eventfd(2).
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_297_eventfd_ofd_refcount() { passed += 1; }
+    }
+
     // ── Test 629: compositor rate-gate + damage-driven recompose ───────────
     // The cooperative BSP poll loop calls the compositor at spin rate.  The
     // rate gate (`compose_due_decision`) must (a) cap repaints to the minimum
@@ -48035,6 +48048,320 @@ fn test_295_proc_fd_memfd_reopen() -> bool {
     crate::subsys::linux::syscall::sys_close_test(memfd as u64);
     test_pass!("/proc/self/fd/N reopen of an unlinked memfd succeeds + reads contents");
     true
+}
+
+// ── Test 297: eventfd open-file-description refcount across fork/dup ─────────
+//
+// Per POSIX.1-2017 §2.14, fork(2), and dup(2): duplicated file descriptors
+// refer to the SAME open file description; per close(2), "If fildes is the
+// last file descriptor referring to the open file description, the resources
+// associated with the open file description shall be released" — i.e. only
+// the LAST close frees the object.  An eventfd inherited across fork(2) is
+// one shared counter with two references: the child's pre-execve(2)
+// close-on-exec scrub (a plain close(2) loop) must NOT free the slot the
+// parent still writes to.  Without the refcount, the child's scrub freed the
+// parent's waker slot, the parent's next write(2) returned EBADF, and a later
+// eventfd2(2) recycled the slot under the stale id (CWE-416 class via reuse).
+//
+// Coverage drives the REAL inc/dec call sites end to end so a future
+// regression that drops a dec (re-introducing the LEAK direction) fails here,
+// not just by inspection: Part 2 the close(2)/dup(2) dispatch arms, Part 2b
+// the dup2(2) displaced-slot dec, Part 3 the scm_drop_fds SCM-drop dec, and
+// Part 4 fork_process (real fork inc) -> exit_group teardown (real exit dec).
+// Refs: close(2), fork(2), dup(2), eventfd(2), unix(7) SCM_RIGHTS.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_297_eventfd_ofd_refcount() -> bool {
+    test_header!("eventfd OFD refcount across fork/dup (Test 297)");
+    let dispatch = crate::syscall::dispatch_linux_kernel;
+    let mut ok = true;
+
+    // Linux ABI for this process (eventfd/dup are Linux-personality calls).
+    let pid = crate::proc::current_pid();
+    {
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        if let Some(p) = procs.iter_mut().find(|p| p.pid == pid) {
+            p.linux_abi = true;
+            p.subsystem = crate::win32::SubsystemType::Linux;
+        }
+    }
+
+    // ── Part 1: module level — simulated fork inheritance ───────────────────
+    // create() takes the creating fd's reference; inc_ref() is exactly what
+    // `inc_eventfd_refs_for_fork` does for each inherited eventfd fd; the
+    // first close() models the child's CLOEXEC scrub.
+    {
+        use crate::ipc::eventfd;
+        let id = eventfd::create(0, 0);
+        if id == u64::MAX {
+            test_fail!("efd-refs", "create() returned no slot");
+            return false;
+        }
+        if eventfd::debug_ref_count(id) != 1 {
+            test_fail!("efd-refs", "refs after create = {} (want 1)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        eventfd::inc_ref(id); // fork: child inherits the fd
+        if eventfd::debug_ref_count(id) != 2 {
+            test_fail!("efd-refs", "refs after fork-inherit = {} (want 2)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        eventfd::close(id);   // child's CLOEXEC scrub close(2)
+        // THE regression: parent's write must still succeed (was Err(-9)
+        // EBADF — the child's close freed the shared slot).
+        match eventfd::write(id, 1) {
+            Ok(()) => test_println!("  parent write after child close -> Ok"),
+            Err(e) => {
+                test_fail!("efd-refs",
+                    "parent write after child close = {} (want Ok) — \
+                     child close freed the shared slot", e);
+                ok = false;
+            }
+        }
+        if !eventfd::is_readable(id) {
+            test_fail!("efd-refs", "slot not readable after parent write");
+            ok = false;
+        }
+        eventfd::close(id);   // parent's close — the LAST reference
+        if eventfd::write(id, 1) != Err(-9) {
+            test_fail!("efd-refs", "write after last close should be EBADF");
+            ok = false;
+        }
+        if eventfd::debug_ref_count(id) != 0 {
+            test_fail!("efd-refs", "refs after last close = {} (want 0)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        if ok {
+            test_println!("  simulated fork: 1->2->1->0 refs, free on last close");
+        }
+    }
+
+    // ── Part 1b: last-close frees; the freed slot is reusable ───────────────
+    // Documents the recycle the refcount protects: only after the LAST close
+    // is a slot available for reuse.  NOTE: eventfd ids are bare slot indices
+    // with no generation tag, so a genuinely-recycled slot cannot reject a
+    // stale id — Fix A's guarantee is that a premature free never happens, so
+    // no live holder is ever left holding an id whose slot got reused (a
+    // generation tag to reject truly-stale ids is a possible follow-up).
+    {
+        use crate::ipc::eventfd;
+        let a = eventfd::create(0, 0);
+        eventfd::close(a);                 // last ref -> freed
+        let b = eventfd::create(0, 0);     // may reuse slot `a`
+        if eventfd::debug_ref_count(b) != 1 {
+            test_fail!("efd-refs", "refs on recycled slot = {} (want 1)",
+                eventfd::debug_ref_count(b));
+            ok = false;
+        }
+        eventfd::close(b);
+    }
+
+    // ── Part 2: syscall level — dup(2) bumps, close(2) arm drops ────────────
+    {
+        const SYS_EVENTFD2: u64 = 290;
+        const SYS_DUP:      u64 = 32;
+        const SYS_CLOSE:    u64 = 3;
+        const SYS_WRITE:    u64 = 1;
+        const SYS_READ:     u64 = 0;
+
+        let efd = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+        if efd < 0 {
+            test_fail!("efd-refs", "eventfd2 = {}", efd);
+            return false;
+        }
+        let id = crate::syscall::get_eventfd_id(pid, efd as usize);
+        let dupfd = dispatch(SYS_DUP, efd as u64, 0, 0, 0, 0, 0);
+        if dupfd < 0 {
+            test_fail!("efd-refs", "dup(eventfd) = {}", dupfd);
+            ok = false;
+        }
+        if crate::ipc::eventfd::debug_ref_count(id) != 2 {
+            test_fail!("efd-refs", "refs after dup = {} (want 2)",
+                crate::ipc::eventfd::debug_ref_count(id));
+            ok = false;
+        }
+        // Close the ORIGINAL fd through the real close(2) dispatch arm —
+        // the duplicate must keep the slot alive.
+        let r = dispatch(SYS_CLOSE, efd as u64, 0, 0, 0, 0, 0);
+        if r != 0 {
+            test_fail!("efd-refs", "close(efd) = {}", r);
+            ok = false;
+        }
+        let v: u64 = 7;
+        let w = dispatch(SYS_WRITE, dupfd as u64, (&v as *const u64) as u64, 8, 0, 0, 0);
+        if w == 8 {
+            test_println!("  write via dup'd fd after close(original) -> 8");
+        } else {
+            test_fail!("efd-refs",
+                "write via dup'd fd after close(original) = {} (want 8)", w);
+            ok = false;
+        }
+        let mut rbuf = [0u8; 8];
+        let n = dispatch(SYS_READ, dupfd as u64, rbuf.as_mut_ptr() as u64, 8, 0, 0, 0);
+        if n != 8 || u64::from_le_bytes(rbuf) != 7 {
+            test_fail!("efd-refs", "read via dup'd fd = {} val={} (want 8/7)",
+                n, u64::from_le_bytes(rbuf));
+            ok = false;
+        }
+        let _ = dispatch(SYS_CLOSE, dupfd as u64, 0, 0, 0, 0, 0);
+        if crate::ipc::eventfd::debug_ref_count(id) != 0 {
+            test_fail!("efd-refs", "refs after closing both fds = {} (want 0)",
+                crate::ipc::eventfd::debug_ref_count(id));
+            ok = false;
+        }
+    }
+
+    // ── Part 2b: dup2(2) displaced-slot drop (real dispatch dec) ────────────
+    // dup2 onto an fd that already names a DIFFERENT eventfd must close the
+    // displaced eventfd (POSIX dup2(2): fildes2 "shall be closed first").
+    // Drives the sys_dup2 inc AND the displaced-slot dec through the real
+    // dispatch arm — a regression dropping either fails here.
+    {
+        const SYS_EVENTFD2: u64 = 290;
+        const SYS_DUP2:     u64 = 33;
+        const SYS_CLOSE:    u64 = 3;
+
+        let fd_a = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+        let fd_b = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+        if fd_a < 0 || fd_b < 0 {
+            test_fail!("efd-refs", "eventfd2 (dup2 subcase) a={} b={}", fd_a, fd_b);
+            return false;
+        }
+        let id_a = crate::syscall::get_eventfd_id(pid, fd_a as usize);
+        let id_b = crate::syscall::get_eventfd_id(pid, fd_b as usize);
+        // dup2(fd_a -> fd_b): fd_b's eventfd (id_b) is displaced+closed
+        // (refs 1->0, freed); id_a gains the duplicate (refs 1->2).
+        let r = dispatch(SYS_DUP2, fd_a as u64, fd_b as u64, 0, 0, 0, 0);
+        if r != fd_b {
+            test_fail!("efd-refs", "dup2 = {} (want {})", r, fd_b);
+            ok = false;
+        }
+        if crate::ipc::eventfd::debug_ref_count(id_b) != 0 {
+            test_fail!("efd-refs",
+                "refs on displaced eventfd = {} (want 0 — dup2 displaced-slot dec)",
+                crate::ipc::eventfd::debug_ref_count(id_b));
+            ok = false;
+        }
+        if crate::ipc::eventfd::debug_ref_count(id_a) != 2 {
+            test_fail!("efd-refs", "refs after dup2 = {} (want 2 — dup2 inc)",
+                crate::ipc::eventfd::debug_ref_count(id_a));
+            ok = false;
+        } else {
+            test_println!("  dup2 inc (1->2) + displaced-slot dec (1->0) via dispatch ✓");
+        }
+        // Both fd_a and fd_b now name id_a; close both to release it.
+        let _ = dispatch(SYS_CLOSE, fd_a as u64, 0, 0, 0, 0, 0);
+        let _ = dispatch(SYS_CLOSE, fd_b as u64, 0, 0, 0, 0, 0);
+    }
+
+    // ── Part 3: SCM_RIGHTS enqueue -> drop round trip (real scm_drop_fds) ───
+    // An eventfd passed via SCM_RIGHTS is inc_ref'd at enqueue; if the batch
+    // is never received, scm_drop_fds must balance it (unix(7) SCM_RIGHTS).
+    // Build the in-flight descriptor the enqueue path would create, inc_ref
+    // exactly as the enqueue does, then drive the REAL scm_drop_fds so a
+    // regression dropping its eventfd arm re-introduces the leak and fails
+    // here (not just by inspection).
+    {
+        use crate::ipc::eventfd;
+        let id = eventfd::create(0, 0);   // refs = 1 (the sender's fd)
+        if id == u64::MAX {
+            test_fail!("efd-refs", "create() (SCM subcase) returned no slot");
+            return false;
+        }
+        eventfd::inc_ref(id);             // SCM enqueue inc: refs = 2
+        let fd = crate::vfs::FileDescriptor {
+            mount_idx:  usize::MAX,
+            inode:      id,
+            offset:     0,
+            flags:      0x0001_0000,      // eventfd flag bit (see sys_eventfd_linux)
+            is_console: false,
+            cloexec:    false,
+            file_type:  crate::vfs::FileType::EventFd,
+            open_path:  alloc::string::String::new(),
+        };
+        crate::syscall::scm_drop_fds(alloc::vec![fd]); // real drop: refs 2->1
+        if eventfd::debug_ref_count(id) != 1 {
+            test_fail!("efd-refs",
+                "refs after scm_drop_fds = {} (want 1 — SCM-drop dec)",
+                eventfd::debug_ref_count(id));
+            ok = false;
+        } else {
+            test_println!("  SCM enqueue inc (1->2) + scm_drop_fds dec (2->1) ✓");
+        }
+        eventfd::close(id);               // release the create ref: 1 -> 0
+    }
+
+    // ── Part 4: fork(2) inherit -> child exit_group teardown (real decs) ────
+    // The leak direction the whole re-land exists to prevent: fork_process
+    // bumps the shared eventfd's ref via inc_eventfd_refs_for_fork, and the
+    // child's process-exit teardown drops it — so a regression that removes
+    // the exit-teardown dec (or the fork inc) fails HERE, not just by
+    // inspection.  `exit_group_pid` is the sanctioned out-of-band teardown
+    // entry for a synthetic target process (yield_self=false: the caller
+    // returns normally after driving the child's full teardown).
+    //
+    // NOTE: the execve(2) FD_CLOEXEC purge dec (a distinct call site) is not
+    // driven here — driving a real execve in-kernel replaces the address
+    // space and needs a target program — but it invokes the SAME
+    // `eventfd::close` refcounted dec proven by Parts 1/2/4, so a regression
+    // there would still surface a refcount imbalance under any CLOEXEC-eventfd
+    // workload.  Left to inspection + the exit/close coverage above.
+    {
+        const SYS_EVENTFD2: u64 = 290;
+        const SYS_CLOSE:    u64 = 3;
+
+        let efd = dispatch(SYS_EVENTFD2, 0, 0, 0, 0, 0, 0);
+        if efd < 0 {
+            test_fail!("efd-refs", "eventfd2 (fork subcase) = {}", efd);
+            return false;
+        }
+        let id = crate::syscall::get_eventfd_id(pid, efd as usize);
+        let ptid = crate::proc::current_tid();
+        match crate::proc::fork_process(pid, ptid, &crate::proc::ForkUserRegs::default()) {
+            Some((child_pid, _child_tid)) => {
+                // fork_process copies the fd table and inc_eventfd_refs_for_fork
+                // bumps the shared eventfd's ref: 1 -> 2.
+                if crate::ipc::eventfd::debug_ref_count(id) != 2 {
+                    test_fail!("efd-refs",
+                        "refs after fork = {} (want 2 — inc_eventfd_refs_for_fork)",
+                        crate::ipc::eventfd::debug_ref_count(id));
+                    ok = false;
+                }
+                // Child _exit(0): the real exit teardown loop drops the child's
+                // inherited eventfd ref: 2 -> 1 (the parent's fd still holds it).
+                crate::proc::exit_group_pid(child_pid, 0);
+                if crate::ipc::eventfd::debug_ref_count(id) != 1 {
+                    test_fail!("efd-refs",
+                        "refs after child exit = {} (want 1 — exit-teardown dec)",
+                        crate::ipc::eventfd::debug_ref_count(id));
+                    ok = false;
+                } else {
+                    test_println!(
+                        "  fork inherit (1->2) + child exit_group teardown (2->1) ✓");
+                }
+                // Reap the zombie child so it does not leak a table slot.
+                let _ = crate::proc::waitpid(pid, child_pid as i64);
+            }
+            None => {
+                test_println!(
+                    "  fork_process returned None — exit-teardown dec left to inspection");
+            }
+        }
+        // The parent's own close drops the last reference: 1 -> 0.
+        let _ = dispatch(SYS_CLOSE, efd as u64, 0, 0, 0, 0, 0);
+        if crate::ipc::eventfd::debug_ref_count(id) != 0 {
+            test_fail!("efd-refs", "refs after parent close = {} (want 0)",
+                crate::ipc::eventfd::debug_ref_count(id));
+            ok = false;
+        }
+    }
+
+    if ok {
+        test_pass!("eventfd OFD refcount across fork/dup (Test 297)");
+    }
+    ok
 }
 
 /// Test 295b — reopening /proc/self/fd/<N> for a SENTINEL fd (eventfd) must


### PR DESCRIPTION
## Summary

Re-lands **Fix A** of the original **PR #545**, which merged on the pre-rewrite history and was **not carried across the 2026-06-10 history rewrite**. Fix B of that PR (EPOLLET wakeup-driven re-fire) was separately re-landed as **#605 / #609** via the rise-generation mechanism and is intentionally **not** duplicated here.

## The bug

An eventfd slot was freed unconditionally on the **first** `close(2)`, while `fork(2)`/`vfork(2)`/`clone(2)`-without-`CLONE_FILES`, `dup(2)`/`dup2(2)` (and thus `fcntl` `F_DUPFD` / `dup3`), and `SCM_RIGHTS` all duplicate descriptors that refer to the **same open file description** (POSIX.1-2017 §2.14).

A child process's pre-`execve(2)` close-on-exec scrub therefore destroyed the **parent's** live counter:

- the parent's next `write(2)` failed `EBADF`, and
- a later `eventfd2(2)` recycled the slot out from under the stale id, silently routing writes to an unrelated eventfd (CWE-416 class via slot reuse).

gecko's per-content-process `CloseSuperfluousFds` hits this on every content-process spawn (the AudioIPC waker eventfd).

Per `close(2)`: *"If fildes is the last file descriptor referring to the open file description, the resources associated with the open file description shall be released"* — only the last close may free.

## The fix (entry-side refcount)

- `EventFdEntry` gains `refs`; `create()` = 1, `close()` now decrements and frees (+ wakes parked readers) **only at zero**.
- `inc_ref()` at each descriptor duplication, mirroring the existing unix-socket / pipe refcount discipline:
  - fork / vfork / clone fd-table duplication (`inc_eventfd_refs_for_fork` at all three sites),
  - `dup(2)` / `dup2(2)`,
  - `SCM_RIGHTS` enqueue.
- A drop where a descriptor reference dies **outside** the `close(2)` arm:
  - `execve(2)` `FD_CLOEXEC` purge,
  - `dup2(2)` displaced-slot close,
  - process-exit fd teardown,
  - `scm_drop_fds` (undelivered in-flight SCM batches).

The inc/dec surface is balanced: create/dup/dup2/fork×3/SCM-enqueue increment; close-arm / process-exit / exec-CLOEXEC / dup2-displaced / scm-drop / create-rollback decrement. SCM delivery adds no ref (the enqueue-time inc already accounts for the receiver's copy), exactly matching the socket/pipe model.

## Tests

**Test 297** (`test_runner.rs`, gated on `firefox-test-core` / `test-mode`) drives the **real inc/dec call sites end to end**, so a future regression that drops a dec (re-introducing the *leak* direction) fails in the test, not just by inspection:

1. **Live trigger** — an eventfd shared across a simulated fork inherit + close scrub: the parent's `write(2)`/`read(2)`/readiness must survive the child's close; free only on last close (refs 1→2→1→0); write-after-last-close = `EBADF`.
2. **Recycle** — last-close-frees-then-`create()`-reuses check.
3. **Part 2** — the real `eventfd2`/`dup`/`close`/`write`/`read` dispatch arms (close-arm + dup inc/dec).
4. **Part 2b** — the real `dup2(2)` dispatch arm displacing an eventfd (dup2 inc + displaced-slot dec).
5. **Part 3** — an SCM enqueue → `scm_drop_fds` round trip (the real `scm_drop_fds` eventfd dec).
6. **Part 4** — `fork_process` (real fork inc via `inc_eventfd_refs_for_fork`) → `exit_group_pid` process-exit teardown (real exit-teardown dec), asserting the shared count returns to 1 across the child's teardown and 0 on the parent's own close.

The `execve(2)` `FD_CLOEXEC` purge dec is left to inspection (driving a real `execve` in-kernel replaces the address space and needs a target program), but it invokes the same `eventfd::close` dec the test proves via the close/exit paths.

## Known limitations (out of scope, matching the original PR's follow-up notes)

- eventfd ids are bare slot indices with **no generation tag**, so a genuinely-recycled slot cannot *reject* a truly-stale id. The guarantee here is that a **premature free never happens**, so no live holder is ever left holding a reused id. A generation tag to reject stale ids is a possible follow-up.
- `timerfd` / `signalfd` / `inotify` share the same unconditional-free defect and are left for a follow-up.
- `close_range(2)` routes each fd only through `vfs::close`, which **does** drop *pipe* reader/writer counts but **not** socket / eventfd / timerfd / signalfd refcounts — a **pre-existing** gap **unchanged** by this change (an eventfd closed via `close_range` leaked its slot before this change too), best fixed by routing `close_range` through the full close teardown.

## Verification

`scripts/qemu-harness.py check` passes clean for `test-mode`, `firefox-test-core`, and the default profile (no boot — a live measurement session owns the box; CI runs the full build + QEMU test suite).

Refs: POSIX.1-2017 §2.14 (open file description), close(2), fork(2), dup(2), eventfd(2), unix(7) SCM_RIGHTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
