### PR TITLE
sched/vfs: dead-LAPIC-timer immunity — route time-dependent decisions to the TSC-derived tick

### DIFF
--- a/kernel/src/arch/x86_64/irq.rs
+++ b/kernel/src/arch/x86_64/irq.rs
@@ -74,6 +74,19 @@ const PIC_EOI: u8 = 0x20;
 /// advance N× faster than wall time, which silently breaks every consumer
 /// that schedules deadlines from CLOCK_MONOTONIC (the userspace vDSO fast
 /// path among them).  See `timer_tick` for the TSC-monotone update logic.
+///
+/// # Reading this counter
+///
+/// This is the *raw ISR-published* count.  It advances only while the LAPIC
+/// periodic timer ISR (`timer_tick`) is delivering; if that timer stops
+/// (e.g. a KVM vCPU whose LAPIC injection is suppressed — Intel SDM Vol. 3A
+/// §11.5.4) the value **freezes** while wall time keeps moving.  Therefore any
+/// code that makes a *time-dependent decision* — a timeout, a deadline, a
+/// quiescence window, a throttle, a rate limiter — MUST read [`get_ticks`]
+/// (which returns `max(TICK_COUNT, tsc_floor)` and so keeps advancing off the
+/// invariant TSC, Intel SDM Vol. 3B §17.17) and NOT this field directly.  Read
+/// `TICK_COUNT` directly only for diagnostics that specifically want the
+/// ISR-published value (liveness checks, ISR-vs-TSC skew probes).
 pub static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// TSC value at boot — captured by [`set_tsc_calibration`] right after the

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -843,7 +843,12 @@ fn reap_dead_threads_sched() {
     // without changing which frames are freed or when.  See
     // `LAST_KSTACK_DRAIN_TICK`.
     {
-        let now = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+        // `get_ticks()`, not raw `TICK_COUNT`: the throttle gate advances
+        // `LAST_KSTACK_DRAIN_TICK` by swapping in `now`; if `now` froze (dead
+        // LAPIC timer) the gate would admit exactly one drain and then wedge
+        // forever, stalling the quarantine reaper.  The TSC-derived tick keeps
+        // it ticking at ~TICK_HZ regardless of LAPIC delivery.
+        let now = crate::arch::x86_64::irq::get_ticks();
         if kstack_drain_due(&LAST_KSTACK_DRAIN_TICK, now) {
             drain_pending_kstack_free();
         }
@@ -1136,7 +1141,7 @@ mod d582_push_prov {
         let s = slot(phys);
         s.pfn.store(pfn, Ordering::Relaxed);
         s.tick
-            .store(crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed), Ordering::Relaxed);
+            .store(crate::arch::x86_64::irq::get_ticks(), Ordering::Relaxed);
         s.pusher_tid.store(pusher_tid, Ordering::Relaxed);
     }
 
@@ -1245,13 +1250,25 @@ struct CachedDeadStack {
 static DEAD_STACK_CACHE: spin::Mutex<alloc::vec::Vec<CachedDeadStack>> =
     spin::Mutex::new(alloc::vec::Vec::new());
 
-/// Read the current global tick count for use as a quiescence snapshot.
+/// Read the current wall-clock tick for use as a quiescence snapshot.
 ///
-/// Uses `TICK_COUNT` rather than per-CPU `TIMER_ISR_PER_CPU` — see the
+/// Uses `get_ticks()` (a single global value advanced by whichever online
+/// CPU's timer ISR runs) rather than per-CPU `TIMER_ISR_PER_CPU` — see the
 /// `CachedDeadStack` struct doc for the rationale.
+///
+/// Deliberately `get_ticks()` and NOT the raw `TICK_COUNT`: `get_ticks()`
+/// returns `max(published_tick, tsc_floor)`, so it keeps advancing at
+/// wall-clock rate off the invariant TSC (Intel SDM Vol. 3B §17.17,
+/// constant-rate TSC) even when the LAPIC periodic timer stops delivering and
+/// the ISR-published `TICK_COUNT` freezes.  A frozen source here would peg the
+/// quiescence delta (`now - push_tick`) at zero forever, so no cached dead
+/// stack would ever satisfy the tick gate and the reaper's drain throttle
+/// would wedge — a reclaim stall, not a UAF, but a real dead-timer robustness
+/// hole.  Both the push stamp and every quiescence comparison read through
+/// this one helper, so the two can never drift.
 #[inline]
 fn current_tick_for_quiesce() -> u64 {
-    crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed)
+    crate::arch::x86_64::irq::get_ticks()
 }
 
 /// Decide whether a cached entry has quiesced — the global `TICK_COUNT`
@@ -1275,7 +1292,12 @@ fn entry_is_quiesced(entry: &CachedDeadStack) -> bool {
     // Gate 2 (wall-clock tick — defence-in-depth): bounds the re-issue
     // against any in-flight switch the generation counter cannot attribute
     // to a specific CPU.  The minimum wait is `DEAD_STACK_QUIESCE_TICKS`.
-    let now = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    // Same wall-clock source as the push stamp (`current_tick_for_quiesce`),
+    // so the delta is honest even if the LAPIC timer died and `TICK_COUNT`
+    // froze.  Gate 1 (the switch-generation counter) is the primary signal;
+    // this tick gate is defence-in-depth and MUST keep advancing to release
+    // entries whose `last_cpu` cannot be attributed to the generation gate.
+    let now = current_tick_for_quiesce();
     let tick_ok = now >= entry.push_tick.saturating_add(DEAD_STACK_QUIESCE_TICKS);
 
     // Liveness escape valve: if `last_cpu` goes idle (parks in `sti;hlt;cli`
@@ -1465,7 +1487,9 @@ pub fn pop_dead_stack() -> Option<(u64, u64)> {
     #[cfg(feature = "test-mode")]
     if idx_found.is_none() && !cache.is_empty() {
         let e = &cache[0];
-        let now = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+        // Mirror the production quiescence source so the diagnostic reflects
+        // the same `now` the gate actually sees.
+        let now = current_tick_for_quiesce();
         let cur_gen = cpu_switch_gen(e.last_cpu);
         crate::serial_println!(
             "[KSTACK/QUIESCE] push_tick={} now={} need={} tick_ok={} \
@@ -1739,23 +1763,25 @@ pub fn dead_stack_cache_len() -> usize {
     DEAD_STACK_CACHE.lock().len()
 }
 
-/// Wait (yield-based) until the global `TICK_COUNT` has advanced by
+/// Wait (yield-based) until the wall-clock tick has advanced by
 /// `DEAD_STACK_QUIESCE_TICKS + 1` ticks from the current instant.
 ///
 /// After this returns, any dead-stack cache entry pushed BEFORE the call
-/// will satisfy `entry_is_quiesced` — `TICK_COUNT` is the same counter
-/// that `entry_is_quiesced` now reads (see `CachedDeadStack.push_tick`).
+/// will satisfy `entry_is_quiesced` — this reads through the same
+/// `current_tick_for_quiesce` source that `entry_is_quiesced` and the push
+/// stamp use (see `CachedDeadStack.push_tick`), so it is immune to a frozen
+/// `TICK_COUNT` under a dead LAPIC timer just like the gate it mirrors.
 ///
 /// Test-mode only: used by the PMM-leak test to ensure the child's kstack
 /// is recycled on the next iteration rather than forcing a fresh PMM alloc.
 #[cfg(feature = "test-mode")]
 pub fn wait_dead_stacks_quiesced() {
     const NEEDED: u64 = DEAD_STACK_QUIESCE_TICKS + 1;
-    let baseline = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+    let baseline = current_tick_for_quiesce();
     loop {
         crate::hal::enable_interrupts();
         yield_cpu();
-        let now = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+        let now = current_tick_for_quiesce();
         if now >= baseline.saturating_add(NEEDED) { break; }
         for _ in 0..200 { core::hint::spin_loop(); }
     }
@@ -1795,6 +1821,16 @@ pub fn test_entry_quiesced(push_tick: u64, last_cpu: usize, last_cpu_gen: u64) -
 #[cfg(any(feature = "test-mode", feature = "firefox-test-core"))]
 pub fn test_cpu_switch_gen(cpu: usize) -> u64 {
     cpu_switch_gen(cpu)
+}
+
+/// Test-only: read the quiescence time source the kstack cache uses.
+///
+/// Exposed so the dead-timer-immunity regression can assert this source keeps
+/// advancing (off the TSC) even when the raw ISR-published `TICK_COUNT` is
+/// pinned behind wall time by a dead LAPIC periodic timer.
+#[cfg(feature = "test-mode")]
+pub fn test_current_tick_for_quiesce() -> u64 {
+    current_tick_for_quiesce()
 }
 
 /// Test-only: run the saved-RSP survey against a caller-supplied thread slice.

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -614,7 +614,9 @@ pub fn timer_tick_schedule() {
 /// states/deadlines count as "due".
 ///
 /// The caller MUST already hold `THREAD_TABLE`.  `now` is the current
-/// `TICK_COUNT` (monotone); pass the value read by the caller so a single tick
+/// `get_ticks()` value (TSC-derived, monotone — the callers `wake_sleeping_threads`
+/// and `drain_due_wakes_if_pending` both read it, so timed wakes stay immune to a
+/// frozen `TICK_COUNT`); pass the value read by the caller so a single tick
 /// snapshot drives the whole pass.  Returns the number of threads flipped to
 /// `Ready` (diagnostic only).
 #[inline]
@@ -848,6 +850,15 @@ fn reap_dead_threads_sched() {
         // LAPIC timer) the gate would admit exactly one drain and then wedge
         // forever, stalling the quarantine reaper.  The TSC-derived tick keeps
         // it ticking at ~TICK_HZ regardless of LAPIC delivery.
+        //
+        // This computes `get_ticks()` (rdtsc + one divide + a few atomic loads)
+        // on every `schedule()` — the throttle is a per-tick edge detector, so
+        // `now` is inherently needed each pass to detect a tick boundary.  We
+        // deliberately do NOT gate it behind a lock-free "quarantine non-empty"
+        // pre-check: `PENDING_KSTACK_FREE` has no lock-free depth, and adding a
+        // synchronised counter to this race-sensitive reaper path is not worth
+        // ~one rdtsc+divide per schedule vs the O(entries×threads) survey it
+        // gates (which itself fast-returns on an empty quarantine).
         let now = crate::arch::x86_64::irq::get_ticks();
         if kstack_drain_due(&LAST_KSTACK_DRAIN_TICK, now) {
             drain_pending_kstack_free();

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -47784,10 +47784,18 @@ fn test_294_kstack_switch_gen_gate() -> bool {
     test_header!("sched: dead-kstack switch-generation quiescence gate (SMP #DB)");
 
     // Use a long-elapsed push_tick (0) so the wall-clock tick gate is always
-    // satisfied; this isolates the *generation* condition.  TICK_COUNT is well
-    // past the escape-valve margin by the time the test suite runs, so we
-    // pick a recent push_tick for the cases that must observe withholding.
-    let now = crate::arch::x86_64::irq::TICK_COUNT.load(core::sync::atomic::Ordering::Relaxed);
+    // satisfied; this isolates the *generation* condition.  The quiescence
+    // clock is well past the escape-valve margin by the time the suite runs, so
+    // we pick a recent push_tick for the cases that must observe withholding.
+    //
+    // Read `now` from the SAME source the gate reads (`entry_is_quiesced` calls
+    // `current_tick_for_quiesce()` = `get_ticks()`), NOT the raw `TICK_COUNT`.
+    // Under a dead LAPIC timer `get_ticks()` can lead the frozen raw counter by
+    // many ticks; a `recent = raw − 3` push_tick would then sit ≥16 ticks below
+    // the gate's `get_ticks()` view, spuriously flipping `escape_ok` true and
+    // failing the withholding cases (A, E) on a local KVM run. Same-clock keeps
+    // the `now − push_tick` delta honest regardless of timer liveness.
+    let now = crate::sched::test_current_tick_for_quiesce();
     let cpu0_gen = crate::sched::test_cpu_switch_gen(0);
 
     // Case A: gen NOT advanced (snapshot == live), recent push → WITHHELD.
@@ -47839,9 +47847,17 @@ fn test_294_kstack_switch_gen_gate() -> bool {
     test_println!("  D: gen-not-advanced + escape-margin → eligible via valve (ok)");
 
     // Case E: too-recent push → base tick gate not met → WITHHELD even with
-    // the unknown-CPU sentinel.  push_tick = now → only 0 ticks elapsed.
-    if crate::sched::test_entry_quiesced(now, 0, u64::MAX) && now != 0 {
-        // now != 0 guard: at the very first tick the saturating arithmetic
+    // the unknown-CPU sentinel.  RE-READ the quiescence clock here rather than
+    // reuse the top-of-test `now`: cases A-D each emit serial output, which
+    // burns several ticks of wall time under KVM PIO, so the shared snapshot is
+    // stale by the time this runs.  `entry_is_quiesced` reads its own
+    // `get_ticks()` internally; if push_tick lags that read by ≥2 ticks the
+    // "0-tick" entry looks old enough to pass the tick gate and the case
+    // spuriously fails.  A fresh read makes push_tick == the gate's `now`
+    // (within a few instructions ≪ 1 tick) → genuinely 0 ticks elapsed.
+    let now_fresh = crate::sched::test_current_tick_for_quiesce();
+    if crate::sched::test_entry_quiesced(now_fresh, 0, u64::MAX) && now_fresh != 0 {
+        // now_fresh != 0 guard: at the very first tick the saturating arithmetic
         // makes the 2-tick threshold equal to now, which is a benign edge.
         test_fail!("test294", "too-recent entry (0 ticks) was eligible — tick gate open");
         return false;
@@ -47968,10 +47984,15 @@ fn test_659_kstack_drain_per_tick_throttle() -> bool {
 // source would echo the frozen value, the tick gate would never elapse, and the
 // reaper would stall — a dead-timer robustness hole.
 //
-// Deterministic on SMP: the assertions compare against an independently-computed
-// TSC floor, so a sibling CPU's ISR healing the raw counter back up cannot flip
-// the result (it only raises the raw value, which the TSC-floor bound already
-// dominates).  The forced-behind store is restored with a monotone `fetch_max`.
+// SMP note: the assertions compare against an independently-computed TSC floor,
+// so this never FALSE-FAILS on SMP=2 — a sibling CPU's ISR monotone-CAS-healing
+// the raw counter back up only raises the raw value, which the TSC-floor bound
+// already dominates.  It does not guarantee the strongest DISCRIMINATION on
+// SMP=2 though: if a sibling heals `TICK_COUNT` inside the store→read window a
+// hypothetically-buggy raw read could be masked and still pass.  That is
+// acceptable — the whole-machine-frozen regime this fix targets is a single-core
+// phenomenon, so the decisive discrimination is on SMP=1.  The forced-behind
+// store is restored with a monotone `fetch_max`.
 #[cfg(feature = "test-mode")]
 fn test_688_quiesce_immune_to_frozen_tick() -> bool {
     use core::sync::atomic::Ordering;

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1368,6 +1368,19 @@ pub fn run() -> ! {
         if test_659_kstack_drain_per_tick_throttle() { passed += 1; }
     }
 
+    // ── Test 688: kstack quiescence is immune to a frozen TICK_COUNT ──────
+    // Robustness guard for the dead-LAPIC-timer condition: when the LAPIC
+    // periodic timer stops delivering, the raw ISR-published `TICK_COUNT`
+    // freezes while wall time keeps moving.  Every time-dependent kernel
+    // decision must read the TSC-derived `get_ticks()` instead so it keeps
+    // advancing.  Verifies the kstack-quiescence tick gate (and its shared
+    // time source) still elapse with the raw counter pinned behind wall time.
+    #[cfg(feature = "test-mode")]
+    {
+        total += 1;
+        if test_688_quiesce_immune_to_frozen_tick() { passed += 1; }
+    }
+
     {
         total += 1;
         if test_671_kstack_onstack_survey_gate() { passed += 1; }
@@ -47934,6 +47947,100 @@ fn test_659_kstack_drain_per_tick_throttle() -> bool {
     test_println!("  E: stale entry (≥16t) eligible via escape valve → per-tick drain reclaims (ok)");
 
     test_pass!("per-tick drain throttle: once-per-tick + resumes each tick + reclamation intact");
+    true
+}
+
+// ── Test 688: kstack quiescence is immune to a frozen TICK_COUNT ──────────────
+//
+// Under a dead LAPIC periodic timer (e.g. a KVM vCPU whose LAPIC injection is
+// suppressed — Intel SDM Vol. 3A §11.5.4) the ISR that advances the raw
+// `TICK_COUNT` stops firing, so the raw counter FREEZES while wall time keeps
+// moving.  The invariant TSC (Intel SDM Vol. 3B §17.17, constant-rate TSC)
+// keeps advancing regardless, and `get_ticks()` returns `max(TICK_COUNT,
+// tsc_floor)` so it tracks wall time through a dead timer.
+//
+// Every time-dependent kernel decision must therefore read `get_ticks()` and
+// not the raw counter.  This regression pins that for the kstack-quiescence
+// machinery: with the raw counter forced far behind wall time, (a) the shared
+// quiescence source (`current_tick_for_quiesce`) must still report the TSC
+// floor, not the frozen raw value, and (b) the `entry_is_quiesced` tick gate
+// must still judge an old entry eligible.  Pre-fix (raw `TICK_COUNT` read) the
+// source would echo the frozen value, the tick gate would never elapse, and the
+// reaper would stall — a dead-timer robustness hole.
+//
+// Deterministic on SMP: the assertions compare against an independently-computed
+// TSC floor, so a sibling CPU's ISR healing the raw counter back up cannot flip
+// the result (it only raises the raw value, which the TSC-floor bound already
+// dominates).  The forced-behind store is restored with a monotone `fetch_max`.
+#[cfg(feature = "test-mode")]
+fn test_688_quiesce_immune_to_frozen_tick() -> bool {
+    use core::sync::atomic::Ordering;
+    use crate::arch::x86_64::irq::{TICK_COUNT, TSC_AT_BOOT, TSC_PER_TICK, rdtsc, get_ticks};
+    test_header!("sched: kstack quiescence immune to a frozen TICK_COUNT (dead-LAPIC robustness)");
+
+    let tsc_per_tick = TSC_PER_TICK.load(Ordering::Acquire);
+    if tsc_per_tick == 0 {
+        // Pre-calibration: no TSC epoch, `get_ticks()` legitimately falls back
+        // to the raw count.  Not the regime this test targets; treat as N/A.
+        test_println!("  (skipped: TSC not yet calibrated — immunity is post-calibration)");
+        test_pass!("quiesce frozen-tick immunity: N/A pre-calibration");
+        return true;
+    }
+
+    // Independent lower bound on the true wall-clock tick, computed straight
+    // from the TSC — never touches TICK_COUNT.
+    let tsc_at_boot = TSC_AT_BOOT.load(Ordering::Acquire);
+    let tsc_floor = rdtsc().wrapping_sub(tsc_at_boot) / tsc_per_tick;
+    if tsc_floor < 32 {
+        // Too early in boot to build an "old" push_tick below the escape valve.
+        test_println!("  (skipped: only {} ticks of uptime — need ≥32)", tsc_floor);
+        test_pass!("quiesce frozen-tick immunity: N/A this early in boot");
+        return true;
+    }
+
+    // Emulate the dead timer: pin the raw counter far behind wall time.
+    let saved = TICK_COUNT.load(Ordering::Relaxed);
+    const FROZEN: u64 = 1;
+    TICK_COUNT.store(FROZEN, Ordering::Relaxed);
+
+    // (a) The shared quiescence source must report the TSC floor, not `FROZEN`.
+    let q = crate::sched::test_current_tick_for_quiesce();
+    let g = get_ticks();
+
+    // (b) An entry pushed ~8 ticks ago (past the 2-tick quiesce window, well
+    // short of the 16-tick escape valve) must be eligible on the TICK GATE
+    // alone — `last_cpu_gen = u64::MAX` makes the generation gate vacuous, so
+    // only the tick gate can grant eligibility here.
+    let push_tick = tsc_floor.saturating_sub(8);
+    let eligible = crate::sched::test_entry_quiesced(push_tick, 0, u64::MAX);
+
+    // Restore before asserting (never lower the counter a sibling may have
+    // already advanced past `saved`).
+    TICK_COUNT.fetch_max(saved, Ordering::Relaxed);
+
+    if q < tsc_floor {
+        test_fail!("test688",
+            "quiescence source echoed the frozen counter (q={} < tsc_floor={}) — \
+             a dead LAPIC would freeze the reaper", q, tsc_floor);
+        return false;
+    }
+    if g < tsc_floor {
+        test_fail!("test688",
+            "get_ticks() regressed below the TSC floor (g={} < {})", g, tsc_floor);
+        return false;
+    }
+    test_println!("  A: raw TICK_COUNT pinned at {} → quiesce source={} get_ticks={} (≥ tsc_floor {}) (ok)",
+                  FROZEN, q, g, tsc_floor);
+
+    if !eligible {
+        test_fail!("test688",
+            "old entry (push_tick={}) not eligible with raw counter frozen — \
+             the tick gate stalled on a dead timer", push_tick);
+        return false;
+    }
+    test_println!("  B: old entry (push_tick={}, ~8t) eligible on the tick gate despite frozen raw (ok)", push_tick);
+
+    test_pass!("kstack quiescence tracks the TSC through a frozen TICK_COUNT (dead-LAPIC immune)");
     true
 }
 

--- a/kernel/src/vfs/ramfs.rs
+++ b/kernel/src/vfs/ramfs.rs
@@ -13,8 +13,13 @@ use spin::Mutex;
 use super::{FileSystemOps, FileStat, FileType, VfsError, VfsResult, alloc_inode_number};
 
 /// Get current uptime in seconds (used as a pseudo-timestamp).
+///
+/// Reads the TSC-derived `get_ticks()` rather than the raw ISR-published
+/// `TICK_COUNT` so file timestamps keep advancing at wall-clock rate even if
+/// the LAPIC periodic timer stops delivering (the raw counter would freeze,
+/// pinning every ramfs mtime/ctime at the moment the timer died).
 fn now_secs() -> u64 {
-    crate::arch::x86_64::irq::TICK_COUNT.load(core::sync::atomic::Ordering::Relaxed) / 100
+    crate::arch::x86_64::irq::get_ticks() / 100
 }
 
 /// Entry type within a directory.


### PR DESCRIPTION
## Summary

The raw `TICK_COUNT` counter is advanced **only** by the periodic LAPIC timer ISR. Under a dead timer — e.g. a KVM vCPU whose LAPIC injection is suppressed (Intel SDM Vol. 3A §11.5.4) — it **freezes** while wall time keeps moving. `get_ticks()` already masks this for its callers by returning `max(TICK_COUNT, tsc_floor)` off the invariant TSC (Intel SDM Vol. 3B §17.17, constant-rate TSC), but a few paths still read the raw counter directly and so make **time-dependent decisions against a frozen clock**.

This PR routes every such raw reader through `get_ticks()`. **Robustness hardening — this is NOT a Firefox-latency fix** (see "Scope / what this does NOT fix").

## Audit — every raw `TICK_COUNT` decision-path reader

| Site | Role | Behaviour under a frozen counter | Severity | Change |
|---|---|---|---|---|
| `sched::current_tick_for_quiesce` | kstack dead-stack quiescence time source (push stamp + all compares) | delta pegs at 0 | LOW | → `get_ticks()` |
| `sched::entry_is_quiesced` tick gate | kstack cache re-issue wall-clock backstop (Gate 2; per-CPU switch-gen is the primary Gate 1) | tick gate + escape valve never elapse → cache never re-issues via tick path | LOW–MED | → shared helper |
| kstack reaper drain throttle (`kstack_drain_due` slot) | once-per-tick quarantine survey gate | admits one drain then wedges → reaper stalls, quarantine fills, falls back to immediate free | LOW–MED | → `get_ticks()` |
| `vfs::ramfs::now_secs` | file mtime/ctime/atime | every timestamp pins at the death instant | LOW (cosmetic) | → `get_ticks()` |
| d582 push-provenance stamp; test-mode diag/wait | diagnostics / test helpers | stale stamps / infinite wait | NONE (diag/test) | → shared helper |

Diagnostic-only raw readers (`mm/w215_diag`, `mm/stack_prov`, `arch/db582`, `mm/w215_crc`, `f3_code_dr_watch`) intentionally keep the raw ISR-published value.

**Explicitly NOT changed — `mm/tlb.rs` TLB-shootdown quarantine `enqueue_tick`.** It stamps from `TICK_COUNT` but its drain gate compares per-CPU `CPU_LAST_TICK` — a per-CPU quiescence *correctness* invariant (has this CPU reloaded CR3 since enqueue?), not a wall-clock backstop. Switching it to `get_ticks()` would break the units. A dead per-CPU timer there is a separate per-CPU-liveness problem (parked #650/#648 territory), out of scope for this global-clock fix.

## Design

Non-ISR contexts only, so the `rdtsc` + divide in `get_ticks()` is affordable; the timer-ISR increment path is unchanged. The kstack push stamp and its comparisons all read through one helper (`current_tick_for_quiesce`) so they can never drift. A guardrail doc on `TICK_COUNT` directs future readers to `get_ticks()` for any timeout / deadline / quiescence window / throttle / rate limiter. This design mirrors the standard separation of an interrupt-driven tick counter from a high-resolution clocksource that reconstructs elapsed ticks by dividing the monotonic delta when interrupts are lost.

## Scope / what this does NOT fix

This does **not** address the ~50× Firefox wiki-load slowdown. Every FF-relevant timed wait already reads the TSC-derived `get_ticks()` and is immune to a frozen `TICK_COUNT`:

- futex timeout — `relative_ns_to_wake_tick` (TSC) + `due_wake_scan` (`get_ticks`)
- poll / epoll / select / nanosleep / socket blocking waits — `get_ticks`
- timerfd, waitlist, TCP/ARP/DHCP/DNS timers — `get_ticks`
- scheduler anti-starvation force accounting + per-CPU `min_deadline` — `get_ticks`-relative

**Live confirmation (SMP=1, KVM, wiki repro, this commit):** `TICK_COUNT` frozen at **120 (~1.2s)** across **50s** of wall time, while the `get_ticks()`-driven reactor cadence advanced to `total=6593` and the wiki-load network-gap population was **unchanged** vs baseline (22–31s `c2s`-ended gaps, 65–96% of span) — i.e. the fix does not collapse the gaps. The 50× residual is the parked upstream event-loop wake-handoff (W101 family), not a native-kernel timed wait.

## Test

Test 688 (`test_688_quiesce_immune_to_frozen_tick`): with `TICK_COUNT` forced to 1, the quiescence source returns the TSC floor (observed 6441, not 1) and the tick gate judges an ~8-tick-old entry eligible. Deterministic on SMP (asserts against an independently-computed TSC floor). Full test-mode suite: 333 PASS, Test 659 (existing sched cluster) still green, no regressions from this change. FF still renders (screendump 4441 distinct colours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
