### PR TITLE
proc/metrics: allocation-free periodic dump — stop the timer-ISR heap alloc that corrupts a block header under SMP=2

### DIFF
--- a/kernel/src/proc/proc_metrics.rs
+++ b/kernel/src/proc/proc_metrics.rs
@@ -398,26 +398,22 @@ pub fn maybe_emit_periodic(tick: u64) {
     emit_periodic(tick);
 }
 
-/// Emit one `[PROC-METRICS]` block to the serial console.  Skipped if
+/// Emit one `[PROC-METRICS]` block to the serial console.  Skipped per-PID if
 /// `PROCESS_TABLE` is contended — the next interval will retry.
+///
+/// ALLOCATION-FREE by construction.  This runs from the timer ISR (via
+/// [`maybe_emit_periodic`]); a heap allocation here would take the global
+/// allocator lock from interrupt context, and any allocation whose bytes land
+/// in a live block header corrupts the heap.  Names and the stuck-syscall tag
+/// are rendered into fixed stack buffers, the slot table is iterated directly
+/// (no `live_pids()` `Vec`), and `serial_println!` formats straight to the UART
+/// — nothing on this path calls the allocator.
 fn emit_periodic(tick: u64) {
-    use alloc::format;
-    // Resolve process names without blocking; if PROCESS_TABLE is held by
-    // a long syscall (mmap/fork), the next 5 s window will re-attempt and
-    // we lose only one sample.  Cosmetic.
-    let names: alloc::vec::Vec<(Pid, alloc::string::String)> =
-        match crate::proc::PROCESS_TABLE.try_lock() {
-            Some(g) => g.iter().map(|p| {
-                let end = p.name.iter().position(|&b| b == 0)
-                    .unwrap_or(p.name.len());
-                let name = alloc::string::String::from_utf8_lossy(
-                    &p.name[..end]).into_owned();
-                (p.pid, name)
-            }).collect(),
-            None => alloc::vec::Vec::new(),
-        };
+    use crate::util::no_alloc_fmt::ArrayWriter;
 
-    for pid in live_pids() {
+    for idx in 0..METRICS_TABLE_SIZE {
+        if !REGISTERED[idx].load(Ordering::Acquire) { continue; }
+        let pid = idx as Pid;
         let Some(s) = snapshot(pid) else { continue };
         // Skip PID 0 (idle) and pids that have no recorded activity at all —
         // they pollute the dump with empty lines.
@@ -426,21 +422,42 @@ fn emit_periodic(tick: u64) {
             && s.disk_w_bytes == 0 && s.net_r_bytes == 0 && s.net_w_bytes == 0
         { continue; }
 
-        let name = names.iter().find(|(p, _)| *p == pid)
-            .map(|(_, n)| n.as_str()).unwrap_or("?");
-
-        // Stuck-syscall tag.  Only meaningful when last_sc_nr is non-negative
-        // (i.e. the process is currently inside the kernel).
-        let stuck = if s.last_sc_nr >= 0 {
-            let delta = tick.saturating_sub(s.last_sc_tick);
-            if delta >= STUCK_TICKS {
-                format!(" STUCK_IN_NR={}@{}t", s.last_sc_nr, delta)
-            } else {
-                format!(" cur_nr={}@{}t", s.last_sc_nr, delta)
+        // Resolve the process name into a fixed stack buffer.  A brief
+        // `try_lock` copies the NUL-terminated name bytes without holding
+        // PROCESS_TABLE across the (slow) serial write and without a heap
+        // String; if the table is contended we emit "?" (cosmetic — the next
+        // 5 s window re-attempts).
+        let mut namebuf = [0u8; 64];
+        let mut nlen = 0usize;
+        if let Some(g) = crate::proc::PROCESS_TABLE.try_lock() {
+            if let Some(p) = g.iter().find(|p| p.pid == pid) {
+                let end = p.name.iter().position(|&b| b == 0)
+                    .unwrap_or(p.name.len())
+                    .min(namebuf.len());
+                namebuf[..end].copy_from_slice(&p.name[..end]);
+                nlen = end;
             }
+        }
+        let name = if nlen > 0 {
+            core::str::from_utf8(&namebuf[..nlen]).unwrap_or("?")
         } else {
-            alloc::string::String::new()
+            "?"
         };
+
+        // Stuck-syscall tag rendered into a fixed stack buffer (no `format!`).
+        // Only meaningful when last_sc_nr is non-negative (process currently
+        // inside the kernel); `last_sc_nr >= 0` makes the `as u64` cast exact.
+        let mut tagbuf = [0u8; 48];
+        let mut tagw = ArrayWriter::new(&mut tagbuf);
+        if s.last_sc_nr >= 0 {
+            let delta = tick.saturating_sub(s.last_sc_tick);
+            tagw.push_str(if delta >= STUCK_TICKS { " STUCK_IN_NR=" } else { " cur_nr=" });
+            tagw.push_dec_u64(s.last_sc_nr as u64);
+            tagw.push_byte(b'@');
+            tagw.push_dec_u64(delta);
+            tagw.push_byte(b't');
+        }
+        let stuck = core::str::from_utf8(tagw.as_bytes()).unwrap_or("");
 
         crate::serial_println!(
             "[PROC-METRICS] tick={} pid={} name={} sc={} (vm={} file={} net={} sync={} proc={} sig={} other={}) pf={} disk=R{}/W{} rreq={} net=R{}/W{}{}",
@@ -501,4 +518,45 @@ pub fn run_self_test() -> bool {
     let ok4 = snapshot(METRICS_TABLE_SIZE as Pid + 100).is_none();
 
     ok && ok2 && ok3 && ok4
+}
+
+/// Test-only: assert the periodic ISR emit path allocates ZERO heap blocks.
+///
+/// `emit_periodic` runs from the timer ISR (via [`maybe_emit_periodic`]).  A
+/// heap allocation there takes the global allocator lock from interrupt context
+/// and — observed under SMP=2 heavy load — corrupted a live block header (the
+/// former `format!`/`String`/`Vec` emit path).  This registers a PID with
+/// activity and a stuck-syscall tag (the exact `STUCK_IN_NR=` render that used
+/// to `format!`), then measures the monotonic heap-alloc counter across a direct
+/// `emit_periodic` call with interrupts masked (so the timer ISR cannot fire on
+/// this core and perturb the count; the AP idles without allocating).  Returns
+/// `true` iff the counter did not advance — i.e. the emit path is alloc-free.
+#[cfg(feature = "test-mode")]
+pub fn emit_no_alloc_selftest() -> bool {
+    let pid: Pid = 201;
+    register(pid);
+    bump_page_fault(pid);        // activity so the pid isn't skipped
+    enter_syscall(pid, 202, 5);  // last_sc_nr=202, last_sc_tick=5
+
+    let prior_flags: u64;
+    unsafe {
+        core::arch::asm!(
+            "pushfq", "pop {f}", "cli",
+            f = out(reg) prior_flags,
+            options(nomem, preserves_flags),
+        );
+    }
+
+    let (alloc_before, ..) = crate::perf::heap_alloc_stats();
+    // Large tick so (tick - last_sc_tick) >= STUCK_TICKS → exercises the
+    // STUCK_IN_NR tag render (the former `format!` path).
+    emit_periodic(5 + STUCK_TICKS + 10);
+    let (alloc_after, ..) = crate::perf::heap_alloc_stats();
+
+    if prior_flags & (1 << 9) != 0 {
+        unsafe { core::arch::asm!("sti", options(nomem, nostack, preserves_flags)); }
+    }
+
+    unregister(pid);
+    alloc_after == alloc_before
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -296,6 +296,14 @@ pub fn run() -> ! {
     total += 1;
     if test_proc_metrics_self() { passed += 1; }
 
+    // ── Test 700: proc_metrics periodic ISR emit is allocation-free ──────
+    // emit_periodic runs from the timer ISR; a heap allocation there can
+    // corrupt a live block header under SMP=2 (the format!/String/Vec path).
+    // Assert the monotonic heap-alloc counter does not advance across a direct
+    // emit_periodic call (interrupts masked).
+    total += 1;
+    if test_700_proc_metrics_emit_no_alloc() { passed += 1; }
+
     // ── Test 0c: virtio-serial / /dev/vport0p0 (Phase QGA-1) ─────────────
     #[cfg(feature = "qga")]
     {
@@ -39197,6 +39205,30 @@ fn test_proc_metrics_self() -> bool {
         true
     } else {
         test_fail!("proc_metrics self-test", "category bucketing or snapshot mismatch");
+        false
+    }
+}
+
+// ── Test 700: proc_metrics periodic ISR emit is allocation-free ─────────────
+//
+// The `[PROC-METRICS]` periodic dump runs from the timer ISR
+// (`maybe_emit_periodic` → `emit_periodic`).  It formerly built a `Vec` of
+// process names, a per-process `String`, and a `format!` stuck-syscall tag —
+// three heap allocations from interrupt context.  Under SMP=2 heavy load an
+// allocation whose bytes land in a live block header corrupted the heap (the
+// canary panic whose overwrite content decoded to proc-metrics format data).
+// The fix renders names + the stuck tag into fixed stack buffers and iterates
+// the slot table directly, so the path is alloc-free.  This asserts it: the
+// monotonic heap-alloc counter must not advance across a direct `emit_periodic`
+// call (implementation masks interrupts so the timer ISR cannot perturb it).
+fn test_700_proc_metrics_emit_no_alloc() -> bool {
+    test_header!("proc_metrics periodic ISR emit is allocation-free");
+    if crate::proc::proc_metrics::emit_no_alloc_selftest() {
+        test_pass!("proc_metrics emit alloc-free");
+        true
+    } else {
+        test_fail!("proc_metrics/emit",
+                   "emit_periodic allocated from the ISR path (heap-alloc counter advanced)");
         false
     }
 }


### PR DESCRIPTION
## Summary
Fixes the heap-corruption crash the post-#698 SMP=2 census hit (`nk-crash-autopsy.md`). Root: `emit_periodic` — the `[PROC-METRICS]` periodic dump — **allocates heap from the timer ISR** (`on_cpu_tick` → `maybe_emit_periodic` → `emit_periodic`): a `Vec<(Pid,String)>` of names, a per-process `String`, and a `format!` stuck-tag. An allocation whose bytes land in a live block's header corrupts the heap; under SMP=2 heavy load this surfaced as a `[HEAP CORRUPT]` canary panic whose overwrite content decoded to proc-metrics format data, cascading into an unrecoverable fault.

## Fix — allocation-free emit
- Iterate the fixed `METRICS`/`REGISTERED` slot table directly (no `live_pids()` `Vec`).
- Copy the process name into a fixed 64-byte **stack** buffer under a brief `PROCESS_TABLE.try_lock()` (no `String`; lock not held across the serial write).
- Render the stuck-syscall tag into a 48-byte **stack** buffer via `util::no_alloc_fmt::ArrayWriter` (no `format!`).
- `serial_println!` already formats straight to the UART without allocating — so nothing on the path calls the global allocator. Output is byte-for-byte equivalent.

## NK (#698) mechanism ruling — EXPOSED, not INDUCED (conf ~0.85)
Per task #22, ruling on #698's role: **#698 did not cause this corruption.** Evidence:
- #698's ACK-spin helper `service_incoming_shootdown_and_drain` is **alloc-free, lock-free, IF-neutral** (verified: no `format!`/`String`/`Vec`/`lock()`/`sti`/`cli`/serial in its body); it only invlpg's + reloads CR3 + does atomic slot ops. It cannot be the heap writer and does not touch the allocator.
- It runs in the ACK spin with interrupts as the caller left them and does not re-enable them, so it opens no new ISR-reentrancy window; it also *shortens* shootdown spins (breaks the livelock), reducing rather than widening any critical-section.
- The writer is unambiguously the `proc_metrics` `format!`/`String`/`Vec` path (autopsy content-match), which runs from the timer ISR independent of shootdowns.
- #698 merely let the SMP=2 load run ~41M syscalls (vs the pre-#698 throttled crawl) — far enough to hit this pre-existing latent ISR-allocation race. So **#698 stands; no revert.**

## Honest nuance for review
`heap.rs`'s `HeapIrqGuard` (cli-while-locked, :826-844) was added specifically to make `proc_metrics`'s ISR allocation *same-core* safe, and the `Mutex` serializes cross-core — so the exact corruption mechanism (why a guarded allocator still corrupted) is not fully resolved from static reading; it may be a residual SMP path or a realloc/stale-frame interaction. This fix removes ISR allocation entirely (the correct discipline regardless — no ISR should allocate), which closes the named-content path. **Verification is the re-census (task #20), not assumed** — if corruption recurs, the mechanism is deeper and needs GDB forensics.

## Test
Test 700 (`test_700_proc_metrics_emit_no_alloc`): registers a PID with activity + a stuck-syscall tag (the exact former-`format!` path), asserts the monotonic heap-alloc counter (`perf::heap_alloc_stats`) does not advance across a direct `emit_periodic` call (interrupts masked). **PASSES** live (test-mode); fails on the pre-fix code. Compiles clean under `test-mode` and `firefox-test-core,kdb`.

Diff: `proc_metrics.rs` +116/-29 (mostly the emit rewrite) + `test_runner.rs` +32 (Test 700). Public-spec citations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
