### PR TITLE
perf(firefox-test-core): de-gate hot per-event serial emitters + keep the cheap mmap-so symbol table

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2008,7 +2008,7 @@ pub fn exit_thread(exit_code: i64) {
                 .map(|t| t.clear_child_tid)
                 .unwrap_or(0)
         };
-        #[cfg(feature = "firefox-test-core")]
+        #[cfg(feature = "firefox-test-trace")]
         crate::serial_println!(
             "[CLEARTID] tid={} pid={} clear_addr={:#x}",
             tid, pid, clear_addr
@@ -2019,7 +2019,7 @@ pub fn exit_thread(exit_code: i64) {
                 let procs = PROCESS_TABLE.lock();
                 procs.iter().find(|p| p.pid == pid).map(|p| p.cr3).unwrap_or(0)
             };
-            #[cfg(feature = "firefox-test-core")]
+            #[cfg(feature = "firefox-test-trace")]
             crate::serial_println!("[CLEARTID] tid={} cr3={:#x}", tid, cr3);
             if cr3 != 0 {
                 crate::syscall::write_u32_to_user_pub(cr3, clear_addr, 0);

--- a/kernel/src/proc/usermode.rs
+++ b/kernel/src/proc/usermode.rs
@@ -64,6 +64,12 @@ pub fn create_user_thread(
         }
     }
 
+    // Per-thread clone-create trace: fires once per pthread_create, so it
+    // spikes during Firefox thread-churn phases.  Diagnostic only — gate it
+    // behind the full-trace profile so the lean `firefox-test-core` perf/CI
+    // boot stays quiet.  `[USER] Bootstrap` (per thread first-schedule) is
+    // deliberately kept on the lean profile as the harness CR3 fallback.
+    #[cfg(feature = "firefox-test-trace")]
     crate::serial_println!(
         "[USER] Created clone thread TID {} in PID {}: RIP={:#x} RSP={:#x} TLS={:#x} RDX={:#x} R8={:#x} R9={:#x}",
         tid, pid, user_rip, user_rsp, tls, entry_rdx, entry_r8, parent_regs.r9

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -3364,6 +3364,10 @@ fn dispatch_body(num: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64
                 let child_tidptr  = arg4; // r10 = child_tid
                 match crate::proc::usermode::create_user_thread(pid, user_rip, new_stack, tls_val, 0, 0) {
                     Some(tid) => {
+                        // Per-thread clone trace (fires once per pthread_create);
+                        // gate behind the full-trace profile so the lean
+                        // `firefox-test-core` perf boot pays nothing.
+                        #[cfg(feature = "firefox-test-trace")]
                         crate::serial_println!("[CLONE] Thread TID {} spawned in PID {}", tid, pid);
                         // CLONE-ARGS-DIAG: snapshot pthread args at clone time.
                         // Per upstream musl libc x86_64 __clone, before the
@@ -6639,7 +6643,13 @@ pub fn sys_read_linux(fd: u64, buf: u64, count: u64) -> i64 {
     match crate::vfs::fd_read(pid, fd as usize, buf_ptr, count) {
         Ok(n) => {
             crate::mm::file_buf_witness::post_read(__fbw_snap, n as i64);
-            #[cfg(feature = "firefox-test-core")]
+            // `[FF/read-bytes]` synthetic-read capture: the path-lookup lock,
+            // per-read staging copy, snapshot alloc and the serial emit are all
+            // diagnostic (the functional read already completed above).  Gate
+            // the whole block behind the full-trace profile so the lean
+            // `firefox-test-core` perf/CI boot skips the per-read memcpy + the
+            // serial write it feeds.
+            #[cfg(feature = "firefox-test-trace")]
             {
                 // Look up the fd's open_path to decide whether to peek.  We
                 // do this AFTER the read so we see the actual returned bytes.

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2275,7 +2275,7 @@ pub fn futex_wake_for_exit(pid: u64, uaddr: u64, max_wake: u64) {
             alloc::vec::Vec::new()
         }
     };
-    #[cfg(feature = "firefox-test-core")]
+    #[cfg(feature = "firefox-test-trace")]
     {
         // Snapshot remaining keys for diagnosis if our lookup missed.
         let waiters = FUTEX_WAITERS.lock();
@@ -3234,9 +3234,11 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
         // can emit a `[FFTEST/mmap-so]` trace AFTER dropping the lock.  Letting
         // the print happen under PROCESS_TABLE could block other CPUs on a
         // slow serial port.  The capture is gated to match the emit cfg
-        // below — the `*-trace` features — so neither the per-mmap String
-        // allocation nor the serial line is paid in the fast/perf builds.
-        #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace"))]
+        // below — `firefox-test-core` (the lean profile also needs the
+        // load-base table for harness user-RIP symbolisation) or `test-mode` —
+        // so on a bare default kernel neither the per-mmap String allocation
+        // nor the serial line is paid.
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode-trace"))]
         let so_trace_path: Option<alloc::string::String> = {
             let fd_num = fd as usize;
             proc.file_descriptors
@@ -3298,18 +3300,18 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
             }
         };
 
-        #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace"))]
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode-trace"))]
         {
             (space.cr3, vma_backing, vma_name, chosen_base, so_trace_path)
         }
-        #[cfg(not(any(feature = "firefox-test-trace", feature = "test-mode-trace")))]
+        #[cfg(not(any(feature = "firefox-test-core", feature = "test-mode-trace")))]
         {
             (space.cr3, vma_backing, vma_name, chosen_base)
         }
     };
-    #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace"))]
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode-trace"))]
     let (cr3, backing, name, base, so_trace_path_out) = mmap_setup;
-    #[cfg(not(any(feature = "firefox-test-trace", feature = "test-mode-trace")))]
+    #[cfg(not(any(feature = "firefox-test-core", feature = "test-mode-trace")))]
     let (cr3, backing, name, base) = mmap_setup;
 
     // W215 H3a diagnostic: count MAP_SHARED+PROT_WRITE file-backed mappings.
@@ -3342,17 +3344,18 @@ pub(crate) fn sys_mmap(addr_hint: u64, length: u64, prot: u32, flags: u32, fd: u
     // The first executable LOAD segment for a given .so is the load base;
     // later segments are placed by ld-linux at base+seg_vaddr via MAP_FIXED.
     //
-    // The host symboliser in `qemu-harness.py` consumes these lines to
-    // resolve user RIPs to `<library>+offset`.  Emit on any of:
-    //   - `firefox-test` (W101 plateau investigation requires symbolised
-    //     RIP samples; the cost is one log line per mmap, ~80 lines total
-    //     across a Firefox boot)
+    // The host symboliser in `qemu-harness.py` (`rip-sample --symbolise`,
+    // `ustack`, `autopsy`, `rip-trace-resolve`) consumes these lines to build
+    // the RIP→DSO load-base map and resolve user RIPs to `<library>+offset`.
+    // Emit on any of:
+    //   - `firefox-test-core` (the lean perf/render/CI profile): user-RIP
+    //     symbolisation must work on lean boots too, so the load-base table is
+    //     part of the functional core, not the trace superset.  This is one log
+    //     line per DSO mmap (~80 lines total across a Firefox boot) — a cheap
+    //     boot-time table, NOT a hot per-syscall emitter, so it belongs on the
+    //     fast profile.  `firefox-test-trace` still emits it (it pulls the core).
     //   - `test-mode` (headless dynamic-linker tests verify placement)
-    // The previous `firefox-trace-verbose` gate was an oversight — without
-    // mmap-so traces the harness symbolicator cannot resolve user RIPs to
-    // `<lib>+offset`, which made `rip-trace`'s output uninterpretable for
-    // PIE binaries.
-    #[cfg(any(feature = "firefox-test-trace", feature = "test-mode-trace"))]
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode-trace"))]
     if let Some(path) = so_trace_path_out {
         crate::serial_println!(
             "[FFTEST/mmap-so] pid={} base={:#x} len={:#x} off={:#x} prot={:#x} fd={} path={}",

--- a/kernel/src/x11/mod.rs
+++ b/kernel/src/x11/mod.rs
@@ -1110,7 +1110,11 @@ fn build_setup_ok() -> [u8; 128] {
 fn handle_request(fd: u64, data: &[u8]) {
     if data.len() < 4 { return; }
     let opcode = data[0];
-    #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+    // Per-request protocol trace ([X11] req#… + [X11HEX]…): diagnostic only.
+    // Gate behind the full-trace profile (was `firefox-test-core`) so the lean
+    // perf/CI boot skips the per-request atomic + drawable decode + serial emit;
+    // keep it on `xeyes-test` for the X11 client bring-up path.
+    #[cfg(any(feature = "firefox-test-trace", feature = "xeyes-test"))]
     {
         static X11_REQ_N: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
         let n = X11_REQ_N.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
@@ -2119,6 +2123,10 @@ fn op_intern_atom(fd: u64, data: &[u8], seq: u16) {
     let atom = atoms::intern(name, oie);
     let mut b = [0u8; 32]; b[0]=1; w16(&mut b,2,seq); w32(&mut b,8,atom);
     with_client(fd, |c| c.send(&b));
+    // Per-InternAtom-request decode line: redundant with the (now trace-gated)
+    // `[X11] req#` line for the same request, so keep the X11 trace coherent by
+    // gating it to the same full-trace / xeyes-test profile.
+    #[cfg(any(feature = "firefox-test-trace", feature = "xeyes-test"))]
     crate::serial_println!("[X11] InternAtom({:?}) -> {}", name, atom);
 }
 
@@ -4535,7 +4543,10 @@ fn op_damage(fd: u64, data: &[u8], seq: u16) {
 fn op_xinput(fd: u64, data: &[u8], seq: u16) {
     if data.len() < 4 { return; }
     let minor = data[1];
-    #[cfg(any(feature = "firefox-test-core", feature = "xeyes-test"))]
+    // Per-XI-request trace: uncapped, so it is the hot X11 serial line under a
+    // Firefox render load (GTK drives XInput2 heavily).  Gate behind the
+    // full-trace profile; keep it on `xeyes-test`.
+    #[cfg(any(feature = "firefox-test-trace", feature = "xeyes-test"))]
     crate::serial_println!("[X11/XI] minor={} len={}", minor, data.len());
     match minor {
         // ── XI v1 (subset commonly issued by libXi during device discovery) ───


### PR DESCRIPTION
## Summary

Makes `firefox-test-core` a clean measurement profile. Follow-up to #680 (which moved the heavy per-syscall trace ring off the fast profile — this is the bigger win #680 named next).

Live RIP-sampling an SMP=1 Firefox Wikipedia load on a lean `firefox-test-core,kdb` build showed the kernel side of the syscall storm was still **~52% serial `write_str`** (66/126 kernel samples, plus the memcpy/memset feeding it) — from non-rate-limited **per-event** serial emitters still gated into the "fast" functional profile. A prior session measured this cost as phase-dependent (~2.6% steady, ~51% during thread-churn phases): both a real tax on every Firefox boot and measurement fog on the profile that is meant to be the low-overhead perf/render/CI build.

## Part 1 — de-gate the hot per-event emitters off the lean profile

Re-gated behind the established full-trace gate `firefox-test-trace` (which pulls `syscall-trace`, so `firefox-test` / `--trace` boots keep every line — the full-trace profile stays a strict superset):

- `[USER] Created clone thread` (was **unconditional**) + `[CLONE] Thread TID spawned` (was **unconditional**) — the paired per-`pthread_create` lines.
- `[CLEARTID]` x2 and the `[FUTEX_WAKE_EXIT]` remaining-keys snapshot block — per thread-exit.
- `[FF/read-bytes]` synthetic-read capture — the whole diagnostic block (path-lookup lock + per-read staging copy + snapshot alloc + `set_read_bytes` + serial emit).
- `[X11] req#`/`[X11HEX]` per-request block and `[X11/XI] minor` (the uncapped, hot X11 line under a render load — GTK drives XInput2 heavily) + `[X11] InternAtom` (was **unconditional**, redundant with `[X11] req#`). `xeyes-test` preserved on the X11 traces.

**Deliberately kept on the lean profile** (bounded, not hot, or load-bearing): `[USER] Bootstrap` (per thread first-schedule — the harness autopsy CR3 serial fallback source), the per-exec `[USER]` process one-shots, `[X11] Xastryx ready` (smoke-script boot marker), `[X11] MapWindow` (asserted by the x11-tests native test), the X11 connect/setup lines, and the unknown-opcode / unhandled-XI warnings.

## Part 2 — keep the one cheap table that makes lean-profile profiling possible

`[FFTEST/mmap-so]` (~80 lines per boot, one per DSO mmap — a boot-time table, **not** a hot per-syscall emitter) was gated behind `firefox-test-trace`/`test-mode-trace`, so the harness could not build the RIP→DSO load-base map on a lean boot and `rip-sample --symbolise` / `ustack` / `autopsy` user-RIP symbolisation were impossible on `firefox-test-core`. Gated the emitter **and** its capture (the `so_trace_path` binding + the tuple that carries it) **into** `firefox-test-core`. Emitter format unchanged → the existing `qemu-harness.py` `_MMAP_SO` parser consumes the lean-profile lines verbatim (**no harness change required**; verified the regex matches all 7 fields). `[SC-USTACK]` (per-syscall, hot) is left on the trace profile as instructed, so `rip-sample --symbolise` — not `ustack` — is what becomes available on lean.

## Verification

Builds green for `firefox-test-core,kdb`, `firefox-test-trace,kdb`, `test-mode`, and the default (no-features) kernel. No new unused-variable warnings at the gated sites. No pixel or ABI behaviour change — diagnostic serial output only. No QEMU run this change (build-only dispatch; GitHub CI is the boot/functional gate).

## ⚠️ Measurement note for downstream A/Bs

This commit **reduces** lean-profile serial `write_str` on the Firefox hot path, so any perf comparison whose baseline and candidate **straddle this commit** will see a shift in measured kernel% that is due to the removed instrumentation, not a kernel-behaviour change. **Re-baseline across this commit.** All changes are additive to the harness contract (no renamed JSON fields; the `[FFTEST/mmap-so]` line format is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
