### PR TITLE
tooling: build + boot a glibc-Firefox data image without clobbering the shared musl image

### DIFF
--- a/scripts/create-data-disk.sh
+++ b/scripts/create-data-disk.sh
@@ -16,10 +16,33 @@
 #   ./scripts/create-data-disk.sh 128       # Create 128 MiB image
 #   ./scripts/create-data-disk.sh --force   # Recreate even if it exists
 #
+# Isolated / alternate-image builds (additive — default behaviour unchanged):
+#   --output=PATH        Write the produced image to PATH instead of
+#                        build/data.img (env: ASTRYXOS_DATA_IMG).  Lets a
+#                        variant image (e.g. build/data-glibc.img) be built
+#                        WITHOUT clobbering the shared build/data.img.
+#   --build-dir=PATH     Stage into PATH/disk instead of build/disk (env:
+#                        ASTRYXOS_BUILD_DIR).  Exported to the install-*.sh
+#                        sub-scripts so a variant build never overwrites the
+#                        shared build/disk staging tree.  When --output is
+#                        omitted the image defaults to PATH/data.img.
+# Example — build a glibc Firefox image in an isolated tree:
+#   ASTRYXOS_FIREFOX_VARIANT=glibc ASTRYXOS_BUILD_DIR="${PWD}/build-glibc" \
+#     ./scripts/create-data-disk.sh --output="${PWD}/build/data-glibc.img" --force
+#
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="${ROOT_DIR}/build"
+# BUILD_DIR (staging root) and the output image are overridable via env or the
+# --build-dir / --output flags so a variant image can be produced in isolation.
+# The sub-scripts (install-glibc.sh, install-firefox.sh, ...) honour the same
+# ASTRYXOS_BUILD_DIR env, so exporting it below keeps the whole pipeline pointed
+# at one staging root.  Precedence: flag > env > ${ROOT_DIR}/build default.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
+# Output-image override captured here from env; the --output flag replaces it in
+# the arg loop.  DATA_IMG is finalised (from this override or ${BUILD_DIR}/data.img)
+# after BUILD_DIR is known — see the normalisation block below the arg loop.
+DATA_IMG_OVERRIDE="${ASTRYXOS_DATA_IMG:-}"
 DATA_IMG="${BUILD_DIR}/data.img"
 SIZE_MB=2048
 FORCE=false
@@ -178,6 +201,8 @@ for arg in "$@"; do
         --firefox-debug=*) FIREFOX_DEBUG="${arg#--firefox-debug=}" ;;
         --firefox-debug)   FIREFOX_DEBUG=1 ;;
         --firefox-package=*) FIREFOX_PACKAGE="${arg#--firefox-package=}" ;;
+        --output=*)    DATA_IMG_OVERRIDE="${arg#--output=}" ;;
+        --build-dir=*) BUILD_DIR="${arg#--build-dir=}" ;;
         --xeyes) XEYES=1; FORCE=true ;;
         --busybox) BUSYBOX_CLI=1; FORCE=true ;;
         --sshd) SSHD=1; FORCE=true ;;
@@ -198,6 +223,22 @@ case "${FIREFOX_VARIANT}" in
         ;;
 esac
 echo "[DATA-DISK] Firefox variant: ${FIREFOX_VARIANT}"
+
+# ── Finalise the staging root + output image (after --build-dir / --output) ───
+# Export ASTRYXOS_BUILD_DIR so every install-*.sh sub-script stages into the
+# SAME (possibly isolated) build root rather than its own ${ROOT_DIR}/build.
+# This is what keeps a variant build (e.g. glibc) from overwriting the shared
+# build/disk musl staging tree.  Output-image precedence: --output flag /
+# ASTRYXOS_DATA_IMG env > ${BUILD_DIR}/data.img.
+export ASTRYXOS_BUILD_DIR="${BUILD_DIR}"
+if [ -n "${DATA_IMG_OVERRIDE}" ]; then
+    DATA_IMG="${DATA_IMG_OVERRIDE}"
+else
+    DATA_IMG="${BUILD_DIR}/data.img"
+fi
+mkdir -p "$(dirname "${DATA_IMG}")" 2>/dev/null || true
+echo "[DATA-DISK] Staging root: ${BUILD_DIR}"
+echo "[DATA-DISK] Output image: ${DATA_IMG}"
 
 case "${FIREFOX_PACKAGE}" in
     firefox-esr|firefox) ;;

--- a/scripts/inject-libxul-symbols.sh
+++ b/scripts/inject-libxul-symbols.sh
@@ -57,6 +57,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# BUILD_DIR is overridable via ASTRYXOS_BUILD_DIR so an isolated variant build
+# (create-data-disk.sh --build-dir) injects into the libxul.so staged under
+# that root instead of build/disk.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
 INJECT_SCRIPT="${ROOT_DIR}/scripts/inject-libxul-symtab.py"
 
 # ── Argument parsing ─────────────────────────────────────────────────────────
@@ -80,7 +84,7 @@ done
 
 # ── Mode-specific paths and URLs ─────────────────────────────────────────────
 if [ "${MODE}" = "glibc" ]; then
-    LIBXUL="${ROOT_DIR}/build/disk/opt/firefox/libxul.so"
+    LIBXUL="${BUILD_DIR}/disk/opt/firefox/libxul.so"
     SYM_DIR="${HOME}/.cache/astryxos-firefox/dbg-symbols"
     SYM_FILE="${SYM_DIR}/libxul.so.sym"
     SYM_COMPRESSED="${SYM_DIR}/libxul_sym_compressed.bin"
@@ -98,7 +102,7 @@ if [ "${MODE}" = "glibc" ]; then
     ZIP_DATA_BYTE_SIZE=135889978   # 129.6 MiB compressed
 else
     # --musl
-    LIBXUL="${ROOT_DIR}/build/disk/usr/lib/firefox-esr/libxul.so"
+    LIBXUL="${BUILD_DIR}/disk/usr/lib/firefox-esr/libxul.so"
     SYM_DIR="${HOME}/.cache/astryxos-firefox-musl/dbg-symbols"
     SYM_FILE="${SYM_DIR}/libxul.so.sym"
     SYM_GZ="${SYM_DIR}/libxul.so.sym.gz"

--- a/scripts/install-dbus-real.sh
+++ b/scripts/install-dbus-real.sh
@@ -81,7 +81,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="${ROOT_DIR}/build"
+# BUILD_DIR is overridable via ASTRYXOS_BUILD_DIR so an isolated variant build
+# (create-data-disk.sh --build-dir) stages into that root instead of build/.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
 DISK_LIB64="${BUILD_DIR}/disk/lib64"
 DISK_GNU="${BUILD_DIR}/disk/lib/x86_64-linux-gnu"
 

--- a/scripts/install-firefox-stubs.sh
+++ b/scripts/install-firefox-stubs.sh
@@ -35,7 +35,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="${ROOT_DIR}/build"
+# BUILD_DIR is overridable via ASTRYXOS_BUILD_DIR so an isolated variant build
+# (create-data-disk.sh --build-dir) stages into that root instead of build/.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
 DISK_LIB64="${BUILD_DIR}/disk/lib64"
 # Firefox runs with LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:/disk/lib/firefox.
 # The first entry is searched before /lib64, so any older copy of these

--- a/scripts/install-firefox.sh
+++ b/scripts/install-firefox.sh
@@ -21,7 +21,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="${ROOT_DIR}/build"
+# BUILD_DIR is overridable via ASTRYXOS_BUILD_DIR so an isolated variant build
+# (create-data-disk.sh --build-dir) stages into that root instead of build/.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
 DISK_OPT="${BUILD_DIR}/disk/opt/firefox"
 FIREFOX_BIN="${DISK_OPT}/firefox"
 CACHE_DIR="${HOME}/.cache/astryxos-firefox"

--- a/scripts/install-fonts-real.sh
+++ b/scripts/install-fonts-real.sh
@@ -74,7 +74,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="${ROOT_DIR}/build"
+# BUILD_DIR is overridable via ASTRYXOS_BUILD_DIR so an isolated variant build
+# (create-data-disk.sh --build-dir) stages into that root instead of build/.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
 DISK_LIB64="${BUILD_DIR}/disk/lib64"
 DISK_GNU="${BUILD_DIR}/disk/lib/x86_64-linux-gnu"
 DISK_ETC_FONTS="${BUILD_DIR}/disk/etc/fonts"

--- a/scripts/install-glibc.sh
+++ b/scripts/install-glibc.sh
@@ -14,7 +14,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="${ROOT_DIR}/build"
+# BUILD_DIR is overridable via ASTRYXOS_BUILD_DIR so an isolated variant build
+# (create-data-disk.sh --build-dir) stages into that root instead of build/.
+BUILD_DIR="${ASTRYXOS_BUILD_DIR:-${ROOT_DIR}/build}"
 DISK_LIB64="${BUILD_DIR}/disk/lib64"
 DISK_GNU="${BUILD_DIR}/disk/lib/x86_64-linux-gnu"
 

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -604,6 +604,95 @@ def run_staleness_check():
     print()
 
 
+def run_variant_data_img_check():
+    """
+    Tier 1.5 host-only check: exercise `_variant_data_img_candidate` directly to
+    confirm the `--firefox-variant glibc` prebuilt-image selection is correct
+    and NON-destructive.
+
+    A future refactor must not (a) auto-select a glibc image for the musl
+    default, (b) ignore an explicit --data-img, or (c) fail to pick up a present
+    build/data-glibc.img — each of those would silently break the glibc
+    'does the ~50x slowdown reproduce?' discriminator.  No QEMU launched.
+    """
+    print("=== Tier 1.5: --firefox-variant glibc image selection (host-only) ===")
+    print()
+    import importlib.util
+    import os
+    import tempfile
+    spec = importlib.util.spec_from_file_location("qh_smoke_variant", str(HARNESS))
+    mod = importlib.util.module_from_spec(spec)
+    _orig_argv = sys.argv
+    sys.argv = ["qemu-harness.py", "list"]
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    finally:
+        sys.argv = _orig_argv
+
+    fn = getattr(mod, "_variant_data_img_candidate", None)
+    check("variant-select fn importable", fn is not None, "")
+    if fn is None:
+        return
+
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        di = tdp / "data.img"
+        di.write_text("musl")
+        gi = tdp / "data-glibc.img"
+
+        # Make the check hermetic: repoint the canonical-build fallback at the
+        # sandbox so a real build/data-glibc.img on the host cannot leak into
+        # the "no image" cases.  Restored in the finally below.
+        _orig_canon = getattr(mod, "_CANONICAL_BUILD_DIR", None)
+        mod._CANONICAL_BUILD_DIR = tdp
+        try:
+            _run_variant_data_img_cases(fn, di, gi)
+        finally:
+            if _orig_canon is not None:
+                mod._CANONICAL_BUILD_DIR = _orig_canon
+
+    print()
+
+
+def _run_variant_data_img_cases(fn, di, gi):
+    """Hermetic assertion body for run_variant_data_img_check (sandbox paths)."""
+    import os
+    import tempfile
+    # Case A: musl (default) never auto-selects a variant image.
+    check("musl → None", fn(di, "musl", None) is None)
+
+    # Case B: glibc requested but no prebuilt image → None (legacy re-stage).
+    check("glibc, no image → None", fn(di, "glibc", None) is None)
+
+    # Case C: glibc requested + sibling data-glibc.img present → selected.
+    gi.write_text("glibc")
+    r = fn(di, "glibc", None)
+    check("glibc + sibling image → selected", r == gi, str(r))
+
+    # Case D: an explicit --data-img always wins (helper stays out of it).
+    check("explicit --data-img → None",
+          fn(di, "glibc", "/some/explicit.img") is None)
+
+    # Case E: $ASTRYX_GLIBC_DATA_IMG env escape hatch honoured when it exists.
+    with tempfile.NamedTemporaryFile(suffix=".img") as envimg:
+        os.environ["ASTRYX_GLIBC_DATA_IMG"] = envimg.name
+        try:
+            r = fn(di, "glibc", None)
+            check("env override → selected", str(r) == envimg.name, str(r))
+        finally:
+            os.environ.pop("ASTRYX_GLIBC_DATA_IMG", None)
+
+    # Case F: a non-existent env override falls through to the sibling image.
+    os.environ["ASTRYX_GLIBC_DATA_IMG"] = "/nonexistent/data-glibc.img"
+    try:
+        r = fn(di, "glibc", None)
+        check("missing env override → sibling fallback", r == gi, str(r))
+    finally:
+        os.environ.pop("ASTRYX_GLIBC_DATA_IMG", None)
+
+
 def run_allowlist_check():
     """
     Tier 1.5 host-only check: exercise `allowlist` subcommands directly.
@@ -1454,6 +1543,7 @@ def main():
     # the corresponding silent-wedge guards (W7 staleness; ci/allow-fail
     # registry) against future refactors of qemu-harness.py.
     run_staleness_check()
+    run_variant_data_img_check()
     run_allowlist_check()
     run_snapgate_argv_check()
     run_read_ff_png_check()

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -1703,6 +1703,7 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
                           snapshottable: bool = False,
                           data_overlay: Optional[str] = None,
                           vmstate_qcow2: Optional[str] = None,
+                          data_img_override: Optional[str] = None,
                           ) -> subprocess.Popen:
     """
     Launch QEMU with a per-session serial log and QMP socket.
@@ -1729,7 +1730,10 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
     wt = _get_watch_test()
     ROOT     = wt.ROOT
     ESP_DIR  = Path(esp_dir_override) if esp_dir_override else wt.ESP_DIR
-    DATA_IMG = wt.DATA_IMG
+    # data_img_override lets `start` boot a prebuilt per-variant image (e.g.
+    # build/data-glibc.img) WITHOUT repointing the shared build/data.img symlink
+    # — the shared musl image on disk is never touched.  Absent => unchanged.
+    DATA_IMG = data_img_override if data_img_override else wt.DATA_IMG
     OVMF_CODE     = wt.OVMF_CODE
     OVMF_VARS_SRC = wt.OVMF_VARS_SRC
 
@@ -1857,6 +1861,60 @@ def _launch_qemu_harness(sid: str, serial_log: str, qmp_sock: str,
 # is sufficient. We early-exit on the first newer file.
 _STALENESS_SCAN_FILE_BUDGET = 20000
 _STALENESS_SCAN_TIME_BUDGET_S = 4.0
+
+# Canonical (non-worktree) build root; a worktree's build/data.img is usually a
+# symlink back to here, so variant images live alongside the canonical data.img.
+_CANONICAL_BUILD_DIR = Path("/home/ubuntu/AstryxOS/build")
+
+
+def _variant_data_img_candidate(data_img_path: Path,
+                                 requested_variant: str,
+                                 explicit_override) -> "Path | None":
+    """
+    Resolve the prebuilt, per-variant data image for `--firefox-variant`.
+
+    Today only the ``glibc`` variant ships a separate prebuilt image
+    (``build/data-glibc.img``): the shared ``build/data.img`` carries the musl
+    Firefox, and the glibc Firefox lives on its own image so the two can coexist
+    without a re-stage.  When the caller asks for the glibc variant (and did NOT
+    pass an explicit ``--data-img``), this returns the first candidate image
+    that exists so ``start`` can boot it NON-destructively (the shared musl
+    ``build/data.img`` file is never touched).
+
+    Returns the resolved image ``Path`` when a prebuilt variant image should be
+    used, else ``None`` (fall back to the on-disk ``build/data.img`` and the
+    normal staleness / variant-regen machinery).
+
+    Purely functional (no I/O beyond ``exists()``) so it is host-unit-testable.
+
+    Candidate search order (first existing wins):
+      1. ``$ASTRYX_GLIBC_DATA_IMG`` (explicit env escape hatch)
+      2. ``<dir of data_img_path>/data-<variant>.img`` (worktree-local)
+      3. ``<canonical build>/data-<variant>.img`` (shared repo tree)
+    """
+    # An explicit --data-img always wins; never second-guess it.
+    if explicit_override:
+        return None
+    # Only glibc ships a separate prebuilt image; musl is the shared default.
+    if requested_variant != "glibc":
+        return None
+    candidates = []
+    env_override = os.environ.get("ASTRYX_GLIBC_DATA_IMG")
+    if env_override:
+        candidates.append(Path(env_override))
+    fname = f"data-{requested_variant}.img"
+    try:
+        candidates.append(Path(data_img_path).parent / fname)
+    except Exception:
+        pass
+    candidates.append(_CANONICAL_BUILD_DIR / fname)
+    for cand in candidates:
+        try:
+            if cand.exists():
+                return cand
+        except Exception:
+            continue
+    return None
 
 
 def _data_img_staleness(data_img: Path, disk_dir: Path,
@@ -3551,6 +3609,40 @@ def cmd_start(args):
     # visible banner regardless so the operator always knows the state.
     _data_img_path = Path(wt.DATA_IMG)
 
+    # ── --firefox-variant glibc → prebuilt data-glibc.img (NON-destructive) ──
+    # The shared build/data.img carries the musl Firefox; the glibc Firefox
+    # ships as a SEPARATE prebuilt image (build/data-glibc.img).  When the
+    # caller asks for the glibc variant and did NOT pass an explicit --data-img,
+    # boot that image directly — WITHOUT repointing/unlinking the shared
+    # build/data.img (that file is left untouched, so a concurrent musl session
+    # and a later musl re-stage both keep working).  The image path is threaded
+    # into _launch_qemu_harness(data_img_override=...) at launch time; the
+    # on-disk staleness / variant-regen machinery is skipped for a prebuilt
+    # image (a prebuilt image is authoritative, exactly like --data-img).
+    # Additive: when no prebuilt variant image exists this is a no-op and the
+    # legacy re-stage path below runs unchanged.
+    _prebuilt_data_img = None   # str path to boot, or None (use build/data.img)
+    _variant_prebuilt_img = _variant_data_img_candidate(
+        _data_img_path,
+        getattr(args, "firefox_variant", None) or "musl",
+        getattr(args, "data_img_override", None),
+    )
+    if _variant_prebuilt_img is not None:
+        _prebuilt_data_img = str(_variant_prebuilt_img)
+        # A prebuilt image must not be regenerated from build/disk/.
+        try:
+            setattr(args, "no_regen_data_img", True)
+        except Exception:
+            pass
+        print(
+            "╔══════════════════════════════════════════════════════════════╗\n"
+            "║  --firefox-variant glibc → prebuilt image (no-regen, shared   ║\n"
+            "║  build/data.img left untouched)                              ║\n"
+            f"║  {_prebuilt_data_img[:60]:<60}  ║\n"
+            "╚══════════════════════════════════════════════════════════════╝",
+            file=sys.stderr,
+        )
+
     # --data-img OVERRIDE: point the worktree's build/data.img at an explicit
     # prebuilt image (e.g. /home/ubuntu/gui-complete.img) by replacing the
     # worktree symlink target.  A prebuilt complete image is authoritative — we
@@ -3676,6 +3768,11 @@ def cmd_start(args):
         "restage_extra_flags": list(_demo_bin["flags"]),
         "restage_extra_env":   dict(_demo_bin["env"]),
         "restage_flag_sources": dict(_demo_bin["sources"]),
+        # Prebuilt per-variant image booted NON-destructively (build/data-glibc.img
+        # for --firefox-variant glibc), or None when the shared build/data.img is
+        # used.  Additive; downstream agents may read it to confirm the glibc
+        # discriminator booted the intended image.
+        "prebuilt_data_img": _prebuilt_data_img,
     }
     # D10 fix-it: in worktrees the local build/disk/ is typically absent;
     # if build/data.img is a symlink into the canonical tree, inspect that
@@ -3698,7 +3795,7 @@ def cmd_start(args):
         _data_img_staleness_info = _data_img_staleness(
             _data_img_path, _disk_dir, extra_src_dirs=_extra_src_dirs)
         _data_img_stale = bool(_data_img_staleness_info.get("stale"))
-    if _data_img_stale:
+    if _data_img_stale and _prebuilt_data_img is None:
         _newest = _data_img_staleness_info.get("newest_path") or "?"
         _di_mt  = _data_img_staleness_info.get("data_img_mtime")
         _new_mt = _data_img_staleness_info.get("newest_mtime")
@@ -3780,6 +3877,7 @@ def cmd_start(args):
     _need_variant_regen = (
         not _data_img_missing
         and not _data_img_regenerated  # avoid back-to-back regens
+        and _prebuilt_data_img is None  # prebuilt variant image is authoritative
         and _staged_family is not None
         and _staged_family != _requested_variant
     )
@@ -4061,7 +4159,10 @@ def cmd_start(args):
     snap_topology = None
     if snapshottable:
         wt_for_di = _get_watch_test()
-        snap_topology = _make_snap_topology(sid, str(wt_for_di.DATA_IMG))
+        # A prebuilt per-variant image (build/data-glibc.img) is the snapshot
+        # backing file when one was selected; else the shared build/data.img.
+        _snap_base_img = _prebuilt_data_img or str(wt_for_di.DATA_IMG)
+        snap_topology = _make_snap_topology(sid, _snap_base_img)
 
     proc = _launch_qemu_harness(sid, serial_log, qmp_sock, ovmf_vars,
                                  gdb_port=gdb_port, gdb_wait=gdb_wait,
@@ -4076,7 +4177,8 @@ def cmd_start(args):
                                  extra_qemu_args=extra_qemu_args,
                                  snapshottable=snapshottable,
                                  data_overlay=(snap_topology or {}).get("data_overlay"),
-                                 vmstate_qcow2=(snap_topology or {}).get("vmstate_qcow2"))
+                                 vmstate_qcow2=(snap_topology or {}).get("vmstate_qcow2"),
+                                 data_img_override=_prebuilt_data_img)
 
     session = {
         "sid":        sid,
@@ -12810,15 +12912,25 @@ def main():
                                "disk must carry: 'musl' (Alpine packages at "
                                "/usr/lib/firefox*) or 'glibc' (Mozilla tarball "
                                "at /opt/firefox).  Default 'musl' — the "
-                               "primary demo target.  When the staged tree "
-                               "doesn't match, the harness re-runs "
-                               "scripts/create-data-disk.sh with "
-                               "ASTRYXOS_FIREFOX_VARIANT exported so the boot "
-                               "image carries the requested binaries.  After "
+                               "primary demo target.  'glibc' boots a SEPARATE "
+                               "prebuilt image (build/data-glibc.img, or "
+                               "$ASTRYX_GLIBC_DATA_IMG) NON-destructively when "
+                               "present — the shared musl build/data.img file is "
+                               "never touched or regenerated, so the glibc "
+                               "'does the ~50x slowdown reproduce?' discriminator "
+                               "needs no re-stage.  Build that image with "
+                               "`ASTRYXOS_FIREFOX_VARIANT=glibc "
+                               "ASTRYXOS_BUILD_DIR=build-glibc "
+                               "scripts/create-data-disk.sh "
+                               "--output=build/data-glibc.img --force`.  If no "
+                               "prebuilt glibc image exists the legacy in-place "
+                               "re-stage path runs instead (create-data-disk.sh "
+                               "with ASTRYXOS_FIREFOX_VARIANT exported).  After "
                                "boot the kernel's [FFTEST] FF binary probe "
                                "line is parsed and a `firefox_variant_probe` "
                                "event records the actual selection (read it "
-                               "via `events <sid>` or `status <sid>`). "
+                               "via `events <sid>` or `status <sid>`; the chosen "
+                               "image is in firefox_variant_info.prebuilt_data_img). "
                                "Suppress the auto-restage with "
                                "--no-regen-data-img — the mismatch is still "
                                "warned about on stderr.")


### PR DESCRIPTION
## What

Make the glibc Firefox build a first-class, **isolated** artefact so the "does the ~50x wiki-load slowdown reproduce on the glibc build?" discriminator can run without disturbing the shared musl demo image.

## Why

`build/data.img` carries only the musl firefox-esr. `--firefox-variant glibc` previously either no-op'd (the glibc binary isn't on the image) or forced a destructive in-place `create-data-disk.sh --force` that overwrites the shared musl image every session. The glibc `libxul.so` (BuildID `492cd905…`) already has a fully-named `.symtab` companion, so the right move is to stage that binary onto its **own** image and boot it directly.

## Changes (all additive; default behaviour unchanged)

**`create-data-disk.sh` + `install-*.sh`**
- `--output=PATH` / `$ASTRYXOS_DATA_IMG` — write the image somewhere other than `build/data.img` (e.g. `build/data-glibc.img`).
- `--build-dir=PATH` / `$ASTRYXOS_BUILD_DIR` — stage into `PATH/disk` instead of `build/disk`. Exported to the `install-glibc/firefox/stubs/fonts/dbus` + `inject-libxul-symbols` sub-scripts (same override pattern already used by `patch-gui-caches.sh` / `patch-gui-gl.sh`) so the whole glibc pipeline stays in one isolated staging root and never overwrites the shared `build/disk` musl tree. Precedence: flag > env > `${ROOT_DIR}/build`.
- Upstream binaries are staged **as-shipped**; the wrappers are unchanged in what they install.

**`qemu-harness.py` (new JSON fields only — no renames)**
- `--firefox-variant glibc` auto-selects a **separate** prebuilt image (`build/data-glibc.img`, or `$ASTRYX_GLIBC_DATA_IMG`) when present and boots it **non-destructively** via a new `_launch_qemu_harness(data_img_override=…)` parameter — the shared `build/data.img` file is never unlinked, re-symlinked, or regenerated. On-disk staleness / variant-regen is skipped for a prebuilt image (authoritative, like `--data-img`). An explicit `--data-img` still wins.
- New pure, host-unit-testable helper `_variant_data_img_candidate`; `firefox_variant_info.prebuilt_data_img` records the booted image.

**`qemu-harness-smoke.py`** — new host-only (no-QEMU) check `run_variant_data_img_check` locking down the selection precedence, hermetic against a real image on the host.

## Failure mode this prevents

The pre-existing `--data-img` override unlinks `build/data.img` and replaces it with a symlink — fine in a throwaway worktree, destructive in the canonical checkout, where a later musl re-stage would write **through** the symlink and clobber the glibc image too. The glibc path deliberately avoids that mechanism, so a musl session and a glibc session can run back-to-back on the same tree with neither image corrupting the other.

## Verification (no QEMU boot — another agent owns the box)

Built `build/data-glibc.img` with the patched scripts (isolated `ASTRYXOS_BUILD_DIR`):
- `e2fsck -fn`: clean (239 files, 0 errors).
- `readelf -n` on the image's `libxul.so`: **BuildID `492cd905271cba58d3544dcbc1d3de79e9319d2b`** — matches the fully-named `.symtab` companion (398,675 FUNC symbols injected; `.symtab`/`.strtab` present).
- ld.so closure: `firefox-bin` interpreter `/lib64/ld-linux-x86-64.so.2` present; all 49 `libxul.so` `DT_NEEDED` sonames resolve within the image.
- Kernel variant probe: only `/opt/firefox` present, `/usr/lib/firefox*` absent → kernel selects glibc.
- Shared musl `build/data.img` byte-identical (mtime unchanged); `build/disk/` untouched.
- Host-only smoke: `qemu-harness-smoke.py --staleness-only` → exit 0 (120 checks, incl. 6 new selection cases).

**A boot still verifies:** that the glibc Firefox actually runs to the wiki-load stage on AstryxOS and whether the ~50x slowdown reproduces. Image is a build artefact (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
