### PR TITLE
mm/pf: drop PROCESS_TABLE before the write-fault-path TLB shootdown — fix the SMP lock-vs-IPI deadlock (the [TLB/TIMEOUT] residual)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1558,6 +1558,21 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             let old_phys = pte & 0x000F_FFFF_FFFF_F000;
             let new_pte = old_phys | page_flags | PAGE_PRESENT;
             crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            // Release PROCESS_TABLE before the cross-CPU shootdown.  The
+            // shootdown IPI needs every target CPU to run its handler to ACK,
+            // but any peer CPU that is itself in `handle_page_fault` spins on
+            // PROCESS_TABLE with interrupts disabled (#PF is an interrupt
+            // gate).  While we hold this lock that target can never take the
+            // IPI, so we spin the full 10M-iter ACK bound — a lock-vs-IPI
+            // cross-CPU deadlock that stalls every concurrent fault and shows
+            // up as the residual `[TLB/TIMEOUT]` stream on SMP.  The PTE write
+            // above is already published and nothing below reads the process
+            // table; the shootdown takes only the Copy `cr3`/`page_addr` — so
+            // drop the lock first, exactly as the file-backed demand path below
+            // already does before its VFS work.  (Intel SDM Vol. 3A §10.6.1:
+            // IPI delivery to a CPU that cannot service it is the sender's
+            // responsibility; here we remove the reason it cannot service.)
+            drop(procs);
             crate::mm::tlb::shootdown_page(cr3, page_addr);
             // NOTE: this does not set the PTE dirty bit nor mark the backing
             // page-cache frame dirty.  Inert today (VFS writeback is not yet
@@ -1627,6 +1642,13 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                     }
                     // else: unrelated bump — proceed; the CAS guards the install.
                 }
+                // Release PROCESS_TABLE before the CAS-install + cross-CPU
+                // shootdown below (same lock-vs-IPI deadlock as the MAP_SHARED
+                // arm above).  All uses of `vm_space` — including the gen-abort
+                // re-check — are complete; the install is a self-guarding CAS
+                // (`map_page_in_cow_if_unchanged`) and the refcount ops carry
+                // their own locking, so none of this needs the process table.
+                drop(procs);
                 // The private copy (new_phys) takes sole ownership; mark it
                 // before publishing so a concurrent faulter that observes the
                 // installed PTE never sees a 0-refcount frame.
@@ -1676,6 +1698,9 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             // entry-point for the whole CoW arm.
             let new_pte = old_phys | page_flags | PAGE_PRESENT;
             crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            // Release PROCESS_TABLE before the shootdown (lock-vs-IPI deadlock;
+            // see the MAP_SHARED arm above).
+            drop(procs);
             crate::mm::tlb::shootdown_page(cr3, page_addr);
             return true;
         }
@@ -1722,6 +1747,10 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             // first ifetch.
             let new_pte = pte & !crate::mm::vmm::PAGE_NO_EXECUTE;
             crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            // Release PROCESS_TABLE before the shootdown (lock-vs-IPI deadlock;
+            // see the MAP_SHARED arm above).  `vma` is not read past its
+            // PROT_EXEC test in the guard, so the borrow is already released.
+            drop(procs);
             crate::mm::tlb::shootdown_page(cr3, page_addr);
             return true;
         }

--- a/kernel/src/kdb.rs
+++ b/kernel/src/kdb.rs
@@ -2102,12 +2102,22 @@ fn op_cpu_state(out: &mut String) {
     // (H2: a monopolising in-kernel path).  `force_total` is the cumulative
     // anti-starvation force-select count.  `gate_skips` (feature `sched-gate-
     // stats`) is the population of Ready threads skipped by each candidate gate.
+    // `benign_current_defers` / `double_dispatch_defers` are the #673 on-CPU
+    // interlock split (see `sched::defer_if_live_on_other_cpu`): the former
+    // counts refusals because a candidate is another CPU's *current* thread
+    // (benign steady-state), the latter the genuine switch-OUT on-stack window.
+    // At an interlock livelock a reader can tell which condition is firing —
+    // a climbing `benign_current` with a flat `double_dispatch` means a peer
+    // CPU is wedged holding the candidate as current (downstream), whereas a
+    // climbing `double_dispatch` is a genuine on-stack-flag-stuck interlock bug.
     let _ = write!(
         out,
-        r#","sched":{{"maintain_passes":{},"ctx_switches":{},"force_total":{}"#,
+        r#","sched":{{"maintain_passes":{},"ctx_switches":{},"force_total":{},"benign_current_defers":{},"double_dispatch_defers":{}"#,
         crate::sched::percpu::maintain_passes(),
         crate::perf::context_switches(),
         crate::sched::starve_force_count(),
+        crate::sched::benign_current_defers(),
+        crate::sched::double_dispatch_defers(),
     );
     #[cfg(feature = "sched-gate-stats")]
     {

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -1410,40 +1410,83 @@ pub fn is_tid_on_stack_any_cpu(tid: Tid) -> bool {
     false
 }
 
-/// On-CPU dispatch interlock: returns `true` if `tid` is still live — currently
-/// dispatched (`PER_CPU_CURRENT_TID`) **or** physically executing on its kernel
-/// stack (`PER_CPU_ONSTACK_TID`) — on any logical CPU OTHER than `self_cpu`.
+/// On-CPU dispatch interlock, classifier form.
 ///
 /// A thread that is still live on another CPU must never be dispatched/resumed
 /// here: it owns a single kernel stack, and running it on two CPUs at once lets
 /// each tear the other's saved `switch_context` frame in place (the SMP
-/// kernel-stack double-dispatch corruption).  This is the realisation, at our
-/// cooperative pick site, of the standard SMP wakeup interlock — a task carries
-/// an "on-CPU" marker held across the context switch, and a remote runqueue must
-/// not re-place the task until that marker clears.  Both signals are published
-/// with `Release` (`set_current_tid` / `set_onstack_tid`); the `Acquire` loads
-/// here pair with them so observing a CPU as no longer running/holding `tid` also
-/// observes that CPU's final stack writes for `tid` as retired.
+/// kernel-stack double-dispatch corruption, #655).  This is the realisation, at
+/// our cooperative pick site, of the standard SMP wakeup interlock — a task
+/// carries an "on-CPU" marker held across the context switch, and a remote
+/// runqueue must not re-place the task until that marker clears.  Both signals
+/// are published with `Release` (`set_current_tid` / `set_onstack_tid`); the
+/// `Acquire` loads here pair with them so observing a CPU as no longer
+/// running/holding `tid` also observes that CPU's final stack writes for `tid`
+/// as retired.  `self_cpu` is excluded so a thread legitimately re-selected on
+/// the very CPU it last ran on (the common no-migration case) is never
+/// spuriously deferred.
 ///
-/// `self_cpu` is excluded so a thread legitimately re-selected on the very CPU
-/// it last ran on (the common no-migration case) is never spuriously deferred.
-pub fn is_tid_live_on_other_cpu(tid: Tid, self_cpu: usize) -> bool {
+/// This enum classifies WHY a thread is live on another CPU.
+/// The interlock DECISION (defer or not) is the same for both live kinds — a
+/// thread live on another CPU must never be dispatched here.  The distinction
+/// exists only so diagnostics can separate the high-volume, expected
+/// steady-state refusal from the rare event the interlock was actually built to
+/// catch:
+///
+///   * [`Current`](Self::Current) — the thread is the CURRENT thread on another
+///     CPU (running there, or that CPU is idle-halting *on the thread's kernel
+///     stack* — no context switch leaves that stack, so `PER_CPU_CURRENT_TID`
+///     legitimately still names it).  Declining to also dispatch it here is
+///     ordinary "don't run one thread on two CPUs" and recurs at up to millions
+///     of refusals per second when one CPU is saturated and a peer repeatedly
+///     probes it for stealable work.  It is NOT the double-dispatch race.
+///
+///   * [`OnStack`](Self::OnStack) — the thread is no longer named current on any
+///     CPU, but a CPU is still physically on its kernel stack through the
+///     `switch_context_asm` epilogue (`PER_CPU_ONSTACK_TID`).  Dispatching it
+///     here would resume it onto the very stack that CPU is still unwinding and
+///     tear its saved switch frame in place.  This is precisely the switch-OUT
+///     double-dispatch window the interlock exists to close.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OtherCpuLiveness {
+    /// Not current and not on-stack on any CPU other than `self_cpu`.
+    None,
+    /// Named current on another CPU (running or idle-on-its-stack there).
+    Current,
+    /// Off-current everywhere, but a CPU is still on its kernel stack.
+    OnStack,
+}
+
+/// Classify why `tid` is live on a CPU other than `self_cpu` (see
+/// [`OtherCpuLiveness`]).  `Current` takes precedence over `OnStack`: a thread
+/// named current somewhere is actively live regardless of any on-stack slot.
+/// `tid == 0` (the idle/bootstrap sentinel) and a uniprocessor (`self_cpu` the
+/// only CPU) both classify as [`OtherCpuLiveness::None`], so SMP=1 is inert.
+/// Each slot is read `Acquire` to pair with the `Release` publish in
+/// `set_current_tid` / `set_onstack_tid`.
+pub fn other_cpu_liveness(tid: Tid, self_cpu: usize) -> OtherCpuLiveness {
     if tid == 0 {
-        return false;
+        return OtherCpuLiveness::None;
     }
     let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
         .min(crate::arch::x86_64::apic::MAX_CPUS);
+    let mut on_stack = false;
     for cpu in 0..ncpus {
         if cpu == self_cpu {
             continue;
         }
-        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid
-            || PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid
-        {
-            return true;
+        if PER_CPU_CURRENT_TID[cpu].load(Ordering::Acquire) == tid {
+            return OtherCpuLiveness::Current;
+        }
+        if PER_CPU_ONSTACK_TID[cpu].load(Ordering::Acquire) == tid {
+            on_stack = true;
         }
     }
-    false
+    if on_stack {
+        OtherCpuLiveness::OnStack
+    } else {
+        OtherCpuLiveness::None
+    }
 }
 
 /// Read the currently running PID for an arbitrary CPU index.  See

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -102,17 +102,38 @@ pub fn note_switch_completed() {
     crate::proc::set_onstack_tid(crate::proc::current_tid());
 }
 
-/// On-CPU dispatch-interlock counter: number of times a candidate was DEFERRED
-/// from dispatch/work-steal because it was still live (current or on-stack) on
-/// another CPU.  A non-zero value proves the #655 double-dispatch race was
-/// occurring and is now being caught.  Read via [`double_dispatch_defers`].
+/// On-CPU dispatch-interlock counter: number of times a candidate was deferred
+/// from dispatch/work-steal because a CPU was still physically on its kernel
+/// stack through the `switch_context_asm` epilogue — the genuine switch-OUT
+/// double-dispatch window (`OtherCpuLiveness::OnStack`).  A non-zero value proves
+/// the #655 double-dispatch race was occurring and is now being caught.  The
+/// high-volume benign case (the candidate is simply another CPU's *current*
+/// thread) is tallied separately in [`BENIGN_CURRENT_DEFERS`] so it never drowns
+/// this signal.  Read via [`double_dispatch_defers`].
 static DOUBLE_DISPATCH_DEFERS: AtomicU64 = AtomicU64::new(0);
+
+/// Benign on-CPU-interlock refusals: the candidate was the CURRENT thread on
+/// another CPU (running there, or that CPU idle-halting on its stack).  Declining
+/// to also dispatch it is ordinary "don't run one thread on two CPUs" and can
+/// recur at millions of refusals per second when one CPU is saturated (e.g. a
+/// content futex storm) and a peer's `try_steal_to` repeatedly probes it for
+/// stealable work — so this is counted without a per-event serial line.  Kept
+/// separate from [`DOUBLE_DISPATCH_DEFERS`] so the genuine switch-OUT signal is
+/// not buried.  Diagnostic only; does not affect scheduling.
+static BENIGN_CURRENT_DEFERS: AtomicU64 = AtomicU64::new(0);
 
 /// Read the on-CPU dispatch-interlock defer counter (see
 /// [`DOUBLE_DISPATCH_DEFERS`]).
 #[inline]
 pub fn double_dispatch_defers() -> u64 {
     DOUBLE_DISPATCH_DEFERS.load(Ordering::Relaxed)
+}
+
+/// Read the benign steady-state interlock-refusal counter (see
+/// [`BENIGN_CURRENT_DEFERS`]).
+#[inline]
+pub fn benign_current_defers() -> u64 {
+    BENIGN_CURRENT_DEFERS.load(Ordering::Relaxed)
 }
 
 /// The on-CPU dispatch interlock, applied at every dispatch/resume/work-steal
@@ -129,18 +150,33 @@ pub fn double_dispatch_defers() -> u64 {
 /// executions tore its single kernel stack's saved switch frame in place.
 #[inline]
 pub(crate) fn defer_if_live_on_other_cpu(tid: proc::Tid, self_cpu: usize) -> bool {
-    if proc::is_tid_live_on_other_cpu(tid, self_cpu) {
-        let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
-        if n <= 16 || n % 4096 == 0 {
-            crate::serial_println!(
-                "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
-                 (still live on another CPU) total_defers={}",
-                tid, self_cpu, n,
-            );
+    match proc::other_cpu_liveness(tid, self_cpu) {
+        // Not live elsewhere — dispatch is safe.
+        proc::OtherCpuLiveness::None => false,
+        // Benign steady-state refusal: `tid` is another CPU's current thread.
+        // Correct to defer, but expected and extremely high-volume (a saturated
+        // peer probed for work), so tally it separately and do NOT emit a serial
+        // line — otherwise this drowns the genuine switch-OUT signal below (a
+        // single wedged workload once emitted ~15M of these lines).
+        proc::OtherCpuLiveness::Current => {
+            BENIGN_CURRENT_DEFERS.fetch_add(1, Ordering::Relaxed);
+            true
         }
-        true
-    } else {
-        false
+        // The genuine #655 double-dispatch window: `tid` is off-current
+        // everywhere but a CPU is still on its kernel stack through the switch
+        // epilogue.  This is the event the interlock exists to catch — count and
+        // (rate-limited) log it so the signal stays visible.
+        proc::OtherCpuLiveness::OnStack => {
+            let n = DOUBLE_DISPATCH_DEFERS.fetch_add(1, Ordering::Relaxed) + 1;
+            if n <= 16 || n % 4096 == 0 {
+                crate::serial_println!(
+                    "[SCHED/INTERLOCK] deferred dispatch of tid={} on cpu={} \
+                     (on-stack mid-switch on another CPU) total_defers={}",
+                    tid, self_cpu, n,
+                );
+            }
+            true
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a **lock-vs-IPI cross-CPU deadlock** in `handle_page_fault` that is the dominant source of the residual `[TLB/TIMEOUT]` stream and the ~10× SMP=2 slowdown. On a live SMP=2 Wikipedia boot the fix drives `[TLB/TIMEOUT]` from the pre-fix ~0.92/s (369 by load-end) to **0**, and yields the healthiest SMP=2 boot the reliability program has seen.

## Root cause (GDB-autopsied on a live SMP=2 boot)

`handle_page_fault` takes `PROCESS_TABLE` (a spin mutex) on every fault to look up the faulting process's `VmSpace`, then — in the copy-on-write / write-fault fast path — mutates the leaf PTE and issues a cross-CPU TLB shootdown **while still holding it**. The shootdown spins (bounded, 10M iters) waiting for every peer CPU that maps the CR3 to ACK the IPI.

`#PF` is delivered through an interrupt gate, so a peer CPU handling its *own* fault runs `handle_page_fault` with `IF=0`. If it is spinning to acquire `PROCESS_TABLE` — the lock this CPU holds — it can never take the shootdown IPI (`IF=0` keeps vector `0xF0` pending in the IRR; Intel SDM Vol. 3A §10.6.1), so the initiator spins the full ACK bound and records a `[TLB/TIMEOUT]`. The bound lets it eventually proceed, but the pattern recurs on every concurrent write-fault under load.

Both vCPUs were caught `IF=0`:
- CPU A in `mm::tlb::shootdown_range` — the 10M-iter ACK-wait spin
- CPU B at the `lock cmpxchg`/`pause` spin acquiring `PROCESS_TABLE` inside `handle_page_fault`

Live kdb counters confirmed the concurrently-observed "#673 interlock livelock" was 99.9995% the **benign `Current`** case (`benign_current_defers` 12.5M vs `double_dispatch_defers` 60) — a downstream symptom of this deadlock, not an interlock defect. This is the ~80% residual that the `#698` ACK-spin reentrancy fix could not reach (that fix only rescues a target already inside the shootdown ACK-spin, not one wedged in a plain `PROCESS_TABLE` acquire).

## Fix

Release `PROCESS_TABLE` immediately before each of the four fast-path shootdowns (MAP_SHARED write-through, CoW private-copy install, single-owner make-writable, NX fixup). The PTE write is already published and nothing after it reads the process table; the shootdown and the CoW CAS-install take only Copy values (`cr3`, `page_addr`) and carry their own locking (`VMM_LOCK`/`mm_sem`) — exactly the pattern the file-backed demand path in the *same function* already uses (it drops `PROCESS_TABLE` before its VFS work).

Also includes (diagnostic enablers used to root-cause this):
- `600073c2` — split the #673 interlock accounting into benign `Current` vs genuine `OnStack` (silences the ~15M-line benign flood).
- kdb: expose `benign_current_defers`/`double_dispatch_defers` in `cpu-state` (one-call livelock classification).

## Verification (SMP=2, KVM, Wikipedia, 2048 MiB)

| Metric | Before fix (same phase) | With fix |
|---|---|---|
| `[TLB/TIMEOUT]` | ~113 at content-load → 369 by load-end (0.92/s) | **0** (held 0 through ~15 min / tick 91000) |
| `[SCHED/STARVE]` | 15+ | 1 (boot only) |
| `benign_current_defers` | 12.5M (CPUs wedged IF=0) | 2.3K |
| bugcheck / freeze / heap-corrupt | — | 0 |

Content procs (pid12/pid13 firefox-bin) run heavy and healthy (pf>400K, sc>9M, network flowing).

## Independent adversarial review

Confirmed SAFE for the PROCESS_TABLE class: the PTE writes are idempotent/atomic; the CoW install self-guards under `VMM_LOCK` (the W215/d4fb7fa two-frames-one-VA class is **not** reopened); no residual PROCESS_TABLE cycle; borrow placements sound.

## Tracked follow-ups (out of scope here — pre-existing, separate instances)

- **mm_sem lock-vs-IPI class (same shape, different lock):** `free_process_memory` (`proc/mod.rs:2215`), `free_vm_space` (`:2337`), and `clone_for_fork` (`vma.rs:874`) hold `mm_sem.write()` across their own shootdown, against a #PF-fast-path peer spinning on `mm_sem.read()` (IF=0). Empirically **not** the dominant contributor (TLB/TIMEOUT stayed 0 through heavy fork/teardown here), and `mm_sem` is load-bearing for the W216 exclusion invariant, so the fix is the `service_incoming_shootdown_and_drain` reentrancy pattern on the `mm_sem` acquire path, not a bare drop. Separate PR.
- **exit-teardown liveness gate:** `exit_thread`'s `all_dead → free_process_memory` (`proc/mod.rs:1985`) lacks the `any_sibling_on_cpu` cross-CPU gate that `exit_group_inner` has (`proc/mod.rs:2825-2841`) — a pre-existing narrow UAF window (the file-backed demand path already exposes a larger one). Minimal fix: mirror the gate. Separate PR.

Cite: Intel SDM Vol. 3A §10.6.1 (IPI delivery / a wedged target is the sender's responsibility), §4.10.4.2 (TLB shootdown protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)