### PR TITLE
syscall/ring: W101 op-trace instrumentation — ns/tid/wake + gap-end freeze trigger (Phase 0)

### DIFF
--- a/kernel/src/ipc/waitlist.rs
+++ b/kernel/src/ipc/waitlist.rs
@@ -375,12 +375,17 @@ pub fn wait_poll_event(caller_deadline: u64, mut ready_now: impl FnMut() -> bool
     } else {
         POLL_BELL_BELL_WAKES.fetch_add(1, Ordering::Relaxed);
     }
-    // Op-trace wake-source annotation (diagnostic only; provably free when the
-    // ring feature is off).  A bell ring drained us → readiness/data arrived;
-    // otherwise the scheduler tick woke us — attribute the caller's own
-    // deadline (Timeout) apart from the resync floor (Resync) so an offline
-    // chain reconstruction can tell "woken by data" from "gave up".
-    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    // Op-trace wake-source annotation.  Gated on `syscall-trace` — the only
+    // profile whose ring `begin()`/`end()` actually reads this slot — so a
+    // bare `firefox-test-core` build (the A/B baseline arm) pays nothing and
+    // stays byte-identical.  `syscall-trace` implies `firefox-test-core` via
+    // the feature bundles, so `ring`/`WakeReason` stay in scope (same gating
+    // as the ring `begin()`/`end()` call sites in the syscall dispatch).
+    // A bell ring drained us → readiness/data arrived; otherwise the
+    // scheduler tick woke us — attribute the caller's own deadline (Timeout)
+    // apart from the resync floor (Resync) so an offline chain reconstruction
+    // can tell "woken by data" from "gave up".
+    #[cfg(feature = "syscall-trace")]
     {
         use crate::syscall::ring::WakeReason;
         let r = if !still_parked {

--- a/kernel/src/ipc/waitlist.rs
+++ b/kernel/src/ipc/waitlist.rs
@@ -375,6 +375,25 @@ pub fn wait_poll_event(caller_deadline: u64, mut ready_now: impl FnMut() -> bool
     } else {
         POLL_BELL_BELL_WAKES.fetch_add(1, Ordering::Relaxed);
     }
+    // Op-trace wake-source annotation (diagnostic only; provably free when the
+    // ring feature is off).  A bell ring drained us → readiness/data arrived;
+    // otherwise the scheduler tick woke us — attribute the caller's own
+    // deadline (Timeout) apart from the resync floor (Resync) so an offline
+    // chain reconstruction can tell "woken by data" from "gave up".
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        use crate::syscall::ring::WakeReason;
+        let r = if !still_parked {
+            WakeReason::Bell
+        } else if caller_deadline != u64::MAX
+            && crate::arch::x86_64::irq::get_ticks() >= caller_deadline
+        {
+            WakeReason::Timeout
+        } else {
+            WakeReason::Resync
+        };
+        crate::syscall::ring::note_wake_reason(r);
+    }
     false
 }
 

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -422,6 +422,23 @@ pub fn dispatch(req: &str, out: &mut String) {
         "futex-stats"           => op_futex_stats(out),
         #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
         "futex-set-cluster-wake" => op_futex_set_cluster_wake(req, out),
+        // optrace: W101 op-trace gap-end freeze trigger controls + on-demand
+        // non-destructive dump of a frozen per-pid syscall ring.  See
+        // syscall::ring::optrace.
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "optrace-arm"      => op_optrace_arm(req, out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "optrace-disarm"   => op_optrace_disarm(out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "optrace-status"   => op_optrace_status(out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "optrace-freeze"   => op_optrace_freeze(out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "optrace-unfreeze" => op_optrace_unfreeze(out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "optrace-depth"    => op_optrace_depth(req, out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "scrings-dump"     => op_scrings_dump(req, out),
         "futex-ghost-hist" => op_futex_ghost_hist(req, out),
         // cond-autopsy: one-shot musl pthread_cond/mutex wake-target-vs-
         // wait-addr report.  Composes the live struct dump + parked waiters +
@@ -1366,6 +1383,110 @@ fn op_bell_stats(out: &mut String) {
         bell_wakes, resync_wakes, bell_ratio_permille
     );
 }
+// ── optrace: W101 op-trace gap-end freeze trigger ─────────────────────────────
+//
+// Arms/queries the freeze trigger and drives the on-demand non-destructive
+// frozen-ring dump.  All ops are additive JSON.  See syscall::ring::optrace.
+
+/// `optrace-arm` — arm the gap-end trigger.  Optional `quiet_ms` / `grace_ms`
+/// override the defaults (2000 / 500).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_optrace_arm(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let quiet_ms = extract_field(req, "quiet_ms").and_then(|s| parse_u64(&s)).unwrap_or(2000);
+    let grace_ms = extract_field(req, "grace_ms").and_then(|s| parse_u64(&s)).unwrap_or(500);
+    crate::syscall::ring::optrace::arm(quiet_ms, grace_ms);
+    let _ = write!(
+        out,
+        r#"{{"armed":true,"quiet_ms":{},"grace_ms":{}}}"#,
+        quiet_ms, grace_ms
+    );
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_optrace_disarm(out: &mut String) {
+    crate::syscall::ring::optrace::disarm();
+    out.push_str(r#"{"armed":false}"#);
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_optrace_freeze(out: &mut String) {
+    crate::syscall::ring::optrace::freeze_now();
+    let (_, _, _, _, freeze_at, frozen) = crate::syscall::ring::optrace::status();
+    use core::fmt::Write;
+    let _ = write!(out, r#"{{"frozen":{},"freeze_at_ns":{}}}"#, frozen, freeze_at);
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_optrace_unfreeze(out: &mut String) {
+    crate::syscall::ring::optrace::unfreeze();
+    out.push_str(r#"{"frozen":false,"freeze_at_ns":0}"#);
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_optrace_status(out: &mut String) {
+    use core::fmt::Write;
+    let (armed, quiet_ns, grace_ns, last_send_ns, freeze_at_ns, frozen) =
+        crate::syscall::ring::optrace::status();
+    let _ = write!(
+        out,
+        r#"{{"armed":{},"quiet_ms":{},"grace_ms":{},"last_tcp_send_ns":{},"freeze_at_ns":{},"frozen":{},"default_depth":{},"rings":["#,
+        armed, quiet_ns / 1_000_000, grace_ns / 1_000_000,
+        last_send_ns, freeze_at_ns, frozen,
+        crate::syscall::ring::default_capacity()
+    );
+    for (i, (pid, cap, len)) in crate::syscall::ring::tracked_rings().iter().enumerate() {
+        if i > 0 { out.push(','); }
+        let _ = write!(out, r#"{{"pid":{},"cap":{},"len":{}}}"#, pid, cap, len);
+    }
+    out.push_str("]}");
+}
+
+/// `optrace-depth` — set per-pid ring depth for a capture.  With `pid`,
+/// resize (and clear) that pid's ring; without, set the default for new
+/// rings.  `depth` is required.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_optrace_depth(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let depth = match extract_field(req, "depth").and_then(|s| parse_u64(&s)) {
+        Some(d) if d >= 1 => d as usize,
+        _ => { out.push_str(r#"{"error":"missing or bad 'depth' (>=1)"}"#); return; }
+    };
+    match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(pid) if pid != 0 => {
+            let applied = crate::syscall::ring::resize_ring(pid, depth);
+            if applied == 0 {
+                let _ = write!(out, r#"{{"error":"pid {} not tracked"}}"#, pid);
+            } else {
+                let _ = write!(out, r#"{{"pid":{},"cap":{}}}"#, pid, applied);
+            }
+        }
+        _ => {
+            crate::syscall::ring::set_default_capacity(depth);
+            let _ = write!(out, r#"{{"default_depth":{}}}"#, depth);
+        }
+    }
+}
+
+/// `scrings-dump` — non-destructively emit the frozen ring(s) to serial so
+/// the harness `scrings` parser can ingest them.  With `pid`, just that pid;
+/// without, every tracked pid.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_scrings_dump(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
+        Some(pid) if pid != 0 => {
+            crate::syscall::ring::dump_for_pid(pid);
+            let _ = write!(out, r#"{{"dumped":true,"pid":{}}}"#, pid);
+        }
+        _ => {
+            crate::syscall::ring::dump_all_tracked();
+            let n = crate::syscall::ring::tracked_rings().len();
+            let _ = write!(out, r#"{{"dumped":true,"pids":{}}}"#, n);
+        }
+    }
+}
+
 // ── compose-stats ─────────────────────────────────────────────────────────────
 //
 // Reports the rate-gated compositor's blit-vs-skip split: how many

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -341,9 +341,11 @@ pub fn socket_send(id: u64, data: &[u8]) -> Result<usize, &'static str> {
         let pid = crate::proc::current_pid_lockless();
         crate::proc::proc_metrics::bump_net_write(pid, *n as u64);
         // Gap-end freeze trigger (W101 op-trace): a successful TCP data send
-        // is the observable "gap end".  Diagnostic only; disarmed by default,
-        // so this is a single atomic load off the fast path.
-        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        // is the observable "gap end".  Disarmed by default, so this is a
+        // single atomic load off the fast path.  Gated on `syscall-trace`
+        // (the only profile whose ring is captured) so a bare
+        // `firefox-test-core` build stays byte-identical.
+        #[cfg(feature = "syscall-trace")]
         if matches!(socket_type, SocketType::Tcp) {
             crate::syscall::ring::optrace::note_tcp_send(pid);
         }

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -338,8 +338,15 @@ pub fn socket_send(id: u64, data: &[u8]) -> Result<usize, &'static str> {
     };
     // Attribute outbound bytes to the caller.  Counted on success only.
     if let Ok(n) = r.as_ref() {
-        crate::proc::proc_metrics::bump_net_write(
-            crate::proc::current_pid_lockless(), *n as u64);
+        let pid = crate::proc::current_pid_lockless();
+        crate::proc::proc_metrics::bump_net_write(pid, *n as u64);
+        // Gap-end freeze trigger (W101 op-trace): a successful TCP data send
+        // is the observable "gap end".  Diagnostic only; disarmed by default,
+        // so this is a single atomic load off the fast path.
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        if matches!(socket_type, SocketType::Tcp) {
+            crate::syscall::ring::optrace::note_tcp_send(pid);
+        }
     }
     r
 }

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -10025,11 +10025,13 @@ pub fn sys_futex_linux(
             // If we removed ourselves from the waiter list, the scheduler woke us = timeout.
             // If the list entry was already gone, FUTEX_WAKE removed us = success.
             //
-            // Op-trace wake-source annotation (diagnostic only; provably free
-            // when the ring feature is off): FutexTimeout vs FutexWake so an
+            // Op-trace wake-source annotation: FutexTimeout vs FutexWake so an
             // offline chain reconstruction can tell "gave up on a timeout"
-            // apart from "woken by a matching FUTEX_WAKE".
-            #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+            // apart from "woken by a matching FUTEX_WAKE".  Gated on
+            // `syscall-trace` (the only profile whose ring reads it) so a bare
+            // `firefox-test-core` build stays byte-identical — same gating as
+            // the ring begin()/end() call sites.
+            #[cfg(feature = "syscall-trace")]
             crate::syscall::ring::note_wake_reason(if timed_out {
                 crate::syscall::ring::WakeReason::FutexTimeout
             } else {

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -10024,6 +10024,17 @@ pub fn sys_futex_linux(
             }
             // If we removed ourselves from the waiter list, the scheduler woke us = timeout.
             // If the list entry was already gone, FUTEX_WAKE removed us = success.
+            //
+            // Op-trace wake-source annotation (diagnostic only; provably free
+            // when the ring feature is off): FutexTimeout vs FutexWake so an
+            // offline chain reconstruction can tell "gave up on a timeout"
+            // apart from "woken by a matching FUTEX_WAKE".
+            #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+            crate::syscall::ring::note_wake_reason(if timed_out {
+                crate::syscall::ring::WakeReason::FutexTimeout
+            } else {
+                crate::syscall::ring::WakeReason::FutexWake
+            });
             if timed_out {
                 #[cfg(feature = "firefox-test-trace")]
                 crate::serial_println!(

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -24,14 +24,22 @@ use spin::Mutex;
 /// Per-process syscall ring buffer (firefox-test diagnostic aid).  Active
 /// code is feature-gated inside; the module itself compiles out cleanly when
 /// the feature is off because nothing outside the module references it.
-#[cfg(feature = "firefox-test-core")]
+///
+/// Compiled under `test-mode` in addition to `firefox-test-core` so the
+/// in-kernel test suite (which boots `test-mode`) can exercise the ring's
+/// wake-source annotation and gap-end freeze-trigger plumbing directly.
+/// Under pure `test-mode` no PID is ever tracked (`enable_for` is only
+/// called on the firefox-test path), so the real module behaves exactly like
+/// the stub for production callers — `is_tracked` returns false, no ring is
+/// allocated — while remaining reachable from unit tests.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
 pub mod ring;
 
-/// Stub `ring` module for builds without the firefox-test feature.  Provides
-/// the `is_tracked()` predicate so generic syscall-trace gates can compile
-/// uniformly; always returns false because no PIDs are tracked outside of
-/// the firefox-test diagnostic build.
-#[cfg(not(feature = "firefox-test-core"))]
+/// Stub `ring` module for builds without the firefox-test / test-mode
+/// feature.  Provides the `is_tracked()` predicate so generic syscall-trace
+/// gates can compile uniformly; always returns false because no PIDs are
+/// tracked outside of the firefox-test diagnostic build.
+#[cfg(not(any(feature = "firefox-test-core", feature = "test-mode")))]
 pub mod ring {
     #[inline]
     pub fn is_tracked(_pid: u64) -> bool { false }

--- a/kernel/src/syscall/ring.rs
+++ b/kernel/src/syscall/ring.rs
@@ -78,6 +78,11 @@ pub enum WakeReason {
     /// The caller's own absolute deadline expired (poll/epoll timeout).
     Timeout      = 3,
     /// A signal delivery flipped us Ready (EINTR-shaped wake).
+    ///
+    /// Reserved: no producer yet — EINTR-shaped wakes currently surface as
+    /// `Bell`/`Resync`/`Timeout` (the underlying primitive's classification).
+    /// A dedicated producer can be wired if signal-interrupted parks need to
+    /// be distinguished in a future capture; the value is stable meanwhile.
     Signal       = 4,
     /// A matching FUTEX_WAKE removed us from the waiter list.
     FutexWake    = 5,
@@ -256,11 +261,19 @@ pub fn is_tracked(pid: u64) -> bool {
 // A blocking wait path (poll/epoll/select via `wait_poll_event`, or the
 // FUTEX_WAIT arm) records how it concluded here, AFTER its final `schedule()`
 // returns.  `begin()` resets the slot at syscall entry; `end()` folds it into
-// the entry.  Because no `schedule()` runs between a wait path's post-wake
-// note and `end()`, the calling thread stays on the same CPU across that
-// window, so a lock-free per-CPU slot is race-free for the reader.  Writes
-// from other threads while this thread is parked land on whichever CPU they
-// run on and are overwritten by this thread's own post-wake note on resume.
+// the entry.  For the wait paths themselves the annotation is exact: no
+// `schedule()` runs between a wait path's post-wake note and `end()`, so the
+// calling thread stays on the same CPU across that window and a lock-free
+// per-CPU slot is race-free for the reader.
+//
+// LIMITATION (mislabel-only, never unsafe): a *non-wait* syscall that happens
+// to reschedule mid-flight — e.g. a blocking demand-page fault or blk I/O
+// between `begin()` and `end()` — can, if a foreign thread runs a wait on the
+// same CPU meanwhile, read that foreign reason at `end()` and mislabel its own
+// entry.  This never corrupts state (the slot is a diagnostic u8); it only
+// misattributes the `wake` field on the occasional non-wait entry.  On SMP≥2
+// the same window also permits a cross-CPU mislabel; the W101 capture runs
+// `--smp 1`, where the wait paths' same-CPU invariant holds and this is moot.
 
 static WAKE_REASON: [AtomicU8; MAX_CPUS] =
     [const { AtomicU8::new(0) }; MAX_CPUS];

--- a/kernel/src/syscall/ring.rs
+++ b/kernel/src/syscall/ring.rs
@@ -6,13 +6,21 @@
 //! lines; each entry is printed on a single `[SC-RING]` line.
 //!
 //! The ring is a purely diagnostic aid: the information it captures (syscall
-//! number, six argument registers, return value, user RIP, optional resolved
-//! path, optional first bytes returned from read) is what a userspace strace
-//! would observe.  For Firefox debugging this is the cheapest way to answer
-//! "what was the process looking at immediately before it decided to abort?"
+//! number, six argument registers, return value, user RIP, a TSC-derived
+//! monotonic-ns timestamp, the calling thread id, how any blocking wait
+//! concluded, and optional resolved path / first read bytes) is a superset of
+//! what a userspace strace would observe.  For Firefox debugging this is the
+//! cheapest way to answer "what was the process looking at — and what woke it
+//! — immediately before it acted?"
 //!
-//! Feature-gated: code is only compiled under `firefox-test` so the general
-//! syscall path remains untouched for production builds.
+//! The `optrace` submodule adds a kdb-armable gap-end freeze trigger so a
+//! single Wikipedia-load wake-chain transition can be captured and
+//! reconstructed offline (W101 op-trace, Phase 0).
+//!
+//! Feature-gated: compiled under `firefox-test-core` (the Firefox bring-up
+//! profile) and `test-mode` (so the in-kernel test suite can exercise the
+//! plumbing).  Nothing is ever auto-tracked under bare `test-mode`, so the
+//! general syscall path stays untouched for production builds.
 
 extern crate alloc;
 
@@ -20,16 +28,93 @@ use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use spin::Mutex;
 
-/// Ring capacity per process (last N syscalls).
-pub const RING_CAP: usize = 256;
+use crate::arch::x86_64::apic::{cpu_index, MAX_CPUS};
+
+/// Default ring capacity per process (last N syscalls).
+///
+/// The gap-end freeze trigger (see `optrace` below) stops recording once the
+/// captured transition tail has settled, so the *live* requirement on this
+/// number is only "deep enough to span the gap-ending send through the grace
+/// window at storm rate".  The historical value was 256 (≈2 ms of storm) —
+/// far too shallow for a W101 op-trace capture where the post-gap burst runs
+/// at ~10^5 syscalls/s.  The default is bumped modestly (holds ~24 ms of
+/// storm) and the per-pid depth is raised to a capture depth via the kdb
+/// `optrace-depth` op right before arming, which bounds heap cost to just the
+/// two focus PIDs rather than every tracked process.  Each slot is a fixed
+/// ~104 B header plus (empty) `String`/`Vec` handles — see the PR notes for
+/// the memory model.
+pub const RING_CAP: usize = 4096;
+
+/// Runtime default capacity for newly-created rings.  Seeded from `RING_CAP`;
+/// raised via `set_default_capacity` (kdb `optrace-depth` with no pid).
+static RING_CAP_RUNTIME: AtomicUsize = AtomicUsize::new(RING_CAP);
 
 /// Max bytes of `open()`'d path stored per entry.
 pub const PATH_BYTES: usize = 128;
 
 /// Max bytes of `read()` content captured per entry.
 pub const READ_BYTES: usize = 256;
+
+/// How a blocking wait concluded, captured at syscall exit so an offline
+/// chain reconstruction can tell "woken by data/readiness" apart from "gave
+/// up on a timeout" — the one discrimination a userspace strace cannot make.
+///
+/// `NeverBlocked` is the default for every entry; a wait path overwrites the
+/// per-CPU slot (see [`note_wake_reason`]) *after* its final `schedule()`
+/// returns, and [`end`] folds the slot into the entry.  Values are stable
+/// (append-only) so the harness/JSON mapping never shifts.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum WakeReason {
+    /// Syscall did not park (or is not a wait syscall) — data was immediate.
+    NeverBlocked = 0,
+    /// A poll-bell ring (an IPC/readiness writer) drained the waiter.
+    Bell         = 1,
+    /// The bounded resync-floor scheduler tick woke us (no bell fired).
+    Resync       = 2,
+    /// The caller's own absolute deadline expired (poll/epoll timeout).
+    Timeout      = 3,
+    /// A signal delivery flipped us Ready (EINTR-shaped wake).
+    Signal       = 4,
+    /// A matching FUTEX_WAKE removed us from the waiter list.
+    FutexWake    = 5,
+    /// FUTEX_WAIT deadline expired (ETIMEDOUT).
+    FutexTimeout = 6,
+    /// Blocked, but the wait path could not cheaply attribute the wake.
+    Unknown      = 7,
+}
+
+impl WakeReason {
+    #[inline]
+    fn from_u8(v: u8) -> WakeReason {
+        match v {
+            1 => WakeReason::Bell,
+            2 => WakeReason::Resync,
+            3 => WakeReason::Timeout,
+            4 => WakeReason::Signal,
+            5 => WakeReason::FutexWake,
+            6 => WakeReason::FutexTimeout,
+            7 => WakeReason::Unknown,
+            _ => WakeReason::NeverBlocked,
+        }
+    }
+    /// Stable string label used by the serial dumper and the scrings JSON.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WakeReason::NeverBlocked => "never_blocked",
+            WakeReason::Bell         => "bell",
+            WakeReason::Resync       => "resync",
+            WakeReason::Timeout      => "timeout",
+            WakeReason::Signal       => "signal",
+            WakeReason::FutexWake    => "futex_wake",
+            WakeReason::FutexTimeout => "futex_timeout",
+            WakeReason::Unknown      => "unknown",
+        }
+    }
+}
 
 /// One entry in the ring.
 #[derive(Clone)]
@@ -55,9 +140,21 @@ pub struct Entry {
     /// First PATH_BYTES of read content, if this entry is a read() that we
     /// captured.  Hex-escaped by the dumper; kept as raw bytes here.
     pub read_bytes: Vec<u8>,
-    /// Tick counter when the entry was committed — lets the dumper show the
-    /// approximate rate and interleaving.
+    /// Tick counter (10 ms `get_ticks`) when the entry was committed — lets
+    /// the dumper show the approximate rate and interleaving.
     pub tick: u64,
+    /// TSC-derived monotonic nanoseconds at syscall entry.  Unlike `tick`
+    /// (10 ms granularity, and frozen on a dead LAPIC timer under KVM — see
+    /// PR #692), this reads the vDSO calibration directly, so cross-process
+    /// op ordering at a gap transition is unambiguous even inside one tick.
+    pub ns: u64,
+    /// Calling thread id (per-CPU `current_tid`).  The ring is per-PID; this
+    /// records which thread issued the call so a chain reconstruction knows
+    /// which-thread-did-what across the process's threads.
+    pub tid: u64,
+    /// How the wait concluded, if this entry blocked.  `NeverBlocked` for the
+    /// common (non-parking) case.  See [`WakeReason`].
+    pub wake: WakeReason,
 }
 
 impl Entry {
@@ -68,15 +165,22 @@ impl Entry {
             path: String::new(),
             read_bytes: Vec::new(),
             tick: 0,
+            ns: 0,
+            tid: 0,
+            wake: WakeReason::NeverBlocked,
         }
     }
 }
 
 /// Per-process ring state.
+///
+/// `buf` is a runtime-sized boxed slice (was a const-generic array) so a
+/// focus PID's depth can be raised for a capture without recompiling — see
+/// [`optrace`] and the kdb `optrace-depth` op.  `cap()` is always `buf.len()`.
 pub struct Ring {
-    pub buf: Box<[Entry; RING_CAP]>,
+    pub buf: Box<[Entry]>,
     pub head: usize,   // index where the NEXT entry will be written
-    pub len:  usize,   // number of valid entries (<= RING_CAP)
+    pub len:  usize,   // number of valid entries (<= cap())
     /// Pending entry: we record at syscall-entry (nr/args/rip) and patch the
     /// return value at syscall-exit.  None when no entry is in-flight for
     /// this process on the current CPU.
@@ -84,30 +188,45 @@ pub struct Ring {
 }
 
 impl Ring {
+    fn with_capacity(cap: usize) -> Self {
+        let cap = cap.max(1);
+        // Box the slice directly to avoid stack-allocating a large array.
+        let mut v: Vec<Entry> = Vec::with_capacity(cap);
+        for _ in 0..cap { v.push(Entry::zero()); }
+        Ring { buf: v.into_boxed_slice(), head: 0, len: 0, pending_idx: None }
+    }
+
     fn new() -> Self {
-        // Box large arrays directly to avoid stack-allocation of ~128 KiB.
-        let mut v: Vec<Entry> = Vec::with_capacity(RING_CAP);
-        for _ in 0..RING_CAP { v.push(Entry::zero()); }
-        let boxed: Box<[Entry; RING_CAP]> = v.into_boxed_slice().try_into().ok()
-            .expect("RING_CAP-sized vec should convert to boxed array");
-        Ring { buf: boxed, head: 0, len: 0, pending_idx: None }
+        Ring::with_capacity(RING_CAP_RUNTIME.load(Ordering::Relaxed))
+    }
+
+    #[inline]
+    fn cap(&self) -> usize { self.buf.len() }
+
+    /// Re-allocate the ring to `cap` entries, discarding history.  Called
+    /// only from the kdb `optrace-depth` op before a capture, so clearing is
+    /// intentional (the capture happens after the resize).
+    fn resize(&mut self, cap: usize) {
+        *self = Ring::with_capacity(cap);
     }
 
     fn push_begin(&mut self, mut e: Entry) -> usize {
+        let cap = self.cap();
         let idx = self.head;
         // Drop old content at this slot to free its String/Vec allocations
         // before overwriting (avoids unbounded memory retention).
         self.buf[idx] = core::mem::replace(&mut e, Entry::zero());
-        self.head = (self.head + 1) % RING_CAP;
-        if self.len < RING_CAP { self.len += 1; }
+        self.head = (self.head + 1) % cap;
+        if self.len < cap { self.len += 1; }
         self.pending_idx = Some(idx);
         idx
     }
 
     fn iter_chronological(&self) -> impl Iterator<Item = &Entry> {
-        let start = if self.len < RING_CAP { 0 } else { self.head };
+        let cap = self.cap();
+        let start = if self.len < cap { 0 } else { self.head };
         let len = self.len;
-        (0..len).map(move |i| &self.buf[(start + i) % RING_CAP])
+        (0..len).map(move |i| &self.buf[(start + i) % cap])
     }
 }
 
@@ -132,6 +251,198 @@ pub fn is_tracked(pid: u64) -> bool {
     t.contains(&pid)
 }
 
+// ── Per-CPU wake-reason slot ────────────────────────────────────────────────
+//
+// A blocking wait path (poll/epoll/select via `wait_poll_event`, or the
+// FUTEX_WAIT arm) records how it concluded here, AFTER its final `schedule()`
+// returns.  `begin()` resets the slot at syscall entry; `end()` folds it into
+// the entry.  Because no `schedule()` runs between a wait path's post-wake
+// note and `end()`, the calling thread stays on the same CPU across that
+// window, so a lock-free per-CPU slot is race-free for the reader.  Writes
+// from other threads while this thread is parked land on whichever CPU they
+// run on and are overwritten by this thread's own post-wake note on resume.
+
+static WAKE_REASON: [AtomicU8; MAX_CPUS] =
+    [const { AtomicU8::new(0) }; MAX_CPUS];
+
+/// Record how the current syscall's blocking wait concluded.  Called by the
+/// wait paths (feature-gated at the call site) right after the wake.
+#[inline]
+pub fn note_wake_reason(r: WakeReason) {
+    WAKE_REASON[cpu_index()].store(r as u8, Ordering::Relaxed);
+}
+
+/// Reset this CPU's wake-reason slot to `NeverBlocked` (syscall entry).
+#[inline]
+fn clear_wake_reason() {
+    WAKE_REASON[cpu_index()].store(WakeReason::NeverBlocked as u8, Ordering::Relaxed);
+}
+
+/// Read (and reset) this CPU's wake-reason slot (syscall exit).
+#[inline]
+fn take_wake_reason() -> WakeReason {
+    let v = WAKE_REASON[cpu_index()]
+        .swap(WakeReason::NeverBlocked as u8, Ordering::Relaxed);
+    WakeReason::from_u8(v)
+}
+
+// ── Gap-end freeze trigger (W101 op-trace capture) ──────────────────────────
+//
+// Arm from kdb; then the FIRST TCP send from a tracked FF pid after a
+// configurable quiet interval sets a freeze deadline `now + grace`.  Once the
+// deadline passes, `begin()` becomes a no-op, so the gap-ending send AND its
+// immediate consequent chain are captured, then the post-gap storm cannot
+// overwrite them.  A single serial marker is emitted when the trigger fires
+// (one line per gap-end — not a hot path) so the harness can `wait` on it.
+//
+// All state is plain atomics; the only hot-path reader is `is_frozen_at`
+// (one relaxed load) from `begin()`.
+pub mod optrace {
+    use super::*;
+
+    /// Master arm flag.  When false, `note_tcp_send` is a single atomic load.
+    static ARMED: AtomicBool = AtomicBool::new(false);
+    /// Quiet threshold (ns) a TCP-send stream must be silent for before the
+    /// next send counts as a gap end.  Default 2000 ms.
+    static QUIET_NS: AtomicU64 = AtomicU64::new(2_000_000_000);
+    /// Grace window (ns) recorded after the trigger fires before the ring
+    /// freezes.  Default 500 ms.
+    static GRACE_NS: AtomicU64 = AtomicU64::new(500_000_000);
+    /// Monotonic ns of the last observed tracked-pid TCP send (0 = none yet).
+    static LAST_TCP_SEND_NS: AtomicU64 = AtomicU64::new(0);
+    /// Absolute monotonic ns at which the ring freezes (0 = not frozen /
+    /// not triggered).  Set once by the trigger or by a manual freeze.
+    static FREEZE_AT_NS: AtomicU64 = AtomicU64::new(0);
+
+    /// Arm the trigger with the given quiet/grace thresholds (ms).  Resets
+    /// the last-send timestamp and any prior freeze deadline so a fresh gap
+    /// is captured.
+    pub fn arm(quiet_ms: u64, grace_ms: u64) {
+        QUIET_NS.store(quiet_ms.saturating_mul(1_000_000), Ordering::Relaxed);
+        GRACE_NS.store(grace_ms.saturating_mul(1_000_000), Ordering::Relaxed);
+        LAST_TCP_SEND_NS.store(0, Ordering::Relaxed);
+        FREEZE_AT_NS.store(0, Ordering::Relaxed);
+        ARMED.store(true, Ordering::Relaxed);
+    }
+
+    /// Disarm the trigger.  Leaves any existing freeze deadline untouched
+    /// (use `unfreeze` to resume recording).
+    pub fn disarm() { ARMED.store(false, Ordering::Relaxed); }
+
+    /// Manually freeze the ring right now (`freeze_at = now`).
+    pub fn freeze_now() {
+        let now = crate::proc::vdso::monotonic_ns();
+        // A monotonic_ns() of 0 (pre-calibration) would never freeze; clamp
+        // to 1 so the gate (`now >= freeze_at`) engages immediately.
+        FREEZE_AT_NS.store(now.max(1), Ordering::Relaxed);
+    }
+
+    /// Clear any freeze deadline and resume recording.
+    pub fn unfreeze() { FREEZE_AT_NS.store(0, Ordering::Relaxed); }
+
+    /// Hot-path gate for `begin()`: has the freeze deadline passed?
+    #[inline]
+    pub fn is_frozen_at(now_ns: u64) -> bool {
+        let f = FREEZE_AT_NS.load(Ordering::Relaxed);
+        f != 0 && now_ns >= f
+    }
+
+    /// Snapshot: `(armed, quiet_ns, grace_ns, last_send_ns, freeze_at_ns,
+    /// frozen_now)`.  Used by the kdb `optrace-status` op.
+    pub fn status() -> (bool, u64, u64, u64, u64, bool) {
+        let now = crate::proc::vdso::monotonic_ns();
+        (
+            ARMED.load(Ordering::Relaxed),
+            QUIET_NS.load(Ordering::Relaxed),
+            GRACE_NS.load(Ordering::Relaxed),
+            LAST_TCP_SEND_NS.load(Ordering::Relaxed),
+            FREEZE_AT_NS.load(Ordering::Relaxed),
+            is_frozen_at(now),
+        )
+    }
+
+    /// Core trigger logic, parameterised on `now` for deterministic testing.
+    /// Returns `true` when this call fired the trigger.
+    pub fn tcp_send_at(pid: u64, now_ns: u64) -> bool {
+        if !ARMED.load(Ordering::Relaxed) { return false; }
+        if !is_tracked(pid) { return false; }
+        let last = LAST_TCP_SEND_NS.swap(now_ns, Ordering::Relaxed);
+        // Already triggered → don't re-fire (keeps the first gap end).
+        if FREEZE_AT_NS.load(Ordering::Relaxed) != 0 { return false; }
+        let quiet = QUIET_NS.load(Ordering::Relaxed);
+        if last == 0 || now_ns.saturating_sub(last) < quiet {
+            return false;
+        }
+        let grace = GRACE_NS.load(Ordering::Relaxed);
+        let freeze_at = now_ns.saturating_add(grace).max(1);
+        // CAS 0 → freeze_at so exactly one send wins the trigger.
+        if FREEZE_AT_NS
+            .compare_exchange(0, freeze_at, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            crate::serial_println!(
+                "[OPTRACE] gap-end trigger fired pid={} quiet_ms={} grace_ms={} \
+                 last_ns={} now_ns={} freeze_at_ns={}",
+                pid, quiet / 1_000_000, grace / 1_000_000, last, now_ns, freeze_at
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Hook from the socket TCP-send path (feature-gated at the call site).
+    pub fn note_tcp_send(pid: u64) {
+        // Fast bail before reading the clock when disarmed.
+        if !ARMED.load(Ordering::Relaxed) { return; }
+        let now = crate::proc::vdso::monotonic_ns();
+        let _ = tcp_send_at(pid, now);
+    }
+}
+
+// ── Ring depth control (kdb `optrace-depth`) ────────────────────────────────
+
+/// Set the default capacity used for rings created from now on.  Does NOT
+/// resize existing rings (use `resize_ring` for a specific focus pid).
+pub fn set_default_capacity(cap: usize) {
+    RING_CAP_RUNTIME.store(cap.max(1), Ordering::Relaxed);
+}
+
+/// Read the current default capacity for new rings.
+pub fn default_capacity() -> usize {
+    RING_CAP_RUNTIME.load(Ordering::Relaxed)
+}
+
+/// Resize (and clear) the ring for `pid` to `cap` entries, creating it if the
+/// pid is tracked but has no ring yet.  Returns the resulting capacity, or 0
+/// if `pid` is not tracked.  Called from kdb before a capture, so discarding
+/// history is intentional.
+pub fn resize_ring(pid: u64, cap: usize) -> usize {
+    if !is_tracked(pid) { return 0; }
+    let cap = cap.max(1);
+    let mut rings = RINGS.lock();
+    let ring = rings.entry(pid).or_insert_with(|| Ring::with_capacity(cap));
+    ring.resize(cap);
+    ring.cap()
+}
+
+/// Current capacity of `pid`'s ring (0 if none).  Used by `optrace-status`.
+pub fn ring_capacity(pid: u64) -> usize {
+    RINGS.lock().get(&pid).map(|r| r.cap()).unwrap_or(0)
+}
+
+/// Snapshot of tracked pids and their ring depth/occupancy, for kdb status.
+pub fn tracked_rings() -> Vec<(u64, usize, usize)> {
+    let rings = RINGS.lock();
+    let t = TRACKED.lock();
+    t.iter()
+        .map(|&pid| {
+            let (cap, len) = rings.get(&pid).map(|r| (r.cap(), r.len)).unwrap_or((0, 0));
+            (pid, cap, len)
+        })
+        .collect()
+}
+
 /// Record syscall entry — stores (nr, args, rip, caller_rip) in a new ring
 /// slot and returns its index.  Caller passes the index back to `end()`
 /// together with the syscall's return value.
@@ -145,7 +456,19 @@ pub fn begin(
     rip: u64, caller_rip: u64,
 ) -> Option<usize> {
     if !is_tracked(pid) { return None; }
+    // TSC-derived monotonic ns; also drives the gap-end freeze gate so we
+    // read the clock exactly once per entry.
+    let ns = crate::proc::vdso::monotonic_ns();
+    // Gap-end freeze: once the trigger has fired and the grace window has
+    // elapsed, stop recording so the captured transition tail is not
+    // overwritten by the post-gap storm.  Pure instrumentation — no syscall
+    // behaviour changes, the call still runs; only the trace slot is skipped.
+    if optrace::is_frozen_at(ns) { return None; }
+    // Reset the per-CPU wake-reason slot for this syscall.  A blocking wait
+    // path overwrites it after its final schedule(); end() folds it in.
+    clear_wake_reason();
     let tick = crate::arch::x86_64::irq::get_ticks();
+    let tid = crate::proc::current_tid();
     let mut rings = RINGS.lock();
     let ring = rings.entry(pid).or_insert_with(Ring::new);
     let entry = Entry {
@@ -154,6 +477,9 @@ pub fn begin(
         path: String::new(),
         read_bytes: Vec::new(),
         tick,
+        ns,
+        tid,
+        wake: WakeReason::NeverBlocked,
     };
     Some(ring.push_begin(entry))
 }
@@ -186,13 +512,19 @@ pub fn set_read_bytes(pid: u64, idx: Option<usize>, data: &[u8]) {
     }
 }
 
-/// Patch the return value onto the entry previously created by `begin()`.
+/// Patch the return value (and the wake reason recorded by any blocking wait
+/// this syscall performed) onto the entry previously created by `begin()`.
 pub fn end(pid: u64, idx: Option<usize>, ret: i64) {
     let Some(idx) = idx else { return; };
+    // Read the per-CPU wake-reason slot BEFORE taking RINGS.  No schedule()
+    // runs between a wait path's post-wake note and here, so this CPU's slot
+    // still reflects THIS thread's wait outcome.
+    let wake = take_wake_reason();
     let mut rings = RINGS.lock();
     if let Some(ring) = rings.get_mut(&pid) {
         if let Some(slot) = ring.buf.get_mut(idx) {
             slot.ret = ret;
+            slot.wake = wake;
         }
         ring.pending_idx = None;
     }
@@ -273,23 +605,18 @@ fn nr_name(nr: u64) -> &'static str {
     }
 }
 
-/// Dump the ring for `pid` to the serial console, framed by
-/// `[SC-RING-BEGIN]` / `[SC-RING-END]`.  Called from `exit_group` when the
-/// exit code is non-zero.  Clears the ring afterwards so a crashed process
-/// doesn't leak its entries into a re-used PID.
-pub fn dump_for_exit(pid: u64, exit_code: i64) {
-    let mut rings = RINGS.lock();
-    let Some(ring) = rings.remove(&pid) else {
-        // No ring — nothing to dump.  Still emit the frame so the harness
-        // can record that a non-zero exit happened but produced no trace.
-        crate::serial_println!("[SC-RING-BEGIN] pid={} exit_code={} entries=0", pid, exit_code);
-        crate::serial_println!("[SC-RING-END] pid={}", pid);
-        return;
-    };
-
+/// Emit the entries of `ring` framed by `[SC-RING-BEGIN]`/`[SC-RING-END]`.
+///
+/// The BEGIN line carries the legacy `pid`/`exit_code`/`entries` fields the
+/// harness regex anchors on, plus additive `kind=` (exit|frozen) and
+/// `ns_now=` tail fields (ignored by the anchored regex).  Each `[SC-RING]`
+/// line gains additive `ns=`/`tid=`/`wake=` fields, appended after `ret=` so
+/// older parsers keep matching.
+fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str) {
+    let ns_now = crate::proc::vdso::monotonic_ns();
     crate::serial_println!(
-        "[SC-RING-BEGIN] pid={} exit_code={} entries={}",
-        pid, exit_code, ring.len
+        "[SC-RING-BEGIN] pid={} exit_code={} entries={} kind={} ns_now={}",
+        pid, exit_code, ring.len, kind, ns_now
     );
 
     for (i, e) in ring.iter_chronological().enumerate() {
@@ -305,10 +632,11 @@ pub fn dump_for_exit(pid: u64, exit_code: i64) {
         // a libxul / firefox-bin function name when the offset-from-base is
         // looked up in the Breakpad .sym symbol files.
         crate::serial_println!(
-            "[SC-RING] i={:03} t={} {} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x} ret={}",
+            "[SC-RING] i={:03} t={} {} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x} ret={} ns={} tid={} wake={}",
             i, e.tick, name_field,
             e.rip, e.caller_rip,
-            e.a1, e.a2, e.a3, e.a4, e.a5, e.a6, e.ret
+            e.a1, e.a2, e.a3, e.a4, e.a5, e.a6, e.ret,
+            e.ns, e.tid, e.wake.as_str()
         );
         if !e.path.is_empty() {
             crate::serial_println!("[SC-RING-PATH] i={:03} path={:?}", i, &e.path);
@@ -330,6 +658,48 @@ pub fn dump_for_exit(pid: u64, exit_code: i64) {
     }
 
     crate::serial_println!("[SC-RING-END] pid={}", pid);
+}
+
+/// Dump the ring for `pid` to the serial console, framed by
+/// `[SC-RING-BEGIN]` / `[SC-RING-END]`.  Called from `exit_group` when the
+/// exit code is non-zero.  Clears the ring afterwards so a crashed process
+/// doesn't leak its entries into a re-used PID.
+pub fn dump_for_exit(pid: u64, exit_code: i64) {
+    let mut rings = RINGS.lock();
+    let Some(ring) = rings.remove(&pid) else {
+        // No ring — nothing to dump.  Still emit the frame so the harness
+        // can record that a non-zero exit happened but produced no trace.
+        crate::serial_println!(
+            "[SC-RING-BEGIN] pid={} exit_code={} entries=0 kind=exit ns_now=0", pid, exit_code);
+        crate::serial_println!("[SC-RING-END] pid={}", pid);
+        return;
+    };
+    emit_ring(pid, &ring, exit_code, "exit");
+}
+
+/// Non-destructively dump the (typically frozen) ring for `pid` on demand —
+/// called from the kdb `scrings-dump` op during a live W101 capture, where
+/// the process is still running.  Reuses the `[SC-RING-BEGIN]`/`[SC-RING-END]`
+/// framing so the existing `scrings` parser handles it unchanged; `kind=frozen`
+/// distinguishes it from an exit dump.  The ring is left in place so it can be
+/// re-dumped.
+pub fn dump_for_pid(pid: u64) {
+    let rings = RINGS.lock();
+    let Some(ring) = rings.get(&pid) else {
+        crate::serial_println!(
+            "[SC-RING-BEGIN] pid={} exit_code=0 entries=0 kind=frozen ns_now=0", pid);
+        crate::serial_println!("[SC-RING-END] pid={}", pid);
+        return;
+    };
+    emit_ring(pid, ring, 0, "frozen");
+}
+
+/// Dump every tracked pid's ring on demand (frozen capture convenience).
+pub fn dump_all_tracked() {
+    let pids: Vec<u64> = TRACKED.lock().clone();
+    for pid in pids {
+        dump_for_pid(pid);
+    }
 }
 
 const HEX: &[u8; 16] = b"0123456789abcdef";
@@ -674,4 +1044,29 @@ pub fn dump_futex_wait_stack(tid: u64, pid: u64, uaddr: u64, cr3: u64,
         "[FUTEX_WAIT_STACK] tid={} pid={} uaddr={:#x} leaf={:#x}{}",
         tid, pid, uaddr, leaf_rip, suffix
     );
+}
+
+// ── Test accessors ──────────────────────────────────────────────────────────
+//
+// Read-only snapshots of ring internals for the in-kernel test suite
+// (`test_runner.rs`).  Compiled in every build the module is (so
+// `firefox-test-core` and `test-mode`); they take the same locks as the live
+// paths and never mutate state.
+
+/// Snapshot the most-recently committed entry for `pid`:
+/// `(nr, tid, ns, wake, ret)`.  `None` if the pid has no ring / no entries.
+pub fn snapshot_last(pid: u64) -> Option<(u64, u64, u64, WakeReason, i64)> {
+    let rings = RINGS.lock();
+    let ring = rings.get(&pid)?;
+    if ring.len == 0 { return None; }
+    let cap = ring.cap();
+    // head points at the NEXT write slot; the last written is one behind it.
+    let idx = (ring.head + cap - 1) % cap;
+    let e = &ring.buf[idx];
+    Some((e.nr, e.tid, e.ns, e.wake, e.ret))
+}
+
+/// Number of valid entries currently held for `pid` (0 if none).
+pub fn entry_count(pid: u64) -> usize {
+    RINGS.lock().get(&pid).map(|r| r.len).unwrap_or(0)
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -273,6 +273,17 @@ pub fn run() -> ! {
         if test_641_crossproc_mapshared_memfd_visibility() { passed += 1; }
     }
 
+    // ── W101 op-trace instrumentation (syscall ring optrace, Phase 0) ────
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_optrace_ring_fields_and_wake() { passed += 1; }
+        total += 1;
+        if test_optrace_freeze_trigger() { passed += 1; }
+        total += 1;
+        if test_optrace_freeze_gate_and_depth() { passed += 1; }
+    }
+
     // ── Test 0bc3: vfork/CLONE_VM child thread has tls_base=0 ────────────
     total += 1;
     if test_vfork_clone_vm_child_tls_base_zero() { passed += 1; }
@@ -58495,5 +58506,207 @@ fn test_relative_futex_timeout_no_undershoot() -> bool {
     test_println!("  all relative intervals (1/5/10/15/100 ms): wake_tick >= deadline, \
                    over-shoot < 2 ticks ✓");
     test_pass!("relative futex timeout — wake never precedes the requested interval (Test 296)");
+    true
+}
+
+// ── W101 op-trace instrumentation tests (syscall ring optrace) ──────────────
+//
+// Exercise the Phase-0 additions to the per-process syscall ring:
+//   • ns / tid / wake-reason fields plumbed through begin()/end()
+//   • the per-CPU wake-reason slot resets per-syscall and folds into the entry
+//   • the gap-end freeze trigger arithmetic + freeze gate + depth control
+//
+// Pure in-kernel logic — no process creation, no scheduler dependency.  The
+// ring module is compiled under `test-mode` as well as `firefox-test-core`
+// (nothing is ever auto-tracked under `test-mode`, so this is the only path
+// that populates a ring in the test build).
+
+/// Read RFLAGS.IF so the per-CPU-slot critical section can be run with
+/// interrupts masked (another thread doing a poll/futex wait could otherwise
+/// clobber this CPU's wake-reason slot between our note() and end()).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+#[inline]
+fn _optrace_irqs_enabled() -> bool {
+    let f: u64;
+    unsafe {
+        core::arch::asm!("pushfq", "pop {0}", out(reg) f, options(nomem, preserves_flags));
+    }
+    (f & (1 << 9)) != 0
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_optrace_ring_fields_and_wake() -> bool {
+    use crate::syscall::ring::{self, WakeReason};
+    let pid: u64 = 0xF00D_0001;
+    ring::drop_ring(pid);          // clean slate (removes any prior ring)
+    ring::enable_for(pid);
+
+    let cur_tid = crate::proc::current_tid();
+    let irqs = _optrace_irqs_enabled();
+    crate::hal::disable_interrupts();
+
+    // Entry A: a blocking wait that timed out on a futex.
+    let idx_a = ring::begin(pid, 202, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0xdead, 0xbeef);
+    ring::note_wake_reason(WakeReason::FutexTimeout);
+    ring::end(pid, idx_a, -110);
+    let snap_a = ring::snapshot_last(pid);
+
+    // Entry B: a non-blocking syscall — begin() must have reset the slot, so
+    // with no note the recorded reason is NeverBlocked (proves per-syscall
+    // reset, not stale inheritance from entry A).
+    let idx_b = ring::begin(pid, 39, 0, 0, 0, 0, 0, 0, 0x1111, 0x2222);
+    ring::end(pid, idx_b, 42);
+    let snap_b = ring::snapshot_last(pid);
+
+    // Entry C: a poll that ended on a bell (data/readiness arrived).
+    let idx_c = ring::begin(pid, 7, 0, 0, 0, 0, 0, 0, 0x3333, 0x4444);
+    ring::note_wake_reason(WakeReason::Bell);
+    ring::end(pid, idx_c, 1);
+    let snap_c = ring::snapshot_last(pid);
+
+    let count = ring::entry_count(pid);
+    if irqs { crate::hal::enable_interrupts(); }
+
+    ring::drop_ring(pid);
+
+    if idx_a.is_none() || idx_b.is_none() || idx_c.is_none() {
+        test_fail!("optrace_ring_fields_and_wake", "begin() returned None while tracked");
+        return false;
+    }
+    let (nr_a, tid_a, _ns_a, wake_a, ret_a) = match snap_a {
+        Some(s) => s, None => { test_fail!("optrace_ring_fields_and_wake", "no entry A"); return false; }
+    };
+    if nr_a != 202 || ret_a != -110 || wake_a != WakeReason::FutexTimeout || tid_a != cur_tid {
+        test_fail!("optrace_ring_fields_and_wake",
+            "entry A: nr={} ret={} wake={} tid={} (want 202/-110/futex_timeout/{})",
+            nr_a, ret_a, wake_a.as_str(), tid_a, cur_tid);
+        return false;
+    }
+    let (nr_b, _tb, _nb, wake_b, ret_b) = match snap_b {
+        Some(s) => s, None => { test_fail!("optrace_ring_fields_and_wake", "no entry B"); return false; }
+    };
+    if nr_b != 39 || ret_b != 42 || wake_b != WakeReason::NeverBlocked {
+        test_fail!("optrace_ring_fields_and_wake",
+            "entry B: nr={} ret={} wake={} (want 39/42/never_blocked — reset failed)",
+            nr_b, ret_b, wake_b.as_str());
+        return false;
+    }
+    let (_nc, _tc, _nsc, wake_c, _rc) = match snap_c {
+        Some(s) => s, None => { test_fail!("optrace_ring_fields_and_wake", "no entry C"); return false; }
+    };
+    if wake_c != WakeReason::Bell {
+        test_fail!("optrace_ring_fields_and_wake",
+            "entry C: wake={} (want bell)", wake_c.as_str());
+        return false;
+    }
+    if count < 3 {
+        test_fail!("optrace_ring_fields_and_wake", "entry_count={} (want >=3)", count);
+        return false;
+    }
+    test_pass!("optrace ring ns/tid/wake fields + per-syscall reset (W101 Phase 0)");
+    true
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_optrace_freeze_trigger() -> bool {
+    use crate::syscall::ring::{self, optrace};
+    let pid: u64 = 0xF00D_0002;
+    ring::drop_ring(pid);
+    ring::enable_for(pid);
+
+    // Deterministic synthetic clock (ns).  arm: 2000 ms quiet / 100 ms grace.
+    optrace::unfreeze();
+    optrace::arm(2000, 100);
+    let quiet_ns: u64 = 2_000_000_000;
+    let grace_ns: u64 = 100_000_000;
+    let t0: u64 = 10_000_000_000;
+
+    // First send: seeds last-send, must NOT trigger (no prior send).
+    if optrace::tcp_send_at(pid, t0) {
+        test_fail!("optrace_freeze_trigger", "first send fired the trigger");
+        ring::drop_ring(pid); return false;
+    }
+    // A send within the quiet window: still must NOT trigger.
+    if optrace::tcp_send_at(pid, t0 + quiet_ns / 2) {
+        test_fail!("optrace_freeze_trigger", "in-window send fired the trigger");
+        ring::drop_ring(pid); return false;
+    }
+    // A send after >= quiet since the last one: the gap-end trigger fires.
+    let t_gap_end = t0 + quiet_ns / 2 + quiet_ns + 1;
+    if !optrace::tcp_send_at(pid, t_gap_end) {
+        test_fail!("optrace_freeze_trigger", "gap-end send did NOT fire the trigger");
+        ring::drop_ring(pid); return false;
+    }
+    // freeze_at must be now + grace; frozen only once now >= freeze_at.
+    let (_armed, _q, _g, _last, freeze_at, _fr) = optrace::status();
+    let want_freeze = t_gap_end + grace_ns;
+    if freeze_at != want_freeze {
+        test_fail!("optrace_freeze_trigger",
+            "freeze_at={} (want {})", freeze_at, want_freeze);
+        ring::drop_ring(pid); return false;
+    }
+    if optrace::is_frozen_at(freeze_at - 1) {
+        test_fail!("optrace_freeze_trigger", "frozen before the grace window elapsed");
+        ring::drop_ring(pid); return false;
+    }
+    if !optrace::is_frozen_at(freeze_at) {
+        test_fail!("optrace_freeze_trigger", "not frozen at the freeze deadline");
+        ring::drop_ring(pid); return false;
+    }
+    // A second gap-end send must NOT move the freeze deadline (first wins).
+    let _ = optrace::tcp_send_at(pid, t_gap_end + 10 * quiet_ns);
+    let (_a2, _q2, _g2, _l2, freeze_at2, _f2) = optrace::status();
+    if freeze_at2 != want_freeze {
+        test_fail!("optrace_freeze_trigger", "second gap moved freeze_at to {}", freeze_at2);
+        ring::drop_ring(pid); return false;
+    }
+
+    optrace::unfreeze();
+    optrace::disarm();
+    ring::drop_ring(pid);
+    test_pass!("optrace gap-end freeze trigger arithmetic + gate (W101 Phase 0)");
+    true
+}
+
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_optrace_freeze_gate_and_depth() -> bool {
+    use crate::syscall::ring::{self, optrace};
+    let pid: u64 = 0xF00D_0003;
+    ring::drop_ring(pid);
+    ring::enable_for(pid);
+
+    // Depth control: raise this pid's ring to a capture depth and confirm.
+    let applied = ring::resize_ring(pid, 8192);
+    if applied != 8192 || ring::ring_capacity(pid) != 8192 {
+        test_fail!("optrace_freeze_gate_and_depth",
+            "resize_ring -> {} (cap now {}), want 8192", applied, ring::ring_capacity(pid));
+        ring::drop_ring(pid); return false;
+    }
+
+    // Manual freeze must make begin() a no-op (None) so the storm cannot
+    // overwrite the captured tail; unfreeze restores recording.
+    optrace::unfreeze();
+    let before = ring::begin(pid, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+    ring::end(pid, before, 0);
+    if before.is_none() {
+        test_fail!("optrace_freeze_gate_and_depth", "begin() None while unfrozen+tracked");
+        ring::drop_ring(pid); return false;
+    }
+    optrace::freeze_now();
+    let during = ring::begin(pid, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+    if during.is_some() {
+        test_fail!("optrace_freeze_gate_and_depth", "begin() recorded while frozen");
+        optrace::unfreeze(); ring::drop_ring(pid); return false;
+    }
+    optrace::unfreeze();
+    let after = ring::begin(pid, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+    ring::end(pid, after, 0);
+    if after.is_none() {
+        test_fail!("optrace_freeze_gate_and_depth", "begin() None after unfreeze");
+        ring::drop_ring(pid); return false;
+    }
+
+    ring::drop_ring(pid);
+    test_pass!("optrace freeze gate skips begin() + per-pid depth resize (W101 Phase 0)");
     true
 }

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7292,8 +7292,36 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
               # op_virtio_wait_hist.
               "virtio-wait-hist", "virtio-wait-reset",
               # INFRA-3 record/replay: zero-arg introspection.
-              "record-status"):
+              "record-status",
+              # optrace: W101 gap-end freeze-trigger controls (zero-arg).
+              "optrace-disarm", "optrace-status",
+              "optrace-freeze", "optrace-unfreeze"):
         return {"op": op}
+    if op == "optrace-arm":
+        # Arm the gap-end freeze trigger.  Optional positional
+        # `[quiet_ms [grace_ms]]` (defaults 2000 / 500).
+        d = {"op": op}
+        if len(rest) >= 1:
+            d["quiet_ms"] = str(int(rest[0]))
+        if len(rest) >= 2:
+            d["grace_ms"] = str(int(rest[1]))
+        return d
+    if op == "optrace-depth":
+        # Set per-pid ring depth for a capture: `<depth> [pid]`.  With pid,
+        # resize that ring; without, set the default for new rings.
+        if not rest:
+            raise ValueError("optrace-depth requires <depth> [pid]")
+        d = {"op": op, "depth": str(int(rest[0]))}
+        if len(rest) >= 2:
+            d["pid"] = str(int(rest[1]))
+        return d
+    if op == "scrings-dump":
+        # Non-destructively dump the frozen ring(s) to serial for `scrings`.
+        # Optional positional `[pid]` (absent = every tracked pid).
+        d = {"op": op}
+        if rest:
+            d["pid"] = str(int(rest[0]))
+        return d
     if op == "virtio-wait-mode":
         # Flip the wait strategy at runtime: adaptive (poll + peer-aware yield) |
         # legacy (unconditional schedule()-yield).  Absent → query-only.  Carried
@@ -10864,29 +10892,44 @@ def _scan_line(line_bytes: bytes, tests: list, libs_loaded: list,
 # ── scrings: parse per-process syscall ring-buffer dumps ─────────────────────
 #
 # The kernel (with the firefox-test feature) emits ring-buffer traces on any
-# `exit_group(code)` where `code != 0`.  Format, from kernel/src/syscall/ring.rs:
+# `exit_group(code)` where `code != 0`, and on demand via the kdb
+# `scrings-dump` op (W101 op-trace).  Format, from kernel/src/syscall/ring.rs:
 #
-#   [SC-RING-BEGIN] pid=<N> exit_code=<N> entries=<N>
+#   [SC-RING-BEGIN] pid=<N> exit_code=<N> entries=<N> [kind=<exit|frozen> ns_now=<N>]
 #   [SC-RING] i=NNN t=<tick> <name>/<nr> rip=0x.. a1=0x.. a2=0x.. a3=0x.. \
-#             a4=0x.. a5=0x.. a6=0x.. ret=<i64>
+#             a4=0x.. a5=0x.. a6=0x.. ret=<i64> [ns=<N> tid=<N> wake=<label>]
 #   [SC-RING-PATH] i=NNN path="..."                    (for open/openat only)
 #   [SC-RING-BYTES] i=NNN len=<N> hex=<hex-ascii>      (for captured reads)
 #   [SC-RING-END] pid=<N>
 #
+# The `kind`/`ns_now` (BEGIN) and `ns`/`tid`/`wake` (per-entry) fields are
+# additive: they appear only on optrace-capable kernels and are parsed with
+# separate optional regexes so pre-optrace logs still parse.  `wake` is the
+# wake-source annotation (never_blocked|bell|resync|timeout|signal|
+# futex_wake|futex_timeout|unknown).
+#
 # `scrings` finds every dump in the serial log and returns a JSON array — one
-# object per dump — each containing pid, exit_code, and a chronological list
-# of parsed entries.  The path / bytes lines are attached to their parent
-# [SC-RING] entry by matching `i=NNN`.
+# object per dump — each containing pid, exit_code, kind, ns_now, and a
+# chronological list of parsed entries.  The path / bytes lines are attached to
+# their parent [SC-RING] entry by matching `i=NNN`.
 
 _SC_RING_BEGIN = re.compile(
     r"\[SC-RING-BEGIN\] pid=(\d+) exit_code=(-?\d+) entries=(\d+)"
 )
+# Additive tail on the BEGIN line: `kind=<exit|frozen>` distinguishes an
+# exit-time dump from an on-demand frozen-ring dump; `ns_now=<n>` is the
+# monotonic-ns clock at dump time.  Absent on pre-optrace logs.
+_SC_RING_BEGIN_EXT = re.compile(r"kind=(\w+) ns_now=(\d+)")
 _SC_RING_LINE = re.compile(
     r"\[SC-RING\] i=(\d+) t=(\d+) (\S+) rip=(0x[0-9a-fA-F]+) "
     r"a1=(0x[0-9a-fA-F]+) a2=(0x[0-9a-fA-F]+) a3=(0x[0-9a-fA-F]+) "
     r"a4=(0x[0-9a-fA-F]+) a5=(0x[0-9a-fA-F]+) a6=(0x[0-9a-fA-F]+) "
     r"ret=(-?\d+)"
 )
+# Additive per-entry tail (appended after ret=): monotonic-ns timestamp,
+# calling thread id, and the wake-source annotation.  Absent on pre-optrace
+# logs, so parsed with a separate optional regex to keep back-compat.
+_SC_RING_LINE_EXT = re.compile(r"ns=(\d+) tid=(\d+) wake=(\w+)")
 _SC_RING_PATH = re.compile(r'\[SC-RING-PATH\] i=(\d+) path="([^"]*)"')
 _SC_RING_BYTES = re.compile(r'\[SC-RING-BYTES\] i=(\d+) len=(\d+) hex=([0-9a-fA-F]+)')
 _SC_RING_END = re.compile(r"\[SC-RING-END\] pid=(\d+)")
@@ -10904,8 +10947,16 @@ def _parse_ring_dump(lines):
                 "pid":         int(m.group(1)),
                 "exit_code":   int(m.group(2)),
                 "entry_count": int(m.group(3)),
+                # kind: "exit" (non-zero exit dump) | "frozen" (on-demand
+                # optrace dump) | None (pre-optrace log).
+                "kind":        None,
+                "ns_now":      None,
                 "entries":     [],
             }
+            mx = _SC_RING_BEGIN_EXT.search(ln)
+            if mx:
+                cur["kind"] = mx.group(1)
+                cur["ns_now"] = int(mx.group(2))
             entries_by_idx = {}
             continue
         if cur is None:
@@ -10924,10 +10975,19 @@ def _parse_ring_dump(lines):
                 "a5":   int(m.group(9), 16),
                 "a6":   int(m.group(10), 16),
                 "ret":  int(m.group(11)),
+                # Additive optrace fields (None on pre-optrace logs).
+                "ns":   None,
+                "tid":  None,
+                "wake": None,
                 "path": None,
                 "bytes_hex": None,
                 "bytes_len": 0,
             }
+            mx = _SC_RING_LINE_EXT.search(ln)
+            if mx:
+                e["ns"]   = int(mx.group(1))
+                e["tid"]  = int(mx.group(2))
+                e["wake"] = mx.group(3)
             cur["entries"].append(e)
             entries_by_idx[e["i"]] = e
             continue
@@ -13299,6 +13359,16 @@ def main():
         # FUTEX_WAKE cluster-wake compensation (firefox-test/test-mode only).
         # See subsys/linux/futex_cluster.rs.
         "futex-stats", "futex-set-cluster-wake",
+        # optrace: W101 op-trace gap-end freeze trigger + on-demand frozen
+        # per-pid ring dump.  `optrace-arm [quiet_ms [grace_ms]]` arms the
+        # trigger; `optrace-status` reports state + per-pid ring depth;
+        # `optrace-freeze`/`optrace-unfreeze` are the manual fallback;
+        # `optrace-depth <depth> [pid]` sizes the capture ring;
+        # `scrings-dump [pid]` emits the frozen ring(s) for the `scrings`
+        # parser.  See syscall::ring::optrace + kdb::op_optrace_*.
+        "optrace-arm", "optrace-disarm", "optrace-status",
+        "optrace-freeze", "optrace-unfreeze", "optrace-depth",
+        "scrings-dump",
         # INFRA-3 record/replay introspection (record-replay feature).
         # `record-status` returns seed + virtual ticks + ordinal; safe to
         # query under any build (returns enabled:false when the feature


### PR DESCRIPTION
## What

Phase 0 of the W101 reopen protocol (`.claude/session/W101-REOPEN-PLAN-2026-07-02.md` §4): extend the per-process syscall ring (feature `syscall-trace`, drained via `qemu-harness.py scrings`) so **one** gap-ending wake-chain transition in the Firefox Wikipedia load can be captured and reconstructed offline.

**Instrumentation only — zero syscall behaviour changes.** Everything is gated behind `syscall-trace` (the wake-note sites) or `firefox-test-core`/`test-mode` (the ring module + kdb ops), so the fast `firefox-test-core` functional profile — the perturbation A/B **baseline arm** — and production builds stay byte-identical.

## Work items (plan §4)

1. **ns timestamps** — each ring entry gains a TSC-derived monotonic-ns field from the vDSO calibration (`crate::proc::vdso::monotonic_ns`), so cross-process op ordering at a gap transition is unambiguous inside one 10 ms tick and immune to a dead LAPIC timer freezing `TICK_COUNT` (Intel SDM Vol. 3B §17.17). Read once per `begin()`, also driving the freeze gate.
2. **tid** — each entry records the calling thread id (per-CPU `current_tid`) so chain reconstruction knows which-thread-did-what.
3. **Wake-source annotation** — a `WakeReason` enum (`never_blocked`/`bell`/`resync`/`timeout`/`signal`/`futex_wake`/`futex_timeout`/`unknown`) recorded via a lock-free per-CPU slot, reset at `begin()` and folded in at `end()`. Wired at the single chokepoint `ipc::waitlist::wait_poll_event` (bell vs resync-floor vs the caller's own deadline — covers poll/ppoll/select/epoll_wait/epoll_pwait **and** the blocking unix read/recv paths that route through it; POSIX poll(2)/epoll(7)) and at the FUTEX_WAIT conclusion (wake vs ETIMEDOUT; futex(2)). **The three note sites are gated `#[cfg(feature = "syscall-trace")]`** — the only profile whose ring `end()` reads the slot — identical gating to the ring `begin()`/`end()` call sites, so a bare `firefox-test-core` build pays nothing and stays byte-identical. Paths that can't cheaply attribute a wake stay `unknown`; wait paths are **not** restructured.
4. **Gap-end freeze trigger** (`syscall::ring::optrace`, kdb-armable) — once armed, the first tracked-pid TCP data send after ≥ `quiet_ms` (default 2000) of TCP-send quiet sets `freeze_at = now + grace_ms` (default 500); once it passes, `begin()` becomes a no-op so the gap-ending send **and** its immediate consequent chain are captured, then the post-gap storm cannot overwrite them. Exactly one serial marker (`[OPTRACE] gap-end trigger fired ...`) per gap-end so the harness can `wait` on it — the only serial output on any path. Manual `optrace-freeze`/`optrace-unfreeze` fallback. Hook is the userspace TCP data-send arm in `net::socket::socket_send` (single atomic load when disarmed).
5. **Ring depth calibration** — the ring buf is now a runtime-sized boxed slice (was a fixed 256-entry array). Default bumped 256 → 4096; per-focus-pid depth raised for a capture via the new kdb `optrace-depth <depth> [pid]`, which resizes just that pid's ring, bounding heap cost to the two focus PIDs. **Memory model:** each slot is a ~104 B fixed header + (empty) `String`/`Vec` handles; a focus-pid depth of ~131072 (holds ≥ the `grace_ms` window at ~10^5 syscalls/s storm rate) is ≈ 20 MB/pid, within the 384 MiB heap (`ASTRYX_MEM_MIB=2048`). Per-op cost is unchanged by depth. Guidance: pick `depth ≥ storm_rate × grace_ms`.
6. **Tests** (`test_runner.rs`, run under `test-mode`) — (a) ns/tid/wake field plumbing + per-syscall wake-slot reset (futex-timeout + poll-bell cases), (b) gap-end freeze-trigger arithmetic + freeze gate + first-send-wins, (c) freeze gate skips `begin()` + per-pid depth resize. **All three pass** on SMP=1 `test-mode` (local + CI kernel-smoke); suite otherwise unchanged. The tests call `note_wake_reason`/`optrace::*` directly, so the F1 re-gate does not affect them.

## Harness (additive JSON, back-compatible)

- `scrings` parses the additive `kind`/`ns_now` (BEGIN) and `ns`/`tid`/`wake` (per-entry) fields with separate optional regexes — **pre-optrace logs still parse**.
- New kdb ops: `optrace-arm [quiet_ms [grace_ms]]`, `optrace-disarm`, `optrace-status`, `optrace-freeze`, `optrace-unfreeze`, `optrace-depth <depth> [pid]`, `scrings-dump [pid]` (non-destructive frozen-ring dump reusing the existing `[SC-RING-BEGIN]`/`[SC-RING-END]` framing so the `scrings` parser ingests it unchanged).

## Validation

- Both A/B arms compile clean via the harness: `firefox-test-core,kdb` (baseline — note sites gated OUT, byte-identical) and `firefox-test-core,kdb,syscall-trace` (capture). All CI feature-combo legs green.
- 3 new tests pass on an SMP=1 `test-mode` boot (verified via `[TEST-JSON]`); the suite failures observed (`pie_elf`, `TCC compile`, `busybox basic`) are missing-fixture cases already on the CI allow-fail list, unrelated to this change.
- Harness `scrings` parser + kdb request-builder verified for all new ops.

## Review fix round (from APPROVE-WITH-NITS)

- **F1 (done)**: the three wake-note sites re-gated `firefox-test-core|test-mode` → `syscall-trace`, so the `firefox-test-core` baseline arm no longer executes per-wake atomic stores + a vDSO ns read for values nothing reads. The "byte-identical" claim above is now true.
- **Doc nits (done)**: corrected the allow-fail count to 3; softened the wake-slot comment to state the non-wait-reschedule mislabel limitation; marked `WakeReason::Signal` as reserved (no producer yet).
- **F3 (done)**: `WakeReason::Signal` documented as reserved.

## Known limitations

- **Wake mislabel (never unsafe)**: a traced *non-wait* syscall that reschedules mid-flight (blocking demand-page / blk I/O) can inherit a foreign wake reason at `end()` — a diagnostic-only misattribution of the `wake` field, never a state corruption.
- **F2 (SMP≥2, deferred)**: on SMP≥2 the per-CPU wake slot also permits a cross-CPU mislabel; the tid-stamp hardening for that is deferred because the W101 capture runs `--smp 1`, where the wait paths' same-CPU invariant holds and this is moot.

## Notes

- **Do not merge without user authorization.** The perturbation A/B gate and the live capture (Phase A) are separate steps.
- Diff is ~900 insertions across 8 files (over the ~400 soft target). The overage is entirely the 6 numbered work items — the ring core (WakeReason + per-CPU slot + optrace + depth + dump refactor + test accessors), 3 comprehensive tests, and 7 kdb ops — with no scope creep. Splitting the instrumentation from its tests/ops would have made the change harder to review, not easier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
