### PR TITLE
sched: candidate-gate starvation hypothesis REFUTED (0/43M gate-skips) + instrumentation + latent self-resume wait-stamp fix

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -16,6 +16,12 @@ default = []
 # deterministic Test 648 is the authoritative merge gate; this is supplementary
 # live evidence.
 sched-pick-xcheck = []
+# `sched-gate-stats` — count the population of Ready threads skipped by each
+# scheduler candidate gate (ctx_rsp_valid / affinity / mirror-slot) and how
+# often the picker returns to a self-resuming Ready current.  Diagnostic-only:
+# the increments compile out entirely by default so the pick hot path (and the
+# `firefox-test-core` profile) stays byte-identical.  Read via kdb `cpu-state`.
+sched-gate-stats = []
 # `heap-canary` — fence every live kernel-heap allocation with front/rear
 # magic red-zone words (validated on free) so an out-of-bounds write that
 # clobbers free-list metadata is caught at free-time, naming the victim

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1898,9 +1898,9 @@ fn op_cpu_state(out: &mut String) {
                 let crv = t.ctx_rsp_valid.load(core::sync::atomic::Ordering::Relaxed);
                 let _ = write!(
                     out,
-                    r#"{{"tid":{},"pid":{},"st":"{:?}","lcpu":{},"aff":{},"mcpu":{},"mprio":{},"prio":{},"wt":{},"crv":{}}}"#,
+                    r#"{{"tid":{},"pid":{},"st":"{:?}","lcpu":{},"aff":{},"mcpu":{},"mprio":{},"prio":{},"wt":{},"crv":{},"rst":{}}}"#,
                     t.tid, t.pid, t.state, t.last_cpu, aff, ms_cpu, ms_prio,
-                    t.priority, t.wake_tick, crv as u8);
+                    t.priority, t.wake_tick, crv as u8, t.ready_since_tick);
             }
             out.push(']');
         }
@@ -1908,6 +1908,31 @@ fn op_cpu_state(out: &mut String) {
             out.push_str(r#","threads":"THREAD_TABLE held""#);
         }
     }
+
+    // ── Scheduler-liveness + candidate-gate skip population ──────────────────
+    // `maintain_passes` and `ctx_switches` advance once per picker pass / real
+    // context switch; a reader sampling them twice across a STARVE window can
+    // tell whether `schedule()` is running (H3: gate/stamp artifact) or frozen
+    // (H2: a monopolising in-kernel path).  `force_total` is the cumulative
+    // anti-starvation force-select count.  `gate_skips` (feature `sched-gate-
+    // stats`) is the population of Ready threads skipped by each candidate gate.
+    let _ = write!(
+        out,
+        r#","sched":{{"maintain_passes":{},"ctx_switches":{},"force_total":{}"#,
+        crate::sched::percpu::maintain_passes(),
+        crate::perf::context_switches(),
+        crate::sched::starve_force_count(),
+    );
+    #[cfg(feature = "sched-gate-stats")]
+    {
+        let (ctx_rsp, aff, mirror, self_resume) = crate::sched::gate_stats::snapshot();
+        let _ = write!(
+            out,
+            r#","gate_skips":{{"ctx_rsp_invalid":{},"affinity":{},"mirror":{},"self_resume_ready":{}}}"#,
+            ctx_rsp, aff, mirror, self_resume);
+    }
+    out.push('}');
+
     out.push('}');
 }
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -452,6 +452,48 @@ pub fn starve_force_count() -> u64 {
     SCHED_STARVE_FORCE_TOTAL.load(Ordering::Relaxed)
 }
 
+// ── Candidate-gate skip population counters (diagnostic, feature-gated) ──────
+//
+// The force-select backstop only logs a thread whose stale wait-age survives
+// past its deadline; a Ready thread skipped by a candidate gate for a sub-log
+// interval leaves no trace.  These counters record the POPULATION of gate
+// skips so an A/B can show how often each gate hides a Ready thread from the
+// fairness ladder, and how often the picker returns to a self-resuming Ready
+// current (the path that historically left an uncleared `ready_since_tick`).
+//
+// Gated behind `sched-gate-stats` so the shipped hot path (default and
+// `firefox-test-core`) is byte-identical — the increments compile out entirely.
+#[cfg(feature = "sched-gate-stats")]
+pub mod gate_stats {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    /// A Ready candidate was skipped because `ctx_rsp_valid == false` (its saved
+    /// kernel RSP is not yet valid — mid switch-out or self-resume window).
+    pub static SKIP_CTX_RSP_INVALID: AtomicU64 = AtomicU64::new(0);
+    /// A Ready candidate was skipped because its hard `cpu_affinity` pin does
+    /// not match the picking CPU.
+    pub static SKIP_AFFINITY: AtomicU64 = AtomicU64::new(0);
+    /// A Ready non-idle thread was filtered out of the per-CPU candidate set
+    /// because its `mirror_slot` targets a different CPU (or is still `None`).
+    pub static SKIP_MIRROR: AtomicU64 = AtomicU64::new(0);
+    /// The picker found no other Ready peer and returned to the current thread
+    /// whose state the due-wake drain had flipped to Ready (self-resume).  This
+    /// is the path that must reset `ready_since_tick`; the counter measures how
+    /// often it is taken so a stale-stamp regression is visible as a divergence
+    /// between this count and the force-select count.
+    pub static SELF_RESUME_READY: AtomicU64 = AtomicU64::new(0);
+
+    #[inline]
+    pub fn snapshot() -> (u64, u64, u64, u64) {
+        (
+            SKIP_CTX_RSP_INVALID.load(Ordering::Relaxed),
+            SKIP_AFFINITY.load(Ordering::Relaxed),
+            SKIP_MIRROR.load(Ordering::Relaxed),
+            SELF_RESUME_READY.load(Ordering::Relaxed),
+        )
+    }
+}
+
 /// The BSP poll-reactor (TID 0) force-deadline in 100 Hz ticks.  Exposed for
 /// the scheduler regression test to assert the latency guarantee without
 /// reaching into the private constant.
@@ -1814,6 +1856,21 @@ pub fn test_saved_rsp_aliases(
     saved_rsp_aliases_live_frame(threads, base, size, excluding_tid)
 }
 
+/// Test-only: run the picker's self-resume promotion against a caller-supplied
+/// thread slice.  Lets the test suite verify the self-resume bookkeeping
+/// invariant (a Ready current that the picker returns to in place must be
+/// promoted to `Running` with its `ready_since_tick` cleared, so a stale wait
+/// stamp cannot later mis-fire the anti-starvation force backstop; a non-Ready
+/// current must be left untouched) without spinning a live scheduler.
+#[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
+pub fn test_resume_current_if_ready(
+    threads: &mut [proc::Thread],
+    current_tid: proc::Tid,
+    cpu: u8,
+) -> Option<ThreadState> {
+    resume_current_if_ready(threads, current_tid, cpu)
+}
+
 /// Pure selection core: the scoring loop + two-pass split + force-backstop
 /// resolution, with NO side effects (no `READY_DEPTH` publish, no
 /// `SCHED_STARVE_FORCE_TOTAL` bump, no diagnostic).  Returns the selected table
@@ -1849,10 +1906,14 @@ fn select_next_core(
             ready_peers += 1;
         }
         if !t.ctx_rsp_valid.load(core::sync::atomic::Ordering::Acquire) {
+            #[cfg(feature = "sched-gate-stats")]
+            gate_stats::SKIP_CTX_RSP_INVALID.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
             continue;
         }
         if let Some(aff) = t.cpu_affinity {
             if aff != cpu {
+                #[cfg(feature = "sched-gate-stats")]
+                gate_stats::SKIP_AFFINITY.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
                 continue;
             }
         }
@@ -2008,6 +2069,52 @@ fn test_percpu_candidates(
     out
 }
 
+/// Resolve the current thread when the picker reaches its "no other Ready peer"
+/// fallback, promoting a self-resuming Ready current back to `Running`.
+///
+/// The picker's candidate walk deliberately excludes the current thread's own
+/// index (`(1..len)` rotation), so the current thread is never selected by the
+/// scoring loop.  When no OTHER thread is Ready, `schedule()` returns to the
+/// current thread in place (no context switch).  Normally the current thread is
+/// still `Running`, but the in-picker due-wake drain can flip a current thread
+/// that had blocked with a sleep/timeout deadline back to `Ready` when that
+/// deadline elapses during this same pass — and then this fallback runs it.
+///
+/// That in-place resume IS a selection of the current thread to run, so it must
+/// apply the same post-selection bookkeeping the normal pick applies to the
+/// thread it selects (see the `Some(idx)` arm: `state = Running`,
+/// `ready_since_tick = 0`).  Otherwise the thread keeps a `Ready` state and its
+/// original `ready_since_tick` while it actually runs; the anti-starvation
+/// design (`ready_since_tick` "cleared the moment the thread is selected to
+/// Run") is then violated, and when the thread later yields to a freshly-Ready
+/// peer it re-enters the ready set carrying that stale stamp — the force-select
+/// backstop then rescues it on a wait age that was never real.
+///
+/// `ctx_rsp_valid` is deliberately NOT touched: the thread runs on its live
+/// kernel stack and its saved `context.rsp` is stale until the next real
+/// switch-out re-validates it — the exact invariant the picker's
+/// `ctx_rsp_valid` candidate gate and the #672/#673 on-CPU interlock rely on
+/// (a thread must never be dispatched onto another CPU via a stale saved RSP).
+/// Promoting the state to `Running` here only STRENGTHENS that exclusion (a
+/// `Running` thread is not a candidate at all), so it cannot weaken the SMP
+/// interlock.  Returns the state observed BEFORE promotion so the caller's
+/// match arms (and the self-resume diagnostic) are unchanged.
+#[inline]
+fn resume_current_if_ready(
+    threads: &mut [proc::Thread],
+    current_tid: proc::Tid,
+    cpu: u8,
+) -> Option<ThreadState> {
+    let t = threads.iter_mut().find(|t| t.tid == current_tid)?;
+    let observed = t.state;
+    if observed == ThreadState::Ready {
+        t.state = ThreadState::Running;
+        t.last_cpu = cpu;
+        t.ready_since_tick = 0;
+    }
+    Some(observed)
+}
+
 /// Schedule the next thread to run.
 ///
 /// This is the core scheduling function. It:
@@ -2146,10 +2253,10 @@ was_emergency_4k={}",
             //                         ever produce another runnable
             //                         thread on this kernel.  Returning
             //                         would sysretq into dead user code.
-            let current_state = threads
-                .iter()
-                .find(|t| t.tid == current_tid)
-                .map(|t| t.state);
+            // Promote a self-resuming Ready current back to Running and clear
+            // its run-queue wait stamp (a successful in-place pick of the
+            // current thread — see `resume_current_if_ready`).
+            let current_state = resume_current_if_ready(&mut threads, current_tid, cpu);
             drop(threads);
             match current_state {
                 // Running, or freshly re-Readied (e.g. by the due-wake drain
@@ -2160,6 +2267,10 @@ was_emergency_4k={}",
                 // it is exactly the intended self-resume.  Clear the burst so a
                 // brief wedge that just self-resolved does not leave stale state.
                 Some(ThreadState::Running) | Some(ThreadState::Ready) => {
+                    #[cfg(feature = "sched-gate-stats")]
+                    if current_state == Some(ThreadState::Ready) {
+                        gate_stats::SELF_RESUME_READY.fetch_add(1, Ordering::Relaxed);
+                    }
                     clear_picker_burst();
                     crate::arch::x86_64::irq::reset_watchdog_counter();
                     crate::hal::enable_interrupts();
@@ -2307,7 +2418,18 @@ was_emergency_4k={}",
             cpu,
             (1..len)
                 .map(|i| (current_idx + i) % len)
-                .filter(|&idx| matches!(threads[idx].mirror_slot, Some((c, _)) if c == percpu_cpu))
+                .filter(|&idx| {
+                    let on_this_cpu =
+                        matches!(threads[idx].mirror_slot, Some((c, _)) if c == percpu_cpu);
+                    #[cfg(feature = "sched-gate-stats")]
+                    if !on_this_cpu
+                        && threads[idx].state == ThreadState::Ready
+                        && threads[idx].tid < 0x1000
+                    {
+                        gate_stats::SKIP_MIRROR.fetch_add(1, Ordering::Relaxed);
+                    }
+                    on_this_cpu
+                })
                 // ── #655 on-CPU dispatch interlock (the dispatch chokepoint) ──
                 // Skip-and-defer any candidate still live (current or on-stack)
                 // on another CPU, so one thread is never dispatched onto two CPUs
@@ -2474,10 +2596,10 @@ was_emergency_4k={}",
                 //                         to Ready, then continue 'pick.
                 //                         Returning would sysretq into
                 //                         dead user code.
-                let current_state = threads
-                    .iter()
-                    .find(|t| t.tid == current_tid)
-                    .map(|t| t.state);
+                // Promote a self-resuming Ready current back to Running and
+                // clear its run-queue wait stamp (a successful in-place pick of
+                // the current thread — see `resume_current_if_ready`).
+                let current_state = resume_current_if_ready(&mut threads, current_tid, cpu);
                 drop(threads);
                 match current_state {
                     // Running, or freshly re-Readied by the due-wake drain at
@@ -2491,6 +2613,10 @@ was_emergency_4k={}",
                     // then self-resumed would carry a stale burst into the next
                     // transient idle.
                     Some(ThreadState::Running) | Some(ThreadState::Ready) => {
+                        #[cfg(feature = "sched-gate-stats")]
+                        if current_state == Some(ThreadState::Ready) {
+                            gate_stats::SELF_RESUME_READY.fetch_add(1, Ordering::Relaxed);
+                        }
                         clear_picker_burst();
                         crate::perf::record_idle_tick();
                         crate::arch::x86_64::irq::reset_watchdog_counter();

--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -803,6 +803,15 @@ pub fn mirror_audit_failures() -> u32 {
     MIRROR_AUDIT_FAILURES.load(Ordering::Relaxed)
 }
 
+/// Snapshot of [`MAINTAIN_PASSES`]: the number of `mirror_maintain` calls, i.e.
+/// scheduling passes that reached the picker.  A monotone, always-advancing
+/// value while the scheduler is live; a diagnostic reader that sees this frozen
+/// across a wall-clock interval knows `schedule()` itself is not running (as
+/// opposed to running but declining to pick a Ready thread).
+pub fn maintain_passes() -> u32 {
+    MAINTAIN_PASSES.load(Ordering::Relaxed)
+}
+
 /// Cumulative count of live scheduling passes (debug builds only) where the
 /// phase-2b per-CPU runqueue pick selected a DIFFERENT thread than the
 /// authoritative legacy table-scan pick.  Must stay zero on SMP=1: a non-zero

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1336,6 +1336,8 @@ pub fn run() -> ! {
         total += 1;
         if test_649_percpu_min_deadline_gate() { passed += 1; }
         total += 1;
+        if test_681_self_resume_clears_wait_stamp() { passed += 1; }
+        total += 1;
         if test_650_percpu_wake_target() { passed += 1; }
         total += 1;
         if test_652_percpu_audit_image_off_stack() { passed += 1; }
@@ -50344,6 +50346,109 @@ fn test_649_percpu_min_deadline_gate() -> bool {
     test_println!("  PerCpuRq::overdue(now) == per-candidate force gate \
 (max(wait_age-deadline)>=0) across A-empty/B-single/C-bsp-tight/D-mixed/E-late-tid0 \
 with full now-sweep — min_deadline refinement is force-decision-preserving GREEN");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 681: self-resume clears the run-queue wait stamp ──────────────────
+//
+// When the picker finds no OTHER Ready peer it returns to the current thread in
+// place (no context switch).  If the in-picker due-wake drain had flipped that
+// current thread from Blocked to Ready (its own sleep/timeout deadline elapsed
+// during the pass), the return IS a selection of the current thread to run —
+// so `resume_current_if_ready` must apply the same post-selection bookkeeping
+// the normal pick applies: promote it to `Running` and clear its
+// `ready_since_tick`.  Otherwise the thread keeps a `Ready` state and an
+// ancient wait stamp while it actually runs, and when it later yields to a
+// freshly-Ready peer it re-enters the ready set carrying that stale stamp — the
+// anti-starvation force-select backstop then rescues it on a wait age that was
+// never real (a spurious `[SCHED/STARVE] force-select`).
+//
+// The regression this guards: the pre-fix self-resume path left the thread
+// `Ready` with its stamp intact.  `ctx_rsp_valid` must NOT be touched (the
+// saved RSP stays stale until a real switch-out re-validates it — the invariant
+// the ctx_rsp_valid gate and the #672/#673 on-CPU interlock depend on).
+//
+// Cite: POSIX sched(7) SCHED_OTHER — every runnable thread must eventually get
+// the CPU, and a thread's fairness wait must reflect real run-queue wait time.
+fn test_681_self_resume_clears_wait_stamp() -> bool {
+    use crate::proc::{Thread, Tid, ThreadState, PRIORITY_NORMAL};
+    const NAME: &str = "[SCHED] self-resume promotes Ready→Running + clears wait stamp (Test 681)";
+    test_header!(NAME);
+
+    // A synthetic current thread with a chosen state + a stale wait stamp.
+    fn mk(tid: Tid, state: ThreadState, ready_since: u64, ctx_valid: bool) -> Thread {
+        let mut t = Thread::new_for_test(PRIORITY_NORMAL);
+        t.tid = tid;
+        t.state = state;
+        t.last_cpu = 0xFE; // sentinel: prove resume rewrites it to the picking CPU
+        t.ready_since_tick = ready_since;
+        t.ctx_rsp_valid = alloc::boxed::Box::new(
+            core::sync::atomic::AtomicBool::new(ctx_valid));
+        t
+    }
+
+    // Case A: a self-resuming Ready current with a stale stamp is promoted.
+    {
+        let mut threads = [mk(42, ThreadState::Ready, 1000, false)];
+        let observed = crate::sched::test_resume_current_if_ready(&mut threads, 42, 0);
+        let t = &threads[0];
+        if observed != Some(ThreadState::Ready) {
+            test_fail!(NAME, "A: observed state should be the pre-promotion Ready");
+            return false;
+        }
+        if t.state != ThreadState::Running {
+            test_fail!(NAME, "A: Ready current must be promoted to Running");
+            return false;
+        }
+        if t.ready_since_tick != 0 {
+            test_fail!(NAME, "A: stale wait stamp must be cleared on self-resume");
+            return false;
+        }
+        if t.last_cpu != 0 {
+            test_fail!(NAME, "A: last_cpu must be stamped to the picking CPU");
+            return false;
+        }
+        // ctx_rsp_valid must be left exactly as-is (still false here): the saved
+        // RSP is stale until a real switch-out re-validates it.
+        if t.ctx_rsp_valid.load(core::sync::atomic::Ordering::Relaxed) {
+            test_fail!(NAME, "A: ctx_rsp_valid must NOT be touched by self-resume");
+            return false;
+        }
+    }
+
+    // Case B: an already-Running current is returned unchanged (no promotion,
+    // stamp and ctx_rsp_valid untouched — the common self-yield-with-no-peer).
+    {
+        let mut threads = [mk(43, ThreadState::Running, 0, true)];
+        let observed = crate::sched::test_resume_current_if_ready(&mut threads, 43, 0);
+        let t = &threads[0];
+        if observed != Some(ThreadState::Running)
+            || t.state != ThreadState::Running
+            || t.last_cpu != 0xFE
+        {
+            test_fail!(NAME, "B: Running current must be returned untouched");
+            return false;
+        }
+    }
+
+    // Case C: a Blocked/Sleeping current is NOT promoted (it goes on to HLT).
+    // A stale stamp on a non-Ready thread is the stamper's concern, not this
+    // path's — resume must leave state, stamp and last_cpu alone.
+    for st in [ThreadState::Blocked, ThreadState::Sleeping, ThreadState::Dead] {
+        let mut threads = [mk(44, st, 777, true)];
+        let observed = crate::sched::test_resume_current_if_ready(&mut threads, 44, 0);
+        let t = &threads[0];
+        if observed != Some(st) || t.state != st || t.ready_since_tick != 777
+            || t.last_cpu != 0xFE
+        {
+            test_fail!(NAME, "C: non-Ready current must be left untouched");
+            return false;
+        }
+    }
+
+    test_println!("  self-resume: Ready→Running + stamp cleared + last_cpu set; \
+Running/Blocked/Sleeping/Dead untouched; ctx_rsp_valid never mutated GREEN");
     test_pass!(NAME);
     true
 }


### PR DESCRIPTION
## Summary

Investigation of the reported **scheduler candidate-gate starvation** of freshly-spawned content-process threads (dispatched as the prime suspect for a ~50x page-load slowdown). The hypothesis is **REFUTED by live measurement**; this PR lands the instrumentation that proves it, plus a real-but-latent anti-starvation bookkeeping fix surfaced along the way.

**Do NOT merge without independent review** (self-authored kernel change).

## Hypothesis under test

A freshly-Ready thread was thought to sit `Ready` with `ctx_rsp_valid == false` for seconds — invisible to the entire fairness ladder (`select_next_core`'s `ctx_rsp_valid`/affinity candidate gates and the force backstop) — producing occasional very-high wait-age `[SCHED/STARVE] force-select` events (e.g. 706 ticks).

## Result: refuted by live evidence (SMP=1, KVM, live Wikipedia load)

Over **43.1M picker passes** the per-gate skip population was:

```
ctx_rsp_invalid = 0    affinity = 0    mirror = 0    self_resume_ready = 0
```

- Not once was a Ready thread skipped by the `ctx_rsp_valid` gate; every Ready thread in the live table read `ctx_rsp_valid == 1` (5 samples x ~21 threads, 0 with `crv==0`).
- `maintain_passes == ctx_switches` (43.1M each) — schedule() runs continuously; it is not frozen.
- The `[SCHED/STARVE] force-select` lines are ~99% the **by-design TID-0 reactor cadence** ("waited 1 tick", per its tight `STARVE_FORCE_TICKS_BSP` deadline), plus occasional legitimate rescues of a low-priority worker out-scored in a busy run-queue that reached its ~1 s force deadline — all with `ctx_rsp_valid == true`. The high wait-age is real run-queue wait under momentary contention, not a gate-invisible thread.

A force-select log's own semantics require the fired thread to be a *candidate* (it passed every gate), so it cannot have been `ctx_rsp_valid == false` at fire time. **The candidate-gate starvation hypothesis does not hold; the page-load slowdown is not a scheduler gate.**

## Changes

1. **Diagnostic instrumentation** (feature `sched-gate-stats`, compiled OUT by default — the pick hot path and `firefox-test-core` stay byte-identical): per-gate skip counters (`ctx_rsp_invalid`/`affinity`/`mirror`) + a `self_resume_ready` counter, surfaced via kdb `cpu-state` alongside a new `sched` object (`maintain_passes`, `ctx_switches`, `force_total`). Per-thread `cpu-state` rows gain `rst` (`ready_since_tick`) so a reader can compute each Ready thread's true wait age. New `percpu::maintain_passes()` accessor.

2. **Latent fix** — the picker's in-place self-resume path (no other thread Ready; the in-picker due-wake drain flipped the current thread `Blocked -> Ready` as its own sleep/timeout deadline elapsed) returned to the thread leaving it `Ready` with its original `ready_since_tick`, violating the documented invariant ("`ready_since_tick` cleared the moment the thread is selected to Run"). It now applies the normal pick's post-selection bookkeeping (`state -> Running`, `ready_since_tick -> 0`, `last_cpu -> this CPU`). `ctx_rsp_valid` is deliberately untouched (the saved RSP stays stale until a real switch-out re-validates it — the invariant the `ctx_rsp_valid` gate and the #672/#673 on-CPU interlock depend on); promoting to `Running` only strengthens candidate exclusion, so SMP correctness is preserved. The live counter shows this path never fires under the busy load run-queue (`self_resume_ready = 0`) — this is **hardening for quieter regimes, NOT the cause of the slowdown**.

3. **Test 681** (`test_681_self_resume_clears_wait_stamp`): deterministic proof that a self-resuming `Ready` current is promoted to `Running` with its wait stamp cleared and `last_cpu` set, while `Running`/`Blocked`/`Sleeping`/`Dead` currents are untouched and `ctx_rsp_valid` is never mutated.

## Verification

- **Test-mode**: Test 681 PASS; scheduler cluster (648/649/681/650/652) all green; 208 PASS / 3 FAIL where all 3 FAILs are pre-existing environmental (missing `/disk/bin/tcc`, `/disk/bin/busybox`, `pie_elf` process test) — unrelated to this change.
- **A/B (live Wikipedia load, SMP=1)**: baseline (instrumentation only) vs fixed build are byte-identical in scheduler behaviour — both `gate_skips` all 0, both `maintain_passes == ctx_switches`, both idle-dominant, same force-select wait-age distribution, 0 bugchecks/faults. Gap profile and time-to-content are unchanged by construction (scheduler exonerated).

Harness-only testing (`scripts/qemu-harness.py`). Cite: POSIX sched(7) SCHED_OTHER.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
