### PR TITLE
tooling: fd-map TCP 4-tuples + paged kdb scrings dump (retire the log-ring route)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -439,6 +439,8 @@ pub fn dispatch(req: &str, out: &mut String) {
         "optrace-depth"    => op_optrace_depth(req, out),
         #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
         "scrings-dump"     => op_scrings_dump(req, out),
+        #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+        "scrings-page"     => op_scrings_page(req, out),
         "futex-ghost-hist" => op_futex_ghost_hist(req, out),
         // cond-autopsy: one-shot musl pthread_cond/mutex wake-target-vs-
         // wait-addr report.  Composes the live struct dump + parked waiters +
@@ -1468,49 +1470,77 @@ fn op_optrace_depth(req: &str, out: &mut String) {
     }
 }
 
-/// `scrings-dump` — non-destructively emit the frozen ring(s) so the harness
-/// `scrings` parser can ingest them.  With `pid`, just that pid; without,
-/// every tracked pid.
+/// `scrings-dump` — non-destructively emit the frozen ring(s) to the COM1
+/// serial log so the harness `scrings` parser can ingest them.  With `pid`,
+/// just that pid; without, every tracked pid.
 ///
-/// Routes through the guest-RAM log ring by default (a single reservation +
-/// memcpy per line — no per-byte UART VM-exits), so dumping a deep ring does
-/// not monopolise the vCPU or wedge kdb during a live capture.  Retrieve the
-/// lines out of band with `qemu-harness.py log-ring flush` (re-emits to the
-/// serial log for `scrings`) or `log-ring drain` (JSON).  The log ring is
-/// bounded (`log_ring::CAP`, 4 MiB ≈ 20K lines): a larger dump keeps only the
-/// newest lines — the entries nearest the freeze, which is what the chain
-/// reconstruction needs.  Pass `com1` to force the complete-but-slow COM1
-/// path instead (use only when the vCPU is free).
+/// This is the SERIAL FALLBACK: it streams the whole ring over COM1 (~one
+/// VM-exit per byte on the 16550 THR — complete but slow, minutes for a deep
+/// ring), for use when the kdb channel is wedged.  The PREFERRED path for a
+/// live capture is `scrings-page` (below), which pages the ring straight back
+/// over kdb — fast, complete, and immune to the `[SC]` firehose that made the
+/// previous guest-RAM-log-ring route (PR #695) unusable under `syscall-trace`.
 #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
 fn op_scrings_dump(req: &str, out: &mut String) {
     use core::fmt::Write;
-    let com1 = extract_field(req, "com1")
-        .map(|s| matches!(s.as_str(), "1" | "true" | "on" | "yes"))
-        .unwrap_or(false);
-    let route = if com1 {
-        crate::syscall::ring::DumpRoute::Com1
-    } else {
-        crate::syscall::ring::DumpRoute::LogRing
-    };
-    let route_name = if com1 { "com1" } else { "log-ring" };
     match extract_field(req, "pid").and_then(|s| parse_u64(&s)) {
         Some(pid) if pid != 0 => {
-            let entries = crate::syscall::ring::dump_for_pid(pid, route);
+            let entries = crate::syscall::ring::dump_for_pid(pid);
             let _ = write!(
                 out,
-                r#"{{"dumped":true,"pid":{},"entries":{},"route":"{}"}}"#,
-                pid, entries, route_name
+                r#"{{"dumped":true,"pid":{},"entries":{},"route":"com1"}}"#,
+                pid, entries
             );
         }
         _ => {
-            let pids = crate::syscall::ring::dump_all_tracked(route);
+            let pids = crate::syscall::ring::dump_all_tracked();
             let _ = write!(
-                out,
-                r#"{{"dumped":true,"pids":{},"route":"{}"}}"#,
-                pids, route_name
+                out, r#"{{"dumped":true,"pids":{},"route":"com1"}}"#, pids
             );
         }
     }
+}
+
+/// `scrings-page` — return a bounded WINDOW of `pid`'s frozen ring directly in
+/// the kdb response, for the fast harness dump path.  Request fields:
+///   `pid`   (required) — the process whose frozen ring to page;
+///   `from`  (default 0) — absolute chronological entry index to start at;
+///   `count` (default 4096) — max entries this page (also capped by a byte
+///           budget so the response stays under `MAX_RESP_BYTES`).
+///
+/// Response: `{"pid",​"from","emitted","next","total","eof","ns_now","lines"}`
+/// where `lines` is the JSON-escaped `[SC-RING]`(+PATH/BYTES) block for the
+/// window (no BEGIN/END frame — the host synthesises it once it has paged to
+/// `eof`).  The host loops `from = next` until `eof`, i.e. the same offset-
+/// cursor protocol the base64 PNG read (`read-png`) uses to stream a payload
+/// larger than one response.  Firehose-immune (no shared ring) and capacity-
+/// independent (each page is bounded), unlike the retired #695 log-ring route.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn op_scrings_page(req: &str, out: &mut String) {
+    use core::fmt::Write;
+    let pid = extract_field(req, "pid").and_then(|s| parse_u64(&s)).unwrap_or(0);
+    let from = extract_field(req, "from").and_then(|s| parse_u64(&s)).unwrap_or(0) as usize;
+    let count = extract_field(req, "count").and_then(|s| parse_u64(&s))
+        .unwrap_or(4096).max(1) as usize;
+
+    // Keep the escaped `lines` block + JSON envelope under MAX_RESP_BYTES.
+    // 24 KiB of raw lines leaves comfortable room for escaping (`"`→`\"`,
+    // `\n`→`\\n`) plus the ~128-byte envelope inside the 32 KiB cap.
+    const PAGE_BYTE_BUDGET: usize = 24 * 1024;
+
+    let mut block = String::new();
+    let (emitted, total, ns_now) =
+        crate::syscall::ring::page_for_pid(pid, from, count, PAGE_BYTE_BUDGET, &mut block);
+    let next = from + emitted;
+    let eof = next >= total;
+
+    let _ = write!(
+        out,
+        r#"{{"pid":{},"from":{},"emitted":{},"next":{},"total":{},"eof":{},"ns_now":{},"lines":"#,
+        pid, from, emitted, next, total, eof, ns_now
+    );
+    j_str(out, &block);
+    out.push('}');
 }
 
 // ── compose-stats ─────────────────────────────────────────────────────────────
@@ -2694,6 +2724,11 @@ fn op_unix_table(out: &mut String) {
     out.push_str("]}");
 }
 
+/// Format an IPv4 address + port as `a.b.c.d:port` for the fd-map 4-tuple.
+fn fmt_ipv4_port(ip: [u8; 4], port: u16) -> alloc::string::String {
+    alloc::format!("{}.{}.{}.{}:{}", ip[0], ip[1], ip[2], ip[3], port)
+}
+
 fn op_fd_map(req: &str, out: &mut String) {
     use core::fmt::Write;
 
@@ -2804,28 +2839,64 @@ fn op_fd_map(req: &str, out: &mut String) {
                 j_kv_str(out, "kind", "socket");
                 j_kv(out, "socket_id", &alloc::format!("{}", snap.inode));
 
-                // Resolve peer socket id from the snapshot.
-                let peer_socket_id = sock_snaps.iter()
-                    .find(|s| s.id == snap.inode)
-                    .map(|s| s.peer_id)
-                    .unwrap_or(u64::MAX);
+                // Disambiguate AF_UNIX vs AF_INET by the fd flag captured at
+                // snapshot time (bit 23; same predicate `is_unix_socket_fd`
+                // uses) — the two socket tables have independent id spaces, so
+                // looking `snap.inode` up in the AF_UNIX table alone would
+                // mis-key an INET socket that happened to share the id.
+                let is_unix = snap.flags & crate::syscall::UNIX_SOCKET_FLAG != 0;
 
-                if peer_socket_id == u64::MAX {
-                    j_kv_str(out, "peer_socket_id", "none");
-                    j_kv_str(out, "peer_pid", "none");
-                    j_kv_str(out, "peer_fd",  "none");
-                } else {
-                    j_kv(out, "peer_socket_id", &alloc::format!("{}", peer_socket_id));
-                    match find_socket_owner(peer_socket_id) {
-                        Some((ppid, pfd)) => {
-                            j_kv(out, "peer_pid", &alloc::format!("{}", ppid));
-                            j_kv(out, "peer_fd",  &alloc::format!("{}", pfd));
+                if !is_unix {
+                    // AF_INET / AF_INET6: emit the IPv4 4-tuple + L4 proto so a
+                    // gap-ending send can be bound to its peer HOST.  The
+                    // AF_UNIX peer_socket_id resolution below never covers an
+                    // INET socket (getsockname(2)/getpeername(2)-shaped fields).
+                    match crate::net::socket::socket_inet_snapshot(snap.inode) {
+                        Some(t) => {
+                            j_kv_str(out, "af", "inet");
+                            j_kv_str(out, "l4", match t.socket_type {
+                                crate::net::socket::SocketType::Tcp => "tcp",
+                                crate::net::socket::SocketType::Udp => "udp",
+                            });
+                            j_kv_str(out, "local",  &fmt_ipv4_port(t.local_ip,  t.local_port));
+                            j_kv_str(out, "remote", &fmt_ipv4_port(t.remote_ip, t.remote_port));
+                            j_kv(out, "local_port",  &alloc::format!("{}", t.local_port));
+                            j_kv(out, "remote_port", &alloc::format!("{}", t.remote_port));
+                            j_kv_str(out, "bound",     if t.bound { "true" } else { "false" });
+                            j_kv_str(out, "connected", if t.connected { "true" } else { "false" });
                         }
                         None => {
-                            // Peer socket exists in TABLE but no process owns it yet
-                            // (e.g. created but not yet dup'd/installed in any FD table).
-                            j_kv_str(out, "peer_pid", "unowned");
-                            j_kv_str(out, "peer_fd",  "unowned");
+                            // Socket-flagged fd that is neither AF_UNIX-flagged
+                            // nor present in the INET table — report the
+                            // ambiguity rather than mislabel it as a UNIX peer.
+                            j_kv_str(out, "af", "unknown");
+                        }
+                    }
+                } else {
+                    j_kv_str(out, "af", "unix");
+                    // Resolve peer socket id from the snapshot.
+                    let peer_socket_id = sock_snaps.iter()
+                        .find(|s| s.id == snap.inode)
+                        .map(|s| s.peer_id)
+                        .unwrap_or(u64::MAX);
+
+                    if peer_socket_id == u64::MAX {
+                        j_kv_str(out, "peer_socket_id", "none");
+                        j_kv_str(out, "peer_pid", "none");
+                        j_kv_str(out, "peer_fd",  "none");
+                    } else {
+                        j_kv(out, "peer_socket_id", &alloc::format!("{}", peer_socket_id));
+                        match find_socket_owner(peer_socket_id) {
+                            Some((ppid, pfd)) => {
+                                j_kv(out, "peer_pid", &alloc::format!("{}", ppid));
+                                j_kv(out, "peer_fd",  &alloc::format!("{}", pfd));
+                            }
+                            None => {
+                                // Peer socket exists in TABLE but no process owns it yet
+                                // (e.g. created but not yet dup'd/installed in any FD table).
+                                j_kv_str(out, "peer_pid", "unowned");
+                                j_kv_str(out, "peer_fd",  "unowned");
+                            }
                         }
                     }
                 }

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -280,6 +280,47 @@ pub fn socket_peer_addr(id: u64) -> Option<(Ipv4Address, u16)> {
     Some((sock.remote_ip, sock.remote_port))
 }
 
+/// A read-only snapshot of a socket's IPv4 4-tuple + type/state, for the
+/// diagnostic fd-map (kdb `fd-map`).  Shape mirrors `getsockname(2)` +
+/// `getpeername(2)` (IEEE 1003.1): `local_*` is the bound source address
+/// (zeroed when unbound), `remote_*` the connected peer (zeroed when not
+/// connected).
+pub struct InetFdSnapshot {
+    pub socket_type: SocketType,
+    pub bound:       bool,
+    pub connected:   bool,
+    pub local_ip:    Ipv4Address,
+    pub local_port:  u16,
+    pub remote_ip:   Ipv4Address,
+    pub remote_port: u16,
+}
+
+/// Snapshot the IPv4 4-tuple + type/state for socket `id`, or `None` if no
+/// such socket exists in [`SOCKETS`] (e.g. the id belongs to the AF_UNIX
+/// table, not this INET table).  Read-only; the [`SOCKETS`] lock is held
+/// only to copy out the scalar fields, then released before the (TCP) local
+/// IP is resolved from the TCB — the same discipline as [`socket_local_addr`],
+/// so a diagnostic caller cannot deadlock against the net fast path.
+pub fn socket_inet_snapshot(id: u64) -> Option<InetFdSnapshot> {
+    let (socket_type, bound, connected, local_port, remote_ip, remote_port) = {
+        let sockets = SOCKETS.lock();
+        let s = sockets.iter().find(|s| s.id == id)?;
+        (s.socket_type, s.bound, s.connected, s.local_port, s.remote_ip, s.remote_port)
+    };
+    let local_ip = if bound {
+        match socket_type {
+            SocketType::Tcp => super::tcp::lookup_local_ip(local_port).unwrap_or([0; 4]),
+            SocketType::Udp => super::our_ip(),
+        }
+    } else {
+        [0; 4]
+    };
+    Some(InetFdSnapshot {
+        socket_type, bound, connected,
+        local_ip, local_port, remote_ip, remote_port,
+    })
+}
+
 /// Send data through a socket.
 pub fn socket_send(id: u64, data: &[u8]) -> Result<usize, &'static str> {
     let sockets = SOCKETS.lock();

--- a/kernel/src/syscall/ring.rs
+++ b/kernel/src/syscall/ring.rs
@@ -618,49 +618,6 @@ fn nr_name(nr: u64) -> &'static str {
     }
 }
 
-/// Where a ring dump's `[SC-RING-*]` lines are routed.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum DumpRoute {
-    /// Classic COM1 `serial_println!` — every line pays ~one VM-exit per byte
-    /// on the 16550 THR (Intel SDM Vol. 3C §25.1.3).  Complete, but slow: a
-    /// deep frozen ring can monopolise the vCPU for minutes and wedge kdb.
-    /// Used by the crash-path exit dump (always reaches the log) and as the
-    /// `scrings-dump --com1` fallback.
-    Com1,
-    /// The near-zero-overhead guest-RAM log ring (`drivers::log_ring`): each
-    /// line is a single reservation + `memcpy`, no lock, no `outb`, no exit —
-    /// so a 10^5-entry dump completes in well under a second without starving
-    /// a live capture.  Drained out of band via `qemu-harness.py log-ring
-    /// drain|flush`.  Bounded to `log_ring::CAP` (4 MiB ≈ 20K lines): a dump
-    /// larger than that keeps only the NEWEST lines — which are the entries
-    /// nearest the freeze/gap-end, i.e. exactly the ones the W101 chain
-    /// reconstruction walks backwards from.
-    LogRing,
-}
-
-/// Format one already-composed line into the guest-RAM log ring, appending the
-/// `'\n'` terminator (matching the fast-path `log_fast` framing so a
-/// `log-ring flush` re-emits it as a proper serial line).  Mirrors
-/// `drivers::serial::log_fast`'s bounded-stack-buffer commit; no heap, no lock.
-fn record_line_to_ring(args: core::fmt::Arguments) {
-    use core::fmt::Write;
-    const CAP: usize = crate::drivers::log_ring::MAX_RECORD;
-    struct RingBuf { buf: [u8; CAP], len: usize }
-    impl core::fmt::Write for RingBuf {
-        fn write_str(&mut self, s: &str) -> core::fmt::Result {
-            for &b in s.as_bytes() {
-                if self.len >= self.buf.len() { break; }
-                self.buf[self.len] = b;
-                self.len += 1;
-            }
-            Ok(())
-        }
-    }
-    let mut rb = RingBuf { buf: [0u8; CAP], len: 0 };
-    let _ = rb.write_fmt(format_args!("{}\n", args));
-    crate::drivers::log_ring::record(&rb.buf[..rb.len]);
-}
-
 /// Emit the entries of `ring` framed by `[SC-RING-BEGIN]`/`[SC-RING-END]`.
 ///
 /// The BEGIN line carries the legacy `pid`/`exit_code`/`entries` fields the
@@ -669,63 +626,129 @@ fn record_line_to_ring(args: core::fmt::Arguments) {
 /// line gains additive `ns=`/`tid=`/`wake=` fields, appended after `ret=` so
 /// older parsers keep matching.
 ///
-/// `route` selects COM1 (crash-path exit dump) vs the guest-RAM log ring
-/// (`scrings-dump`, so a live capture is not starved by per-byte UART I/O).
-fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str, route: DumpRoute) {
-    // Route one formatted line to the selected sink.  A `macro_rules!` (not a
-    // closure) so each call site can pass ordinary `format_args`-style tokens.
-    macro_rules! line {
-        ($($a:tt)*) => {
-            match route {
-                DumpRoute::Com1    => crate::serial_println!($($a)*),
-                DumpRoute::LogRing => record_line_to_ring(format_args!($($a)*)),
-            }
-        };
-    }
-
+/// Streams line-by-line to COM1 (`serial_println!`) so a deep ring never needs
+/// a multi-MiB kernel-side `String`.  Complete but slow (~one VM-exit per byte
+/// on the 16550 THR, Intel SDM Vol. 3C §25.1.3): used by the crash-path exit
+/// dump (must reach the log even if kdb is dead) and as the `scrings-dump`
+/// serial fallback.  For a fast, kdb-paged, firehose-immune dump of a live
+/// capture use [`page_for_pid`] instead.
+fn emit_ring(pid: u64, ring: &Ring, exit_code: i64, kind: &str) {
     let ns_now = crate::proc::vdso::monotonic_ns();
-    line!(
+    crate::serial_println!(
         "[SC-RING-BEGIN] pid={} exit_code={} entries={} kind={} ns_now={}",
         pid, exit_code, ring.len, kind, ns_now
     );
 
     for (i, e) in ring.iter_chronological().enumerate() {
-        let name = nr_name(e.nr);
-        let name_field = if name.is_empty() {
-            alloc::format!("nr={}", e.nr)
-        } else {
-            alloc::format!("{}/{}", name, e.nr)
-        };
-        // Print one header line per entry.  `caller_rip` is the return
-        // address at `[user_rsp]` captured at syscall entry: typically the
-        // caller of libc's `syscall()` wrapper, which resolves directly to
-        // a libxul / firefox-bin function name when the offset-from-base is
-        // looked up in the Breakpad .sym symbol files.
-        line!(
-            "[SC-RING] i={:03} t={} {} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x} ret={} ns={} tid={} wake={}",
-            i, e.tick, name_field,
-            e.rip, e.caller_rip,
-            e.a1, e.a2, e.a3, e.a4, e.a5, e.a6, e.ret,
-            e.ns, e.tid, e.wake.as_str()
-        );
-        if !e.path.is_empty() {
-            line!("[SC-RING-PATH] i={:03} path={:?}", i, &e.path);
-        }
-        if !e.read_bytes.is_empty() {
-            // Hex-encode the bytes.  Keep everything on a single line — the
-            // harness parses this by regex so line boundaries matter.
-            let mut hex = alloc::string::String::with_capacity(e.read_bytes.len() * 2);
-            for b in &e.read_bytes {
-                let hi = b >> 4;
-                let lo = b & 0xF;
-                hex.push(HEX[hi as usize] as char);
-                hex.push(HEX[lo as usize] as char);
-            }
-            line!("[SC-RING-BYTES] i={:03} len={} hex={}", i, e.read_bytes.len(), hex);
-        }
+        format_entry(i, e, &mut EntrySink::Serial);
     }
 
-    line!("[SC-RING-END] pid={}", pid);
+    crate::serial_println!("[SC-RING-END] pid={}", pid);
+}
+
+/// Sink for a single formatted ring entry — either the COM1 serial console
+/// (streamed, bounded memory) or an in-RAM `String` (the kdb-paged path,
+/// bounded by the caller's byte budget).
+enum EntrySink<'a> {
+    Serial,
+    Buf(&'a mut alloc::string::String),
+}
+
+/// Format one ring entry's `[SC-RING]` (+ optional `[SC-RING-PATH]` /
+/// `[SC-RING-BYTES]`) lines to `sink` at absolute chronological index `i`.
+/// Single source of truth for the entry line format shared by [`emit_ring`]
+/// (COM1) and [`page_for_pid`] (kdb) so the two transports can never drift.
+///
+/// `caller_rip` (`cr=`) is the return address at `[user_rsp]` captured at
+/// syscall entry: typically the caller of libc's `syscall()` wrapper, which
+/// resolves to a libxul / firefox-bin function name via the Breakpad `.sym`.
+fn format_entry(i: usize, e: &Entry, sink: &mut EntrySink) {
+    use core::fmt::Write;
+    // Route one formatted line to the selected sink.
+    macro_rules! line {
+        ($($a:tt)*) => {
+            match sink {
+                EntrySink::Serial => crate::serial_println!($($a)*),
+                EntrySink::Buf(b) => { let _ = writeln!(b, $($a)*); }
+            }
+        };
+    }
+
+    let name = nr_name(e.nr);
+    let name_field = if name.is_empty() {
+        alloc::format!("nr={}", e.nr)
+    } else {
+        alloc::format!("{}/{}", name, e.nr)
+    };
+    line!(
+        "[SC-RING] i={:03} t={} {} rip={:#x} cr={:#x} a1={:#x} a2={:#x} a3={:#x} a4={:#x} a5={:#x} a6={:#x} ret={} ns={} tid={} wake={}",
+        i, e.tick, name_field,
+        e.rip, e.caller_rip,
+        e.a1, e.a2, e.a3, e.a4, e.a5, e.a6, e.ret,
+        e.ns, e.tid, e.wake.as_str()
+    );
+    if !e.path.is_empty() {
+        line!("[SC-RING-PATH] i={:03} path={:?}", i, &e.path);
+    }
+    if !e.read_bytes.is_empty() {
+        // Hex-encode the bytes.  Keep everything on a single line — the
+        // harness parses this by regex so line boundaries matter.
+        let mut hex = alloc::string::String::with_capacity(e.read_bytes.len() * 2);
+        for b in &e.read_bytes {
+            let hi = b >> 4;
+            let lo = b & 0xF;
+            hex.push(HEX[hi as usize] as char);
+            hex.push(HEX[lo as usize] as char);
+        }
+        line!("[SC-RING-BYTES] i={:03} len={} hex={}", i, e.read_bytes.len(), hex);
+    }
+}
+
+/// Format a bounded WINDOW of `pid`'s frozen ring — entries `[from, from+count)`
+/// — into `out` as `[SC-RING]`(+PATH/BYTES) lines (NO BEGIN/END frame: the
+/// caller pages until eof and synthesises the frame host-side).  Absolute
+/// chronological indices are used for `i=` so consecutive pages concatenate
+/// seamlessly.
+///
+/// This is the transport that replaces #695's guest-RAM-log-ring route, which
+/// the 2026-07-02 recapture proved unusable during a live `syscall-trace`
+/// session: the ~220K rec/s `[SC]` firehose shares the single 4 MiB log ring
+/// and laps it in ~0.18 s, evicting dump lines before they can be drained, and
+/// a >4 MiB dump cannot fit the ring at all.  Paging straight into the kdb
+/// response instead is firehose-immune (no shared ring) and capacity-
+/// independent (each page stays under the kdb `MAX_RESP_BYTES`; the host loops
+/// `from += emitted` until `eof`, the same offset-cursor pattern the base64
+/// PNG read uses).
+///
+/// Emission stops early once `out` reaches `max_bytes` (so the page fits under
+/// the kdb response cap) but always emits at least the first windowed entry, so
+/// the host always makes forward progress.  Returns `(emitted, total, ns_now)`:
+/// `emitted` = entries actually written this page, `total` = `ring.len`,
+/// `ns_now` = the monotonic-ns dump clock (stamped once for the whole dump on
+/// the first page).
+pub fn page_for_pid(pid: u64, from: usize, count: usize, max_bytes: usize,
+                    out: &mut alloc::string::String) -> (usize, usize, u64) {
+    let rings = RINGS.lock();
+    let Some(ring) = rings.get(&pid) else {
+        return (0, 0, 0);
+    };
+    let total = ring.len;
+    let ns_now = crate::proc::vdso::monotonic_ns();
+    let mut emitted = 0usize;
+    let mut sink = EntrySink::Buf(out);
+    for (i, e) in ring.iter_chronological().enumerate().skip(from).take(count) {
+        // Byte-budget guard: keep the page under the kdb response cap, but
+        // always emit at least one entry so `from` advances (no livelock even
+        // if a single entry were to exceed the budget).
+        if emitted > 0 {
+            if let EntrySink::Buf(b) = &sink {
+                if b.len() >= max_bytes { break; }
+            }
+        }
+        format_entry(i, e, &mut sink);
+        emitted += 1;
+    }
+    (emitted, total, ns_now)
 }
 
 /// Dump the ring for `pid` to the serial console, framed by
@@ -744,7 +767,7 @@ pub fn dump_for_exit(pid: u64, exit_code: i64) {
         crate::serial_println!("[SC-RING-END] pid={}", pid);
         return;
     };
-    emit_ring(pid, &ring, exit_code, "exit", DumpRoute::Com1);
+    emit_ring(pid, &ring, exit_code, "exit");
 }
 
 /// Non-destructively dump the (typically frozen) ring for `pid` on demand —
@@ -754,31 +777,31 @@ pub fn dump_for_exit(pid: u64, exit_code: i64) {
 /// distinguishes it from an exit dump.  The ring is left in place so it can be
 /// re-dumped.
 ///
-/// `route` selects the sink: `LogRing` (default) keeps a live FF capture from
-/// being starved by per-byte UART I/O — the operator retrieves the lines via
-/// `qemu-harness.py log-ring drain|flush`; `Com1` is the complete-but-slow
-/// fallback for when the vCPU is free.  Returns the number of entries dumped.
-pub fn dump_for_pid(pid: u64, route: DumpRoute) -> usize {
+/// Streams the whole ring to COM1 (complete but slow — see [`emit_ring`]); the
+/// `scrings-dump` serial fallback for when kdb is wedged.  For a fast paged
+/// dump of a live capture, use [`page_for_pid`] via the kdb `scrings-page` op.
+/// Returns the number of entries dumped.
+pub fn dump_for_pid(pid: u64) -> usize {
     let rings = RINGS.lock();
     let Some(ring) = rings.get(&pid) else {
-        // Absent-ring frame always to COM1 (tiny, and confirms the op ran).
+        // Absent-ring frame (tiny, and confirms the op ran).
         crate::serial_println!(
             "[SC-RING-BEGIN] pid={} exit_code=0 entries=0 kind=frozen ns_now=0", pid);
         crate::serial_println!("[SC-RING-END] pid={}", pid);
         return 0;
     };
     let n = ring.len;
-    emit_ring(pid, ring, 0, "frozen", route);
+    emit_ring(pid, ring, 0, "frozen");
     n
 }
 
 /// Dump every tracked pid's ring on demand (frozen capture convenience).
 /// Returns the number of pids dumped.
-pub fn dump_all_tracked(route: DumpRoute) -> usize {
+pub fn dump_all_tracked() -> usize {
     let pids: Vec<u64> = TRACKED.lock().clone();
     let n = pids.len();
     for pid in pids {
-        dump_for_pid(pid, route);
+        dump_for_pid(pid);
     }
     n
 }

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -1286,18 +1286,27 @@ def run_blk_trace_argv_check():
 
 def run_scrings_parse_check():
     """
-    Tier 1.5 host-only check: the `scrings` [SC-RING] parser + `scrings-dump`
-    argv shaping.  No QEMU (< 1s).
+    Tier 1.5 host-only check: the `scrings` [SC-RING] parser, the `scrings-dump`
+    / `scrings-page` argv shaping, AND the `scrings-pull` paged-reassembly loop.
+    No QEMU (< 1s).
 
-    Regression guard for the W101 op-trace parser bug (Phase A): the kernel
-    dumper emits `cr=<caller_rip>` between `rip=` and `a1=`, which the
-    historical `_SC_RING_LINE` regex did not account for, so it matched ZERO
-    entries from a real dump.  This check parses a synthetic block with the
-    real `cr=` field (+ additive ns/tid/wake and a kind=frozen BEGIN), asserts
-    the entries and every additive field land, and confirms a legacy cr-less
-    line still parses.
+    Two regressions are guarded:
+
+    1. The W101 op-trace PARSER bug (Phase A): the kernel dumper emits
+       `cr=<caller_rip>` between `rip=` and `a1=`, which the historical
+       `_SC_RING_LINE` regex did not account for, so it matched ZERO entries.
+
+    2. The FIREHOSE-IMMUNITY of the paged `scrings-pull` path (the task-#8
+       rework): the retired #695 log-ring route shared the 4 MiB firehose ring
+       and a live ~220K rec/s `[SC]` firehose evicted dump lines before drain.
+       The paged path reads the frozen ring straight over kdb in bounded
+       windows (no shared ring), so this test — feeding chunked `scrings-page`
+       responses through the real `_scrings_pull_one` reassembly loop and
+       asserting a complete multi-page dump — is the guard that WOULD have
+       caught the #695 defect (a shared-ring eviction cannot reassemble a
+       complete dump; direct paging always can).
     """
-    print("=== Tier 1.5: scrings [SC-RING] parser + scrings-dump argv (host-only) ===")
+    print("=== Tier 1.5: scrings parser + scrings-page paging (host-only) ===")
     print()
 
     import importlib.util
@@ -1348,20 +1357,73 @@ def run_scrings_parse_check():
                   and e2["ret"] == 64 and e2["a1"] == 0x35,
                   str({k: e2[k] for k in ("cr", "ns", "ret", "a1")}))
 
-    # scrings-dump argv: default (log-ring), com1, pid+com1 in either order.
-    check("scrings-dump default request shape",
+    # Request shaping: scrings-dump is now serial-fallback-only (pid, no route
+    # flag); scrings-page is the paged primitive (pid [from [count]]).
+    check("scrings-dump default (all pids) request shape",
           mod._kdb_build_request("scrings-dump", []) == {"op": "scrings-dump"},
           str(mod._kdb_build_request("scrings-dump", [])))
     check("scrings-dump pid=1 request shape",
           mod._kdb_build_request("scrings-dump", ["1"]) == {"op": "scrings-dump", "pid": "1"},
           str(mod._kdb_build_request("scrings-dump", ["1"])))
-    check("scrings-dump com1 flag request shape",
-          mod._kdb_build_request("scrings-dump", ["com1"]) == {"op": "scrings-dump", "com1": "1"},
-          str(mod._kdb_build_request("scrings-dump", ["com1"])))
-    r_both = mod._kdb_build_request("scrings-dump", ["1", "com1"])
-    check("scrings-dump pid+com1 (either order) request shape",
-          r_both == {"op": "scrings-dump", "pid": "1", "com1": "1"},
-          str(r_both))
+    check("scrings-page pid/from/count request shape",
+          mod._kdb_build_request("scrings-page", ["1", "4096", "256"])
+          == {"op": "scrings-page", "pid": "1", "from": "4096", "count": "256"},
+          str(mod._kdb_build_request("scrings-page", ["1", "4096", "256"])))
+
+    # Paged reassembly: synthesise an N-entry frozen ring, serve it as chunked
+    # `scrings-page` responses (honouring the kernel byte budget so it spans
+    # MANY pages), drive the real `_scrings_pull_one` loop, and assert the
+    # reassembled dump is complete + monotonic across page boundaries.
+    N = 5000
+    synth = []
+    for k in range(N):
+        e = {"t": 10 + k, "op": "futex/202", "rip": "0x7f00",
+             "cr": f"0x{0x401000 + k:x}", "a1": "0x1", "a2": "0x80", "a3": "0x2",
+             "a4": "0x0", "a5": "0x0", "a6": "0x0", "ret": -110,
+             "ns": 1000 + k, "tid": 7, "wake": "futex_timeout"}
+        synth.append(e)
+
+    PAGE_BUDGET = 24 * 1024  # mirrors the kernel op_scrings_page byte budget
+
+    def _entry_line(e, i):
+        return (f"[SC-RING] i={i:03} t={e['t']} {e['op']} rip={e['rip']} "
+                f"cr={e['cr']} a1={e['a1']} a2={e['a2']} a3={e['a3']} "
+                f"a4={e['a4']} a5={e['a5']} a6={e['a6']} ret={e['ret']} "
+                f"ns={e['ns']} tid={e['tid']} wake={e['wake']}\n")
+
+    def _fake_kdb(port, req, timeout=30.0, max_bytes=128 * 1024):
+        assert req["op"] == "scrings-page"
+        frm = int(req["from"]); count = int(req["count"])
+        out = []; nbytes = 0; emitted = 0
+        for j in range(frm, min(frm + count, N)):
+            if emitted > 0 and nbytes >= PAGE_BUDGET:
+                break
+            s = _entry_line(synth[j], j)
+            out.append(s); nbytes += len(s); emitted += 1
+        nxt = frm + emitted
+        resp = {"pid": 1, "from": frm, "emitted": emitted, "next": nxt,
+                "total": N, "eof": nxt >= N, "ns_now": 42, "lines": "".join(out)}
+        return (json.dumps(resp) + "\n").encode()
+
+    saved = mod._kdb_recv
+    try:
+        mod._kdb_recv = _fake_kdb
+        dump, pages, total = mod._scrings_pull_one(port=0, pid=1, timeout=5.0)
+    finally:
+        mod._kdb_recv = saved
+
+    got = len(dump["entries"]) if dump else 0
+    check("scrings-pull reassembles all entries across pages",
+          got == N, f"{got}/{N} entries in {pages} pages")
+    check("scrings-pull spans multiple pages (paging exercised)",
+          pages > 1, f"{pages} pages")
+    if dump and got == N:
+        idx_ok = all(dump["entries"][k]["i"] == k for k in range(N))
+        first, last = dump["entries"][0], dump["entries"][-1]
+        check("scrings-pull entry order monotonic + boundary fields intact",
+              idx_ok and first["cr"] == 0x401000 and first["ns"] == 1000
+              and last["cr"] == 0x401000 + (N - 1) and last["ns"] == 1000 + (N - 1),
+              f"idx_ok={idx_ok} first.cr={first['cr']:#x} last.cr={last['cr']:#x}")
     print()
 
 

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -1370,60 +1370,82 @@ def run_scrings_parse_check():
           == {"op": "scrings-page", "pid": "1", "from": "4096", "count": "256"},
           str(mod._kdb_build_request("scrings-page", ["1", "4096", "256"])))
 
-    # Paged reassembly: synthesise an N-entry frozen ring, serve it as chunked
-    # `scrings-page` responses (honouring the kernel byte budget so it spans
-    # MANY pages), drive the real `_scrings_pull_one` loop, and assert the
-    # reassembled dump is complete + monotonic across page boundaries.
-    N = 5000
-    synth = []
-    for k in range(N):
-        e = {"t": 10 + k, "op": "futex/202", "rip": "0x7f00",
-             "cr": f"0x{0x401000 + k:x}", "a1": "0x1", "a2": "0x80", "a3": "0x2",
-             "a4": "0x0", "a5": "0x0", "a6": "0x0", "ret": -110,
-             "ns": 1000 + k, "tid": 7, "wake": "futex_timeout"}
-        synth.append(e)
-
+    # Synthesise an N-entry frozen ring and a fake `scrings-page` server that
+    # honours the kernel byte budget (so a big ring spans many pages) and can
+    # inject a mid-pull kdb error to exercise the loud-partial path.
     PAGE_BUDGET = 24 * 1024  # mirrors the kernel op_scrings_page byte budget
 
-    def _entry_line(e, i):
-        return (f"[SC-RING] i={i:03} t={e['t']} {e['op']} rip={e['rip']} "
-                f"cr={e['cr']} a1={e['a1']} a2={e['a2']} a3={e['a3']} "
-                f"a4={e['a4']} a5={e['a5']} a6={e['a6']} ret={e['ret']} "
-                f"ns={e['ns']} tid={e['tid']} wake={e['wake']}\n")
+    def _entry_line(k):
+        return (f"[SC-RING] i={k:03} t={10 + k} futex/202 rip=0x7f00 "
+                f"cr=0x{0x401000 + k:x} a1=0x1 a2=0x80 a3=0x2 "
+                f"a4=0x0 a5=0x0 a6=0x0 ret=-110 "
+                f"ns={1000 + k} tid=7 wake=futex_timeout\n")
 
-    def _fake_kdb(port, req, timeout=30.0, max_bytes=128 * 1024):
-        assert req["op"] == "scrings-page"
-        frm = int(req["from"]); count = int(req["count"])
-        out = []; nbytes = 0; emitted = 0
-        for j in range(frm, min(frm + count, N)):
-            if emitted > 0 and nbytes >= PAGE_BUDGET:
-                break
-            s = _entry_line(synth[j], j)
-            out.append(s); nbytes += len(s); emitted += 1
-        nxt = frm + emitted
-        resp = {"pid": 1, "from": frm, "emitted": emitted, "next": nxt,
-                "total": N, "eof": nxt >= N, "ns_now": 42, "lines": "".join(out)}
-        return (json.dumps(resp) + "\n").encode()
+    def _make_server(total, fail_at_page=None):
+        """Return a fake `_kdb_recv` serving `total` entries; if `fail_at_page`
+        is set, the (0-based) page at that index returns a kdb error."""
+        state = {"page": 0}
 
-    saved = mod._kdb_recv
-    try:
-        mod._kdb_recv = _fake_kdb
-        dump, pages, total = mod._scrings_pull_one(port=0, pid=1, timeout=5.0)
-    finally:
-        mod._kdb_recv = saved
+        def fake(port, req, timeout=30.0, max_bytes=128 * 1024):
+            assert req["op"] == "scrings-page"
+            if fail_at_page is not None and state["page"] == fail_at_page:
+                return (json.dumps({"error": "kdb wedged (injected)"}) + "\n").encode()
+            state["page"] += 1
+            frm = int(req["from"]); count = int(req["count"])
+            out = []; nbytes = 0; emitted = 0
+            for j in range(frm, min(frm + count, total)):
+                if emitted > 0 and nbytes >= PAGE_BUDGET:
+                    break
+                s = _entry_line(j)
+                out.append(s); nbytes += len(s); emitted += 1
+            nxt = frm + emitted
+            resp = {"pid": 1, "from": frm, "emitted": emitted, "next": nxt,
+                    "total": total, "eof": nxt >= total, "ns_now": 42,
+                    "lines": "".join(out)}
+            return (json.dumps(resp) + "\n").encode()
+        return fake
 
-    got = len(dump["entries"]) if dump else 0
+    def _pull(total, fail_at_page=None):
+        saved = mod._kdb_recv
+        try:
+            mod._kdb_recv = _make_server(total, fail_at_page)
+            return mod._scrings_pull_one(port=0, pid=1, timeout=5.0)
+        finally:
+            mod._kdb_recv = saved
+
+    # (a) Paging to EOF across MANY pages — complete + monotonic + boundaries.
+    N = 5000
+    r = _pull(N)
+    got = r["have"]
     check("scrings-pull reassembles all entries across pages",
-          got == N, f"{got}/{N} entries in {pages} pages")
+          got == N and r["complete"], f"{got}/{N}, complete={r['complete']}, {r['pages']} pages")
     check("scrings-pull spans multiple pages (paging exercised)",
-          pages > 1, f"{pages} pages")
-    if dump and got == N:
-        idx_ok = all(dump["entries"][k]["i"] == k for k in range(N))
-        first, last = dump["entries"][0], dump["entries"][-1]
+          r["pages"] > 1, f"{r['pages']} pages")
+    if r["dump"] and got == N:
+        ents = r["dump"]["entries"]
+        idx_ok = all(ents[k]["i"] == k for k in range(N))
         check("scrings-pull entry order monotonic + boundary fields intact",
-              idx_ok and first["cr"] == 0x401000 and first["ns"] == 1000
-              and last["cr"] == 0x401000 + (N - 1) and last["ns"] == 1000 + (N - 1),
-              f"idx_ok={idx_ok} first.cr={first['cr']:#x} last.cr={last['cr']:#x}")
+              idx_ok and ents[0]["cr"] == 0x401000 and ents[0]["ns"] == 1000
+              and ents[-1]["cr"] == 0x401000 + (N - 1) and ents[-1]["ns"] == 1000 + (N - 1),
+              f"idx_ok={idx_ok} first.cr={ents[0]['cr']:#x} last.cr={ents[-1]['cr']:#x}")
+
+    # (b) Short / final page: a tiny ring fits one page and reaches eof.
+    r1 = _pull(3)
+    check("scrings-pull short ring = single complete page",
+          r1["complete"] and r1["have"] == 3 and r1["pages"] == 1,
+          f"have={r1['have']} pages={r1['pages']} complete={r1['complete']}")
+
+    # (c) Resume-after-partial: kdb wedges at page 2 (0-based) — the pull must
+    # report INCOMPLETE with the correct resume offset and NOT masquerade the
+    # truncated set as whole.  This is the loud-partial guard the LEAD required.
+    rp = _pull(N, fail_at_page=2)
+    # 2 pages landed before the failure; resume_from = next cursor of page 2.
+    check("scrings-pull partial pull flagged INCOMPLETE (not silent)",
+          rp["complete"] is False and rp["error"] is not None,
+          f"complete={rp['complete']} error={rp['error']}")
+    check("scrings-pull partial reports resume_from = have (offset to restart)",
+          rp["resume_from"] == rp["have"] and 0 < rp["have"] < N,
+          f"resume_from={rp['resume_from']} have={rp['have']}")
     print()
 
 

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -7316,18 +7316,25 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
             d["pid"] = str(int(rest[1]))
         return d
     if op == "scrings-dump":
-        # Non-destructively dump the frozen ring(s).  Routes through the
-        # guest-RAM log ring by default (retrieve via `log-ring flush|drain`);
-        # positional `com1` forces the complete-but-slow COM1 path.
-        # Optional positional `[pid]` (absent = every tracked pid).  `pid` and
-        # `com1` may appear in either order.
+        # Non-destructively emit the frozen ring(s) to the COM1 serial log
+        # (parse with `scrings`).  This is the SERIAL FALLBACK — complete but
+        # slow (per-byte UART); the fast path is `scrings-pull` (kdb-paged).
+        # Optional positional `[pid]` (absent = every tracked pid).
         d = {"op": op}
-        for tok in rest:
-            t = tok.strip().lower()
-            if t in ("com1", "--com1"):
-                d["com1"] = "1"
-            else:
-                d["pid"] = str(int(tok))
+        if rest:
+            d["pid"] = str(int(rest[0]))
+        return d
+    if op == "scrings-page":
+        # One bounded page of a pid's frozen ring, returned in the response.
+        # Positional: pid [from] [count].  Used by the `scrings-pull` wrapper's
+        # offset-cursor loop; rarely invoked by hand.
+        if not rest:
+            raise ValueError("scrings-page requires a pid")
+        d = {"op": op, "pid": str(int(rest[0]))}
+        if len(rest) > 1:
+            d["from"] = str(int(rest[1]))
+        if len(rest) > 2:
+            d["count"] = str(int(rest[2]))
         return d
     if op == "virtio-wait-mode":
         # Flip the wait strategy at runtime: adaptive (poll + peer-aware yield) |
@@ -7591,8 +7598,14 @@ def _kdb_build_request(op: str, rest: list[str]) -> dict:
     raise ValueError(f"unknown kdb op: {op}")
 
 
-def _kdb_recv(port: int, req: dict, timeout: float = 30.0) -> bytes:
+def _kdb_recv(port: int, req: dict, timeout: float = 30.0,
+              max_bytes: int = 128 * 1024) -> bytes:
     """Send one JSON kdb request, return the raw response bytes.
+
+    `max_bytes` caps the client-side read (default 128 KiB — a runaway guard
+    for the common small ops).  Ops that legitimately return MiB-scale bodies
+    (e.g. `log-ring drain` of a multi-MiB ring) must raise it, or the read
+    truncates mid-response and json.loads fails.
 
     `timeout` is the OVERALL DEADLINE (not per-attempt).  The harness retries
     connect/send/read on `ConnectionRefused` / `socket.timeout` /
@@ -7633,7 +7646,7 @@ def _kdb_recv(port: int, req: dict, timeout: float = 30.0) -> bytes:
                 if not chunk:
                     break
                 buf += chunk
-                if len(buf) > 128 * 1024:
+                if len(buf) > max_bytes:
                     break
             if buf.endswith(b"\n"):
                 return buf
@@ -7795,7 +7808,8 @@ def cmd_log_ring(args):
             sys.exit(1)
         timeout = float(getattr(args, "timeout", 30.0) or 30.0)
         try:
-            raw = _kdb_recv(port, {"op": op}, timeout=timeout)
+            raw = _kdb_recv(port, {"op": op}, timeout=timeout,
+                            max_bytes=64 * 1024 * 1024)
             resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
         except (socket.timeout, ConnectionRefusedError, OSError) as e:
             _out({"error": f"kdb connect/io failed on 127.0.0.1:{port}: {e}"})
@@ -11058,6 +11072,117 @@ def cmd_scrings(args):
     _out({"dumps": dumps, "dump_count": len(dumps)})
 
 
+def _scrings_pull_one(port, pid, timeout):
+    """Page a single pid's frozen ring out over kdb (`scrings-page`), assemble
+    the `[SC-RING]` lines under a synthesised BEGIN/END frame, and parse it with
+    `_parse_ring_dump`.  Returns (dump_dict_or_None, pages, total).
+
+    This is the fast, complete, firehose-immune dump path — the offset-cursor
+    loop (`from = next` until `eof`) mirrors `cmd_kdb_read_png`.  Each page stays
+    under the kdb MAX_RESP_BYTES cap, so no single response is truncated and the
+    dump is capacity-independent (unlike the retired #695 guest-RAM-log-ring
+    route, which a live `syscall-trace` firehose evicted before drain).
+    """
+    blocks = []
+    frm = 0
+    total = 0
+    ns_now = 0
+    pages = 0
+    # Safety ceiling: every page emits >= 1 entry, so pages <= total; cap
+    # generously so a pathological loop still terminates.
+    max_pages = 200_000
+    while pages < max_pages:
+        req = {"op": "scrings-page", "pid": str(pid), "from": str(frm),
+               "count": "4096"}
+        # A page's `lines` block can approach MAX_RESP_BYTES (~32 KiB) plus the
+        # envelope; 1 MiB max_bytes is ample headroom for one response.
+        raw = _kdb_recv(port, req, timeout=timeout, max_bytes=1024 * 1024)
+        resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
+        if "error" in resp:
+            return (None, pages, total)
+        pages += 1
+        total = int(resp.get("total", 0))
+        if ns_now == 0:
+            ns_now = int(resp.get("ns_now", 0))
+        blocks.append(resp.get("lines", ""))
+        emitted = int(resp.get("emitted", 0))
+        frm = int(resp.get("next", frm + emitted))
+        if bool(resp.get("eof", False)) or emitted == 0:
+            break
+
+    if total == 0 and not any(blocks):
+        # No ring for this pid (or empty) — emit an empty-frame dump so the
+        # caller still sees the pid was queried.
+        assembled = (f"[SC-RING-BEGIN] pid={pid} exit_code=0 entries=0 "
+                     f"kind=frozen ns_now={ns_now}\n[SC-RING-END] pid={pid}\n")
+    else:
+        assembled = (
+            f"[SC-RING-BEGIN] pid={pid} exit_code=0 entries={total} "
+            f"kind=frozen ns_now={ns_now}\n"
+            + "".join(blocks)
+            + f"[SC-RING-END] pid={pid}\n"
+        )
+    dumps = list(_parse_ring_dump(assembled.splitlines()))
+    return (dumps[0] if dumps else None, pages, total)
+
+
+def cmd_scrings_pull(args):
+    """Fast, complete kdb-paged dump of one or all tracked frozen rings.
+
+    Unlike `scrings-dump` (which streams the ring to the COM1 serial log for
+    `scrings` to parse — complete but minutes-slow, and the retired #695
+    log-ring route which a live firehose evicted), `scrings-pull` pages the
+    frozen ring straight back over the kdb channel and returns the parsed dump
+    directly.  Firehose-immune and capacity-independent.  Requires the session
+    started with `--features kdb`.
+
+    Forms:
+      scrings-pull <sid> --pid N     one pid
+      scrings-pull <sid> --all       every tracked pid (default if no --pid)
+    """
+    sess = _load_session(args.sid)
+    port = int(sess.get("kdb_host_port") or 0)
+    if port <= 0:
+        _out({"ok": False, "error": "session was not started with --features kdb"})
+        sys.exit(1)
+    timeout = float(getattr(args, "timeout", 30.0) or 30.0)
+
+    pid = getattr(args, "pid", None)
+    if pid is not None:
+        pids = [int(pid)]
+    else:
+        # --all (or default): enumerate tracked pids from optrace-status.
+        try:
+            raw = _kdb_recv(port, {"op": "optrace-status"}, timeout=timeout)
+            st = json.loads(raw.strip().decode("utf-8", errors="replace"))
+            pids = [int(r["pid"]) for r in st.get("rings", [])]
+        except (socket.timeout, ConnectionRefusedError, OSError,
+                json.JSONDecodeError, ValueError, KeyError) as e:
+            _out({"ok": False, "error": f"could not list tracked pids: {e}"})
+            sys.exit(1)
+        if not pids:
+            _out({"ok": True, "dumps": [], "dump_count": 0,
+                  "note": "no tracked rings"})
+            return
+
+    dumps = []
+    pages_total = 0
+    for p in pids:
+        try:
+            dump, pages, _total = _scrings_pull_one(port, p, timeout)
+        except (socket.timeout, ConnectionRefusedError, OSError,
+                json.JSONDecodeError, ValueError) as e:
+            _out({"ok": False, "error": f"scrings-page pid={p} failed: {e}",
+                  "dumps": dumps})
+            sys.exit(1)
+        pages_total += pages
+        if dump is not None:
+            dumps.append(dump)
+
+    _out({"ok": True, "dumps": dumps, "dump_count": len(dumps),
+          "pages_total": pages_total})
+
+
 # ── stack: parse exit-time userspace stack snapshots ─────────────────────────
 #
 # On non-zero exit the kernel (firefox-test feature) emits:
@@ -13381,11 +13506,14 @@ def main():
         # trigger; `optrace-status` reports state + per-pid ring depth;
         # `optrace-freeze`/`optrace-unfreeze` are the manual fallback;
         # `optrace-depth <depth> [pid]` sizes the capture ring;
-        # `scrings-dump [pid]` emits the frozen ring(s) for the `scrings`
-        # parser.  See syscall::ring::optrace + kdb::op_optrace_*.
+        # `scrings-dump [pid]` emits the frozen ring(s) to the serial log for
+        # the `scrings` parser (slow serial fallback); `scrings-page <pid>
+        # [from [count]]` returns one bounded page in the response (the fast
+        # `scrings-pull` subcommand's offset-cursor primitive).  See
+        # syscall::ring::optrace + kdb::op_optrace_*.
         "optrace-arm", "optrace-disarm", "optrace-status",
         "optrace-freeze", "optrace-unfreeze", "optrace-depth",
-        "scrings-dump",
+        "scrings-dump", "scrings-page",
         # INFRA-3 record/replay introspection (record-replay feature).
         # `record-status` returns seed + virtual ticks + ordinal; safe to
         # query under any build (returns enabled:false when the feature
@@ -13689,6 +13817,19 @@ def main():
                             help="Only return dumps for this PID")
     p_scrings.add_argument("--last", type=int, default=None,
                             help="Truncate each dump's entries[] to last N")
+
+    # scrings-pull — fast, complete kdb-paged dump (vs `scrings` which parses
+    # the serial log after a slow `scrings-dump`).  Firehose-immune.
+    p_scrings_pull = sub.add_parser(
+        "scrings-pull",
+        help="Page one/all frozen rings over kdb and return the parsed dump "
+             "(fast; needs --features kdb)"
+    )
+    p_scrings_pull.add_argument("sid")
+    p_scrings_pull.add_argument("--pid", type=int, default=None,
+                                help="Pull only this PID (default: all tracked)")
+    p_scrings_pull.add_argument("--timeout", type=float, default=30.0,
+                                help="Per-request kdb timeout in seconds (default 30)")
 
     # stack — parse [SC-RING-STACK] exit-time userspace stack snapshots.
     p_stack = sub.add_parser(
@@ -14206,6 +14347,7 @@ def main():
         "ff-progress": cmd_ff_progress,
         "health":      cmd_health,
         "scrings": cmd_scrings,
+        "scrings-pull": cmd_scrings_pull,
         "stack":   cmd_stack,
         "ustack":  cmd_ustack,
         "parked-tids": cmd_parked_tids,

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -11075,21 +11075,31 @@ def cmd_scrings(args):
 def _scrings_pull_one(port, pid, timeout):
     """Page a single pid's frozen ring out over kdb (`scrings-page`), assemble
     the `[SC-RING]` lines under a synthesised BEGIN/END frame, and parse it with
-    `_parse_ring_dump`.  Returns (dump_dict_or_None, pages, total).
+    `_parse_ring_dump`.
 
-    This is the fast, complete, firehose-immune dump path — the offset-cursor
-    loop (`from = next` until `eof`) mirrors `cmd_kdb_read_png`.  Each page stays
-    under the kdb MAX_RESP_BYTES cap, so no single response is truncated and the
-    dump is capacity-independent (unlike the retired #695 guest-RAM-log-ring
-    route, which a live `syscall-trace` firehose evicted before drain).
+    The offset-cursor loop (`from = next` until `eof`) mirrors
+    `cmd_kdb_read_png`.  Each page stays under the kdb MAX_RESP_BYTES cap, so no
+    single response is truncated and the dump is capacity-independent (unlike
+    the retired #695 guest-RAM-log-ring route, which a live `syscall-trace`
+    firehose evicted before drain).
+
+    Returns a dict so a partial pull is NEVER silently truncated:
+      {dump, pages, total, have, complete, resume_from, error}
+    `complete` is True only when the pull reached `eof` AND the parsed entry
+    count equals the kernel's reported `total`.  On any short pull (kdb error
+    mid-page, a stall, or the safety ceiling) `complete` is False, `error`
+    names the cause, and `resume_from` is the offset to restart from — the
+    caller must surface this loudly, not return a truncated set as if whole.
     """
     blocks = []
     frm = 0
     total = 0
     ns_now = 0
     pages = 0
+    complete = False
+    error = None
     # Safety ceiling: every page emits >= 1 entry, so pages <= total; cap
-    # generously so a pathological loop still terminates.
+    # generously so a pathological loop still terminates and reports partial.
     max_pages = 200_000
     while pages < max_pages:
         req = {"op": "scrings-page", "pid": str(pid), "from": str(frm),
@@ -11099,7 +11109,8 @@ def _scrings_pull_one(port, pid, timeout):
         raw = _kdb_recv(port, req, timeout=timeout, max_bytes=1024 * 1024)
         resp = json.loads(raw.strip().decode("utf-8", errors="replace"))
         if "error" in resp:
-            return (None, pages, total)
+            error = f"scrings-page kdb error at from={frm}: {resp['error']}"
+            break
         pages += 1
         total = int(resp.get("total", 0))
         if ns_now == 0:
@@ -11107,23 +11118,34 @@ def _scrings_pull_one(port, pid, timeout):
         blocks.append(resp.get("lines", ""))
         emitted = int(resp.get("emitted", 0))
         frm = int(resp.get("next", frm + emitted))
-        if bool(resp.get("eof", False)) or emitted == 0:
+        if bool(resp.get("eof", False)):
+            complete = True
             break
-
-    if total == 0 and not any(blocks):
-        # No ring for this pid (or empty) — emit an empty-frame dump so the
-        # caller still sees the pid was queried.
-        assembled = (f"[SC-RING-BEGIN] pid={pid} exit_code=0 entries=0 "
-                     f"kind=frozen ns_now={ns_now}\n[SC-RING-END] pid={pid}\n")
+        if emitted == 0:
+            # Kernel made no progress before eof — a stall (page_for_pid should
+            # always emit >= 1 while entries remain).  Stop and report partial.
+            error = f"scrings-page stalled (emitted=0, not eof) at from={frm}"
+            break
     else:
-        assembled = (
-            f"[SC-RING-BEGIN] pid={pid} exit_code=0 entries={total} "
-            f"kind=frozen ns_now={ns_now}\n"
-            + "".join(blocks)
-            + f"[SC-RING-END] pid={pid}\n"
-        )
+        error = (f"scrings-page exceeded max_pages={max_pages} without eof "
+                 f"at from={frm}")
+
+    assembled = (
+        f"[SC-RING-BEGIN] pid={pid} exit_code=0 entries={total} "
+        f"kind=frozen ns_now={ns_now}\n"
+        + "".join(blocks)
+        + f"[SC-RING-END] pid={pid}\n"
+    )
     dumps = list(_parse_ring_dump(assembled.splitlines()))
-    return (dumps[0] if dumps else None, pages, total)
+    dump = dumps[0] if dumps else None
+    have = len(dump["entries"]) if dump else 0
+    # A clean eof still counts as incomplete if the parsed count disagrees with
+    # the kernel's total (a boundary bug would surface here, not silently).
+    if complete and have != total:
+        complete = False
+        error = f"reassembled {have} entries but kernel reported total={total}"
+    return {"dump": dump, "pages": pages, "total": total, "have": have,
+            "complete": complete, "resume_from": frm, "error": error}
 
 
 def cmd_scrings_pull(args):
@@ -11135,6 +11157,11 @@ def cmd_scrings_pull(args):
     frozen ring straight back over the kdb channel and returns the parsed dump
     directly.  Firehose-immune and capacity-independent.  Requires the session
     started with `--features kdb`.
+
+    A partial pull (kdb wedged mid-page, a stall, or the safety ceiling) is
+    reported LOUDLY: `all_complete=False`, a `partial_pids` list with each
+    pid's `have`/`total`/`resume_from`/`error`, a stderr warning, and a non-zero
+    exit — never a silently truncated dump masquerading as whole.
 
     Forms:
       scrings-pull <sid> --pid N     one pid
@@ -11162,25 +11189,41 @@ def cmd_scrings_pull(args):
             sys.exit(1)
         if not pids:
             _out({"ok": True, "dumps": [], "dump_count": 0,
-                  "note": "no tracked rings"})
+                  "all_complete": True, "note": "no tracked rings"})
             return
 
     dumps = []
+    partials = []
     pages_total = 0
     for p in pids:
         try:
-            dump, pages, _total = _scrings_pull_one(port, p, timeout)
+            r = _scrings_pull_one(port, p, timeout)
         except (socket.timeout, ConnectionRefusedError, OSError,
                 json.JSONDecodeError, ValueError) as e:
-            _out({"ok": False, "error": f"scrings-page pid={p} failed: {e}",
-                  "dumps": dumps})
-            sys.exit(1)
-        pages_total += pages
-        if dump is not None:
-            dumps.append(dump)
+            # Transport blew up entirely — surface it loudly with resume=0.
+            partials.append({"pid": p, "have": 0, "total": 0,
+                             "resume_from": 0, "error": f"transport: {e}"})
+            print(f"[scrings-pull] WARNING: pid {p} FAILED — {e}", file=sys.stderr)
+            continue
+        pages_total += r["pages"]
+        if r["dump"] is not None:
+            dumps.append(r["dump"])
+        if not r["complete"]:
+            partials.append({"pid": p, "have": r["have"], "total": r["total"],
+                             "resume_from": r["resume_from"], "error": r["error"]})
+            print(f"[scrings-pull] WARNING: pid {p} INCOMPLETE — "
+                  f"have {r['have']}/{r['total']} entries, "
+                  f"resume_from={r['resume_from']} ({r['error']})", file=sys.stderr)
 
-    _out({"ok": True, "dumps": dumps, "dump_count": len(dumps),
-          "pages_total": pages_total})
+    all_complete = not partials
+    out = {"ok": all_complete, "dumps": dumps, "dump_count": len(dumps),
+           "pages_total": pages_total, "all_complete": all_complete}
+    if partials:
+        out["partial_pids"] = partials
+    _out(out)
+    if not all_complete:
+        # Fail loudly: a truncated capture must not read as success.
+        sys.exit(2)
 
 
 # ── stack: parse exit-time userspace stack snapshots ─────────────────────────


### PR DESCRIPTION
Probe-cycle hardening from the 2026-07-02 W101 load-phase recapture. Addresses task #8: three defects the recapture found live (host-only smoke missed them — no concurrent firehose) plus the fd-map peer-host gap the verdict flagged.

## ⚠️ Breaking change (harness op semantics)

`scrings-dump` changes again, one PR after #695 introduced its log-ring route. It **no longer routes through the guest-RAM log ring**; its default is now the COM1 serial emit (parse with `scrings`). The `com1` positional and the log-ring `route` field are removed. The fast, complete, firehose-immune path is the new **`scrings-pull`** subcommand. Downstream dispatches calling `scrings-dump [pid] com1` should drop `com1` (COM1 is the only `scrings-dump` route now) and prefer `scrings-pull`. Harness co-changes are in this PR so nothing external breaks silently.

## 1. fd-map TCP 4-tuples (`net/socket.rs`, `kdb.rs`)

The kdb `fd-map` op resolved only the AF_UNIX peer table, so an AF_INET/INET6 socket showed `peer_socket_id:none` with no address — the gap-ending TCP send's peer HOST was **unbindable** in the verdict. `op_fd_map` now branches on the fd's `UNIX_SOCKET_FLAG` (bit 23 — the same predicate `is_unix_socket_fd` uses; the UNIX/INET tables have independent id spaces, so a table-membership guess could mis-key) and for INET sockets emits `af`, `l4` (tcp/udp), `local`/`remote` as `a.b.c.d:port`, `local_port`, `remote_port`, `bound`, `connected`, via a new read-only `socket_inet_snapshot` (getsockname(2)/getpeername(2)-shaped).

## 2. Paged kdb scrings dump — the log-ring route is retired (`ring.rs`, `kdb.rs`, harness)

PR #695 routed `scrings-dump` through the shared 4 MiB guest-RAM log ring. The recapture **proved that unusable under a live `syscall-trace` session**: the ~220K rec/s `[SC]` firehose shares that one ring and laps it in ~0.18 s, evicting dump lines before drain; and a >4 MiB dump (a 32768-entry pid1 ring ≈ 5.5 MB) can't fit the ring at all. A dedicated ring fixes only eviction; firehose-suppression only eviction; a bigger drain cap only the response size — **none makes the route both complete and firehose-immune.**

Replaced with a **paged direct-kdb dump**: the new `scrings-page` op reads the frozen ring in bounded windows straight into the kdb response (each < `MAX_RESP_BYTES`); the harness `scrings-pull` subcommand loops `from = next` until `eof` — the same offset-cursor protocol the base64 PNG read uses. Firehose-immune (no shared ring), capacity-independent (paging), fast (kdb-TCP, not per-byte COM1 PIO — seconds vs the ~8 min a COM1 pid1 dump took). `scrings-dump` stays as the COM1 serial fallback for when kdb is wedged. The `[SC-RING]` line format is now a single `format_entry` shared by both paths so they can't drift; `DumpRoute`/`record_line_to_ring` removed.

**Operational envelope (known dependency):** a full pid1 dump is ~180 kdb round-trips, each subject to the same storm-starvation that could wedge kdb post-load. This is acceptable — dumps are taken at freeze/idle windows where kdb is responsive, and the COM1 `scrings-dump` fallback covers a wedged kdb — but a partial pull must be **loud, not silent**: `scrings-pull` marks `all_complete=false`, lists each incomplete pid's `have`/`total`/`resume_from`/`error`, prints a stderr warning, and exits non-zero. It never returns a truncated set as if whole.

## 3. Harness `_kdb_recv` max_bytes (`qemu-harness.py`)

Incorporates capture-driver's banked fix: `_kdb_recv` hard-broke at 128 KiB with no trailing newline, truncating large responses into "malformed response". Now takes `max_bytes` (default 128 KiB; the paged pull and log-ring drain raise it).

## Validation

- **Kernel builds** under `firefox-test-core,kdb,syscall-trace`; base commit went fully green in CI (all 10 jobs incl. kernel-smoke QEMU boot, all feature combos, cargo clippy).
- **Paged reassembly cross-checked against the REAL archived rings**: simulating the `scrings-page` transport and driving the actual `_scrings_pull_one` loop reassembles **271 (pid5)** and **131072 (pid1)** entries, field-for-field, across 3 and **943 pages** respectively — no boundary loss, `complete=True`.
- **Host-only smoke** (`run_scrings_parse_check`) covers: the `cr=` parser guard, paging to EOF (5000 entries / 29 pages), a short/final single-page ring, and **resume-after-partial** (injected mid-pull kdb error → asserts INCOMPLETE + correct `resume_from`). The multi-page reassembly is the firehose-immunity guard that would have caught the #695 defect.

## Scope

All JSON fields additive. `dump_for_pid`/`dump_all_tracked` drop their `route` param (kdb-internal). **Deferred** (off the critical path after this rework): the `log-ring drain` 32 KiB firehose-response cap — scrings no longer uses the log ring, so that cap now only bounds raw-firehose draining; flagged as a small follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
