### PR TITLE
ci: compile-check the firefox-test* feature combos (cargo check matrix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,82 @@ jobs:
       - name: check fault-immunity tokens (ke::bugcheck + no_alloc_fmt)
         run: bash scripts/check_fault_immune.sh
 
+  feature-combo-check:
+    # Compile-check (cargo check level — no codegen/link, NO QEMU boot) the
+    # firefox-test* kernel feature combinations that the plain `cargo-check` job
+    # never exercises.  `cargo-check` only checks astryx-kernel with DEFAULT
+    # features, so every path behind `firefox-test-core` / `firefox-test-trace`
+    # / `firefox-trace-verbose` / `syscall-trace` / `kdb` (and the diagnostic
+    # emitters those pull in) ships compile-UNVERIFIED: a feature-gated syntax
+    # or type error stays invisible until someone builds that exact flag set by
+    # hand.  Each matrix leg is one `cargo check --features <combo>` against the
+    # bare-metal kernel target — fast, and a HARD gate (compile checks have no
+    # flake surface, unlike the QEMU kernel-smoke job).
+    #
+    # Failure mode this prevents: feature-gated code (e.g. an opt-in trace
+    # emitter, or a firefox-test-core/-trace profile-split move) that compiles
+    # under `default`/`test-mode` but fails under a `firefox-test*` combo,
+    # landing green and only breaking when an agent boots that flag set.
+    #
+    # `fail-fast: false` so one broken combo reports without cancelling the
+    # others (you want to see every failing combo, not just the first).
+    name: feature-combo check (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: kdb
+            features: kdb
+          - name: ff-core-kdb
+            features: firefox-test-core,kdb
+          - name: ff-trace-kdb
+            features: firefox-test-trace,kdb
+          - name: ff-core-verbose-kdb
+            features: firefox-test-core,firefox-trace-verbose,kdb
+          - name: ff-bundle
+            features: firefox-test
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly (matching rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools-preview
+          targets: x86_64-unknown-uefi, x86_64-unknown-none
+
+      # One shared cache across the legs: the expensive artefact is the built
+      # `core`/`alloc` sysroot (-Zbuild-std) + the registry, which is identical
+      # for every combo — only the single astryx-kernel crate re-checks per
+      # combo (cheap, no codegen).  Legs race to save the same key; a duplicate
+      # save is a harmless no-op.  Falls back to the cargo-check cache so a first
+      # run still restores a warm build-std.
+      - name: Cache cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: feature-combo-${{ runner.os }}-${{ hashFiles('Cargo.lock','kernel/x86_64-astryx.json') }}
+          restore-keys: |
+            feature-combo-${{ runner.os }}-
+            cargo-check-${{ runner.os }}-
+
+      # Same bare-metal invocation as the `cargo-check` job (the kernel is
+      # no_std + a custom JSON target and needs -Zbuild-std; checking it against
+      # the host target trips a duplicate panic_impl), plus the combo under test.
+      - name: cargo check (astryx-kernel, --features ${{ matrix.features }})
+        run: >
+          cargo +nightly check -p astryx-kernel
+          --target kernel/x86_64-astryx.json
+          --features ${{ matrix.features }}
+          -Zbuild-std=core,alloc
+          -Zbuild-std-features=compiler-builtins-mem
+          -Zjson-target-spec
+
   tooling-smoke:
     # Host-only smoke tests for the dev-dashboard tooling (no kernel build, no
     # QEMU boot — pure Python against synthetic + real serial-log fixtures, <10s


### PR DESCRIPTION
## What

Adds a `feature-combo-check` matrix job to `build.yml` that compile-checks
(`cargo check` level — no codegen/link, **no QEMU boot**) the `firefox-test*`
kernel feature combinations against the bare-metal kernel target.

Matrix legs (each a hard gate):

| leg | `--features` |
|---|---|
| `kdb` | `kdb` |
| `ff-core-kdb` | `firefox-test-core,kdb` |
| `ff-trace-kdb` | `firefox-test-trace,kdb` |
| `ff-core-verbose-kdb` | `firefox-test-core,firefox-trace-verbose,kdb` |
| `ff-bundle` | `firefox-test` |

## Why — a twice-flagged gap

The existing `cargo-check` job only checks `astryx-kernel` with **default**
features. Everything behind `firefox-test-core` / `firefox-test-trace` /
`firefox-trace-verbose` / `syscall-trace` / `kdb` (and the diagnostic emitters
those pull in) therefore ships **compile-unverified** — a feature-gated syntax
or type error lands green on master and only surfaces when someone builds that
exact flag set by hand.

Two motivating incidents:

1. **The 2026-07-01 FF-slowdown handover note** recorded the standing gap
   that *CI does not compile-check the `firefox-test*` feature sets*, so the
   de-instrumentation / profile-split churn (moving trace emitters between
   `firefox-test-core` and `firefox-test-trace`) was landing without any CI
   compile coverage of the affected flag sets.
2. **PR #689's review caveat** — the opt-in file-op/write/return trace
   diagnostics it adds live entirely behind feature gates and are invisible to
   the default `cargo-check`. The `firefox-test-core,firefox-trace-verbose,kdb`
   leg here is precisely the combo that exercises that class of code.
   (PR #680's `firefox-test-core` vs `firefox-test-trace` profile move is the
   other change class this would have covered.)

## Design notes

- **Hard gate, no flake surface.** These are compile checks, not boots — a
  failing leg reflects a real feature-gated compile error, so the job gates the
  PR. Contrast the QEMU `kernel-smoke` job, which tolerates listed flakes.
- **`fail-fast: false`** so a broken combo reports without cancelling its
  siblings — you see every failing combo in one run, not just the first.
- **One shared cache across legs.** The expensive artefact is the
  `-Zbuild-std` `core`/`alloc` sysroot + registry, identical for every combo;
  only the single `astryx-kernel` crate re-checks per combo (cheap, no codegen).
  Legs race to save the same key — a duplicate save is a harmless no-op — and
  fall back to the `cargo-check` cache so a first run still restores warm.
- Same bare-metal invocation as `cargo-check` (custom JSON target +
  `-Zbuild-std`, because the kernel is `no_std` and checking against the host
  target trips a duplicate `panic_impl`), plus `--features <combo>`.

## Verification

All five combos were confirmed to compile at `master` HEAD (`23fd66ae`, the
#680 merge) **before** landing the job — via `scripts/qemu-harness.py check
--features <combo> --root <worktree>` (the harness's `cargo check` job, one
`{ok:true}` per combo). No red job is being added.

`sched-gate-stats` (PR #685) is **intentionally excluded**: it does not exist
on master — it lives on that PR's open branch (`fix/sched-ready-gate-starvation`).
`cargo check --features sched-gate-stats` errors with *"does not contain this
feature"* at master, so adding it now would gate on a feature the tree does not
define. It should be added to this matrix if/when #685 merges.

Diff: +76 lines, one file (`.github/workflows/build.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
