### PR TITLE
NDE-31: AF_UNIX socket-table diagnostic + abstract-namespace regression tests (glibc display-gate finding)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -369,6 +369,10 @@ pub fn dispatch(req: &str, out: &mut String) {
         "proc-tree"      => op_proc_tree(req, out),
         "fd-table"       => op_fd_table(req, out),
         "fd-map"         => op_fd_map(req, out),
+        // unix-table: live occupancy of the global AF_UNIX socket TABLE.
+        // A full table makes socket(AF_UNIX)/socketpair(2) return EMFILE,
+        // which surfaces to X clients (libxcb) as "cannot open display".
+        "unix-table"     => op_unix_table(out),
         "epoll-watch"    => op_epoll_watch(req, out),
         "syscall-trend"  => op_syscall_trend(req, out),
         "vfs-mounts"     => op_vfs_mounts(out),
@@ -2451,6 +2455,72 @@ fn op_epoll_watch(req: &str, out: &mut String) {
 //
 // Output: { "pid": N | "all", "entries": [ { pid, fd, kind, socket_id,
 //   peer_socket_id, peer_pid, peer_fd, pipe_id, pipe_end, path } ] }
+
+/// unix-table — dump live occupancy of the global AF_UNIX socket TABLE.
+///
+/// Reports `occupied`/`capacity` plus a per-slot summary (state, kind, peer,
+/// and the bound name if any).  When `occupied == capacity` the table is full
+/// and any further `socket(AF_UNIX)`/`socketpair(2)` returns `EMFILE` — which
+/// an X client's libxcb reports as "cannot open display".  The per-slot view
+/// distinguishes the consumers (listening servers vs connected socketpair
+/// endpoints vs pathname binds) so an exhaustion can be attributed.
+fn op_unix_table(out: &mut String) {
+    use core::fmt::Write;
+    let snaps = crate::net::unix::snapshot_all();
+    let cap = crate::net::unix::capacity();
+    let hwm = crate::net::unix::high_water();
+    let _ = write!(out,
+        r#"{{"occupied":{},"capacity":{},"high_water":{},"full":{},"slots":["#,
+        snaps.len(), cap, hwm, snaps.len() >= cap);
+    let mut first = true;
+    for s in &snaps {
+        if !first { out.push(','); }
+        first = false;
+        let state = match s.state {
+            crate::net::unix::UnixState::Free      => "free",
+            crate::net::unix::UnixState::Unbound   => "unbound",
+            crate::net::unix::UnixState::Bound     => "bound",
+            crate::net::unix::UnixState::Listening => "listening",
+            crate::net::unix::UnixState::Connected => "connected",
+        };
+        let kind = match s.kind {
+            crate::net::unix::SockKind::Stream    => "stream",
+            crate::net::unix::SockKind::SeqPacket => "seqpacket",
+        };
+        out.push('{');
+        j_kv(out, "id", &alloc::format!("{}", s.id));
+        j_kv_str(out, "state", state);
+        j_kv_str(out, "kind", kind);
+        if s.peer_id == u64::MAX {
+            j_kv_str(out, "peer", "none");
+        } else {
+            j_kv(out, "peer", &alloc::format!("{}", s.peer_id));
+        }
+        // Render the bound name (if any).  A leading NUL marks the abstract
+        // namespace per unix(7); show it as "@rest" (the ss(8) convention).
+        if s.path_len > 0 {
+            let raw = &s.path[..s.path_len.min(s.path.len())];
+            let mut name = alloc::string::String::new();
+            if raw.first() == Some(&0) {
+                name.push('@');
+                for &b in &raw[1..] {
+                    if (0x20..0x7f).contains(&b) { name.push(b as char); }
+                    else { name.push('.'); }
+                }
+            } else {
+                for &b in raw {
+                    if (0x20..0x7f).contains(&b) { name.push(b as char); }
+                    else { name.push('.'); }
+                }
+            }
+            j_kv_str(out, "name", &name);
+        }
+        // trailing comma-free close for this slot: drop the last ','
+        if out.ends_with(',') { out.pop(); }
+        out.push('}');
+    }
+    out.push_str("]}");
+}
 
 fn op_fd_map(req: &str, out: &mut String) {
     use core::fmt::Write;

--- a/kernel/src/net/unix.rs
+++ b/kernel/src/net/unix.rs
@@ -19,6 +19,25 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use spin::Mutex;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+/// High-water mark of simultaneously-live (non-`Free`) slots in the global
+/// AF_UNIX socket TABLE.  Updated on every successful `create`/`accept`/
+/// `connect`-peer allocation.  Diagnostic-only (kdb `unix-table`): lets an
+/// investigator see the peak AF_UNIX pressure a workload generated, which is
+/// how a transient `MAX_UNIX_SOCKETS` exhaustion (→ EMFILE → "cannot open
+/// display" for X clients) is confirmed after the fact.
+static UNIX_HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
+
+/// Recompute live-slot occupancy under the already-held TABLE lock and fold it
+/// into [`UNIX_HIGH_WATER`].  Called at each allocation site.
+fn note_occupancy(t: &Table) {
+    let live = t.0.iter().filter(|s| s.state != UnixState::Free).count();
+    UNIX_HIGH_WATER.fetch_max(live, Ordering::Relaxed);
+}
+
+/// Peak number of simultaneously-live AF_UNIX slots observed since boot.
+pub fn high_water() -> usize { UNIX_HIGH_WATER.load(Ordering::Relaxed) }
 
 // ── Limits ───────────────────────────────────────────────────────────────────
 
@@ -284,6 +303,7 @@ fn is_abstract(name: &[u8]) -> bool {
 
 pub fn create(kind: SockKind, creds: PeerCreds) -> u64 {
     let mut t = TABLE.lock();
+    let mut allocated = u64::MAX;
     for (i, s) in t.0.iter_mut().enumerate() {
         if s.state == UnixState::Free {
             s.reset();
@@ -293,10 +313,12 @@ pub fn create(kind: SockKind, creds: PeerCreds) -> u64 {
             s.creator_pid = creds.pid;
             s.creator_uid = creds.uid;
             s.creator_gid = creds.gid;
-            return i as u64;
+            allocated = i as u64;
+            break;
         }
     }
-    u64::MAX
+    if allocated != u64::MAX { note_occupancy(&t); }
+    allocated
 }
 
 pub fn bind(id: u64, path: &[u8]) -> i64 {
@@ -436,6 +458,7 @@ pub fn connect(id: u64, path: &[u8], _client_creds: PeerCreds) -> i64 {
         srv.backlog[srv.backlog_len] = peer_id;
         srv.backlog_len += 1;
     }
+    note_occupancy(&t);
     // Drop the table lock before ringing — a `poll`/`epoll_wait`
     // caller blocked on the listener fd for `POLLIN` (the
     // connection-pending readiness signal per `accept(2)`) re-checks
@@ -500,6 +523,7 @@ pub fn socketpair(kind: SockKind, creds: PeerCreds) -> (u64, u64) {
     }
     t.0[a as usize].peer_id = b;
     t.0[b as usize].peer_id = a;
+    note_occupancy(&t);
     (a, b)
 }
 
@@ -1016,3 +1040,9 @@ pub fn snapshot_all() -> Vec<SocketSnap> {
     }
     out
 }
+
+/// Total number of slots in the global AF_UNIX socket table
+/// (`MAX_UNIX_SOCKETS`).  Exposed for the kdb `unix-table` diagnostic so a
+/// caller can report live occupancy against the hard cap (a full table makes
+/// `socket(AF_UNIX)`/`socketpair(2)` return `EMFILE`).
+pub fn capacity() -> usize { MAX_UNIX_SOCKETS }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -808,6 +808,11 @@ pub fn run() -> ! {
     total += 1;
     if test_unix_bind_connect() { passed += 1; }
 
+    // ── AF_UNIX abstract namespace + abstract→pathname fallback (libxcb) ───
+
+    total += 1;
+    if test_unix_abstract_and_fallback() { passed += 1; }
+
     // ── Test 55: /proc/self/maps content ─────────────────────────────────
 
     total += 1;
@@ -15803,6 +15808,120 @@ fn test_unix_bind_connect() -> bool {
     crate::syscall::dispatch_linux_kernel(3, accepted_fd as u64, 0, 0, 0, 0, 0);
 
     test_pass!("AF_UNIX bind/listen/connect/accept");
+    true
+}
+
+// ── AF_UNIX abstract namespace + libxcb-style abstract→pathname fallback ──────
+//
+// Locks in the exact AF_UNIX behaviour an X client relies on when opening the
+// display.  Per unix(7): a sockaddr_un whose sun_path begins with a NUL byte is
+// an *abstract* name whose length is taken from addrlen (not NUL-terminated).
+// libxcb's `_xcb_open` tries the abstract socket first, then falls back to the
+// pathname socket; that abstract-refused → pathname-success sequence is what a
+// working X connection performs, so it is guarded here.
+fn test_unix_abstract_and_fallback() -> bool {
+    test_header!("AF_UNIX abstract namespace + abstract→pathname fallback");
+    use crate::syscall::dispatch_linux_kernel as sc;
+
+    // Build a sockaddr_un for an ABSTRACT name.  addrlen is EXACT:
+    // 2 (sa_family) + 1 (leading NUL) + name.len().  A too-long addrlen would
+    // fold trailing NULs into the abstract name (they are significant), so the
+    // exact length matters — this is the subtlety abstract clients depend on.
+    fn abstract_addr(name: &[u8], buf: &mut [u8; 128]) -> u64 {
+        buf[0] = 1; buf[1] = 0;       // sa_family = AF_UNIX (LE)
+        buf[2] = 0;                   // sun_path[0] = NUL → abstract
+        buf[3..3 + name.len()].copy_from_slice(name);
+        (2 + 1 + name.len()) as u64   // addrlen
+    }
+
+    // ── Phase 1: abstract bind + listen + connect + accept roundtrip ─────────
+    let a_name: &[u8] = b"astryx-x-abs-rt";
+    let mut a_addr = [0u8; 128];
+    let a_len = abstract_addr(a_name, &mut a_addr);
+
+    let srv = sc(41, 1, 1, 0, 0, 0, 0);
+    if srv < 0 { test_fail!("unix_abs_socket", "socket() = {}", srv); return false; }
+    let r = sc(49 /*bind*/, srv as u64, a_addr.as_ptr() as u64, a_len, 0, 0, 0);
+    if r != 0 { test_fail!("unix_abs_bind", "bind(abstract) = {}", r); return false; }
+    if sc(50 /*listen*/, srv as u64, 5, 0, 0, 0, 0) != 0 {
+        test_fail!("unix_abs_listen", "listen() failed"); return false;
+    }
+    let cli = sc(41, 1, 1, 0, 0, 0, 0);
+    let r = sc(42 /*connect*/, cli as u64, a_addr.as_ptr() as u64, a_len, 0, 0, 0);
+    if r != 0 { test_fail!("unix_abs_connect", "connect(abstract) = {} (want 0)", r); return false; }
+    let acc = sc(43 /*accept*/, srv as u64, 0, 0, 0, 0, 0);
+    if acc < 0 { test_fail!("unix_abs_accept", "accept() = {}", acc); return false; }
+    let msg = b"abstract-ok";
+    if sc(1, cli as u64, msg.as_ptr() as u64, msg.len() as u64, 0, 0, 0) != msg.len() as i64 {
+        test_fail!("unix_abs_write", "write failed"); return false;
+    }
+    let mut rb = [0u8; 32];
+    let n = sc(0, acc as u64, rb.as_mut_ptr() as u64, rb.len() as u64, 0, 0, 0);
+    if n != msg.len() as i64 || &rb[..n as usize] != msg {
+        test_fail!("unix_abs_read", "read = {} / mismatch", n); return false;
+    }
+    test_println!("  abstract bind/connect/accept roundtrip ✓");
+    sc(3, srv as u64, 0, 0, 0, 0, 0);
+    sc(3, cli as u64, 0, 0, 0, 0, 0);
+    sc(3, acc as u64, 0, 0, 0, 0, 0);
+
+    // ── Phase 2: abstract-refused → pathname-fallback (the libxcb sequence) ───
+    // A connect to an UNBOUND abstract name must return ECONNREFUSED (-111),
+    // never ENOENT — an abstract name has no filesystem object (unix(7)).  The
+    // client then falls back to the pathname socket, which succeeds.
+    let mut miss_addr = [0u8; 128];
+    let miss_len = abstract_addr(b"astryx-x-absent", &mut miss_addr);
+    let c1 = sc(41, 1, 1, 0, 0, 0, 0);
+    let r = sc(42, c1 as u64, miss_addr.as_ptr() as u64, miss_len, 0, 0, 0);
+    if r != -111 {
+        test_fail!("unix_abs_refused", "connect(unbound abstract) = {} (want -111 ECONNREFUSED)", r);
+        return false;
+    }
+    test_println!("  connect(unbound abstract) → ECONNREFUSED ✓");
+
+    // pathname listener (the fallback target)
+    let psrv = sc(41, 1, 1, 0, 0, 0, 0);
+    let mut p_addr = [0u8; 128];
+    p_addr[0] = 1; p_addr[1] = 0;
+    let ppath = b"/tmp/astryx-x-fb.sock\0";
+    p_addr[2..2 + ppath.len()].copy_from_slice(ppath);
+    let p_len = (2 + ppath.len()) as u64;
+    if sc(49, psrv as u64, p_addr.as_ptr() as u64, p_len, 0, 0, 0) != 0 {
+        test_fail!("unix_fb_bind", "bind(pathname) failed"); return false;
+    }
+    if sc(50, psrv as u64, 5, 0, 0, 0, 0) != 0 {
+        test_fail!("unix_fb_listen", "listen() failed"); return false;
+    }
+    // A FRESH client connects to the pathname (as libxcb's _xcb_open_unix does).
+    let c2 = sc(41, 1, 1, 0, 0, 0, 0);
+    if sc(42, c2 as u64, p_addr.as_ptr() as u64, p_len, 0, 0, 0) != 0 {
+        test_fail!("unix_fb_connect", "pathname fallback connect failed"); return false;
+    }
+    if sc(43, psrv as u64, 0, 0, 0, 0, 0) < 0 {
+        test_fail!("unix_fb_accept", "accept() failed"); return false;
+    }
+    test_println!("  pathname fallback connect after abstract refusal ✓");
+
+    // ── Phase 3: same-fd reconnect after ECONNREFUSED (POSIX connect(2)) ──────
+    // A socket whose connect() failed with ECONNREFUSED is not poisoned and may
+    // be connected again (POSIX.1-2017 connect()).  c1 above already ate a -111
+    // on the abstract name; reconnect the SAME fd to the live pathname listener.
+    let r = sc(42, c1 as u64, p_addr.as_ptr() as u64, p_len, 0, 0, 0);
+    if r != 0 {
+        test_fail!("unix_reconnect_after_refused",
+                   "reconnect same fd after ECONNREFUSED = {} (want 0)", r);
+        return false;
+    }
+    if sc(43, psrv as u64, 0, 0, 0, 0, 0) < 0 {
+        test_fail!("unix_reconnect_accept", "accept() of reconnect failed"); return false;
+    }
+    test_println!("  same-fd reconnect after ECONNREFUSED ✓");
+
+    sc(3, c1 as u64, 0, 0, 0, 0, 0);
+    sc(3, c2 as u64, 0, 0, 0, 0, 0);
+    sc(3, psrv as u64, 0, 0, 0, 0, 0);
+
+    test_pass!("AF_UNIX abstract namespace + abstract→pathname fallback");
     true
 }
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7177,6 +7177,8 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
               "coverage-flush", "proc-metrics",
               # socket-poll: per-AF_INET-socket poll-readiness divergence report
               # (sticky-POLLIN / spurious-EOF busy-poll localizer).
+              # unix-table: live AF_UNIX socket table occupancy (EMFILE localizer).
+              "unix-table",
               "socket-poll",
               "futex-stats",
               # blk-trace: out-of-band drain of the virtio-blk LBA ring.
@@ -13144,6 +13146,11 @@ def main():
     p_kdb.add_argument("sid")
     p_kdb.add_argument("op", choices=[
         "ping", "proc-list", "proc", "proc-tree", "fd-table", "fd-map",
+        # unix-table: live occupancy of the global AF_UNIX socket table
+        # (occupied/capacity + per-slot state/kind/peer/name). A full table
+        # makes socket(AF_UNIX)/socketpair(2) return EMFILE, which an X client
+        # reports as "cannot open display". See kdb::op_unix_table.
+        "unix-table",
         "epoll-watch",
         "syscall-trend", "vfs-mounts",
         "dmesg", "syms", "mem", "read-file", "tframe", "user-mem", "uread", "trace-status",


### PR DESCRIPTION
## Summary

Investigation of the **glibc-Firefox `Error: cannot open display: :0`** gate (which blocks the glibc load-discriminator experiment), plus the reusable tooling and regression guard that came out of it.

**Key finding (the display gate is NOT a socket-layer bug):**
- A per-syscall trace of the glibc firefox launch shows it makes **zero `socket(2)`/`connect(2)` calls** before failing — it never reaches the AF_UNIX layer. `gdk_display_open(":0")` returns before any socket.
- A side-by-side **musl-firefox** trace on the same kernel performs the exact libxcb connection sequence correctly: connect to the **abstract** name (`sun_path[0]==NUL`) is refused with `ECONNREFUSED` per unix(7); the **pathname** fallback connect to `/tmp/.X11-unix/X0` then succeeds and the X server accepts the client (`[X11] client fd=2`).
- Therefore our AF_UNIX abstract+pathname handling is **already correct**, and the dispatch's abstract-fallback hypothesis is **refuted**. The glibc gate is a **pre-socket divergence in the glibc-linked X-client stack** (system libxcb / libX11 / GTK / glibc), out of the socket layer's scope — flagged for the libc/loader/toolkit owners.

This PR **does not change socket behaviour** and **does not (cannot) fix the glibc display gate**. It lands:

- **kdb `unix-table`**: live occupancy of the global AF_UNIX socket TABLE (`occupied` / `capacity` / `high_water` / `full` + per-slot `state`/`kind`/`peer`/`name`, abstract names shown `@name`). A full table makes `socket(AF_UNIX)`/`socketpair(2)` return `EMFILE` (surfaces as "cannot open display"); this op attributes an exhaustion to its consumers. Used here to **refute a table-exhaustion hypothesis** — measured peak occupancy was **1**, not 64.
- **net::unix high-water mark**: since-boot peak of simultaneously-live slots, folded in at each allocation site under the already-held TABLE lock (diagnostic only).
- **Regression test** (`test_runner` Test 54.5): abstract bind/listen/connect/accept roundtrip; connect to an unbound abstract name → `ECONNREFUSED` (never `ENOENT`, per unix(7)); pathname fallback connect after abstract refusal (the libxcb sequence); same-fd reconnect after `ECONNREFUSED` (POSIX.1-2017 `connect()`).
- **qemu-harness**: expose the `unix-table` kdb op.

## Verification
- `--features test-mode`: new Test 54.5 **passes** (all four phases).
- Live **musl smoke** with this kernel: X connection still established (abstract refused → pathname accepted → `[X11] client fd=2`), **zero regression**.
- Live **glibc**: still `cannot open display` (expected — the pre-socket userspace divergence is not addressed here), `unix-table high_water == 1`.

## Spec references
unix(7) (abstract vs pathname sun_path, ECONNREFUSED vs ENOENT), POSIX.1-2017 `connect()` (reconnect after failed connect).

## Do not merge yet
Self-authored; requesting independent review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
