### PR TITLE
mm: W215 write-protect #PF trap — name the in-place page-cache clobber writer (diagnostic, do-not-merge)

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -339,6 +339,15 @@ native-core-tests = []
 # preserving on-demand investigative access.  Implies `firefox-test`
 # because the diagnostic shares the firefox-test cache instrumentation.
 w215-diag = ["firefox-test"]
+# W215 write-protect #PF trap.  Arms a read-only mapping on the higher-half
+# direct-map alias of a verified cluster code page at cache insert; the next
+# supervisor write to it raises a protection-violation #PF that the page-fault
+# handler recognises and freezes on (naming the in-place clobber writer's RIP).
+# Implies `w215-diag` (shares the cluster-key / phys-window definitions and the
+# firefox-test cache instrumentation).  Diagnostic-only; default and plain
+# `w215-diag` builds are byte-identical (the module and all call sites are
+# gated on this feature).
+w215-wptrap = ["w215-diag"]
 # #582 torn-saved-RFLAGS-slot writer probe.  Arms a DR0 8-byte data-write
 # watch on context-switch victims' saved-RFLAGS slots
 # (`Thread::context.rsp + 0`) and classifies the writer of any store to

--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1444,6 +1444,28 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
         }
     }
 
+    // === W215 write-protect trap (w215-wptrap diagnostic) ===
+    //
+    // A supervisor write (U=0, W=1) to a *present* page (P=1) that lands on the
+    // higher-half direct map is a protection violation.  If the target frame is
+    // one this diagnostic write-protected — a verified cluster code page — the
+    // interrupted instruction is the in-place W215 clobber writer.  The
+    // faulting linear address IS the direct-map alias, so the physical frame is
+    // simply `CR2 - PHYS_OFF` (no page walk).  Freeze here for a GDB autopsy.
+    // Checked before the demand-paging path so we do not treat the WP fault as
+    // a recoverable demand fault.  Per Intel SDM Vol. 3A §4.6 (R/W bit).
+    #[cfg(feature = "w215-wptrap")]
+    {
+        const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+        if is_present && is_write && !_is_user && faulting_addr >= PHYS_OFF {
+            let phys = (faulting_addr - PHYS_OFF) & !0xFFFu64;
+            if crate::mm::w215_wptrap::is_protected(phys) {
+                // Does not return — bugchecks to freeze the machine.
+                crate::mm::w215_wptrap::report_and_freeze(phys, faulting_addr, frame);
+            }
+        }
+    }
+
     // Lockless PID lookup: the page-fault handler runs in interrupt context
     // (IF=0 on entry via the interrupt gate).  A kernel-mode #PF can fire
     // while a syscall on the same CPU already holds THREAD_TABLE — taking
@@ -2715,6 +2737,19 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                 #[cfg(feature = "w215-diag")]
                 if is_shared && is_writable_vma {
                     crate::mm::w215_crc::mark_writable_shared(phys);
+                }
+
+                // W215 write-protect trap: arm a read-only trap on this frame's
+                // higher-half direct-map alias so the next in-place kernel write
+                // to it is caught red-handed.  Only for read-only (code) cluster
+                // pages — a legitimately-writable MAP_SHARED page mutates in
+                // place by contract (POSIX mmap(2)) and must never be armed.
+                // Reaching here means `insert_with_expected` verified the frame
+                // content against the source bytes, so we protect a known-good
+                // page.  `arm` itself filters to the cluster phys window.
+                #[cfg(feature = "w215-wptrap")]
+                if !is_writable_vma {
+                    crate::mm::w215_wptrap::arm(phys, inode, foff);
                 }
 
                 // W215 diagnostic Arm-2: my own pre-insert witness is now

--- a/kernel/src/ke/bugcheck.rs
+++ b/kernel/src/ke/bugcheck.rs
@@ -100,6 +100,17 @@ pub const BUGCHECK_W215_INSERT_WRONG_CONTENT: u32 = 0xDEAD_0008;
 /// (P3/P4 give the at-failure occupancy without re-locking the allocator).
 /// See the Rust `core::alloc::{GlobalAlloc, Layout}` allocation-error contract.
 pub const BUGCHECK_HEAP_EXHAUSTED: u32 = 0xDEAD_0009;
+/// AstryxOS (W215 write-protect trap, `w215-wptrap` diagnostic): a supervisor
+/// write faulted on a verified page-cache code frame that this diagnostic had
+/// made read-only on its higher-half direct-map alias.  A verified code page
+/// has no legitimate kernel writer for the rest of its cache residency, so the
+/// interrupted instruction is the in-place W215 clobber writer.  The machine is
+/// frozen here so the store can be autopsied under GDB.  P1 = writer RIP,
+/// P2 = CR2 (faulting direct-map alias), P3 = protected phys, P4 = refcount at
+/// fault.  Per Intel SDM Vol. 3A §4.6 (R/W access-right violation).  Gated on
+/// `w215-wptrap` so non-diagnostic builds remain byte-identical.
+#[cfg(feature = "w215-wptrap")]
+pub const BUGCHECK_W215_WP_TRAP: u32 = 0xDEAD_000A;
 
 /// Human-readable bug-check name, returned as a `&'static str` from a
 /// match against rodata literals.  This MUST NOT allocate — the
@@ -119,6 +130,8 @@ pub fn bugcheck_name(code: u32) -> &'static str {
         BUGCHECK_KERNEL_GPF          => "KERNEL_GPF",
         BUGCHECK_W215_INSERT_WRONG_CONTENT => "W215_INSERT_WRONG_CONTENT",
         BUGCHECK_HEAP_EXHAUSTED      => "HEAP_EXHAUSTED",
+        #[cfg(feature = "w215-wptrap")]
+        BUGCHECK_W215_WP_TRAP        => "W215_WP_TRAP",
         _                            => "UNKNOWN_BUGCHECK",
     }
 }

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -487,6 +487,13 @@ pub fn insert_with_expected(
     }
 
     if let Some(old_phys) = evicted_zero_rc {
+        // W215 write-protect trap: the evicted frame has reached rc==0 and is
+        // about to be recycled.  If this diagnostic had write-protected it,
+        // restore write access first so the recycled frame is not left
+        // read-only for its next tenant.  Runs with no lock held (the cache
+        // lock was released above).
+        #[cfg(feature = "w215-wptrap")]
+        crate::mm::w215_wptrap::disarm(old_phys);
         // Defer PMM release through the quarantine to ensure any stale
         // TLB entry on a sibling CPU is retired before the frame is
         // recycled.  See module-level doc for the quiescent-state

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -26,6 +26,12 @@ pub mod file_buf_witness;
 pub mod w215_crc;
 #[cfg(feature = "firefox-test-core")]
 pub mod w215_diag;
+// W215 write-protect page-fault trap: names the in-place clobber writer by
+// trapping the store to a verified cluster code page.  Gated behind its own
+// feature (implies `w215-diag`) so default and plain-diag builds are
+// unaffected.  See `w215_wptrap.rs`.
+#[cfg(feature = "w215-wptrap")]
+pub mod w215_wptrap;
 // PSE 2026-05-20: `[VMA-DUMP]` on fatal user-mode exceptions.  Used by
 // `vma-dump-on-gp` to anchor PIE-ASLR bases at the moment a process is
 // torn down.  See `vma_dump.rs` for line format and emission cap.

--- a/kernel/src/mm/w215_wptrap.rs
+++ b/kernel/src/mm/w215_wptrap.rs
@@ -1,0 +1,372 @@
+//! W215 write-protect page-fault trap (diagnostic, `w215-wptrap`-gated).
+//!
+//! ## Purpose
+//!
+//! The residual W215 corruption is an **in-place store** into a live,
+//! reference-held page-cache frame that holds verified-correct library code
+//! (libxul / satellite `.text`).  No allocator, free, or page-table event is
+//! hooked at the moment of that store, so the passive per-phys provenance
+//! shadows (`w215_diag` FREE_SHADOW / ALLOC_SHADOW / PROV) can classify the
+//! frame's lifecycle but can never name the *writer's* RIP.
+//!
+//! This module names the writer directly by **trapping the store**: at cache
+//! insert of a hot cluster frame, after the frame's contents are verified to
+//! match the source bytes, the frame is made read-only on its canonical
+//! higher-half direct-map alias (`PHYS_OFF + phys`).  A verified code page has
+//! no legitimate kernel writer for the remainder of its cache residency, so
+//! the *next* supervisor write to it — the W215 clobber — raises a
+//! protection-violation `#PF` (error code P=1, W=1, U=0).  The page-fault
+//! handler recognises the fault as a WP-trap, records the interrupted RIP,
+//! CR2, tid/pid, refcount and tick, then bugchecks to freeze the machine for a
+//! GDB autopsy of the offending instruction.
+//!
+//! ## Coverage and limitations (see the PR body)
+//!
+//! * The write-protect is on the higher-half direct-map alias only.  This is
+//!   the alias every kernel `memset` / `copy_nonoverlapping` / zero-fill path
+//!   uses (`PHYS_OFF + phys`), which is the suspected in-place writer class.
+//!   A writer that reaches the frame through some *other* kernel mapping would
+//!   not trap; user `.text` aliases are already read-only (`r-x`) so they are
+//!   not the writer.
+//! * Device DMA writes bypass CPU paging and cannot raise a `#PF`; the W215
+//!   class under investigation is a CPU-side in-place store (the DMA-recycle
+//!   class was addressed separately).
+//! * Arming is bounded to a small pool and restricted to the historical
+//!   cluster window, so the perturbation to the running system is minimal.
+//!
+//! ## Safety of the direct-map mutation
+//!
+//! The 2 MiB huge page that covers the target frame in the higher-half map is
+//! split into 512 × 4 KiB entries by the existing, boot-proven
+//! `vmm::get_or_create_entry` split path (invoked through `vmm::map_page`).
+//! That split fills every sub-entry with the *same* physical base + flags the
+//! huge page carried, so neighbouring frames keep their exact mapping and
+//! writability; only the single target PTE has its writable bit cleared.  A
+//! local `invlpg` plus a cross-CPU shootdown retires any stale writable TLB
+//! entry before the trap can be relied upon.
+//!
+//! ## Public spec citations
+//!
+//! * Intel SDM Vol. 3A §4.6 (access rights / the R/W and U/S bits), §4.10.4
+//!   (invalidation of TLBs and paging-structure caches — `INVLPG`), §4.10.5
+//!   (propagating paging-structure changes across processors).
+//! * POSIX 1003.1-2024 mmap(2) — `MAP_PRIVATE`/`PROT_EXEC` file mappings serve
+//!   the file's bytes; a served code page must equal the on-disk bytes.
+//!
+//! ## ISR / lock safety
+//!
+//! `is_protected` and `report_and_freeze` are called from the page-fault
+//! handler (IF=0) and use only atomics — no locks.  `arm` / `disarm` call
+//! `vmm::map_page` (which takes `VMM_LOCK`) and `tlb::shootdown_page`; they run
+//! from the cache-insert path with **no other lock held** (the cache lock has
+//! already been released at the arm/disarm sites).
+
+#![cfg(feature = "w215-wptrap")]
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use crate::mm::vmm::{self, PHYS_OFF, PAGE_PRESENT, PAGE_WRITABLE};
+
+/// Number of frames that can be write-protected concurrently.  Matches the
+/// order of magnitude of the DR pre-arm pool; a handful of hot cluster code
+/// pages is enough to catch the flaky clobber while keeping the perturbation
+/// (and the per-fault scan cost) small.
+const PROT_SLOTS: usize = 64;
+
+/// Cluster window matching `cache.rs`'s `W215_PREARM_PHYS_{LO,HI}` — the
+/// historical libxul fingerprint cluster.  Frames outside this window are
+/// never armed (keeps the trap targeted at the code pages under suspicion).
+const CLUSTER_PHYS_LO: u64 = 0x1000_0000; // 256 MiB
+const CLUSTER_PHYS_HI: u64 = 0x4000_0000; // 1 GiB
+
+/// One protected-frame record.  `phys == 0` means the slot is free.
+#[repr(C)]
+struct ProtEntry {
+    /// Page-aligned physical address of the protected frame (0 = empty).
+    phys: AtomicU64,
+    /// Cache key inode (for the fire line) — best-effort.
+    inode: AtomicU64,
+    /// Cache key page offset (for the fire line) — best-effort.
+    offset: AtomicU64,
+}
+
+impl ProtEntry {
+    const fn new() -> Self {
+        Self {
+            phys: AtomicU64::new(0),
+            inode: AtomicU64::new(0),
+            offset: AtomicU64::new(0),
+        }
+    }
+}
+
+struct ProtTable {
+    slots: [ProtEntry; PROT_SLOTS],
+}
+
+impl ProtTable {
+    const fn new() -> Self {
+        const E: ProtEntry = ProtEntry::new();
+        Self { slots: [E; PROT_SLOTS] }
+    }
+}
+
+static PROT: ProtTable = ProtTable::new();
+
+// ── Counters (kdb-readable) ─────────────────────────────────────────────────
+static ARMED: AtomicU64 = AtomicU64::new(0);
+static DISARMED: AtomicU64 = AtomicU64::new(0);
+static ARM_TABLE_FULL: AtomicU64 = AtomicU64::new(0);
+static SHOOTDOWN_TIMEOUTS: AtomicU64 = AtomicU64::new(0);
+static FIRES: AtomicU64 = AtomicU64::new(0);
+
+pub fn armed_count() -> u64 { ARMED.load(Ordering::Relaxed) }
+pub fn disarmed_count() -> u64 { DISARMED.load(Ordering::Relaxed) }
+pub fn arm_table_full_count() -> u64 { ARM_TABLE_FULL.load(Ordering::Relaxed) }
+pub fn shootdown_timeout_count() -> u64 { SHOOTDOWN_TIMEOUTS.load(Ordering::Relaxed) }
+pub fn fire_count() -> u64 { FIRES.load(Ordering::Relaxed) }
+
+/// Number of slots currently occupied (kdb introspection).
+pub fn protected_count() -> usize {
+    PROT.slots
+        .iter()
+        .filter(|s| s.phys.load(Ordering::Relaxed) != 0)
+        .count()
+}
+
+/// Is `phys` (page-aligned) currently write-protected by this module?
+///
+/// Called from the page-fault handler on every supervisor write-present fault
+/// to a higher-half direct-map address.  A linear scan of `PROT_SLOTS`
+/// atomics; cheap because such faults are rare.
+#[inline]
+pub fn is_protected(phys: u64) -> bool {
+    let p = phys & !0xFFFu64;
+    if p == 0 {
+        return false;
+    }
+    PROT.slots
+        .iter()
+        .any(|s| s.phys.load(Ordering::Acquire) == p)
+}
+
+/// Write-protect `phys` on its higher-half direct-map alias and register it.
+///
+/// No-op when `phys` is outside the cluster window, already protected, or the
+/// table is full.  Must be called with no lock held (takes `VMM_LOCK` via
+/// `map_page`).
+pub fn arm(phys: u64, inode: u64, offset: u64) {
+    let p = phys & !0xFFFu64;
+    if p < CLUSTER_PHYS_LO || p >= CLUSTER_PHYS_HI {
+        return;
+    }
+    // Already protected? (idempotent)
+    if is_protected(p) {
+        return;
+    }
+    // Claim a free slot.
+    let mut slot_idx = None;
+    for (i, s) in PROT.slots.iter().enumerate() {
+        // Claim atomically: only take a slot whose phys is still 0.
+        if s.phys
+            .compare_exchange(0, p, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            s.inode.store(inode, Ordering::Relaxed);
+            s.offset.store(offset, Ordering::Relaxed);
+            slot_idx = Some(i);
+            break;
+        }
+    }
+    if slot_idx.is_none() {
+        ARM_TABLE_FULL.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
+    // Write-protect the higher-half direct-map alias: present, supervisor,
+    // read-only.  `map_page` splits the covering 2 MiB huge page as needed;
+    // neighbouring sub-pages keep their (writable) mapping — see module doc.
+    let va = PHYS_OFF + p;
+    let ok = vmm::map_page(va, p, PAGE_PRESENT); // no PAGE_WRITABLE ⇒ read-only
+    if !ok {
+        // Roll the slot back so we don't claim a frame we failed to protect.
+        for s in PROT.slots.iter() {
+            if s.phys.load(Ordering::Relaxed) == p {
+                s.phys.store(0, Ordering::Release);
+                break;
+            }
+        }
+        return;
+    }
+    vmm::invlpg(va);
+    if !crate::mm::tlb::shootdown_page(vmm::get_cr3(), va) {
+        SHOOTDOWN_TIMEOUTS.fetch_add(1, Ordering::Relaxed);
+    }
+    let n = ARMED.fetch_add(1, Ordering::Relaxed);
+    if n < 16 || n % 256 == 0 {
+        crate::serial_println!(
+            "[W215/WP-ARM] phys={:#x} va={:#x} inode={:#x} offset={:#x} n={}",
+            p, va, inode, offset, n,
+        );
+    }
+}
+
+/// Restore write access to `phys` and free its slot, if it is protected.
+///
+/// Called when the frame leaves the cache (eviction) so a recycled frame is
+/// never left read-only.  No-op when `phys` is not protected.  Takes
+/// `VMM_LOCK` via `map_page`; must be called with no lock held.
+pub fn disarm(phys: u64) {
+    let p = phys & !0xFFFu64;
+    if p == 0 {
+        return;
+    }
+    let mut found = false;
+    for s in PROT.slots.iter() {
+        if s.phys
+            .compare_exchange(p, 0, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return;
+    }
+    // Restore present + writable + supervisor on the direct-map alias.
+    let va = PHYS_OFF + p;
+    let _ = vmm::map_page(va, p, PAGE_WRITABLE);
+    vmm::invlpg(va);
+    if !crate::mm::tlb::shootdown_page(vmm::get_cr3(), va) {
+        SHOOTDOWN_TIMEOUTS.fetch_add(1, Ordering::Relaxed);
+    }
+    DISARMED.fetch_add(1, Ordering::Relaxed);
+}
+
+/// The page-fault handler caught a supervisor write to a protected frame — the
+/// W215 clobber writer, red-handed.  Record everything and bugcheck to freeze
+/// the machine at the offending store for a GDB autopsy.
+///
+/// `phys` is the protected frame, `cr2` the faulting linear address (the
+/// direct-map alias written), `frame` the interrupt frame (its `rip` is the
+/// writer).  Does not return.
+#[inline(never)]
+pub fn report_and_freeze(
+    phys: u64,
+    cr2: u64,
+    frame: &crate::arch::x86_64::idt::InterruptFrame,
+) -> ! {
+    FIRES.fetch_add(1, Ordering::Relaxed);
+    let p = phys & !0xFFFu64;
+    let rip = frame.rip;
+    let tid = crate::proc::current_tid();
+    let pid = crate::proc::current_pid_lockless();
+    let rc = crate::mm::refcount::page_ref_count(p);
+    let tick = crate::arch::x86_64::irq::TICK_COUNT.load(Ordering::Relaxed);
+
+    // Recover the cache key recorded at arm time.
+    let mut inode = 0u64;
+    let mut offset = 0u64;
+    for s in PROT.slots.iter() {
+        if s.phys.load(Ordering::Relaxed) == p {
+            inode = s.inode.load(Ordering::Relaxed);
+            offset = s.offset.load(Ordering::Relaxed);
+            break;
+        }
+    }
+
+    // Sample the current (pre-store) frame bytes.  The frame is present + RO,
+    // so this read is safe.  The store's operand value is not in the frame yet
+    // — decode it from the frozen instruction at `rip` under GDB.
+    let src = (PHYS_OFF + p) as *const u8;
+    let mut b = [0u8; 16];
+    for i in 0..16 {
+        b[i] = unsafe { core::ptr::read_volatile(src.add(i)) };
+    }
+
+    crate::serial_println!(
+        "[W215/WP-TRAP] writer_rip={:#x} cr2={:#x} phys={:#x} rc={} tid={} pid={} \
+         inode={:#x} offset={:#x} tick={} cur_bytes={:02x}{:02x}{:02x}{:02x}\
+         {:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        rip, cr2, p, rc, tid, pid, inode, offset, tick,
+        b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15],
+    );
+    crate::serial_println!(
+        "[W215/WP-TRAP] the interrupted RIP is the in-place clobber writer — \
+         autopsy the store operand at that RIP; phys is a verified cluster code page"
+    );
+
+    crate::ke::bugcheck::ke_bugcheck(
+        crate::ke::bugcheck::BUGCHECK_W215_WP_TRAP,
+        rip,
+        cr2,
+        p,
+        rc as u64,
+    );
+}
+
+/// The cluster phys window (`[lo, hi)`) this trap arms within.  Exposed for
+/// tests and kdb.
+pub fn cluster_window() -> (u64, u64) {
+    (CLUSTER_PHYS_LO, CLUSTER_PHYS_HI)
+}
+
+/// Self-test of the load-bearing correctness property: write-protecting one
+/// frame on the higher-half direct map splits the covering 2 MiB huge page
+/// **without** disturbing its neighbours.
+///
+/// Drives the real `vmm::map_page` protect/restore primitive on `phys` (the
+/// caller supplies a scratch frame it owns) and its `+4 KiB` neighbour, and
+/// returns `(protected_ro_ok, neighbour_safe, restored_ok)`:
+///   * `protected_ro_ok` — after protect, `PHYS_OFF+phys` is present,
+///     **read-only**, and still maps to `phys`.
+///   * `neighbour_safe`  — after protect, `PHYS_OFF+phys+0x1000` is present,
+///     **writable**, and still maps to `phys+0x1000` (the split preserved it).
+///   * `restored_ok`     — after restore, `PHYS_OFF+phys` is present,
+///     **writable**, and still maps to `phys`.
+///
+/// The scratch frame is left writable (restored) on return; the caller frees
+/// it.  Bypasses the cluster-window filter and the `PROT` table on purpose —
+/// this exercises only the page-table split/protect/restore primitive.
+pub fn selftest(phys: u64) -> (bool, bool, bool) {
+    let p = phys & !0xFFFu64;
+    let neigh = p + 0x1000;
+    let va = PHYS_OFF + p;
+    let nva = PHYS_OFF + neigh;
+
+    // Helper: (present, writable, phys) for a leaf VA in the kernel map.
+    let probe = |virt: u64, expect_phys: u64| -> (bool, bool, bool) {
+        match vmm::lookup_pte_in(vmm::get_cr3(), virt) {
+            Some(pte) => {
+                let present = pte & PAGE_PRESENT != 0;
+                let writable = pte & PAGE_WRITABLE != 0;
+                let phys_ok = (pte & crate::mm::vmm::ADDR_MASK) == expect_phys;
+                (present, writable, phys_ok)
+            }
+            // None ⇒ still a huge page or non-present: neither present-leaf.
+            None => (false, false, false),
+        }
+    };
+
+    // Protect the target frame read-only (splits the huge page).
+    let _ = vmm::map_page(va, p, PAGE_PRESENT);
+    vmm::invlpg(va);
+    vmm::invlpg(nva);
+
+    let (t_present, t_writable, t_phys) = probe(va, p);
+    let protected_ro_ok = t_present && !t_writable && t_phys;
+
+    let (n_present, n_writable, n_phys) = probe(nva, neigh);
+    let neighbour_safe = n_present && n_writable && n_phys;
+
+    // Restore write access to the target frame.
+    let _ = vmm::map_page(va, p, PAGE_WRITABLE);
+    vmm::invlpg(va);
+
+    let (r_present, r_writable, r_phys) = probe(va, p);
+    let restored_ok = r_present && r_writable && r_phys;
+
+    (protected_ro_ok, neighbour_safe, restored_ok)
+}

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1410,40 +1410,83 @@ pub fn is_tid_on_stack_any_cpu(tid: Tid) -> bool {
     false
 }
 
-/// On-CPU dispatch interlock: returns `true` if `tid` is still live — currently
-/// dispatched (`PER_CPU_CURRENT_TID`) **or** physically executing on its kernel
-/// stack (`PER_CPU_ONSTACK_TID`) — on any logical CPU OTHER than `self_cpu`.
+/// On-CPU dispatch interlock, classifier form.
 ///
 /// A thread that is still live on another CPU must never be dispatched/resumed
 /// here: it owns a single kernel stack, and running it on two CPUs at once lets
 /// each tear the other's saved `switch_context` frame in place (the SMP
-/// kernel-stack double-dispatch corruption).  This is the realisation, at our
-/// cooperative pick site, of the standard SMP wakeup interlock — a task carries
-/// an "on-CPU" marker held across the context switch, and a remote runqueue must
-/// not re-place the task until that marker clears.  Both signals are published
-/// with `Release` (`set_current_tid` / `set_onstack_tid`); the `Acquire` loads
-/// here pair with them so observing a CPU as no longer running/holding `tid` also
-/// observes that CPU's final stack writes for `tid` as retired.
+/// kernel-stack double-dispatch corruption, #655).  This is the realisation, at
+/// our cooperative pick site, of the standard SMP wakeup interlock — a task
+/// carries an "on-CPU" marker held across the context switch, and a remote
+/// runqueue must not re-place the task until that marker clears.  Both signals
+/// are published with `Release` (`set_current_tid` / `set_onstack_tid`); the
+/// `Acquire` loads here pair with them so observing a CPU as no longer
+/// running/holding `tid` also observes that CPU's final stack writes for `tid`
+/// as retired.  `self_cpu` is excluded so a thread legitimately re-selected on
+/// the very CPU it last ran on (the common no-migration case) is never
+/// spuriously deferred.
 ///
-/// `self_cpu` is excluded so a thread legitimately re-selected on the very CPU
-/// it last ran on (the common no-migration case) is never spuriously deferred.
-pub fn is_tid_live_on_other_cpu(tid: Tid, self_cpu: usize) -> bool {
+/// This enum classifies WHY a thread is live on another CPU.
+/// The interlock DECISION (defer or not) is the same for both live kinds — a
+/// thread live on another CPU must never be dispatched here.  The distinction
+/// exists only so diagnostics can separate the high-volume, expected
+/// steady-state refusal from the rare event the interlock was actually built to
+/// catch:
+///
+///   * [`Current`](Self::Current) — the thread is the CURRENT thread on another
+///     CPU (running there, or that CPU is idle-halting *on the thread's kernel
+///     stack* — no context switch leaves that stack, so `PER_CPU_CURRENT_TID`
+///     legitimately still names it).  Declining to also dispatch it here is
+///     ordinary "don't run one thread on two CPUs" and recurs at up to millions
+///     of refusals per second when one CPU is saturated and a peer repeatedly
+///     probes it for stealable work.  It is NOT the double-dispatch race.
+///
+///   * [`OnStack`](Self::OnStack) — the thread is no longer named current on any
+///     CPU, but a CPU is still physically on its kernel stack through the
+///     `switch_context_asm` epilogue (`PER_CPU_ONSTACK_TID`).  Dispatching it
+///     here would resume it onto the very stack that CPU is still unwinding and
+///     tear its saved switch frame in place.  This is precisely the switch-OUT
+///     double-dispatch window the interlock exists to close.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OtherCpuLiveness {
+    /// Not current and not on-stack on any CPU other than `self_cpu`.
+    None,
+    /// Named current on another CPU (running or idle-on-its-stack there).
+    Current,
+    /// Off-current everywhere, but a CPU is still on its kernel stack.
+    OnStack,
+}
+
+/// Classify why `tid` is live on a CPU other than `self_cpu` (see
+/// [`OtherCpuLiveness`]).  `Current` takes precedence over `OnStack`: a thread
+/// named current somewhere is actively live regardless of any on-stack slot.
+/// `tid == 0` (the idle/bootstrap sentinel) and a uniprocessor (`self_cpu` the
+/// only CPU) both classify as [`OtherCpuLiveness::None`], so SMP=1 is inert.
+/// Each slot is read `Acquire` to pair with the `Release` publish in
+/// `set_current_tid` / `set_onstack_tid`.
+pub fn other_cpu_liveness(tid: Tid, self_cpu: usize) -> OtherCpuLiveness {
     if tid == 0 {
-        return false;
+        return OtherCpuLiveness::None;
     }
     let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
         .min(crate::arch::x86_64::apic::MAX_CPUS);
+    let mut on_stack = false;
     for cpu in 0..ncpus {
         if cpu == self_cpu {
             continue;
         }
-        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid
-            || PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid
-        {
-            return true;
+        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid {
+            return OtherCpuLiveness::Current;
+        }
+        if PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid {
+            on_stack = true;
         }
     }
-    false
+    if on_stack {
+        OtherCpuLiveness::OnStack
+    } else {
+        OtherCpuLiveness::None
+    }
 }
 
 /// Read the currently running PID for an arbitrary CPU index.  See

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -102,17 +102,38 @@ pub fn note_switch_completed() {
     crate::proc::set_onstack_tid(crate::proc::current_tid());
 }
 
-/// On-CPU dispatch-interlock counter: number of times a candidate was DEFERRED
-/// from dispatch/work-steal because it was still live (current or on-stack) on
-/// another CPU.  A non-zero value proves the #655 double-dispatch race was
-/// occurring and is now being caught.  Read via [`double_dispatch_defers`].
+/// On-CPU dispatch-interlock counter: number of times a candidate was deferred
+/// from dispatch/work-steal because a CPU was still physically on its kernel
+/// stack through the `switch_context_asm` epilogue — the genuine switch-OUT
+/// double-dispatch window (`OtherCpuLiveness::OnStack`).  A non-zero value proves
+/// the #655 double-dispatch race was occurring and is now being caught.  The
+/// high-volume benign case (the candidate is simply another CPU's *current*
+/// thread) is tallied separately in [`BENIGN_CURRENT_DEFERS`] so it never drowns
+/// this signal.  Read via [`double_dispatch_defers`].
 static DOUBLE_DISPATCH_DEFERS: AtomicU64 = AtomicU64::new(0);
+
+/// Benign on-CPU-interlock refusals: the candidate was the CURRENT thread on
+/// another CPU (running there, or that CPU idle-halting on its stack).  Declining
+/// to also dispatch it is ordinary "don't run one thread on two CPUs" and can
+/// recur at millions of refusals per second when one CPU is saturated (e.g. a
+/// content futex storm) and a peer's `try_steal_to` repeatedly probes it for
+/// stealable work — so this is counted without a per-event serial line.  Kept
+/// separate from [`DOUBLE_DISPATCH_DEFERS`] so the genuine switch-OUT signal is
+/// not buried.  Diagnostic only; does not affect scheduling.
+static BENIGN_CURRENT_DEFERS: AtomicU64 = AtomicU64::new(0);
 
 /// Read the on-CPU dispatch-interlock defer counter (see
 /// [`DOUBLE_DISPATCH_DEFERS`]).
 #[inline]
 pub fn double_dispatch_defers() -> u64 {
     DOUBLE_DISPATCH_DEFERS.load(Ordering::Relaxed)
+}
+
+/// Read the benign steady-state interlock-refusal counter (see
+/// [`BENIGN_CURRENT_DEFERS`]).
+#[inline]
+pub fn benign_current_defers() -> u64 {
+    BENIGN_CURRENT_DEFERS.load(Ordering::Relaxed)
 }
 
 /// The on-CPU dispatch interlock, applied at every dispatch/resume/work-steal
@@ -129,18 +150,33 @@ pub fn double_dispatch_defers() -> u64 {
 /// executions tore its single kernel stack's saved switch frame in place.
 #[inline]
 pub(crate) fn defer_if_live_on_other_cpu(tid: proc::Tid, self_cpu: usize) -> bool {
-    if proc::is_tid_live_on_other_cpu(tid, self_cpu) {
-        let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
-        if n <= 16 || n % 4096 == 0 {
-            crate::serial_println!(
-                "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
-                 (still live on another CPU) total_defers={}",
-                tid, self_cpu, n,
-            );
+    match proc::other_cpu_liveness(tid, self_cpu) {
+        // Not live elsewhere — dispatch is safe.
+        proc::OtherCpuLiveness::None => false,
+        // Benign steady-state refusal: `tid` is another CPU's current thread.
+        // Correct to defer, but expected and extremely high-volume (a saturated
+        // peer probed for work), so tally it separately and do NOT emit a serial
+        // line — otherwise this drowns the genuine switch-OUT signal below (a
+        // single wedged workload once emitted ~15M of these lines).
+        proc::OtherCpuLiveness::Current => {
+            BENIGN_CURRENT_DEFERS.fetch_add(1, Ordering::Relaxed);
+            true
         }
-        true
-    } else {
-        false
+        // The genuine #655 double-dispatch window: `tid` is off-current
+        // everywhere but a CPU is still on its kernel stack through the switch
+        // epilogue.  This is the event the interlock exists to catch — count and
+        // (rate-limited) log it so the signal stays visible.
+        proc::OtherCpuLiveness::OnStack => {
+            let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
+            if n <= 16 || n % 4096 == 0 {
+                crate::serial_println!(
+                    "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
+                     (on-stack mid-switch on another CPU) total_defers={}",
+                    tid, self_cpu, n,
+                );
+            }
+            true
+        }
     }
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -690,6 +690,15 @@ pub fn run() -> ! {
     total += 1;
     if test_procfs_self_cwd_readlink() { passed += 1; }
 
+    // W215 write-protect trap — huge-page-split neighbour safety.  Placed
+    // BEFORE Test 40 (Desktop Launch) per the note above, so the load-bearing
+    // direct-map-split invariant is verified even if Desktop Launch panics.
+    #[cfg(feature = "w215-wptrap")]
+    {
+        total += 1;
+        if test_w215_wptrap_split_neighbour_safe() { passed += 1; }
+    }
+
     // ── Test 40: Desktop Launch with Timeout ────────────────────────────
 
     total += 1;
@@ -1591,16 +1600,6 @@ pub fn run() -> ! {
         if test_640_frame_recycle_zeroing_invariant() { passed += 1; }
         total += 1;
         if test_643_bucket_a_classifier_content_aware() { passed += 1; }
-    }
-
-    // W215 write-protect trap — the load-bearing correctness property is that
-    // protecting one direct-map frame splits the covering 2 MiB huge page
-    // without corrupting its neighbours.  Gated on `w215-wptrap` (the module
-    // is compiled only in that profile).
-    #[cfg(feature = "w215-wptrap")]
-    {
-        total += 1;
-        if test_w215_wptrap_split_neighbour_safe() { passed += 1; }
     }
 
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1593,6 +1593,16 @@ pub fn run() -> ! {
         if test_643_bucket_a_classifier_content_aware() { passed += 1; }
     }
 
+    // W215 write-protect trap — the load-bearing correctness property is that
+    // protecting one direct-map frame splits the covering 2 MiB huge page
+    // without corrupting its neighbours.  Gated on `w215-wptrap` (the module
+    // is compiled only in that profile).
+    #[cfg(feature = "w215-wptrap")]
+    {
+        total += 1;
+        if test_w215_wptrap_split_neighbour_safe() { passed += 1; }
+    }
+
     // ── Cheap-log-transport: ring framing/drain correctness + cost ─────────
     // Cross-subsystem: drivers::log_ring (the PMM-backed guest-RAM ring) +
     // drivers::serial (the fast-path routing + COM1 fallback).  One test
@@ -57949,6 +57959,65 @@ fn test_640_frame_recycle_zeroing_invariant() -> bool {
     crate::mm::pmm::free_page(clean);
     test_pass!(NAME);
     true
+}
+
+/// W215 write-protect trap — huge-page-split neighbour safety.
+///
+/// The trap makes one page-cache code frame read-only on its higher-half
+/// direct-map alias.  That requires splitting the 2 MiB huge page the frame
+/// lives in into 4 KiB entries.  The load-bearing correctness property — and
+/// the whole reason this diagnostic is safe to run against a live direct map —
+/// is that the split preserves every OTHER sub-page's mapping and writability;
+/// only the single target PTE loses its writable bit.  This test drives the
+/// real `vmm::map_page` protect/restore primitive on a scratch frame and its
+/// neighbour and pins that invariant.
+///
+/// Cite: Intel SDM Vol. 3A §4.6 (R/W access-right bit), §4.10.4 (INVLPG).
+#[cfg(feature = "w215-wptrap")]
+fn test_w215_wptrap_split_neighbour_safe() -> bool {
+    const NAME: &str = "W215 wptrap huge-page-split neighbour safety";
+    test_header!(NAME);
+
+    // A scratch frame we own, plus its neighbour, so the assertions do not
+    // depend on any other tenant of the covering 2 MiB huge page.  Allocate
+    // the neighbour too so nothing else can claim it mid-test.
+    let phys = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => { test_fail!(NAME, "alloc_page returned None"); return false; }
+    };
+    let neigh = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => { test_fail!(NAME, "alloc_page (neighbour) returned None"); crate::mm::pmm::free_page(phys); return false; }
+    };
+
+    // Run the protect / verify-neighbour / restore cycle on `phys`.  Note the
+    // selftest checks `phys`'s own `+4 KiB` neighbour, which is a distinct
+    // frame within the same map; `neigh` above merely keeps the allocator from
+    // handing that region to another test concurrently.
+    let (protected_ro_ok, neighbour_safe, restored_ok) =
+        crate::mm::w215_wptrap::selftest(phys);
+
+    let mut ok = true;
+    if !protected_ro_ok {
+        test_fail!(NAME, "target frame was not present+read-only after protect");
+        ok = false;
+    }
+    if !neighbour_safe {
+        test_fail!(NAME, "neighbour lost its mapping/writability after the huge-page split");
+        ok = false;
+    }
+    if !restored_ok {
+        test_fail!(NAME, "target frame was not restored to present+writable after disarm");
+        ok = false;
+    }
+
+    crate::mm::pmm::free_page(phys);
+    crate::mm::pmm::free_page(neigh);
+
+    if ok {
+        test_pass!(NAME);
+    }
+    ok
 }
 
 /// Test 643 — [FAULT/CACHE-KEY] bucket-A classifier is content/CR2-aware.


### PR DESCRIPTION
## What

A **diagnosis-only** instrument (feature `w215-wptrap`) that names the residual W215 page-cache clobber writer by **trapping the store**, then freezing for a GDB autopsy. Nothing here changes default behaviour; do not merge until the writer is named (or the approach is retired).

## Why the passive shadows could not name it

The residual W215 corruption is an **in-place store into a live, reference-held page-cache frame** holding verified-correct library code (`libxul`/satellite `.text`). No allocator, free, or page-table event is hooked at the moment of that store, so the `w215_diag` per-phys provenance shadows (FREE/ALLOC/PROV) can classify the frame's *lifecycle* but can never name the *writer's RIP*. The only way to name an arbitrary in-place store is to **trap** it.

## Mechanism

1. At cache insert of a hot cluster code frame, **after** `insert_with_expected` has verified the frame content against the source bytes, the frame is made **read-only** on its higher-half direct-map alias (`PHYS_OFF + phys`). A verified code page has no legitimate kernel writer for the rest of its cache residency.
2. The next supervisor write to it raises a protection-violation `#PF` (P=1, W=1, U=0). The page-fault handler recognises it by `CR2 - PHYS_OFF`, records `[W215/WP-TRAP] writer_rip=… cr2=… phys=… rc=… tid=… pid=…`, then bugchecks (`W215_WP_TRAP`, `0xDEAD_000A`) to **freeze** the machine at the offending store.
3. Disarmed on eviction so a recycled frame is never left read-only.

## The load-bearing part — the huge-page split

The `[256 MiB, 1 GiB)` cluster is mapped by **2 MiB huge pages** in the higher-half map. Write-protecting one 4 KiB frame requires splitting the covering huge page. This reuses the **existing, boot-proven** split in `vmm::map_page` / `get_or_create_entry`, which fills every sub-PTE with the *same* physical base + flags the huge page carried — so **neighbouring frames keep their exact mapping and writability**; only the single target PTE loses its writable bit. A local `INVLPG` + cross-CPU shootdown retires the stale writable TLB entry.

`test_w215_wptrap_split_neighbour_safe` pins this invariant against the real primitive: after protect, the target is present+read-only and maps to its phys, **and** its neighbour is still present+writable and maps to *its* phys; after restore, the target is writable again.

## Coverage / limitations (diagnostic scope)

- Protects the higher-half direct-map alias **only** — the alias every kernel `memset`/`copy_nonoverlapping`/zero-fill path uses (the suspected in-place writer class). A writer through some *other* kernel mapping would not trap; user `.text` aliases are already `r-x` (read-only) so they are not the writer.
- Device **DMA** writes bypass CPU paging and cannot raise a `#PF`; the class under investigation is a CPU-side in-place store (the DMA-recycle class was addressed separately).
- Arming is bounded to a **64-slot** pool and the historical cluster window, so system perturbation is minimal.

## Byte-identical guarantee

Everything is gated behind `w215-wptrap` (implies `w215-diag`): the module, all call sites (`idt.rs` arm + PF hook, `cache.rs` disarm), the bugcheck code and its name arm. Verified: default (`--features ""`) and plain-`w215-diag` builds compile clean with **zero** reachable change.

## Reproduction status (honest)

W215 wrong-content is currently **non-reproducing on master** (the deep 14-flip saga is parked). This instrument arms the trap so that *if* the flaky in-place store recurs (historical trigger: SMP=2 + heavy Wikipedia load), the writer is named. If it never fires, the instrument still lands as tooling and the report says plainly "armed, no repro, no writer caught."

## Diff-size note

Larger than a normal diag change (new module + PF hook + huge-page-split reuse + arm/disarm + feature + test) — user-authorised for this investigation. Kept clean; no logical change split.

Cite: Intel SDM Vol. 3A §4.6, §4.10.4, §4.10.5; POSIX 1003.1-2024 mmap(2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
