### PR TITLE
sched: silence benign on-CPU-interlock defer spam; keep the genuine #655 signal

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1410,40 +1410,83 @@ pub fn is_tid_on_stack_any_cpu(tid: Tid) -> bool {
     false
 }
 
-/// On-CPU dispatch interlock: returns `true` if `tid` is still live — currently
-/// dispatched (`PER_CPU_CURRENT_TID`) **or** physically executing on its kernel
-/// stack (`PER_CPU_ONSTACK_TID`) — on any logical CPU OTHER than `self_cpu`.
+/// On-CPU dispatch interlock, classifier form.
 ///
 /// A thread that is still live on another CPU must never be dispatched/resumed
 /// here: it owns a single kernel stack, and running it on two CPUs at once lets
 /// each tear the other's saved `switch_context` frame in place (the SMP
-/// kernel-stack double-dispatch corruption).  This is the realisation, at our
-/// cooperative pick site, of the standard SMP wakeup interlock — a task carries
-/// an "on-CPU" marker held across the context switch, and a remote runqueue must
-/// not re-place the task until that marker clears.  Both signals are published
-/// with `Release` (`set_current_tid` / `set_onstack_tid`); the `Acquire` loads
-/// here pair with them so observing a CPU as no longer running/holding `tid` also
-/// observes that CPU's final stack writes for `tid` as retired.
+/// kernel-stack double-dispatch corruption, #655).  This is the realisation, at
+/// our cooperative pick site, of the standard SMP wakeup interlock — a task
+/// carries an "on-CPU" marker held across the context switch, and a remote
+/// runqueue must not re-place the task until that marker clears.  Both signals
+/// are published with `Release` (`set_current_tid` / `set_onstack_tid`); the
+/// `Acquire` loads here pair with them so observing a CPU as no longer
+/// running/holding `tid` also observes that CPU's final stack writes for `tid`
+/// as retired.  `self_cpu` is excluded so a thread legitimately re-selected on
+/// the very CPU it last ran on (the common no-migration case) is never
+/// spuriously deferred.
 ///
-/// `self_cpu` is excluded so a thread legitimately re-selected on the very CPU
-/// it last ran on (the common no-migration case) is never spuriously deferred.
-pub fn is_tid_live_on_other_cpu(tid: Tid, self_cpu: usize) -> bool {
+/// This enum classifies WHY a thread is live on another CPU.
+/// The interlock DECISION (defer or not) is the same for both live kinds — a
+/// thread live on another CPU must never be dispatched here.  The distinction
+/// exists only so diagnostics can separate the high-volume, expected
+/// steady-state refusal from the rare event the interlock was actually built to
+/// catch:
+///
+///   * [`Current`](Self::Current) — the thread is the CURRENT thread on another
+///     CPU (running there, or that CPU is idle-halting *on the thread's kernel
+///     stack* — no context switch leaves that stack, so `PER_CPU_CURRENT_TID`
+///     legitimately still names it).  Declining to also dispatch it here is
+///     ordinary "don't run one thread on two CPUs" and recurs at up to millions
+///     of refusals per second when one CPU is saturated and a peer repeatedly
+///     probes it for stealable work.  It is NOT the double-dispatch race.
+///
+///   * [`OnStack`](Self::OnStack) — the thread is no longer named current on any
+///     CPU, but a CPU is still physically on its kernel stack through the
+///     `switch_context_asm` epilogue (`PER_CPU_ONSTACK_TID`).  Dispatching it
+///     here would resume it onto the very stack that CPU is still unwinding and
+///     tear its saved switch frame in place.  This is precisely the switch-OUT
+///     double-dispatch window the interlock exists to close.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OtherCpuLiveness {
+    /// Not current and not on-stack on any CPU other than `self_cpu`.
+    None,
+    /// Named current on another CPU (running or idle-on-its-stack there).
+    Current,
+    /// Off-current everywhere, but a CPU is still on its kernel stack.
+    OnStack,
+}
+
+/// Classify why `tid` is live on a CPU other than `self_cpu` (see
+/// [`OtherCpuLiveness`]).  `Current` takes precedence over `OnStack`: a thread
+/// named current somewhere is actively live regardless of any on-stack slot.
+/// `tid == 0` (the idle/bootstrap sentinel) and a uniprocessor (`self_cpu` the
+/// only CPU) both classify as [`OtherCpuLiveness::None`], so SMP=1 is inert.
+/// Each slot is read `Acquire` to pair with the `Release` publish in
+/// `set_current_tid` / `set_onstack_tid`.
+pub fn other_cpu_liveness(tid: Tid, self_cpu: usize) -> OtherCpuLiveness {
     if tid == 0 {
-        return false;
+        return OtherCpuLiveness::None;
     }
     let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
         .min(crate::arch::x86_64::apic::MAX_CPUS);
+    let mut on_stack = false;
     for cpu in 0..ncpus {
         if cpu == self_cpu {
             continue;
         }
-        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid
-            || PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid
-        {
-            return true;
+        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid {
+            return OtherCpuLiveness::Current;
+        }
+        if PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid {
+            on_stack = true;
         }
     }
-    false
+    if on_stack {
+        OtherCpuLiveness::OnStack
+    } else {
+        OtherCpuLiveness::None
+    }
 }
 
 /// Read the currently running PID for an arbitrary CPU index.  See

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -102,17 +102,38 @@ pub fn note_switch_completed() {
     crate::proc::set_onstack_tid(crate::proc::current_tid());
 }
 
-/// On-CPU dispatch-interlock counter: number of times a candidate was DEFERRED
-/// from dispatch/work-steal because it was still live (current or on-stack) on
-/// another CPU.  A non-zero value proves the #655 double-dispatch race was
-/// occurring and is now being caught.  Read via [`double_dispatch_defers`].
+/// On-CPU dispatch-interlock counter: number of times a candidate was deferred
+/// from dispatch/work-steal because a CPU was still physically on its kernel
+/// stack through the `switch_context_asm` epilogue — the genuine switch-OUT
+/// double-dispatch window (`OtherCpuLiveness::OnStack`).  A non-zero value proves
+/// the #655 double-dispatch race was occurring and is now being caught.  The
+/// high-volume benign case (the candidate is simply another CPU's *current*
+/// thread) is tallied separately in [`BENIGN_CURRENT_DEFERS`] so it never drowns
+/// this signal.  Read via [`double_dispatch_defers`].
 static DOUBLE_DISPATCH_DEFERS: AtomicU64 = AtomicU64::new(0);
+
+/// Benign on-CPU-interlock refusals: the candidate was the CURRENT thread on
+/// another CPU (running there, or that CPU idle-halting on its stack).  Declining
+/// to also dispatch it is ordinary "don't run one thread on two CPUs" and can
+/// recur at millions of refusals per second when one CPU is saturated (e.g. a
+/// content futex storm) and a peer's `try_steal_to` repeatedly probes it for
+/// stealable work — so this is counted without a per-event serial line.  Kept
+/// separate from [`DOUBLE_DISPATCH_DEFERS`] so the genuine switch-OUT signal is
+/// not buried.  Diagnostic only; does not affect scheduling.
+static BENIGN_CURRENT_DEFERS: AtomicU64 = AtomicU64::new(0);
 
 /// Read the on-CPU dispatch-interlock defer counter (see
 /// [`DOUBLE_DISPATCH_DEFERS`]).
 #[inline]
 pub fn double_dispatch_defers() -> u64 {
     DOUBLE_DISPATCH_DEFERS.load(Ordering::Relaxed)
+}
+
+/// Read the benign steady-state interlock-refusal counter (see
+/// [`BENIGN_CURRENT_DEFERS`]).
+#[inline]
+pub fn benign_current_defers() -> u64 {
+    BENIGN_CURRENT_DEFERS.load(Ordering::Relaxed)
 }
 
 /// The on-CPU dispatch interlock, applied at every dispatch/resume/work-steal
@@ -129,18 +150,33 @@ pub fn double_dispatch_defers() -> u64 {
 /// executions tore its single kernel stack's saved switch frame in place.
 #[inline]
 pub(crate) fn defer_if_live_on_other_cpu(tid: proc::Tid, self_cpu: usize) -> bool {
-    if proc::is_tid_live_on_other_cpu(tid, self_cpu) {
-        let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
-        if n <= 16 || n % 4096 == 0 {
-            crate::serial_println!(
-                "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
-                 (still live on another CPU) total_defers={}",
-                tid, self_cpu, n,
-            );
+    match proc::other_cpu_liveness(tid, self_cpu) {
+        // Not live elsewhere — dispatch is safe.
+        proc::OtherCpuLiveness::None => false,
+        // Benign steady-state refusal: `tid` is another CPU's current thread.
+        // Correct to defer, but expected and extremely high-volume (a saturated
+        // peer probed for work), so tally it separately and do NOT emit a serial
+        // line — otherwise this drowns the genuine switch-OUT signal below (a
+        // single wedged workload once emitted ~15M of these lines).
+        proc::OtherCpuLiveness::Current => {
+            BENIGN_CURRENT_DEFERS.fetch_add(1, Ordering::Relaxed);
+            true
         }
-        true
-    } else {
-        false
+        // The genuine #655 double-dispatch window: `tid` is off-current
+        // everywhere but a CPU is still on its kernel stack through the switch
+        // epilogue.  This is the event the interlock exists to catch — count and
+        // (rate-limited) log it so the signal stays visible.
+        proc::OtherCpuLiveness::OnStack => {
+            let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
+            if n <= 16 || n % 4096 == 0 {
+                crate::serial_println!(
+                    "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
+                     (on-stack mid-switch on another CPU) total_defers={}",
+                    tid, self_cpu, n,
+                );
+            }
+            true
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The on-CPU dispatch interlock (the #655 double-dispatch guard) defers a candidate whenever it is still live on another CPU — either because that CPU holds it as **current**, or because a CPU is still physically on its kernel stack through the context-switch epilogue (`PER_CPU_ONSTACK_TID`). Both correctly forbid dispatch here, but only the second is the race the interlock was built to catch.

The **"current on another CPU"** case is ordinary steady-state: it fires whenever a peer's `try_steal_to` probe (or the pick candidate filter) considers a thread that is simply running — or idle-halting on its own kernel stack, which per `sti; hlt; cli` never leaves that stack — on the other core. Under a saturated core (one CPU pinned by a busy content workload while its peer repeatedly probes it for stealable work) this refusal recurs at up to millions/sec and, being rate-limit-logged, buries the genuine signal in serial noise — **a single wedged SMP=2 workload emitted ~15M `[SCHED/INTERLOCK]` lines.**

## Change

Classify the liveness instead of collapsing it to a bool: `proc::other_cpu_liveness` → `None` / `Current` / `OnStack` (`Acquire` loads pair with the `Release` publishes in `set_current_tid`/`set_onstack_tid` per the acquire/release ordering rules in Intel SDM Vol. 3A §8.2).

- **`Current`** (benign, high-volume) → tallied in a new `BENIGN_CURRENT_DEFERS` aggregate, **no per-event serial line**.
- **`OnStack`** (the genuine switch-OUT double-dispatch window) → increments `DOUBLE_DISPATCH_DEFERS` and emits the rate-limited `[SCHED/INTERLOCK]` line, restoring that counter to its original purpose of proving the #655 race is caught.

The dispatch **decision is bit-for-bit unchanged** (both live kinds still defer; `None` still dispatches). **SMP=1 is inert** (`other_cpu_liveness` returns `None` when the caller is the only CPU).

## Verification

SMP=2 Firefox (Wikipedia) boot to tick ~28k:
- benign `still live on another CPU` lines: **0** (was the dominant source)
- genuine `on-stack mid-switch` lines: **16** (total_defers=16 — the real #655 window still logged)
- **0** bugcheck/panic, FF loading normally — no scheduling regression.

## Context

Cosmetic/observability only — no behavior change. Found during the SMP=2 "#673 interlock livelock" autopsy: that wedge is a symptom (cpu0 dead-timer + saturated cpu1) whose visible artifact was this benign-defer spam; the interlock itself is correct. Self-authored kernel change — **please review before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
