### PR TITLE
tooling: route scrings-dump through the guest-RAM log ring + fix the scrings cr= parser

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1468,21 +1468,47 @@ fn op_optrace_depth(req: &str, out: &mut String) {
     }
 }
 
-/// `scrings-dump` — non-destructively emit the frozen ring(s) to serial so
-/// the harness `scrings` parser can ingest them.  With `pid`, just that pid;
-/// without, every tracked pid.
+/// `scrings-dump` — non-destructively emit the frozen ring(s) so the harness
+/// `scrings` parser can ingest them.  With `pid`, just that pid; without,
+/// every tracked pid.
+///
+/// Routes through the guest-RAM log ring by default (a single reservation +
+/// memcpy per line — no per-byte UART VM-exits), so dumping a deep ring does
+/// not monopolise the vCPU or wedge kdb during a live capture.  Retrieve the
+/// lines out of band with `qemu-harness.py log-ring flush` (re-emits to the
+/// serial log for `scrings`) or `log-ring drain` (JSON).  The log ring is
+/// bounded (`log_ring::CAP`, 4 MiB ≈ 20K lines): a larger dump keeps only the
+/// newest lines — the entries nearest the freeze, which is what the chain
+/// reconstruction needs.  Pass `com1` to force the complete-but-slow COM1
+/// path instead (use only when the vCPU is free).
 #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
 fn op_scrings_dump(req: &str, out: &mut String) {
     use core::fmt::Write;
+    let com1 = extract_field(req, "com1")
+        .map(|s| matches!(s.as_str(), "1" | "true" | "on" | "yes"))
+        .unwrap_or(false);
+    let route = if com1 {
+        crate::syscall::ring::DumpRoute::Com1
+    } else {
+        crate::syscall::ring::DumpRoute::LogRing
+    };
+    let route_name = if com1 { "com1" } else { "log-ring" };
     match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
         Some(pid) if pid != 0 => {
-            crate::syscall::ring::dump_for_pid(pid);
-            let _ = write!(out, r#"{{"dumped":true,"pid":{}}}"#, pid);
+            let entries = crate::syscall::ring::dump_for_pid(pid, route);
+            let _ = write!(
+                out,
+                r#"{{"dumped":true,"pid":{},"entries":{},"route":"{}"}}"#,
+                pid, entries, route_name
+            );
         }
         _ => {
-            crate::syscall::ring::dump_all_tracked();
-            let n = crate::syscall::ring::tracked_rings().len();
-            let _ = write!(out, r#"{{"dumped":true,"pids":{}}}"#, n);
+            let pids = crate::syscall::ring::dump_all_tracked(route);
+            let _ = write!(
+                out,
+                r#"{{"dumped":true,"pids":{},"route":"{}"}}"#,
+                pids, route_name
+            );
         }
     }
 }

--- a/kernel/src/syscall/ring.rs
+++ b/kernel/src/syscall/ring.rs
@@ -618,6 +618,49 @@ fn nr_name(nr: u64) -> &'static str {
     }
 }
 
+/// Where a ring dump's `[SC-RING-*]` lines are routed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DumpRoute {
+    /// Classic COM1 `serial_println!` — every line pays ~one VM-exit per byte
+    /// on the 16550 THR (Intel SDM Vol. 3C §25.1.3).  Complete, but slow: a
+    /// deep frozen ring can monopolise the vCPU for minutes and wedge kdb.
+    /// Used by the crash-path exit dump (always reaches the log) and as the
+    /// `scrings-dump --com1` fallback.
+    Com1,
+    /// The near-zero-overhead guest-RAM log ring (`drivers::log_ring`): each
+    /// line is a single reservation + `memcpy`, no lock, no `outb`, no exit —
+    /// so a 10^5-entry dump completes in well under a second without starving
+    /// a live capture.  Drained out of band via `qemu-harness.py log-ring
+    /// drain|flush`.  Bounded to `log_ring::CAP` (4 MiB ≈ 20K lines): a dump
+    /// larger than that keeps only the NEWEST lines — which are the entries
+    /// nearest the freeze/gap-end, i.e. exactly the ones the W101 chain
+    /// reconstruction walks backwards from.
+    LogRing,
+}
+
+/// Format one already-composed line into the guest-RAM log ring, appending the
+/// `'\n'` terminator (matching the fast-path `log_fast` framing so a
+/// `log-ring flush` re-emits it as a proper serial line).  Mirrors
+/// `drivers::serial::log_fast`'s bounded-stack-buffer commit; no heap, no lock.
+fn record_line_to_ring(args: core::fmt::Arguments) {
+    use core::fmt::Write;
+    const CAP: usize = crate::drivers::log_ring::MAX_RECORD;
+    struct RingBuf { buf: [u8; CAP], len: usize }
+    impl core::fmt::Write for RingBuf {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            for &b in s.as_bytes() {
+                if self.len >= self.buf.len() { break; }
+                self.buf[self.len] = b;
+                self.len += 1;
+            }
+            Ok(())
+        }
+    }
+    let mut rb = RingBuf { buf: [0u8; CAP], len: 0 };
+    let _ = rb.write_fmt(format_args!("{}\n", args));
+    crate::drivers::log_ring::record(&rb.buf[..rb.len]);
+}
+
 /// Emit the entries of `ring` framed by `[SC-RING-BEGIN]`/`[SC-RING-END]`.
 ///
 /// The BEGIN line carries the legacy `pid`/`exit_code`/`entries` fields the
@@ -625,9 +668,23 @@ fn nr_name(nr: u64) -> &'static str {
 /// `ns_now=` tail fields (ignored by the anchored regex).  Each `[SC-RING]`
 /// line gains additive `ns=`/`tid=`/`wake=` fields, appended after `ret=` so
 /// older parsers keep matching.
-fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str) {
+///
+/// `route` selects COM1 (crash-path exit dump) vs the guest-RAM log ring
+/// (`scrings-dump`, so a live capture is not starved by per-byte UART I/O).
+fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str, route: DumpRoute) {
+    // Route one formatted line to the selected sink.  A `macro_rules!` (not a
+    // closure) so each call site can pass ordinary `format_args`-style tokens.
+    macro_rules! line {
+        ($($a:tt)*) => {
+            match route {
+                DumpRoute::Com1    => crate::serial_println!($($a)*),
+                DumpRoute::LogRing => record_line_to_ring(format_args!($($a)*)),
+            }
+        };
+    }
+
     let ns_now = crate::proc::vdso::monotonic_ns();
-    crate::serial_println!(
+    line!(
         "[SC-RING-BEGIN] pid={} exit_code={} entries={} kind={} ns_now={}",
         pid, exit_code, ring.len, kind, ns_now
     );
@@ -644,7 +701,7 @@ fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str) {
         // caller of libc's `syscall()` wrapper, which resolves directly to
         // a libxul / firefox-bin function name when the offset-from-base is
         // looked up in the Breakpad .sym symbol files.
-        crate::serial_println!(
+        line!(
             "[SC-RING] i={:03} t={} {} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x} ret={} ns={} tid={} wake={}",
             i, e.tick, name_field,
             e.rip, e.caller_rip,
@@ -652,7 +709,7 @@ fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str) {
             e.ns, e.tid, e.wake.as_str()
         );
         if !e.path.is_empty() {
-            crate::serial_println!("[SC-RING-PATH] i={:03} path={:?}", i, &e.path);
+            line!("[SC-RING-PATH] i={:03} path={:?}", i, &e.path);
         }
         if !e.read_bytes.is_empty() {
             // Hex-encode the bytes.  Keep everything on a single line — the
@@ -664,13 +721,11 @@ fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str) {
                 hex.push(HEX[hi as usize] as char);
                 hex.push(HEX[lo as usize] as char);
             }
-            crate::serial_println!(
-                "[SC-RING-BYTES] i={:03} len={} hex={}", i, e.read_bytes.len(), hex
-            );
+            line!("[SC-RING-BYTES] i={:03} len={} hex={}", i, e.read_bytes.len(), hex);
         }
     }
 
-    crate::serial_println!("[SC-RING-END] pid={}", pid);
+    line!("[SC-RING-END] pid={}", pid);
 }
 
 /// Dump the ring for `pid` to the serial console, framed by
@@ -682,12 +737,14 @@ pub fn dump_for_exit(pid: u64, exit_code: i64) {
     let Some(ring) = rings.remove(&pid) else {
         // No ring — nothing to dump.  Still emit the frame so the harness
         // can record that a non-zero exit happened but produced no trace.
+        // Exit dumps always go to COM1 so they survive a crash even if the
+        // log ring is never drained.
         crate::serial_println!(
             "[SC-RING-BEGIN] pid={} exit_code={} entries=0 kind=exit ns_now=0", pid, exit_code);
         crate::serial_println!("[SC-RING-END] pid={}", pid);
         return;
     };
-    emit_ring(pid, &ring, exit_code, "exit");
+    emit_ring(pid, &ring, exit_code, "exit", DumpRoute::Com1);
 }
 
 /// Non-destructively dump the (typically frozen) ring for `pid` on demand —
@@ -696,23 +753,34 @@ pub fn dump_for_exit(pid: u64, exit_code: i64) {
 /// framing so the existing `scrings` parser handles it unchanged; `kind=frozen`
 /// distinguishes it from an exit dump.  The ring is left in place so it can be
 /// re-dumped.
-pub fn dump_for_pid(pid: u64) {
+///
+/// `route` selects the sink: `LogRing` (default) keeps a live FF capture from
+/// being starved by per-byte UART I/O — the operator retrieves the lines via
+/// `qemu-harness.py log-ring drain|flush`; `Com1` is the complete-but-slow
+/// fallback for when the vCPU is free.  Returns the number of entries dumped.
+pub fn dump_for_pid(pid: u64, route: DumpRoute) -> usize {
     let rings = RINGS.lock();
     let Some(ring) = rings.get(&pid) else {
+        // Absent-ring frame always to COM1 (tiny, and confirms the op ran).
         crate::serial_println!(
             "[SC-RING-BEGIN] pid={} exit_code=0 entries=0 kind=frozen ns_now=0", pid);
         crate::serial_println!("[SC-RING-END] pid={}", pid);
-        return;
+        return 0;
     };
-    emit_ring(pid, ring, 0, "frozen");
+    let n = ring.len;
+    emit_ring(pid, ring, 0, "frozen", route);
+    n
 }
 
 /// Dump every tracked pid's ring on demand (frozen capture convenience).
-pub fn dump_all_tracked() {
+/// Returns the number of pids dumped.
+pub fn dump_all_tracked(route: DumpRoute) -> usize {
     let pids: Vec<u64> = TRACKED.lock().clone();
+    let n = pids.len();
     for pid in pids {
-        dump_for_pid(pid);
+        dump_for_pid(pid, route);
     }
+    n
 }
 
 const HEX: &[u8; 16] = b"0123456789abcdef";

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -1284,6 +1284,87 @@ def run_blk_trace_argv_check():
     print()
 
 
+def run_scrings_parse_check():
+    """
+    Tier 1.5 host-only check: the `scrings` [SC-RING] parser + `scrings-dump`
+    argv shaping.  No QEMU (< 1s).
+
+    Regression guard for the W101 op-trace parser bug (Phase A): the kernel
+    dumper emits `cr=<caller_rip>` between `rip=` and `a1=`, which the
+    historical `_SC_RING_LINE` regex did not account for, so it matched ZERO
+    entries from a real dump.  This check parses a synthetic block with the
+    real `cr=` field (+ additive ns/tid/wake and a kind=frozen BEGIN), asserts
+    the entries and every additive field land, and confirms a legacy cr-less
+    line still parses.
+    """
+    print("=== Tier 1.5: scrings [SC-RING] parser + scrings-dump argv (host-only) ===")
+    print()
+
+    import importlib.util
+    h_path = Path(__file__).resolve().parent / "qemu-harness.py"
+    spec = importlib.util.spec_from_file_location("qemu_harness_smoke_scrings", h_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    # A real optrace frozen-ring dump (cr= present, additive ns/tid/wake), plus
+    # one legacy cr-less line to confirm back-compat.
+    lines = [
+        "[SC-RING-BEGIN] pid=1 exit_code=0 entries=3 kind=frozen ns_now=123456789",
+        "[SC-RING] i=000 t=10 futex/202 rip=0x7f00 cr=0x401abc a1=0x1 a2=0x80 a3=0x2 "
+        "a4=0x0 a5=0x0 a6=0x0 ret=-110 ns=1000 tid=7 wake=futex_timeout",
+        "[SC-RING] i=001 t=11 poll/7 rip=0x7f10 cr=0x402def a1=0x5 a2=0x1 a3=0xffffffff "
+        "a4=0x0 a5=0x0 a6=0x0 ret=1 ns=2000 tid=7 wake=bell",
+        "[SC-RING-PATH] i=001 path=\"/etc/hosts\"",
+        # Legacy cr-less line (hypothetical old format) must still parse.
+        "[SC-RING] i=002 t=12 write/1 rip=0x7f20 a1=0x35 a2=0x9000 a3=0x40 "
+        "a4=0x0 a5=0x0 a6=0x0 ret=64",
+        "[SC-RING-END] pid=1",
+    ]
+    dumps = list(mod._parse_ring_dump(lines))
+    ok_block = len(dumps) == 1
+    check("scrings parser yields exactly one dump block", ok_block, f"{len(dumps)} blocks")
+    if ok_block:
+        d = dumps[0]
+        ents = d["entries"]
+        # THE regression: the cr= line used to match zero entries.
+        check("scrings parses SC-RING lines with cr= (was 0 entries)",
+              len(ents) == 3, f"{len(ents)} entries (want 3)")
+        check("scrings BEGIN kind/ns_now captured",
+              d.get("kind") == "frozen" and d.get("ns_now") == 123456789,
+              f"kind={d.get('kind')} ns_now={d.get('ns_now')}")
+        if len(ents) == 3:
+            e0, e1, e2 = ents
+            check("scrings entry[0] cr/ns/tid/wake captured",
+                  e0["cr"] == 0x401abc and e0["ns"] == 1000
+                  and e0["tid"] == 7 and e0["wake"] == "futex_timeout"
+                  and e0["ret"] == -110 and e0["a2"] == 0x80,
+                  str({k: e0[k] for k in ("cr", "ns", "tid", "wake", "ret", "a2")}))
+            check("scrings entry[1] path attached + wake=bell",
+                  e1["path"] == "/etc/hosts" and e1["wake"] == "bell"
+                  and e1["cr"] == 0x402def,
+                  str({k: e1[k] for k in ("path", "wake", "cr")}))
+            check("scrings legacy cr-less line parses (cr=None)",
+                  e2["cr"] is None and e2["ns"] is None
+                  and e2["ret"] == 64 and e2["a1"] == 0x35,
+                  str({k: e2[k] for k in ("cr", "ns", "ret", "a1")}))
+
+    # scrings-dump argv: default (log-ring), com1, pid+com1 in either order.
+    check("scrings-dump default request shape",
+          mod._kdb_build_request("scrings-dump", []) == {"op": "scrings-dump"},
+          str(mod._kdb_build_request("scrings-dump", [])))
+    check("scrings-dump pid=1 request shape",
+          mod._kdb_build_request("scrings-dump", ["1"]) == {"op": "scrings-dump", "pid": "1"},
+          str(mod._kdb_build_request("scrings-dump", ["1"])))
+    check("scrings-dump com1 flag request shape",
+          mod._kdb_build_request("scrings-dump", ["com1"]) == {"op": "scrings-dump", "com1": "1"},
+          str(mod._kdb_build_request("scrings-dump", ["com1"])))
+    r_both = mod._kdb_build_request("scrings-dump", ["1", "com1"])
+    check("scrings-dump pid+com1 (either order) request shape",
+          r_both == {"op": "scrings-dump", "pid": "1", "com1": "1"},
+          str(r_both))
+    print()
+
+
 def run_pcap_argv_check():
     """
     Tier 1.5 host-only check: `start --pcap` filter-dump composition +
@@ -1553,6 +1634,7 @@ def main():
     run_blk_trace_argv_check()
     run_livelock_reap_check()
     run_pcap_argv_check()
+    run_scrings_parse_check()
 
     if args.staleness_only:
         # Early exit for CI cycles that just want the cheap host-only checks.

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7316,11 +7316,18 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
             d["pid"] = str(int(rest[1]))
         return d
     if op == "scrings-dump":
-        # Non-destructively dump the frozen ring(s) to serial for `scrings`.
-        # Optional positional `[pid]` (absent = every tracked pid).
+        # Non-destructively dump the frozen ring(s).  Routes through the
+        # guest-RAM log ring by default (retrieve via `log-ring flush|drain`);
+        # positional `com1` forces the complete-but-slow COM1 path.
+        # Optional positional `[pid]` (absent = every tracked pid).  `pid` and
+        # `com1` may appear in either order.
         d = {"op": op}
-        if rest:
-            d["pid"] = str(int(rest[0]))
+        for tok in rest:
+            t = tok.strip().lower()
+            if t in ("com1", "--com1"):
+                d["com1"] = "1"
+            else:
+                d["pid"] = str(int(tok))
         return d
     if op == "virtio-wait-mode":
         # Flip the wait strategy at runtime: adaptive (poll + peer-aware yield) |
@@ -10896,12 +10903,16 @@ def _scan_line(line_bytes: bytes, tests: list, libs_loaded: list,
 # `scrings-dump` op (W101 op-trace).  Format, from kernel/src/syscall/ring.rs:
 #
 #   [SC-RING-BEGIN] pid=<N> exit_code=<N> entries=<N> [kind=<exit|frozen> ns_now=<N>]
-#   [SC-RING] i=NNN t=<tick> <name>/<nr> rip=0x.. a1=0x.. a2=0x.. a3=0x.. \
+#   [SC-RING] i=NNN t=<tick> <name>/<nr> rip=0x.. cr=0x.. a1=0x.. a2=0x.. a3=0x.. \
 #             a4=0x.. a5=0x.. a6=0x.. ret=<i64> [ns=<N> tid=<N> wake=<label>]
 #   [SC-RING-PATH] i=NNN path="..."                    (for open/openat only)
 #   [SC-RING-BYTES] i=NNN len=<N> hex=<hex-ascii>      (for captured reads)
 #   [SC-RING-END] pid=<N>
 #
+# The `cr=` (caller_rip) field sits between `rip=` and `a1=`.  It has ALWAYS
+# been emitted by the kernel dumper, but the historical `_SC_RING_LINE` regex
+# omitted it and therefore matched zero entries; it is now an optional
+# capturing group (`cr`), back-compatible with any hypothetical cr-less line.
 # The `kind`/`ns_now` (BEGIN) and `ns`/`tid`/`wake` (per-entry) fields are
 # additive: they appear only on optrace-capable kernels and are parsed with
 # separate optional regexes so pre-optrace logs still parse.  `wake` is the
@@ -10920,11 +10931,15 @@ _SC_RING_BEGIN = re.compile(
 # exit-time dump from an on-demand frozen-ring dump; `ns_now=<n>` is the
 # monotonic-ns clock at dump time.  Absent on pre-optrace logs.
 _SC_RING_BEGIN_EXT = re.compile(r"kind=(\w+) ns_now=(\d+)")
+# Named groups so the additive `cr=` (caller_rip) group can slot in between
+# `rip=` and `a1=` without renumbering the rest.  `cr` is optional for
+# forward/back compatibility with any cr-less line.
 _SC_RING_LINE = re.compile(
-    r"\[SC-RING\] i=(\d+) t=(\d+) (\S+) rip=(0x[0-9a-fA-F]+) "
-    r"a1=(0x[0-9a-fA-F]+) a2=(0x[0-9a-fA-F]+) a3=(0x[0-9a-fA-F]+) "
-    r"a4=(0x[0-9a-fA-F]+) a5=(0x[0-9a-fA-F]+) a6=(0x[0-9a-fA-F]+) "
-    r"ret=(-?\d+)"
+    r"\[SC-RING\] i=(?P<i>\d+) t=(?P<t>\d+) (?P<name>\S+) rip=(?P<rip>0x[0-9a-fA-F]+)"
+    r"(?: cr=(?P<cr>0x[0-9a-fA-F]+))?"
+    r" a1=(?P<a1>0x[0-9a-fA-F]+) a2=(?P<a2>0x[0-9a-fA-F]+) a3=(?P<a3>0x[0-9a-fA-F]+)"
+    r" a4=(?P<a4>0x[0-9a-fA-F]+) a5=(?P<a5>0x[0-9a-fA-F]+) a6=(?P<a6>0x[0-9a-fA-F]+)"
+    r" ret=(?P<ret>-?\d+)"
 )
 # Additive per-entry tail (appended after ret=): monotonic-ns timestamp,
 # calling thread id, and the wake-source annotation.  Absent on pre-optrace
@@ -10964,17 +10979,19 @@ def _parse_ring_dump(lines):
         m = _SC_RING_LINE.search(ln)
         if m:
             e = {
-                "i":    int(m.group(1)),
-                "tick": int(m.group(2)),
-                "name": m.group(3),
-                "rip":  int(m.group(4), 16),
-                "a1":   int(m.group(5), 16),
-                "a2":   int(m.group(6), 16),
-                "a3":   int(m.group(7), 16),
-                "a4":   int(m.group(8), 16),
-                "a5":   int(m.group(9), 16),
-                "a6":   int(m.group(10), 16),
-                "ret":  int(m.group(11)),
+                "i":    int(m.group("i")),
+                "tick": int(m.group("t")),
+                "name": m.group("name"),
+                "rip":  int(m.group("rip"), 16),
+                # caller_rip — additive; None only on a (hypothetical) cr-less line.
+                "cr":   int(m.group("cr"), 16) if m.group("cr") else None,
+                "a1":   int(m.group("a1"), 16),
+                "a2":   int(m.group("a2"), 16),
+                "a3":   int(m.group("a3"), 16),
+                "a4":   int(m.group("a4"), 16),
+                "a5":   int(m.group("a5"), 16),
+                "a6":   int(m.group("a6"), 16),
+                "ret":  int(m.group("ret")),
                 # Additive optrace fields (None on pre-optrace logs).
                 "ns":   None,
                 "tid":  None,


### PR DESCRIPTION
## What

Two W101 op-trace **capture-tooling** defects, both surfaced during the Phase A live capture. No change to recorded data, kernel behaviour, or the exit-time crash dump — this is entirely in the on-demand frozen-ring **dump path** and the harness parser.

### 1. `scrings-dump` starved the guest (`kernel/src/kdb.rs`, `kernel/src/syscall/ring.rs`)

The frozen ring can hold ~10^5 entries. Emitting them over COM1 pays roughly one VM-exit per byte on the 16550 THR (Intel SDM Vol. 3C §25.1.3), so a deep dump monopolised the vCPU for ~28 min and wedged kdb *mid-capture*.

`scrings-dump` now routes each composed line through the near-zero-overhead guest-RAM log ring (`drivers::log_ring`): a single reservation + `memcpy` per line — no lock, no `outb`, no VM-exit. A 10^5-entry dump completes in well under a second without perturbing a live capture. Retrieve the lines out of band with `qemu-harness.py log-ring flush` (re-emits for the `scrings` parser) or `log-ring drain` (JSON).

- Bounded to `log_ring::CAP` (4 MiB): a dump larger than that keeps only the **newest** lines — the entries nearest the freeze, which is exactly what the chain reconstruction walks backwards from.
- `com1` fallback retained: `scrings-dump com1` forces the complete-but-slow COM1 path for when the vCPU is free.
- The exit-time crash dump keeps COM1 unconditionally so it survives even if the log ring is never drained.

### 2. The harness `scrings` parser matched **zero** entries (`scripts/qemu-harness.py`)

The kernel dumper has always emitted `cr=<caller_rip>` between `rip=` and `a1=`, but the `_SC_RING_LINE` regex omitted it, so every optrace frozen-ring dump parsed as empty. The regex now captures `cr` as an optional named group (slotted between `rip=` and `a1=`) and switches to named groups so it stays back-compatible with any cr-less line.

### Tests (`scripts/qemu-harness-smoke.py`)

New host-only `run_scrings_parse_check` (< 1 s, no QEMU): parses a synthetic dump with the real `cr=`/ns/tid/wake fields plus a legacy cr-less line, and asserts the `scrings-dump` argv shaping (default log-ring route, `com1` fallback, `pid`+`com1` in either order).

## Validation

- **Parser cross-check on real capture data**: reconstructed the exact kernel serial-line format from the archived Phase A dumps and parsed with both this parser and the reference parser. Byte-identical results: **271 entries (pid5)**, **131072 entries (pid1)**, field-for-field agreement on `cr`/`ret`/`ns`/`tid`/`wake`. (Previously: 0 entries.)
- Host-only smoke suite passes (`--staleness-only`), including the new check.
- Kernel builds with the capture feature set (`firefox-test-core,kdb,syscall-trace`) in 24.8 s.

## Compatibility

All fields additive. `dump_for_pid` / `dump_all_tracked` gained a `route` argument and a returned count, but both are kdb-internal — **no harness-facing breaking change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
