### PR TITLE
ipc/pipe: re-land Linux-parity capacity + byte-preserving launcher drain + blocking-write livelock/atomicity fixes (lost in the 2026-06-10 history rewrite)

### DIFF
--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -465,10 +465,10 @@ pub fn handle_key(msg: u32, wparam: u64, _lparam: u64) {
                     // Async path: spawn child with stdout → pipe.
                     match spawn_async(trimmed) {
                         Ok((pid, pipe_id)) => {
+                            // `spawn_async` already published EXEC_STDOUT_PIPE/
+                            // EXEC_PID/EXEC_RUNNING before unblocking the child;
+                            // set only the cosmetic `running_exec` here.
                             state.running_exec = Some((pid, pipe_id));
-                            EXEC_STDOUT_PIPE.store(pipe_id, Ordering::Release);
-                            EXEC_PID.store(pid, Ordering::Release);
-                            EXEC_RUNNING.store(true, Ordering::Release);
                             // Don't draw prompt yet — poll_output() will do it on exit.
                         }
                         Err(msg) => {
@@ -1321,6 +1321,14 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
     // backstop both defer to it (see `DRAIN_THREAD_STARTED`).
     ensure_output_drain_thread();
 
+    // Publish the authoritative drain handle BEFORE unblocking the child, so
+    // there is no window in which the child can run (and fill its console pipe)
+    // while the drain thread / poll_output still read `EXEC_STDOUT_PIPE == 0`
+    // and park.  Callers only need to set the cosmetic `TERMINAL.running_exec`.
+    EXEC_STDOUT_PIPE.store(pipe_id, Ordering::Release);
+    EXEC_PID.store(pid, Ordering::Release);
+    EXEC_RUNNING.store(true, Ordering::Release);
+
     // Now allow the scheduler to run the child.
     crate::proc::unblock_process(pid);
 
@@ -1346,13 +1354,10 @@ pub fn launch_process(path: &str) {
 
     match spawn_async(path) {
         Ok((pid, pipe_id)) => {
-            // Publish the drain handle FIRST, unconditionally — `poll_output()`
-            // drains `EXEC_STDOUT_PIPE` regardless of whether `TERMINAL` is
-            // currently `Some` or gets re-`init()`d later (which would reset
-            // `running_exec`).  This is the authoritative console-pipe handle.
-            EXEC_STDOUT_PIPE.store(pipe_id, Ordering::Release);
-            EXEC_PID.store(pid, Ordering::Release);
-            EXEC_RUNNING.store(true, core::sync::atomic::Ordering::Release);
+            // `spawn_async` already published the authoritative drain handle
+            // (`EXEC_STDOUT_PIPE`/`EXEC_PID`/`EXEC_RUNNING`) before unblocking
+            // the child, so `poll_output()` drains it regardless of `TERMINAL`
+            // re-`init()`.  Here we only set the cosmetic `running_exec` handle.
             let mut guard = TERMINAL.lock();
             if let Some(ref mut state) = *guard {
                 state.running_exec = Some((pid, pipe_id));

--- a/kernel/src/gui/terminal.rs
+++ b/kernel/src/gui/terminal.rs
@@ -72,6 +72,133 @@ const NO_EXEC_EXIT: i64 = i64::MIN;
 static LAST_EXEC_EXIT_CODE: core::sync::atomic::AtomicI64 =
     core::sync::atomic::AtomicI64::new(NO_EXEC_EXIT);
 
+/// Render-throttle state for the launcher-pipe drain: tick of the last
+/// framebuffer repaint, and whether drained-but-unrendered text is pending.
+/// Draining the launcher pipe (which frees space for POSIX-blocked writers)
+/// must not be rate-limited by framebuffer blit speed, so the dedicated
+/// drain thread only flags `RENDER_DIRTY`; `poll_output()` on the desktop
+/// reactor performs the throttled repaint.
+static LAST_RENDER_TICK: AtomicU64 = AtomicU64::new(0);
+static RENDER_DIRTY: AtomicBool = AtomicBool::new(false);
+
+/// One-shot guard and single source of truth for drain OWNERSHIP of the
+/// launcher pipe.
+///
+/// Exactly one consumer may dequeue bytes from a pipe at a time.  Once this
+/// flag is `true` the dedicated [`output_drain_thread`] owns byte consumption
+/// of whatever `EXEC_STDOUT_PIPE` currently names, and both `poll_output()`
+/// and the inline console-drain backstop (`pipe_write_blocking`) must defer to
+/// it: a second consumer appending to the terminal grid under a separate
+/// TERMINAL-lock acquisition would interleave the child's output on screen.
+///
+/// There is never a window in which NO drainer is responsible for the pipe
+/// (the deadlock class #551 closed): the drain thread never exits — it parks
+/// when no exec is attached and re-snapshots `EXEC_STDOUT_PIPE`/`EXEC_RUNNING`
+/// on every wake — so "flag is true" ⟺ "a live drainer owns the pipe".  Before
+/// the thread is started (pre-first-launch) `poll_output()` remains the drainer
+/// and the inline backstop stays armed.
+static DRAIN_THREAD_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// True once the dedicated drain thread owns byte consumption of the launcher
+/// pipe (so `poll_output()` skips its own dequeue and the inline console-drain
+/// backstop defers to a REAL, byte-preserving drain).  See
+/// [`DRAIN_THREAD_STARTED`].
+#[inline]
+pub fn drain_thread_owns_pipe() -> bool {
+    DRAIN_THREAD_STARTED.load(Ordering::Acquire)
+}
+
+/// Dedicated kernel-thread drain loop for the launcher stdout/stderr pipe.
+///
+/// `poll_output()` runs only on the shared desktop reactor, whose iteration
+/// latency is bounded but non-zero; POSIX write(2) blocks a writer on a full
+/// pipe, so a child whose diagnostic output outruns the reactor drain would
+/// park its writers.  Two pre-existing mechanisms already suppress the park —
+/// the 64 KiB (launcher: 1 MiB) ring absorbs bursts, and an inline
+/// console-drain backstop in `pipe_write_blocking` frees the ring from the
+/// writer's own context — but the backstop *discards* the drained bytes (data
+/// loss for anyone reading the child's stdout/stderr).
+///
+/// This thread provides a REAL, byte-preserving drain decoupled from the
+/// reactor: it parks on the pipe's reader wait-list (`wait_readable`), is woken
+/// DIRECTLY by the child's `write(2)` (`wake_readers_all`), and drains via
+/// `pipe_read_and_wake` — which both frees ring space and wakes any parked
+/// writer (so a blocked `writev(fd=2)` is never wedged) WITHOUT throwing the
+/// bytes away.  Drained text is mirrored to serial (for the harness) and, when
+/// a terminal window exists, appended to the grid; the throttled repaint stays
+/// with `poll_output()` via `RENDER_DIRTY`.
+fn output_drain_thread() {
+    crate::hal::enable_interrupts();
+    let mut raw = [0u8; 4096];
+    loop {
+        // Snapshot the live drain target from the authoritative atomics (NOT
+        // `TERMINAL.running_exec`, which a GUI re-init can clear out from under
+        // a live child — see `EXEC_STDOUT_PIPE`).
+        let running = EXEC_RUNNING.load(Ordering::Acquire);
+        let pipe_id = EXEC_STDOUT_PIPE.load(Ordering::Acquire);
+        if !running || pipe_id == 0 {
+            // No child attached — park on the global poll bell with a bounded
+            // resync so an attach we missed is re-checked within ~100 ms.
+            let now = crate::arch::x86_64::irq::get_ticks();
+            crate::ipc::waitlist::wait_poll_event(now + 10, || {
+                EXEC_RUNNING.load(Ordering::Acquire)
+                    && EXEC_STDOUT_PIPE.load(Ordering::Acquire) != 0
+            });
+            continue;
+        }
+
+        // REAL drain: frees ring space AND wakes any writer parked on a full
+        // pipe (POSIX write(2); man 7 pipe) — WITHOUT discarding the bytes.
+        let n = crate::ipc::pipe::pipe_read_and_wake(pipe_id, &mut raw).unwrap_or(0);
+        if n > 0 {
+            // Mirror the child's stdout/stderr to serial for the harness — the
+            // same child-output stream `poll_output()` emits, NOT a per-read
+            // diagnostic marker (kept off the fast-path spam budget).
+            #[cfg(any(feature = "xeyes-test", feature = "firefox-test-core"))]
+            {
+                let text = core::str::from_utf8(&raw[..n]).unwrap_or("\u{FFFD}");
+                crate::serial_println!("[CHILD-OUT] {}", text.trim_end_matches('\n'));
+            }
+            // Append to the terminal grid for display when a window exists
+            // (windowed Firefox runs with `TERMINAL == None`, in which case
+            // only the serial mirror + the load-bearing drain happen).
+            if let Some(state) = TERMINAL.lock().as_mut() {
+                let text = core::str::from_utf8(&raw[..n]).unwrap_or("\u{FFFD}");
+                state.write_ansi_str(text);
+            }
+            RENDER_DIRTY.store(true, Ordering::Release);
+            continue; // keep draining while data is flowing
+        }
+
+        // Empty: park until the child's next write wakes us (bounded by a
+        // 100-tick resync so an exec swap or a missed wake can never strand us).
+        let now = crate::arch::x86_64::irq::get_ticks();
+        match crate::ipc::pipe::wait_readable(pipe_id, now + 100) {
+            crate::ipc::pipe::WaitOutcome::Ready => continue,
+            crate::ipc::pipe::WaitOutcome::Gone => {
+                // Pipe vanished (exec teardown) — bounded idle, then re-snap.
+                crate::ipc::waitlist::wait_poll_event(now + 10, || false);
+            }
+            crate::ipc::pipe::WaitOutcome::Enqueued => {
+                crate::sched::schedule();
+                crate::ipc::pipe::waiter_cleanup_reader(
+                    pipe_id, crate::proc::current_tid());
+            }
+        }
+    }
+}
+
+/// Start the launcher-pipe drain thread (idempotent — first launch wins).
+fn ensure_output_drain_thread() {
+    if DRAIN_THREAD_STARTED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        let _ = crate::proc::create_kernel_process(
+            "term_out_drain", output_drain_thread as *const () as u64);
+    }
+}
+
 use crate::wm::window::{self, WindowHandle};
 
 // ---------------------------------------------------------------------------
@@ -1176,7 +1303,23 @@ fn spawn_async(cmd: &str) -> Result<(u64, u64), alloc::string::String> {
 
     // Attach pipe to stdout/stderr while the child is still blocked.
     let pipe_id = crate::ipc::pipe::create_pipe();
+    // The launcher pipe captures the child's fd 1/2.  Under a heavy child
+    // (a Firefox page load emits >1 MiB of diagnostic stderr), the POSIX
+    // write(2) block-on-full contract turns an undersized ring into a
+    // convoy: the ring fills, writev(2) parks, and — because stderr writes
+    // serialize under the libc FILE lock — unrelated threads pile up behind
+    // the parked writer.  The console pipe is drained cooperatively
+    // (`poll_output` on the desktop reactor, plus the inline console-drain
+    // in the blocking-write path), so provision the maximum capacity
+    // (fcntl(2) F_SETPIPE_SZ ceiling) to absorb a whole page-load's burst
+    // without the writer ever parking.
+    let _ = crate::ipc::pipe::pipe_set_capacity(
+        pipe_id, crate::ipc::pipe::PIPE_MAX_CAPACITY);
     crate::proc::attach_stdout_pipe(pid, pipe_id);
+    // Start the dedicated byte-preserving drain thread (idempotent).  Once it
+    // owns the launcher pipe, `poll_output()` and the inline console-drain
+    // backstop both defer to it (see `DRAIN_THREAD_STARTED`).
+    ensure_output_drain_thread();
 
     // Now allow the scheduler to run the child.
     crate::proc::unblock_process(pid);
@@ -1458,17 +1601,27 @@ pub fn poll_output() {
     let mut raw = [0u8; 4096];
     let mut any_data = false;
 
-    // First pass: read all available data before locking TERMINAL
+    // Single drain ownership: once the dedicated `output_drain_thread` owns the
+    // launcher pipe it is the SOLE byte consumer (see `DRAIN_THREAD_STARTED`);
+    // `poll_output()` must NOT also dequeue, or the two drainers append to the
+    // terminal grid under separate TERMINAL-lock acquisitions with no ordering
+    // and the child's output interleaves.  In that mode `poll_output()` does
+    // only the throttled render (the drain thread flags `RENDER_DIRTY`) plus the
+    // reap/teardown below.  Before the drain thread is started `poll_output()`
+    // remains the drainer.
+    //
+    // `pipe_read_and_wake` wakes any writer (e.g. the Firefox stdout/stderr
+    // producer) parked for buffer space once this drain frees it.  Without the
+    // wake the producer parks forever and never returns to its event loop — the
+    // actual deadlock this consumer must avoid (`man 7 pipe`).
     let mut chunks: alloc::vec::Vec<alloc::vec::Vec<u8>> = alloc::vec::Vec::new();
-    loop {
-        // `pipe_read_and_wake` wakes any writer (e.g. the Firefox stdout/stderr
-        // producer) parked for buffer space once this drain frees it.  Without
-        // the wake the producer parks forever and never returns to its event
-        // loop — the actual deadlock this consumer must avoid (`man 7 pipe`).
-        let n = crate::ipc::pipe::pipe_read_and_wake(pipe_id, &mut raw).unwrap_or(0);
-        if n == 0 { break; }
-        chunks.push(raw[..n].to_vec());
-        any_data = true;
+    if !drain_thread_owns_pipe() {
+        loop {
+            let n = crate::ipc::pipe::pipe_read_and_wake(pipe_id, &mut raw).unwrap_or(0);
+            if n == 0 { break; }
+            chunks.push(raw[..n].to_vec());
+            any_data = true;
+        }
     }
 
     // Non-blocking waitpid: did the child become a zombie?
@@ -1490,12 +1643,28 @@ pub fn poll_output() {
     // case), the drain above has already done the load-bearing work (freeing
     // pipe space + waking the parked writer); skipping the grid update here is
     // purely cosmetic and must NOT skip the exit handling below.
+    if any_data {
+        RENDER_DIRTY.store(true, Ordering::Release);
+    }
+    // Repaint at most once per throttle window (≤ 20 fps).  This covers text we
+    // drained here (`any_data`) AND text the dedicated drain thread appended to
+    // the grid and flagged via `RENDER_DIRTY`, so the pipe-drain throughput is
+    // never coupled to framebuffer blit speed.  When no window exists (windowed
+    // Firefox: `TERMINAL == None`) the grid work is skipped and the drain
+    // already did the load-bearing byte transfer.
+    const RENDER_THROTTLE_TICKS: u64 = 5; // ≥ 50 ms between repaints (≤ 20 fps)
     if let Some(state) = TERMINAL.lock().as_mut() {
         for chunk in &chunks {
             let text = core::str::from_utf8(chunk).unwrap_or("\u{FFFD}");
             state.write_ansi_str(text);
         }
-        if any_data {
+        let now = crate::arch::x86_64::irq::get_ticks();
+        if RENDER_DIRTY.load(Ordering::Acquire)
+            && now.wrapping_sub(LAST_RENDER_TICK.load(Ordering::Relaxed))
+                >= RENDER_THROTTLE_TICKS
+        {
+            LAST_RENDER_TICK.store(now, Ordering::Relaxed);
+            RENDER_DIRTY.store(false, Ordering::Release);
             state.render_to_surface();
         }
     }

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -27,8 +27,29 @@ use spin::Mutex;
 
 use crate::ipc::waitlist::{ring_poll_bell_for, wake_tids, PollBellSource, WaitList};
 
-/// Pipe buffer size (4 KiB).
+/// POSIX write-atomicity threshold (`limits.h` `PIPE_BUF`; 4096 on Linux).
+/// Writes of at most this many bytes land all-or-nothing and never
+/// interleave with a concurrent writer's record (POSIX.1-2017 write(2),
+/// pipe(7)).  This is a *semantic* bound, distinct from the ring capacity
+/// below — POSIX only requires the ring capacity be at least `PIPE_BUF`.
 const PIPE_BUF_SIZE: usize = 4096;
+
+/// Default ring capacity for a newly created pipe — 64 KiB, matching the
+/// Linux default documented in pipe(7) ("Since Linux 2.6.11, the pipe
+/// capacity is 16 pages (i.e., 65,536 bytes ...)").
+///
+/// The ring used to be `PIPE_BUF`-sized (4 KiB, the bare POSIX minimum).
+/// Combined with the POSIX block-on-full write contract, that
+/// 16×-smaller-than-Linux capacity turns any bursty stdout/stderr producer
+/// into a convoy: a diagnostic burst fills the ring, `writev(2)` parks for
+/// seconds at a time, and — because stderr writes serialize under the libc
+/// FILE lock — unrelated threads pile up behind the parked writer.
+pub const PIPE_DEFAULT_CAPACITY: usize = 65536;
+
+/// Upper bound accepted from fcntl(F_SETPIPE_SZ), mirroring the default
+/// `/proc/sys/fs/pipe-max-size` limit (1 MiB) that applies to unprivileged
+/// callers on Linux (fcntl(2)).
+pub const PIPE_MAX_CAPACITY: usize = 1 << 20;
 
 /// Next pipe ID.
 static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
@@ -36,7 +57,11 @@ static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
 /// A kernel pipe — a bounded ring buffer.
 pub struct Pipe {
     pub id: u64,
-    buffer: [u8; PIPE_BUF_SIZE],
+    /// Ring storage.  Heap-allocated so capacity is per-pipe adjustable
+    /// (fcntl F_SETPIPE_SZ) and `PIPE_TABLE`'s `Vec<Pipe>` reallocations
+    /// stay cheap.  Invariant: `buffer.len()` is the pipe capacity, a
+    /// power of two >= `PIPE_BUF_SIZE`.
+    buffer: Vec<u8>,
     read_pos: usize,
     write_pos: usize,
     count: usize,
@@ -51,7 +76,7 @@ impl Pipe {
     fn new(id: u64) -> Self {
         Self {
             id,
-            buffer: [0; PIPE_BUF_SIZE],
+            buffer: alloc::vec![0; PIPE_DEFAULT_CAPACITY],
             read_pos: 0,
             write_pos: 0,
             count: 0,
@@ -61,8 +86,38 @@ impl Pipe {
         }
     }
 
+    /// Resize the ring to hold `want` bytes, per fcntl(2) F_SETPIPE_SZ:
+    /// the kernel rounds the request up to the next power of two (with a
+    /// floor of `PIPE_BUF_SIZE` — capacity may never drop below the POSIX
+    /// atomicity bound), refuses to exceed `PIPE_MAX_CAPACITY` with
+    /// `EPERM`, and refuses to shrink below the currently buffered byte
+    /// count with `EBUSY`.  Returns the actual capacity on success.
+    fn set_capacity(&mut self, want: usize) -> Result<usize, i32> {
+        let mut cap = PIPE_BUF_SIZE;
+        while cap < want {
+            cap <<= 1;
+            if cap > PIPE_MAX_CAPACITY {
+                return Err(-1); // EPERM — beyond pipe-max-size
+            }
+        }
+        if self.count > cap {
+            return Err(-16); // EBUSY — unread data would not fit
+        }
+        // Linearize the live bytes into the new ring.
+        let mut nb = alloc::vec![0u8; cap];
+        let old_len = self.buffer.len();
+        for i in 0..self.count {
+            nb[i] = self.buffer[(self.read_pos + i) % old_len];
+        }
+        self.buffer = nb;
+        self.read_pos = 0;
+        self.write_pos = self.count % cap;
+        Ok(cap)
+    }
+
     /// Read up to `buf.len()` bytes from the pipe. Returns bytes read.
     pub fn read(&mut self, buf: &mut [u8]) -> usize {
+        let cap = self.buffer.len();
         let to_read = buf.len().min(self.count);
         // SMAP bracket — `buf` typically points to user memory (the
         // syscall layer passes user `buf_ptr` through `from_raw_parts_mut`).
@@ -72,7 +127,7 @@ impl Pipe {
         let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for i in 0..to_read {
             buf[i] = self.buffer[self.read_pos];
-            self.read_pos = (self.read_pos + 1) % PIPE_BUF_SIZE;
+            self.read_pos = (self.read_pos + 1) % cap;
         }
         self.count -= to_read;
         to_read
@@ -80,13 +135,14 @@ impl Pipe {
 
     /// Write up to `data.len()` bytes into the pipe. Returns bytes written.
     pub fn write(&mut self, data: &[u8]) -> usize {
-        let space = PIPE_BUF_SIZE - self.count;
+        let cap = self.buffer.len();
+        let space = cap - self.count;
         let to_write = data.len().min(space);
         // SMAP bracket — `data` typically points to user memory.
         let _g = unsafe { crate::arch::x86_64::smap::UserGuard::new() };
         for i in 0..to_write {
             self.buffer[self.write_pos] = data[i];
-            self.write_pos = (self.write_pos + 1) % PIPE_BUF_SIZE;
+            self.write_pos = (self.write_pos + 1) % cap;
         }
         self.count += to_write;
         to_write
@@ -122,7 +178,12 @@ impl Pipe {
 
     /// Free space remaining in the ring buffer.
     pub fn space(&self) -> usize {
-        PIPE_BUF_SIZE - self.count
+        self.buffer.len() - self.count
+    }
+
+    /// Current ring capacity (fcntl F_GETPIPE_SZ).
+    pub fn capacity(&self) -> usize {
+        self.buffer.len()
     }
 }
 
@@ -206,6 +267,53 @@ pub fn pipe_write(pipe_id: u64, data: &[u8]) -> Option<usize> {
     let mut pipes = PIPE_TABLE.lock();
     let pipe = pipes.iter_mut().find(|p| p.id == pipe_id)?;
     Some(pipe.write(data))
+}
+
+/// Outcome of an atomic (`count <= PIPE_BUF`) deposit attempt.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AtomicWrite {
+    /// Every byte of `data` was deposited in one contiguous piece.
+    Wrote,
+    /// Not enough room for the whole record — NOTHING was written.  The
+    /// caller must park (never publish a partial `<= PIPE_BUF` record).
+    NoSpace,
+    /// Pipe id no longer exists (both ends closed) — treat as `EBADF`.
+    Gone,
+}
+
+/// Atomically deposit `data` iff the pipe has room for ALL of it, under a
+/// SINGLE `PIPE_TABLE` critical section.
+///
+/// Per `man 7 pipe` (`PIPE_BUF`): a write of at most `PIPE_BUF` bytes is
+/// delivered in one contiguous piece — never interleaved with another
+/// writer's data and never split into a short write on a blocking fd.
+/// Performing the space-check and the deposit under one lock is what
+/// enforces that.  Two SEPARATE `PIPE_TABLE` acquisitions (a `pipe_space`
+/// probe followed by `pipe_write`) let two concurrent atomic writers both
+/// observe `space >= count`, after which the ring's self-cap
+/// (`Pipe::write` copies `min(data.len(), space)`) publishes two
+/// interleaved partial records.  This helper closes that window: the
+/// check and the deposit are indivisible.
+///
+/// Returns `Wrote` once the whole record is deposited, `NoSpace` when the
+/// buffer lacks room for all of `data` (nothing written — the caller
+/// parks via [`wait_writable`] with `need == data.len()`), or `Gone` when
+/// the pipe has vanished.
+pub fn pipe_write_atomic(pipe_id: u64, data: &[u8]) -> AtomicWrite {
+    let mut pipes = PIPE_TABLE.lock();
+    let pipe = match pipes.iter_mut().find(|p| p.id == pipe_id) {
+        Some(p) => p,
+        None => return AtomicWrite::Gone,
+    };
+    if pipe.space() < data.len() {
+        return AtomicWrite::NoSpace;
+    }
+    // Room for the whole record — deposit it in one shot.  `Pipe::write`
+    // copies `min(data.len(), space)`, which given the guard above is
+    // exactly `data.len()`, so the published record is whole and contiguous.
+    let n = pipe.write(data);
+    debug_assert_eq!(n, data.len(), "atomic pipe write must deposit the whole record");
+    AtomicWrite::Wrote
 }
 
 /// True if every read end of `pipe_id` is closed (or the pipe no longer
@@ -322,9 +430,11 @@ pub fn pipe_drain_console(pipe_id: u64) -> usize {
     let mut scratch = [0u8; PIPE_BUF_SIZE];
     let mut total = 0usize;
     loop {
-        // Bounded by the ring capacity: at most PIPE_BUF_SIZE bytes are ever
-        // buffered, so this loop drains a full pipe in one pass and then sees
-        // a zero-length read and stops.  `pipe_read` returns None only if the
+        // The ring capacity can exceed this `PIPE_BUF_SIZE` scratch (the
+        // default is 64 KiB per pipe(7); the launcher pipe is provisioned
+        // larger still), so a full pipe may take several passes: each read
+        // drains up to `scratch.len()` bytes and we loop until a short read
+        // signals the ring is empty.  `pipe_read` returns None only if the
         // pipe id has vanished (both ends closed) — treat as "nothing more".
         let n = match pipe_read(pipe_id, &mut scratch) {
             Some(n) => n,
@@ -347,6 +457,35 @@ pub fn pipe_drain_console(pipe_id: u64) -> usize {
         }
     }
     total
+}
+
+/// Ring capacity of `pipe_id` (fcntl F_GETPIPE_SZ).  `None` = no such pipe.
+pub fn pipe_capacity(pipe_id: u64) -> Option<usize> {
+    let pipes = PIPE_TABLE.lock();
+    pipes.iter().find(|p| p.id == pipe_id).map(|p| p.capacity())
+}
+
+/// Set the ring capacity of `pipe_id` (fcntl F_SETPIPE_SZ semantics — see
+/// `Pipe::set_capacity` for the rounding/EBUSY/EPERM contract).  On a
+/// successful GROW, wakes any writer parked on the previously-full ring:
+/// new space is a write-readiness edge exactly like a reader drain, so the
+/// parked writer must re-evaluate (POSIX write(2) blocking contract).
+pub fn pipe_set_capacity(pipe_id: u64, want: usize) -> Result<usize, i32> {
+    let (res, grew) = {
+        let mut pipes = PIPE_TABLE.lock();
+        let pipe = match pipes.iter_mut().find(|p| p.id == pipe_id) {
+            Some(p) => p,
+            None => return Err(-9), // EBADF — pipe vanished
+        };
+        let before = pipe.capacity();
+        let res = pipe.set_capacity(want);
+        let grew = matches!(res, Ok(c) if c > before);
+        (res, grew)
+    };
+    if grew {
+        wake_writers_all(pipe_id);
+    }
+    res
 }
 
 /// Check if a pipe has data.
@@ -433,10 +572,26 @@ pub fn wait_readable(pipe_id: u64, wake_tick: u64) -> WaitOutcome {
     WaitOutcome::Enqueued
 }
 
-/// Atomic check-then-park for a writer on `pipe_id`.  Symmetric with
-/// `wait_readable`; a writer parks when the pipe is full unless the
-/// reader has gone away (in which case the caller will return EPIPE).
-pub fn wait_writable(pipe_id: u64, wake_tick: u64) -> WaitOutcome {
+/// Needs-aware check-then-park for a writer on `pipe_id`.  Symmetric with
+/// `wait_readable`; a writer parks unless it can make the progress it
+/// needs.  `need` is the number of free bytes the writer requires before it
+/// should re-attempt:
+///   * atomic write (`count <= PIPE_BUF`): `need == count` — the writer
+///     must NOT wake until the whole record fits, or it would spin
+///     check -> Ready-on-any-space -> retry -> still-can't-write at 100%
+///     CPU (a write into `0 < space < count` makes no progress);
+///   * large write (`count > PIPE_BUF`): `need == 1` — any free byte is
+///     forward progress.
+///
+/// `Ready` is returned when `space() >= need` (enough room to advance) OR
+/// `readers == 0` (the writer must wake to observe `EPIPE`).  Otherwise the
+/// caller is parked.  The re-check runs under `PIPE_WRITE_WAITERS` while
+/// briefly holding `PIPE_TABLE`, closing the TOCTOU window against a reader
+/// drain that frees space between the caller's own space probe and the park:
+/// a drain that frees `>= need` wakes us (`wake_writers_all`) and we
+/// re-evaluate; a drain that frees `< need` leaves the predicate `Enqueued`
+/// here, so we genuinely park rather than spin (no spurious wake-consume).
+pub fn wait_writable(pipe_id: u64, need: usize, wake_tick: u64) -> WaitOutcome {
     let tid = crate::proc::current_tid();
     let mut waiters = PIPE_WRITE_WAITERS.lock();
 
@@ -444,7 +599,7 @@ pub fn wait_writable(pipe_id: u64, wake_tick: u64) -> WaitOutcome {
         let pipes = PIPE_TABLE.lock();
         match pipes.iter().find(|p| p.id == pipe_id) {
             None => WaitOutcome::Gone,
-            Some(p) if p.space() > 0 || p.readers == 0 => WaitOutcome::Ready,
+            Some(p) if p.space() >= need || p.readers == 0 => WaitOutcome::Ready,
             Some(_) => WaitOutcome::Enqueued,
         }
     };

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -219,7 +219,14 @@ pub enum WaitOutcome {
 /// Create a new pipe. Returns the pipe ID.
 pub fn create_pipe() -> u64 {
     let id = NEXT_PIPE_ID.fetch_add(1, Ordering::Relaxed);
-    PIPE_TABLE.lock().push(Pipe::new(id));
+    // Allocate + zero the ring (PIPE_DEFAULT_CAPACITY bytes) BEFORE taking the
+    // global PIPE_TABLE lock, then insert the ready-made pipe under the lock.
+    // Evaluating `Pipe::new(id)` as the `push` argument would run the 64 KiB
+    // memset while the guard is held, serialising all pipe traffic
+    // system-wide across the allocation — expensive on the FF IPC hot path,
+    // which creates many pipes.
+    let pipe = Pipe::new(id);
+    PIPE_TABLE.lock().push(pipe);
     id
 }
 

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -8367,13 +8367,14 @@ fn sys_fcntl(fd: u64, cmd: u64, arg: u64) -> i64 {
         //
         // Per fcntl(2): F_SETPIPE_SZ changes the pipe's ring capacity; the
         // kernel rounds the request up (power of two, floor PIPE_BUF) and
-        // returns the actual capacity.  EBUSY when the new capacity cannot
-        // hold the currently buffered bytes; EPERM when the request exceeds
-        // the pipe-max-size limit.  F_GETPIPE_SZ returns the capacity.
-        // Both return EBADF when the descriptor does not refer to a pipe.
+        // returns the actual capacity.  A sub-page request (including 0) is
+        // rounded up to the minimum rather than rejected, matching Linux.
+        // EBUSY when the new capacity cannot hold the currently buffered
+        // bytes; EPERM when the request exceeds the pipe-max-size limit.
+        // F_GETPIPE_SZ returns the capacity.  Both return EBADF when the
+        // descriptor does not refer to a pipe.
         1031 /* F_SETPIPE_SZ */ => {
             if !crate::syscall::is_pipe_fd(pid, fd as usize) { return -9; } // EBADF
-            if arg == 0 { return -22; } // EINVAL
             let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
             match crate::ipc::pipe::pipe_set_capacity(pipe_id, arg as usize) {
                 Ok(cap) => cap as i64,

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -7060,9 +7060,12 @@ fn fd_is_nonblocking(pid: u64, fd: usize) -> bool {
 /// never drains, so no frame is ever presented).
 ///
 ///   * **Atomicity (`count <= PIPE_BUF`)** — delivered all in one piece or
-///     not at all.  On a blocking fd we park until `count` contiguous bytes
-///     of space exist, then write them in a single shot; a blocking fd never
-///     returns a short write for `count <= PIPE_BUF`.
+///     not at all.  On a blocking fd we park until `count` bytes of space
+///     exist, then deposit them in a single `PIPE_TABLE` critical section
+///     (`pipe::pipe_write_atomic`): the space-check and the deposit are
+///     indivisible, so two concurrent atomic writers can never both observe
+///     `space >= count` and publish interleaved partial records.  A blocking
+///     fd never returns a short write for `count <= PIPE_BUF`.
 ///   * **Large writes (`count > PIPE_BUF`)** — may be split: write what
 ///     fits, wake readers, block for more space, continue.
 ///   * **`O_NONBLOCK`** — if no progress can be made, return `-EAGAIN`; for
@@ -7109,38 +7112,52 @@ fn pipe_write_blocking(pid: u64, fd: usize, pipe_id: u64, data: &[u8]) -> i64 {
             return -32; // EPIPE
         }
 
-        let space = crate::ipc::pipe::pipe_space(pipe_id);
-        let remaining = count - total;
-
-        // How much we may write THIS pass without violating atomicity:
-        //   * count <= PIPE_BUF: all-or-nothing — only when the whole
-        //     remaining (== count) fits.
-        //   * count  > PIPE_BUF: whatever fits, up to `remaining`.
-        let writable_now = if atomic {
-            if space >= remaining { remaining } else { 0 }
-        } else {
-            space.min(remaining)
-        };
-
-        if writable_now > 0 {
-            let chunk = &data[total..total + writable_now];
-            match crate::ipc::pipe::pipe_write(pipe_id, chunk) {
-                Some(n) => {
-                    if n > 0 {
-                        total += n;
-                        // Wake readers parked on an empty pipe (man 7 pipe).
-                        crate::ipc::pipe::wake_readers_all(pipe_id);
-                    }
-                    if total >= count {
-                        return total as i64;
-                    }
-                    // Partial (count > PIPE_BUF) — loop to write the rest.
-                    continue;
+        // ── Atomic arm (count <= PIPE_BUF) ────────────────────────────────
+        // The check-and-deposit happens under ONE PIPE_TABLE lock so the
+        // record is published whole or not at all, never interleaved with a
+        // concurrent atomic writer (man 7 pipe, PIPE_BUF).  `total` is always
+        // 0 here — an atomic write makes no partial progress, so a NoSpace
+        // just parks (needs-aware `need == count`) until the WHOLE record
+        // fits rather than depositing a short/interleaved partial.
+        if atomic {
+            match crate::ipc::pipe::pipe_write_atomic(pipe_id, data) {
+                crate::ipc::pipe::AtomicWrite::Wrote => {
+                    // Whole record landed — wake readers parked on an empty
+                    // pipe (man 7 pipe) and report the full count.
+                    crate::ipc::pipe::wake_readers_all(pipe_id);
+                    return count as i64;
                 }
-                // Pipe vanished mid-write: EBADF if no progress, else partial.
-                None => {
-                    if total > 0 { return total as i64; }
-                    return -9; // EBADF
+                crate::ipc::pipe::AtomicWrite::Gone => return -9, // EBADF
+                crate::ipc::pipe::AtomicWrite::NoSpace => {
+                    // Not enough contiguous room.  Fall through to the
+                    // O_NONBLOCK / signal / backstop / park handling below.
+                }
+            }
+        } else {
+            // ── Large arm (count > PIPE_BUF) — partials allowed ───────────
+            let space = crate::ipc::pipe::pipe_space(pipe_id);
+            let remaining = count - total;
+            let writable_now = space.min(remaining);
+            if writable_now > 0 {
+                let chunk = &data[total..total + writable_now];
+                match crate::ipc::pipe::pipe_write(pipe_id, chunk) {
+                    Some(n) => {
+                        if n > 0 {
+                            total += n;
+                            // Wake readers parked on an empty pipe (man 7 pipe).
+                            crate::ipc::pipe::wake_readers_all(pipe_id);
+                        }
+                        if total >= count {
+                            return total as i64;
+                        }
+                        // Partial — loop to write the rest.
+                        continue;
+                    }
+                    // Pipe vanished mid-write: EBADF if no progress, else partial.
+                    None => {
+                        if total > 0 { return total as i64; }
+                        return -9; // EBADF
+                    }
                 }
             }
         }
@@ -7160,30 +7177,35 @@ fn pipe_write_blocking(pid: u64, fd: usize, pipe_id: u64, data: &[u8]) -> i64 {
             return -4; // EINTR
         }
 
-        // ── Inline console-drain (windowed-Firefox first-paint wedge) ─────────
+        // ── Inline console-drain — LAST-RESORT backstop only ─────────────────
         //
         // The read end of the kernel-owned console pipe (a child's stdout/stderr
-        // wired up at launch in `gui::terminal`) is drained ONLY by the
-        // cooperatively-scheduled `gui::terminal::poll_output()` on an in-kernel
-        // poll thread.  Under Firefox's ~70-thread `clone(2)` startup burst that
-        // poll thread is starved long enough for this 4 KiB pipe to fill, at
-        // which point a blocking `writev(fd=2)` would park here and — with no
-        // timely drain — never be woken, wedging the whole thread group before
-        // any frame is painted.
+        // wired up at launch in `gui::terminal`) is normally drained by the
+        // dedicated `gui::terminal::output_drain_thread`, which is woken
+        // DIRECTLY by this write and frees ring space AND wakes this parked
+        // writer (`pipe_read_and_wake`) WITHOUT discarding the bytes.  When that
+        // thread owns the pipe we therefore prefer to PARK below (a
+        // byte-preserving wake) over the historical drain-and-*discard* here,
+        // which throws the child's diagnostics away and each cycle costs a
+        // lock+memcpy pass over the whole ring.
         //
-        // Because this pipe has NO real peer reader (only the kernel drains it),
-        // it is always safe to discard its buffered bytes from the writer's own
-        // syscall context.  Doing so here makes forward progress independent of
-        // any poll-thread scheduling: drain inline, then re-evaluate space via
-        // `continue` instead of parking.  A normal user<->user pipe is NEVER the
-        // console drain target (`console_drain_pipe_id()` returns 0 unless THIS
-        // pipe is the running child's stdout/stderr), so this path leaves every
-        // ordinary pipe's blocking-write semantics untouched.
+        // The discard path survives only as a last-resort backstop for a
+        // build/context where NO drain thread owns the pipe (e.g. the drain
+        // thread was never started): there, because this pipe has no real peer
+        // reader, it is safe to discard its buffered bytes from the writer's own
+        // syscall context so a blocking `writev(fd=2)` is never wedged for want
+        // of a timely drain.  A normal user<->user pipe is NEVER the console
+        // drain target (`console_drain_pipe_id()` returns 0 unless THIS pipe is
+        // the running child's stdout/stderr), so this path leaves every ordinary
+        // pipe's blocking-write semantics untouched.
         //
         // `pipe_drain_console` reads into a kernel buffer and takes/drops
         // `PIPE_TABLE` internally, so no pipe lock is held across it and it
         // cannot recurse into this writer.  Refs: write(2), pipe(7).
-        if pipe_id != 0 && pipe_id == crate::gui::terminal::console_drain_pipe_id() {
+        if pipe_id != 0
+            && pipe_id == crate::gui::terminal::console_drain_pipe_id()
+            && !crate::gui::terminal::drain_thread_owns_pipe()
+        {
             let drained = crate::ipc::pipe::pipe_drain_console(pipe_id);
             if drained > 0 {
                 // Freed space — retry the write without parking.
@@ -7191,21 +7213,28 @@ fn pipe_write_blocking(pid: u64, fd: usize, pipe_id: u64, data: &[u8]) -> i64 {
             }
             // Nothing was buffered (a transient zero-space read can race the
             // child's own writes); fall through to the normal park so the
-            // writer is still woken by `poll_output`'s `wake_writers_all` if it
-            // does manage to run, and by the close paths on EOF/EPIPE.  This
-            // keeps the inline drain a pure progress *accelerator*, never the
-            // sole liveness mechanism.
+            // writer is still woken by a drain's `wake_writers_all` and by the
+            // close paths on EOF/EPIPE.  This keeps the backstop a pure progress
+            // *accelerator*, never the sole liveness mechanism.
         }
 
-        // Park atomically against the reader's `wake_writers_all`.  The lock
-        // order PIPE_WRITE_WAITERS -> PIPE_TABLE is taken and released
+        // Park atomically against the reader's `wake_writers_all`, using a
+        // needs-aware predicate so a writer does NOT wake-spin when a reader
+        // frees less room than this write requires:
+        //   * atomic write (count <= PIPE_BUF): need == count — park until the
+        //     WHOLE record fits (a write into 0 < space < count makes no
+        //     progress, so waking on any space would livelock at 100% CPU);
+        //   * large write (count > PIPE_BUF): need == 1 — any free byte is
+        //     forward progress, so wake as soon as room appears.
+        // The lock order PIPE_WRITE_WAITERS -> PIPE_TABLE is taken and released
         // entirely inside `wait_writable`; we hold no pipe lock across the
         // `schedule()` below.
+        let need = if atomic { count } else { 1 };
         let tid = crate::proc::current_tid();
-        match crate::ipc::pipe::wait_writable(pipe_id, u64::MAX) {
-            // Space appeared (or the reader closed) between our check and the
-            // wait-list re-check — retry the loop, which re-evaluates
-            // reader-closed (EPIPE) and available space.
+        match crate::ipc::pipe::wait_writable(pipe_id, need, u64::MAX) {
+            // Enough room appeared (or the reader closed) between our check and
+            // the wait-list re-check — retry the loop, which re-evaluates
+            // reader-closed (EPIPE) and re-attempts the atomic/large deposit.
             crate::ipc::pipe::WaitOutcome::Ready => continue,
             // Pipe id no longer exists — EBADF if no progress, else partial.
             crate::ipc::pipe::WaitOutcome::Gone => {
@@ -8333,6 +8362,31 @@ fn sys_fcntl(fd: u64, cmd: u64, arg: u64) -> i64 {
                 }
             }
             -9 // EBADF
+        }
+        // F_SETPIPE_SZ / F_GETPIPE_SZ — pipe capacity control (fcntl(2)).
+        //
+        // Per fcntl(2): F_SETPIPE_SZ changes the pipe's ring capacity; the
+        // kernel rounds the request up (power of two, floor PIPE_BUF) and
+        // returns the actual capacity.  EBUSY when the new capacity cannot
+        // hold the currently buffered bytes; EPERM when the request exceeds
+        // the pipe-max-size limit.  F_GETPIPE_SZ returns the capacity.
+        // Both return EBADF when the descriptor does not refer to a pipe.
+        1031 /* F_SETPIPE_SZ */ => {
+            if !crate::syscall::is_pipe_fd(pid, fd as usize) { return -9; } // EBADF
+            if arg == 0 { return -22; } // EINVAL
+            let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
+            match crate::ipc::pipe::pipe_set_capacity(pipe_id, arg as usize) {
+                Ok(cap) => cap as i64,
+                Err(e) => e as i64,
+            }
+        }
+        1032 /* F_GETPIPE_SZ */ => {
+            if !crate::syscall::is_pipe_fd(pid, fd as usize) { return -9; } // EBADF
+            let pipe_id = crate::syscall::get_pipe_id(pid, fd as usize);
+            match crate::ipc::pipe::pipe_capacity(pipe_id) {
+                Some(cap) => cap as i64,
+                None => -9, // EBADF — pipe vanished
+            }
         }
         // F_ADD_SEALS / F_GET_SEALS — memfd sealing API.
         //

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -39010,7 +39010,80 @@ fn test_pipe_wake_hook() -> bool {
 // last reader gone fails with -EPIPE.  Per write(2), pipe(7), POSIX.1-2017.
 
 fn test_pipe_blocking_write_semantics() -> bool {
-    test_header!("pipe blocking write — EAGAIN (no no-progress 0) / atomicity / EPIPE");
+    test_header!("pipe blocking write — capacity / EAGAIN (no no-progress 0) / atomicity / EPIPE");
+
+    // Pipes now default to the Linux 64 KiB capacity (pipe(7)); the
+    // exact-fill arithmetic throughout this test was written against the
+    // POSIX-minimum 4 KiB ring, so pin each test pipe back to 4 KiB via
+    // fcntl(2) F_SETPIPE_SZ (which returns the actual capacity).
+    const F_SETPIPE_SZ: u64 = 1031;
+    const F_GETPIPE_SZ: u64 = 1032;
+    let pin4k = |wfd: u64| -> i64 {
+        crate::syscall::dispatch_linux_kernel(72 /*fcntl*/, wfd, F_SETPIPE_SZ, 4096, 0, 0, 0)
+    };
+
+    // ── Sub-test 0: capacity defaults + fcntl(F_SETPIPE_SZ/F_GETPIPE_SZ) ──
+    // pipe(7): "the pipe capacity is 16 pages (i.e., 65,536 bytes)".
+    // fcntl(2): F_SETPIPE_SZ rounds the request up (power of two, floor
+    // PIPE_BUF), fails with EBUSY when the new size cannot hold the
+    // buffered bytes, and EPERM beyond the pipe-max-size ceiling.
+    {
+        let mut fds0 = [0u32; 2];
+        let r = crate::syscall::dispatch_linux_kernel(
+            293 /*pipe2*/, fds0.as_mut_ptr() as u64, 0x0800 /*O_NONBLOCK*/, 0, 0, 0, 0);
+        if r != 0 {
+            test_fail!("pipe_blocking_write", "pipe2 for capacity sub-test returned {}", r);
+            return false;
+        }
+        let (rfd0, wfd0) = (fds0[0] as u64, fds0[1] as u64);
+        let cap = crate::syscall::dispatch_linux_kernel(72, wfd0, F_GETPIPE_SZ, 0, 0, 0, 0);
+        if cap != 65536 {
+            test_fail!("pipe_blocking_write",
+                "F_GETPIPE_SZ default returned {} (expected 65536 per pipe(7))", cap);
+            return false;
+        }
+        // Round-up: 5000 → 8192.
+        let cap2 = crate::syscall::dispatch_linux_kernel(72, wfd0, F_SETPIPE_SZ, 5000, 0, 0, 0);
+        if cap2 != 8192 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ(5000) returned {} (expected round-up to 8192)", cap2);
+            return false;
+        }
+        // EBUSY: buffer 5000 bytes, then try to shrink to 4096.
+        let big = alloc::vec![0x5Au8; 5000];
+        let wn = crate::syscall::dispatch_linux_kernel(
+            1 /*write*/, wfd0, big.as_ptr() as u64, big.len() as u64, 0, 0, 0);
+        if wn != 5000 {
+            test_fail!("pipe_blocking_write",
+                "capacity sub-test 5000B write returned {} (expected 5000 on an 8 KiB ring)", wn);
+            return false;
+        }
+        let shr = crate::syscall::dispatch_linux_kernel(72, wfd0, F_SETPIPE_SZ, 4096, 0, 0, 0);
+        if shr != -16 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ shrink below buffered bytes returned {} (expected -EBUSY)", shr);
+            return false;
+        }
+        // EPERM: beyond the 1 MiB pipe-max-size ceiling.
+        let huge = crate::syscall::dispatch_linux_kernel(
+            72, wfd0, F_SETPIPE_SZ, (1u64 << 20) + 1, 0, 0, 0);
+        if huge != -1 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ(>1MiB) returned {} (expected -EPERM)", huge);
+            return false;
+        }
+        // Non-pipe fd → EBADF.  (Use a never-opened high slot — fd 0 can
+        // legitimately be a pipe in the kernel-test harness context.)
+        let nonpipe = crate::syscall::dispatch_linux_kernel(72, 987, F_SETPIPE_SZ, 4096, 0, 0, 0);
+        if nonpipe != -9 {
+            test_fail!("pipe_blocking_write",
+                "F_SETPIPE_SZ on non-pipe fd returned {} (expected -EBADF)", nonpipe);
+            return false;
+        }
+        crate::syscall::dispatch_linux_kernel(3, rfd0, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd0, 0, 0, 0, 0, 0);
+        test_println!("  capacity: default 65536, round-up 5000→8192, shrink-EBUSY, >1MiB-EPERM, non-pipe-EBADF ✓");
+    }
 
     // ── Sub-test 1: O_NONBLOCK full pipe → -EAGAIN (atomicity preserved) ──
     // pipe2(O_NONBLOCK) so both ends are non-blocking.
@@ -39022,6 +39095,12 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd_nb, wfd_nb) = (fds[0] as u64, fds[1] as u64);
+    if pin4k(wfd_nb) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 1)");
+        crate::syscall::dispatch_linux_kernel(3, rfd_nb, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd_nb, 0, 0, 0, 0, 0);
+        return false;
+    }
 
     // Fill the 4 KiB ring exactly (one PIPE_BUF write fits atomically).
     let filler = [0xABu8; 4096];
@@ -39106,6 +39185,12 @@ fn test_pipe_blocking_write_semantics() -> bool {
         return false;
     }
     let (rfd3, wfd3) = (fds3[0] as u64, fds3[1] as u64);
+    if pin4k(wfd3) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 3)");
+        crate::syscall::dispatch_linux_kernel(3, rfd3, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd3, 0, 0, 0, 0, 0);
+        return false;
+    }
     let pipe_id3 = crate::syscall::get_pipe_id(
         crate::proc::current_pid() as u64, wfd3 as usize);
 
@@ -39164,7 +39249,387 @@ fn test_pipe_blocking_write_semantics() -> bool {
     crate::syscall::dispatch_linux_kernel(3, rfd3, 0, 0, 0, 0, 0);
     crate::syscall::dispatch_linux_kernel(3, wfd3, 0, 0, 0, 0, 0);
 
-    test_pass!("pipe blocking write — EAGAIN / atomicity / EPIPE / reader-wakes-writer");
+    // ── Shared drainer infrastructure for the multi-threaded sub-tests ────
+    use core::sync::atomic::AtomicU32;
+    let pid = crate::proc::current_pid_lockless();
+
+    // A drainer runs as its OWN kernel process and drains via the REAL read(2)
+    // syscall.  Pipe ops are keyed by global pipe-id, but read(2)/write(2)
+    // resolve the fd in the CALLER's process, so each helper process needs its
+    // own fd (with the refcount bumped so neither end drops to zero early).
+    fn install_pipe_read_fd(pid: u64, pipe_id: u64) -> i64 {
+        let read_fd = crate::vfs::FileDescriptor {
+            mount_idx: usize::MAX,
+            inode: pipe_id,
+            offset: 0,
+            flags: 0x8000_0000, // pipe read end
+            is_console: false,
+            cloexec: false,
+            file_type: crate::vfs::FileType::Pipe,
+            open_path: alloc::string::String::new(),
+        };
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        let proc = match procs.iter_mut().find(|p| p.pid == pid) {
+            Some(p) => p,
+            None => return -3, // ESRCH
+        };
+        let mut idx = None;
+        for i in 0..proc.file_descriptors.len() {
+            if proc.file_descriptors[i].is_none() { idx = Some(i); break; }
+        }
+        let i = match idx {
+            Some(i) => { proc.file_descriptors[i] = Some(read_fd); i }
+            None => {
+                if proc.file_descriptors.len() >= crate::vfs::MAX_FDS_PER_PROCESS {
+                    return -24; // EMFILE
+                }
+                let i = proc.file_descriptors.len();
+                proc.file_descriptors.push(Some(read_fd));
+                i
+            }
+        };
+        drop(procs);
+        crate::ipc::pipe::pipe_add_reader(pipe_id);
+        i as i64
+    }
+    fn install_pipe_write_fd(pid: u64, pipe_id: u64) -> i64 {
+        let write_fd = crate::vfs::FileDescriptor {
+            mount_idx: usize::MAX,
+            inode: pipe_id,
+            offset: 0,
+            flags: 0x8000_0001, // pipe write end
+            is_console: false,
+            cloexec: false,
+            file_type: crate::vfs::FileType::Pipe,
+            open_path: alloc::string::String::new(),
+        };
+        let mut procs = crate::proc::PROCESS_TABLE.lock();
+        let proc = match procs.iter_mut().find(|p| p.pid == pid) {
+            Some(p) => p,
+            None => return -3,
+        };
+        let mut idx = None;
+        for i in 0..proc.file_descriptors.len() {
+            if proc.file_descriptors[i].is_none() { idx = Some(i); break; }
+        }
+        let i = match idx {
+            Some(i) => { proc.file_descriptors[i] = Some(write_fd); i }
+            None => {
+                if proc.file_descriptors.len() >= crate::vfs::MAX_FDS_PER_PROCESS { return -24; }
+                let i = proc.file_descriptors.len();
+                proc.file_descriptors.push(Some(write_fd));
+                i
+            }
+        };
+        drop(procs);
+        crate::ipc::pipe::pipe_add_writer(pipe_id);
+        i as i64
+    }
+
+    static DRAIN_STOP: AtomicU32 = AtomicU32::new(0);
+    static DRAINED_TOTAL: AtomicU64 = AtomicU64::new(0);
+    static DRAIN_RFD: AtomicU64 = AtomicU64::new(0);
+    static DRAIN_GATE: AtomicU32 = AtomicU32::new(0);
+
+    // Drainer entry: spin until armed, then drain via real read(2) until the
+    // stop flag is set and the pipe is empty.  Each nonzero read(2) goes
+    // through sys_read_linux, whose pipe arm calls wake_writers_all — that is
+    // the wake under test.
+    fn drainer_entry() {
+        crate::hal::enable_interrupts();
+        while DRAIN_GATE.load(Ordering::SeqCst) == 0 {
+            crate::sched::yield_cpu();
+            crate::hal::enable_interrupts();
+            for _ in 0..200u32 { core::hint::spin_loop(); }
+        }
+        let rfd = DRAIN_RFD.load(Ordering::SeqCst);
+        let mut buf = [0u8; 512];
+        loop {
+            let n = crate::syscall::dispatch_linux_kernel(
+                0 /*read*/, rfd, buf.as_mut_ptr() as u64, buf.len() as u64, 0, 0, 0);
+            if n > 0 {
+                DRAINED_TOTAL.fetch_add(n as u64, Ordering::SeqCst);
+            } else {
+                if DRAIN_STOP.load(Ordering::SeqCst) == 1 {
+                    break;
+                }
+                crate::sched::yield_cpu();
+                crate::hal::enable_interrupts();
+                for _ in 0..200u32 { core::hint::spin_loop(); }
+            }
+        }
+        crate::proc::exit_thread(0);
+    }
+
+    let was_active = crate::sched::is_active();
+    if !was_active { crate::sched::enable(); }
+
+    // ── Sub-test 4: blocking ATOMIC write (count <= PIPE_BUF) into a pipe with
+    //   insufficient nonzero space must PARK (not spin / return 0) and complete
+    //   only after a real read frees >= count room ─────────────────────────
+    //
+    // The atomic-write livelock regression: pre-fix the atomic arm set
+    // writable_now = 0 (space < count) and wait_writable returned Ready on ANY
+    // space, so the loop spun check -> Ready -> continue at 100% CPU forever.
+    // Post-fix the writer parks on the needs-aware predicate (need == count).
+    let mut fds4 = [0u32; 2];
+    let r = crate::syscall::dispatch_linux_kernel(
+        293 /*pipe2*/, fds4.as_mut_ptr() as u64, 0 /*blocking*/, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("pipe_blocking_write", "pipe2(blocking) for atomic-park test returned {}", r);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    let (rfd4, wfd4) = (fds4[0] as u64, fds4[1] as u64);
+    if crate::syscall::dispatch_linux_kernel(72, wfd4, 1031, 4096, 0, 0, 0) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 4)");
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    let pipe_id4 = crate::syscall::get_pipe_id(pid, wfd4 as usize);
+
+    // Pre-fill so that 0 < space < ATOMIC: write 3000 bytes → space = 1096.
+    // Then a blocking atomic write of 2000 needs 2000 > 1096 → MUST park.
+    const PREFILL: usize = 3000;
+    const ATOMIC: usize = 2000;
+    let prefill_buf = [0x11u8; PREFILL];
+    let pn = crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, wfd4, prefill_buf.as_ptr() as u64, PREFILL as u64, 0, 0, 0);
+    if pn != PREFILL as i64 {
+        test_fail!("pipe_blocking_write",
+            "atomic-park prefill write returned {} (expected {})", pn, PREFILL);
+        crate::syscall::dispatch_linux_kernel(3, rfd4, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd4, 0, 0, 0, 0, 0);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+
+    DRAIN_STOP.store(0, Ordering::SeqCst);
+    DRAINED_TOTAL.store(0, Ordering::SeqCst);
+    DRAIN_GATE.store(0, Ordering::SeqCst);
+    let drainer4_pid = crate::proc::create_kernel_process(
+        "pipe_atomic_park_drain", drainer_entry as *const () as u64);
+    let drain4_rfd = install_pipe_read_fd(drainer4_pid, pipe_id4);
+    if drain4_rfd < 0 {
+        test_fail!("pipe_blocking_write",
+            "install_pipe_read_fd(atomic drainer) returned {}", drain4_rfd);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    DRAIN_RFD.store(drain4_rfd as u64, Ordering::SeqCst);
+
+    // Watchdog: arm the drainer ONLY after the writer parks.  If the write spun
+    // (the livelock) it would never park, the watchdog would never observe a
+    // waiter, and the write would never return — the outer settle-loop then
+    // fails the sub-test.
+    static ATOMIC_PARK_OBSERVED: AtomicU32 = AtomicU32::new(0);
+    static ATOMIC_PIPE_ID: AtomicU64 = AtomicU64::new(0);
+    ATOMIC_PARK_OBSERVED.store(0, Ordering::SeqCst);
+    ATOMIC_PIPE_ID.store(pipe_id4, Ordering::SeqCst);
+    fn atomic_watchdog_entry() {
+        crate::hal::enable_interrupts();
+        let pid4 = ATOMIC_PIPE_ID.load(Ordering::SeqCst);
+        loop {
+            if crate::ipc::pipe::debug_writer_waiter_count(pid4) >= 1 {
+                ATOMIC_PARK_OBSERVED.store(1, Ordering::SeqCst);
+                DRAIN_GATE.store(1, Ordering::SeqCst); // release the drainer
+                break;
+            }
+            crate::sched::yield_cpu();
+            crate::hal::enable_interrupts();
+            for _ in 0..200u32 { core::hint::spin_loop(); }
+        }
+        crate::proc::exit_thread(0);
+    }
+    let _wd_pid = crate::proc::create_kernel_process(
+        "pipe_atomic_watchdog", atomic_watchdog_entry as *const () as u64);
+
+    // Blocking atomic write of 2000 into 1096 free.  Must park (watchdog proves
+    // it) and return exactly 2000 once the drainer frees >= 2000.
+    let atomic_buf = [0x22u8; ATOMIC];
+    let an = crate::syscall::dispatch_linux_kernel(
+        1 /*write*/, wfd4, atomic_buf.as_ptr() as u64, ATOMIC as u64, 0, 0, 0);
+
+    DRAIN_STOP.store(1, Ordering::SeqCst);
+    for _ in 0..256u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..200u32 { core::hint::spin_loop(); }
+        if DRAINED_TOTAL.load(Ordering::SeqCst) >= (PREFILL + ATOMIC) as u64 { break; }
+    }
+    let leaked4 = crate::ipc::pipe::debug_writer_waiter_count(pipe_id4);
+    let parked = ATOMIC_PARK_OBSERVED.load(Ordering::SeqCst);
+    crate::syscall::dispatch_linux_kernel(3, rfd4, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, wfd4, 0, 0, 0, 0, 0);
+
+    if parked != 1 {
+        test_fail!("pipe_blocking_write",
+            "blocking ATOMIC write into insufficient space did NOT park (livelock — watchdog never saw a writer on PIPE_WRITE_WAITERS)");
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    if an != ATOMIC as i64 {
+        test_fail!("pipe_blocking_write",
+            "blocking ATOMIC write returned {} (expected {} — whole record after park+drain, never short/0)", an, ATOMIC);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    if leaked4 != 0 {
+        test_fail!("pipe_blocking_write",
+            "{} stale writer(s) on PIPE_WRITE_WAITERS after atomic-park completion", leaked4);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    test_println!("  blocking ATOMIC {}B write parked on insufficient space, woke+completed via read(2) drain ✓", ATOMIC);
+
+    // ── Sub-test 5: concurrent two-writer <=PIPE_BUF atomicity ────────────
+    //
+    // Two writers each blocking-write a distinct <= PIPE_BUF record (all-0xA1
+    // and all-0xB2) into a pipe with room for ~1.5 records.  A reader drains.
+    // Per pipe(7) PIPE_BUF atomicity, each record MUST emerge whole and
+    // contiguous — never split or interleaved.  Pre-fix the check (pipe_space)
+    // and the deposit (pipe_write) were separate locks, so both writers could
+    // observe space >= count, each deposit a SHORT capped record, and publish
+    // two interleaved partials.  Post-fix the single-lock pipe_write_atomic
+    // makes the check-and-deposit indivisible.
+    const REC: usize = 2500; // two records (5000) > 4096 ring → one must park
+    static W5_A_DONE: AtomicU32 = AtomicU32::new(0);
+    static W5_B_DONE: AtomicU32 = AtomicU32::new(0);
+    static W5_A_RET: AtomicU64 = AtomicU64::new(0);
+    static W5_B_RET: AtomicU64 = AtomicU64::new(0);
+    static W5_A_WFD: AtomicU64 = AtomicU64::new(0);
+    static W5_B_WFD: AtomicU64 = AtomicU64::new(0);
+
+    let mut fds5 = [0u32; 2];
+    let r = crate::syscall::dispatch_linux_kernel(
+        293 /*pipe2*/, fds5.as_mut_ptr() as u64, 0 /*blocking*/, 0, 0, 0, 0);
+    if r != 0 {
+        test_fail!("pipe_blocking_write", "pipe2(blocking) for concurrent test returned {}", r);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    let (rfd5, wfd5) = (fds5[0] as u64, fds5[1] as u64);
+    if crate::syscall::dispatch_linux_kernel(72, wfd5, 1031, 4096, 0, 0, 0) != 4096 {
+        test_fail!("pipe_blocking_write", "F_SETPIPE_SZ pin to 4096 failed (sub-test 5)");
+        crate::syscall::dispatch_linux_kernel(3, rfd5, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd5, 0, 0, 0, 0, 0);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    let pipe_id5 = crate::syscall::get_pipe_id(pid, wfd5 as usize);
+
+    fn writer_a_entry() {
+        crate::hal::enable_interrupts();
+        let wfd = W5_A_WFD.load(Ordering::SeqCst);
+        let buf = [0xA1u8; REC];
+        let ret = crate::syscall::dispatch_linux_kernel(
+            1 /*write*/, wfd, buf.as_ptr() as u64, REC as u64, 0, 0, 0);
+        W5_A_RET.store(ret as u64, Ordering::SeqCst);
+        W5_A_DONE.store(1, Ordering::SeqCst);
+        crate::proc::exit_thread(0);
+    }
+    fn writer_b_entry() {
+        crate::hal::enable_interrupts();
+        let wfd = W5_B_WFD.load(Ordering::SeqCst);
+        let buf = [0xB2u8; REC];
+        let ret = crate::syscall::dispatch_linux_kernel(
+            1 /*write*/, wfd, buf.as_ptr() as u64, REC as u64, 0, 0, 0);
+        W5_B_RET.store(ret as u64, Ordering::SeqCst);
+        W5_B_DONE.store(1, Ordering::SeqCst);
+        crate::proc::exit_thread(0);
+    }
+
+    W5_A_DONE.store(0, Ordering::SeqCst);
+    W5_B_DONE.store(0, Ordering::SeqCst);
+    let wa_pid = crate::proc::create_kernel_process(
+        "pipe_writer_a", writer_a_entry as *const () as u64);
+    let wb_pid = crate::proc::create_kernel_process(
+        "pipe_writer_b", writer_b_entry as *const () as u64);
+    let wa_fd = install_pipe_write_fd(wa_pid, pipe_id5);
+    let wb_fd = install_pipe_write_fd(wb_pid, pipe_id5);
+    if wa_fd < 0 || wb_fd < 0 {
+        test_fail!("pipe_blocking_write",
+            "install_pipe_write_fd returned a={} b={}", wa_fd, wb_fd);
+        if !was_active { crate::sched::disable(); }
+        return false;
+    }
+    W5_A_WFD.store(wa_fd as u64, Ordering::SeqCst);
+    W5_B_WFD.store(wb_fd as u64, Ordering::SeqCst);
+
+    // Let both writers attempt their writes before the reader drains, to
+    // maximise the interleave window the old separate-lock code would lose on.
+    for _ in 0..64u32 {
+        crate::sched::yield_cpu();
+        crate::hal::enable_interrupts();
+        for _ in 0..200u32 { core::hint::spin_loop(); }
+    }
+
+    // Reader: drain the whole pipe via real read(2), reconstructing the byte
+    // stream so we can verify each record is contiguous.
+    let mut stream: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(2 * REC);
+    let mut chunk5 = [0u8; 256];
+    let mut spins = 0u32;
+    while stream.len() < 2 * REC && spins < 4096 {
+        let rn = crate::syscall::dispatch_linux_kernel(
+            0 /*read*/, rfd5, chunk5.as_mut_ptr() as u64, chunk5.len() as u64, 0, 0, 0);
+        if rn > 0 {
+            stream.extend_from_slice(&chunk5[..rn as usize]);
+        } else {
+            crate::sched::yield_cpu();
+            crate::hal::enable_interrupts();
+            for _ in 0..200u32 { core::hint::spin_loop(); }
+            spins += 1;
+            if W5_A_DONE.load(Ordering::SeqCst) == 1
+                && W5_B_DONE.load(Ordering::SeqCst) == 1
+                && !crate::ipc::pipe::pipe_has_data(pipe_id5)
+            {
+                break;
+            }
+        }
+    }
+
+    let a_ret = W5_A_RET.load(Ordering::SeqCst) as i64;
+    let b_ret = W5_B_RET.load(Ordering::SeqCst) as i64;
+    let leaked5 = crate::ipc::pipe::debug_writer_waiter_count(pipe_id5);
+    crate::syscall::dispatch_linux_kernel(3, rfd5, 0, 0, 0, 0, 0);
+    crate::syscall::dispatch_linux_kernel(3, wfd5, 0, 0, 0, 0, 0);
+    if !was_active { crate::sched::disable(); }
+
+    if a_ret != REC as i64 || b_ret != REC as i64 {
+        test_fail!("pipe_blocking_write",
+            "concurrent writers returned a={} b={} (expected {} each — a short return means a partial atomic record)", a_ret, b_ret, REC);
+        return false;
+    }
+    if stream.len() != 2 * REC {
+        test_fail!("pipe_blocking_write",
+            "drained {} bytes from concurrent writers (expected {})", stream.len(), 2 * REC);
+        return false;
+    }
+    // Atomicity check: each record is all-0xA1 or all-0xB2; with atomicity there
+    // are EXACTLY two contiguous same-byte runs, each of length REC.  A split /
+    // interleaved record shows up as a short run or a third run.
+    let mut runs: alloc::vec::Vec<(u8, usize)> = alloc::vec::Vec::new();
+    for &b in stream.iter() {
+        match runs.last_mut() {
+            Some((val, len)) if *val == b => { *len += 1; }
+            _ => runs.push((b, 1)),
+        }
+    }
+    let bad = runs.iter().any(|(v, l)| (*v != 0xA1 && *v != 0xB2) || *l != REC);
+    if runs.len() != 2 || bad {
+        test_fail!("pipe_blocking_write",
+            "concurrent atomicity VIOLATED: expected 2 contiguous runs of {} (0xA1, 0xB2); got {} runs {:?} (a split/interleaved <=PIPE_BUF record)",
+            REC, runs.len(), runs);
+        return false;
+    }
+    if leaked5 != 0 {
+        test_fail!("pipe_blocking_write",
+            "{} stale writer(s) on PIPE_WRITE_WAITERS after concurrent completion", leaked5);
+        return false;
+    }
+    test_println!("  concurrent two-writer atomicity: 2 contiguous {}B records, no interleave ✓", REC);
+
+    test_pass!("pipe blocking write — capacity / atomic-park / concurrent-atomicity / EAGAIN / EPIPE / reader-wakes-writer");
     true
 }
 
@@ -39199,6 +39664,15 @@ fn test_pipe_console_drain_on_park() -> bool {
     }
     let (rfd, wfd) = (fds[0] as u64, fds[1] as u64);
     let pipe_id = crate::syscall::get_pipe_id(me, wfd as usize);
+    // Pipes now default to the Linux 64 KiB capacity (pipe(7)); this test's
+    // exact-fill / empty-space arithmetic is written against a 4 KiB ring, so
+    // pin it back via fcntl(2) F_SETPIPE_SZ (cmd 1031, returns the capacity).
+    if crate::syscall::dispatch_linux_kernel(72, wfd, 1031, 4096, 0, 0, 0) != 4096 {
+        test_fail!("pipe_console_drain", "F_SETPIPE_SZ pin to 4096 failed");
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
 
     let filler = [0x5Au8; 4096];
     let n = crate::syscall::dispatch_linux_kernel(

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -39733,6 +39733,19 @@ fn test_pipe_console_drain_on_park() -> bool {
         return false;
     }
     let (ctl_rfd, ctl_wfd) = (ctl_fds[0] as u64, ctl_fds[1] as u64);
+    // Pin the control pipe to 4 KiB too (fcntl F_SETPIPE_SZ, cmd 1031): with
+    // the new 64 KiB default a 4096-byte fill would leave 61440 free, so the
+    // 256-byte O_NONBLOCK write below would legitimately succeed instead of
+    // EAGAIN.  This sub-test needs a FULL control pipe to prove the inline
+    // drain is NOT applied to ordinary (non-console) pipes.
+    if crate::syscall::dispatch_linux_kernel(72, ctl_wfd, 1031, 4096, 0, 0, 0) != 4096 {
+        test_fail!("pipe_console_drain", "F_SETPIPE_SZ pin to 4096 failed (control pipe)");
+        crate::syscall::dispatch_linux_kernel(3, ctl_rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, ctl_wfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, rfd, 0, 0, 0, 0, 0);
+        crate::syscall::dispatch_linux_kernel(3, wfd, 0, 0, 0, 0, 0);
+        return false;
+    }
     crate::syscall::dispatch_linux_kernel(
         1 /*write*/, ctl_wfd, filler.as_ptr() as u64, 4096, 0, 0, 0);
     let ctrl = crate::syscall::dispatch_linux_kernel(


### PR DESCRIPTION
## Re-land: lost pipe subsystem fixes

These changes were originally merged as **PR #559** (Linux-parity pipe capacity + launcher-pipe drain) plus the **#551 follow-ups** (blocking-write livelock / lost-wake / concurrent-writer atomicity) on the pre-rewrite history. The **2026-06-10 git history rewrite** orphaned that lineage; the #577 regraft brought the *base* blocking-write path back but not the follow-up fixes, and PR #559's capacity work was never carried across. A fresh static audit independently re-found the atomic-write livelock, confirming the regression. This PR re-lands the still-missing pieces onto current `master`, adapted to ~3 weeks of drift (`pipe.rs` was partially regrafted, the `syscall.rs` pipe arms and `gui/terminal.rs` evolved through the June GUI/reactor overhaul).

The value here is **capacity parity + data-integrity + a real correctness fix**, not "fixes multi-second parks": HEAD already suppresses the writer park for the console pipe via an inline drain — but that inline drain *discards* the child's bytes, and the atomic-write livelock is a genuine non-yielding 100% CPU spin.

### What's fixed

**1. Linux-parity pipe capacity (`pipe(7)`, `fcntl(2)`).**
The ring was `PIPE_BUF`-sized (4 KiB, the bare POSIX minimum) while `pipe(7)` documents a 65,536-byte default. The ring is now a per-pipe heap buffer, default 64 KiB; `PIPE_BUF` (4096) is preserved as the **atomicity** threshold (`limits.h`), a distinct concept from ring capacity. New `fcntl` `F_SETPIPE_SZ` (1031) / `F_GETPIPE_SZ` (1032) round the request up to a power of two (floor `PIPE_BUF`), return `EBUSY` when the buffered bytes would not fit, `EPERM` above the 1 MiB `pipe-max-size` ceiling, and `EBADF` on a non-pipe fd; a successful grow wakes writers parked on the previously-full ring.

**2. Byte-preserving launcher-pipe drain thread (data integrity).**
The kernel-side capture of a child's fd 1/2 is provisioned at the 1 MiB ceiling and drained by a dedicated kernel thread woken directly by the child's `write(2)`. Previously the only backstop against a starved reader was the inline console-drain in the blocking-write path, which frees the ring by **discarding** the child's stdout/stderr (data loss, plus a lock+memcpy pass per fill at gecko's >1 MiB stderr volume). The drain thread frees ring space **and** wakes the parked writer (`pipe_read_and_wake`) **without** discarding the bytes, mirroring them to serial / the terminal grid.

Single drain ownership (`DRAIN_THREAD_STARTED`): once the thread owns the pipe, `poll_output()` skips its own dequeue (keeping only the throttled render), and the inline console-drain **degrades to a last-resort backstop** that fires only when no drain thread owns the pipe (e.g. a build/context where it was never started). The no-park / no-undrained-window guarantee (#551/#577) is preserved, while the steady state prefers a byte-preserving park-with-wake over silent discard.

**3. Atomic-write livelock (`pipe_write_blocking`, `count <= PIPE_BUF`).**
The old writer-wait predicate returned "ready" on *any* free space, while the atomic arm only deposits when the *whole* record fits — so a blocking atomic write into `0 < space < count` spun `check -> ready -> retry` at 100% CPU (a non-yielding loop; re-found by static audit). `wait_writable` is now needs-aware: it parks unless `space() >= need` (`need == count` for an atomic write, `1` for a large write) and re-checks under the wait-list lock, so a drain freeing less than `need` re-parks cleanly instead of wake-spinning.

**4. `<=PIPE_BUF` atomicity under concurrent writers.**
The space-check (`pipe_space`) and the deposit (`pipe_write`) were separate `PIPE_TABLE` acquisitions, so two concurrent atomic writers could both observe `space >= count`, each deposit a self-capped short record, and publish two interleaved partials. New `pipe_write_atomic` does the check-and-deposit under one `PIPE_TABLE` critical section — the whole record iff `space() >= len`, else `NoSpace` without writing. A partial `<= PIPE_BUF` record is never published (`pipe(7)` `PIPE_BUF` atomicity).

### Deliberately not re-landed
- **The lost-wake fix** from the same follow-up (a reader draining without waking a parked writer) is already present at HEAD — every drain consumer reads through `pipe_read_and_wake`.
- **The kdb / per-syscall-arg diagnostics** from the original capacity commit: the kdb `uread` op already supersedes the proposed `user-mem` op, so re-adding it would be redundant.

### Interaction review (#668 / #678 / #680)
The launcher drain thread emits only the existing `[CHILD-OUT]` child-output mirror (gated as before) — it does **not** reintroduce per-read serial spam on `firefox-test-core`. It defers the repaint to the desktop reactor via `RENDER_DIRTY`, so drain throughput is not coupled to framebuffer blit speed.

### Tests
`test_pipe_blocking_write_semantics`:
- new capacity sub-test — default `65536`, round-up `5000 -> 8192`, shrink-below-buffered `EBUSY`, `>1 MiB` `EPERM`, non-pipe `EBADF`;
- exact-fill sub-tests pinned back to 4 KiB via `F_SETPIPE_SZ` so their arithmetic is capacity-independent;
- blocking-atomic-insufficient-space sub-test — a watchdog proves the writer **parks** on `PIPE_WRITE_WAITERS` (never observed under the old livelock) before any drain, then completes with the full record;
- concurrent two-writer sub-test — asserts the drained stream is exactly two contiguous same-byte runs (no split / interleave).

`test_pipe_console_drain_on_park` pinned to 4 KiB for its space assertions.

Both `test-mode` and `firefox-test-core` compile locally; CI runs the full suite.

Refs: `pipe(7)`, `write(2)`, `fcntl(2)` (`F_SETPIPE_SZ`/`F_GETPIPE_SZ`), POSIX.1-2017 §write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
