### PR TITLE
tooling: hard-bound the scrings-page byte budget under MAX_RESP_BYTES (#696 nit-1 follow-up)

### DIFF
--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -1523,10 +1523,15 @@ fn op_scrings_page(req: &str, out: &mut String) {
     let count = extract_field(req, "count").and_then(|s| parse_u64(&s))
         .unwrap_or(4096).max(1) as usize;
 
-    // Keep the escaped `lines` block + JSON envelope under MAX_RESP_BYTES.
-    // 24 KiB of raw lines leaves comfortable room for escaping (`"`→`\"`,
-    // `\n`→`\\n`) plus the ~128-byte envelope inside the 32 KiB cap.
-    const PAGE_BYTE_BUDGET: usize = 24 * 1024;
+    // Keep the JSON-escaped `lines` block + envelope PROVABLY under
+    // MAX_RESP_BYTES (kdb.rs hard-truncates a larger response, which would
+    // corrupt the page).  `j_str` expands each byte by at most 2× here: the
+    // block is printable ASCII plus `\n` line terminators, and any control
+    // byte in a path is already rendered as an ASCII backslash escape by the
+    // `{:?}` path formatter, so j_str never emits a 6-byte `\uXXXX`.  A 15 KiB
+    // raw budget therefore escapes to <= 30 KiB, which with the ~150-byte
+    // envelope stays inside the 32 KiB cap without any post-hoc drop/re-page.
+    const PAGE_BYTE_BUDGET: usize = 15 * 1024;
 
     let mut block = String::new();
     let (emitted, total, ns_now) =

--- a/scripts/qemu-harness-smoke.py
+++ b/scripts/qemu-harness-smoke.py
@@ -1373,7 +1373,7 @@ def run_scrings_parse_check():
     # Synthesise an N-entry frozen ring and a fake `scrings-page` server that
     # honours the kernel byte budget (so a big ring spans many pages) and can
     # inject a mid-pull kdb error to exercise the loud-partial path.
-    PAGE_BUDGET = 24 * 1024  # mirrors the kernel op_scrings_page byte budget
+    PAGE_BUDGET = 15 * 1024  # mirrors the kernel op_scrings_page byte budget
 
     def _entry_line(k):
         return (f"[SC-RING] i={k:03} t={10 + k} futex/202 rip=0x7f00 "


### PR DESCRIPTION
Follow-up to #696. Its third commit `6ba91d3c` raced the squash-merge (which took head `9f1cb9e9`) and was stranded on the branch, not in master. This re-lands exactly that commit onto master.

## What

pr-reviewer's nit 1 on #696: the `scrings-page` op budgets the raw `[SC-RING]` block at 24 KiB **pre-escape**, so a pathological escape-heavy block could in principle push the JSON-escaped response past the 32 KiB `MAX_RESP_BYTES` hard-truncate (kdb.rs) and corrupt the page.

Lower the raw budget to 15 KiB, which is **provably** under the cap rather than safe-in-practice: `j_str` expands each byte by at most 2× here — the block is printable ASCII plus `\n` line terminators, and any control byte in a path is already rendered as an ASCII backslash escape by the `{:?}` path formatter, so j_str never emits a 6-byte `\uXXXX`. So 15 KiB raw → ≤ 30 KiB escaped, which with the ~150-byte envelope stays inside the 32 KiB cap — no post-hoc drop/re-page path needed. Cost: a modest page-count increase (pid1 ~943 → ~1050 pages). The smoke fake server mirrors the 15 KiB budget.

Note: master is already functional and non-silent without this — #696's `have==total` completeness guard makes a would-be over-cap page read INCOMPLETE (loud), never a silent truncation. This makes it provably-can't-happen.

## Validation

- Kernel builds under `firefox-test-core,kdb,syscall-trace`.
- Host-only smoke passes (5000-entry reassembly now 46 pages, short/final-page, resume-after-partial all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
