### PR TITLE
proc: never hold THREAD_TABLE across schedule() in exit_group()

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2433,11 +2433,27 @@ fn free_user_page_tables(cr3: u64) {
 /// killing the test runner thread itself.
 pub fn exit_group(exit_code: i64) {
     let tid = recover_current_tid();
+    // Resolve the pid inside a SHORT `THREAD_TABLE` critical section and copy
+    // it out, so the guard is released before any scheduling decision.  The
+    // `None` arm below reaches `schedule()`, whose dead-thread reap prologue
+    // re-acquires `THREAD_TABLE` unconditionally; entering `schedule()` while
+    // this guard were still live would re-enter a non-reentrant spinlock and
+    // wedge this CPU spinning on a lock it already holds (a lock the guard's
+    // `Drop` can no longer release, since `Drop` runs only after `schedule()`
+    // returns — which it never will).  Dropping the guard before the branch
+    // keeps the whole scheduling path lock-free.
     let pid = {
         let threads = THREAD_TABLE.lock();
-        match threads.iter().find(|t| t.tid == tid) {
-            Some(t) => t.pid,
-            None => { crate::sched::schedule(); return; }
+        threads.iter().find(|t| t.tid == tid).map(|t| t.pid)
+    };
+    let pid = match pid {
+        Some(p) => p,
+        None => {
+            // This thread is no longer recorded in `THREAD_TABLE` — a sibling's
+            // group teardown already reaped it while it was mid-exit.  There is
+            // nothing left to tear down; yield permanently with no lock held.
+            crate::sched::schedule();
+            return;
         }
     };
 


### PR DESCRIPTION
## Summary

`exit_group()` resolved the caller's pid inside a `THREAD_TABLE` critical
section and, in the "thread no longer in the table" arm, called `schedule()`
while that guard was still live:

```rust
let pid = {
    let threads = THREAD_TABLE.lock();
    match threads.iter().find(|t| t.tid == tid) {
        Some(t) => t.pid,
        None => { schedule(); return; }   // guard still held
    }
};
```

`schedule()`'s dead-thread reap prologue re-acquires `THREAD_TABLE`
unconditionally. `THREAD_TABLE` is a non-reentrant spin lock, so entering
`schedule()` with the guard live makes the CPU spin forever on a lock it
already holds; because the build is `panic = "abort"`, the guard's `Drop` can
only run after `schedule()` returns — which it never does. Result: a
permanently-held `THREAD_TABLE` (lock byte stuck at 1) and a wedged CPU.

The fix copies the pid out of the locked region, drops the guard, then
branches — the whole scheduling path is now lock-free. The `Some` path is
behaviour-identical; only the lock scope is tightened.

## Scope / correctness

- **This is independent invariant-hardening, NOT a fix for the attempt-4 SMP=2
  census freeze.** That freeze's root attribution is separately disputed and
  under discriminator review; this PR should not be conflated with it.
- The window here is narrow: it needs the running thread to have already been
  removed from `THREAD_TABLE` by a sibling's group teardown while it is
  mid-exit. It is a **same-CPU** re-entrant self-deadlock, distinct from the
  census signature (both CPUs waiting, holder on neither).
- **SMP-independent** — the re-entrant self-deadlock fires on a single core as
  well; SMP=1 behaviour on the `Some` path is unchanged.
- Restores the invariant: no `THREAD_TABLE` guard may be live across a
  scheduling decision (dropping a lock before a call that re-acquires it is
  unconditionally sound — Intel SDM Vol. 3A §8.10.1, spin-lock ownership).

## Testing

- Compiles clean via the harness (`qemu-harness.py check`, rc=0).
- No deterministic test-mode regression is feasible: reaching the `None` arm
  requires the currently-running thread to be absent from `THREAD_TABLE`, which
  cannot be synthesised without destabilising the test-runner thread itself.
  Correctness is structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
