### PR TITLE
proc/mm: wait for cross-CPU CR3 drain before free_process_memory — close the exit_thread teardown UAF

### DIFF
--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -436,6 +436,22 @@ fn snapshot_active_mask(cr3: u64) -> u64 {
         .unwrap_or(0)
 }
 
+/// Returns true if `cr3` is currently loaded on any CPU **other than** the
+/// caller's.  Used by process teardown to wait for an address space to drain
+/// off every other CPU before freeing its page tables: a sibling thread —
+/// force-marked `Dead` by `exit_group` but still physically executing on
+/// another CPU (e.g. in user mode, or mid-`#PF`) — still has that CR3 loaded,
+/// and freeing the tables under it is a use-after-free (its next PTE walk or
+/// `SYSRETQ` lands on freed frames; Intel SDM Vol. 3A §4.10).  The caller's own
+/// CPU is excluded so a teardown thread never waits on itself.
+///
+/// Acquires only the leaf `CR3_ACTIVE_CPUS` lock — the caller MUST NOT hold any
+/// other lock (e.g. `PROCESS_TABLE`) across this, per the module lock order.
+pub fn cr3_active_on_other_cpu(cr3: u64) -> bool {
+    let self_mask = 1u64 << (apic::cpu_index() as u64);
+    (snapshot_active_mask(cr3) & !self_mask) != 0
+}
+
 /// Local `invlpg` over `[va_lo, va_hi)`.  Used by both the sender and
 /// the IPI handler.
 #[inline]

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2179,6 +2179,75 @@ pub fn free_process_memory(pid: Pid) {
     use crate::mm::{refcount, pmm, vmm};
     use crate::mm::vma::VmBacking;
 
+    // ── Cross-CPU CR3 drain wait ────────────────────────────────────────────
+    // `exit_group` force-marks every sibling thread `Dead` up front, but a
+    // sibling can still be physically executing on another CPU with this
+    // address space's CR3 loaded (in user mode, or stalled mid-`#PF`).  Freeing
+    // its page tables out from under it is a use-after-free: its next PTE walk
+    // or its `SYSRETQ` back to user mode lands on freed — possibly reallocated —
+    // frames (Intel SDM Vol. 3A §4.10).  `exit_thread`'s `all_dead` call site
+    // (unlike `exit_group_inner`'s) had no cross-CPU guard, so a sibling exiting
+    // on one CPU could free while another sibling was still on-CPU faulting.
+    // (Widened, not introduced, by PR #703's fault-path `drop(PROCESS_TABLE)`.)
+    //
+    // Wait — synchronously, here, so the free stays unconditional and no
+    // deferral/retry machinery is needed — for the address space to drain off
+    // every OTHER CPU before removing the `VmSpace`.  A `Dead` thread is
+    // unschedulable and drops its CR3 at its next preemption (bounded by one
+    // scheduler quantum), so this resolves quickly.  The wait is read BEFORE the
+    // `vm_space.take()` below so a sibling faulting during the wait still finds
+    // its `VmSpace` (returns `Some`) and resolves the fault normally rather than
+    // taking a spurious SIGSEGV.  It runs in the IF=1 exit context with NO lock
+    // held: the not-yet-`Dead` caller (both call sites mark the caller `Dead`
+    // only just before `schedule()`, after this returns) is preemptible and
+    // resumes the wait after any preemption, and each sibling drains via its own
+    // CPU's timer, independent of this one.  `CR3_DRAIN_SPIN_BOUND` is a safety
+    // valve against a sibling that legitimately holds the CR3 for a long
+    // kernel excursion (this kernel does not preempt Ring 0, so a `Dead`
+    // sibling finishing a slow I/O-backed `#PF` keeps its CR3 until it reaches
+    // its own reschedule point) or is pathologically wedged — on expiry we log
+    // and proceed to free, no worse than the pre-fix unconditional free.  The
+    // bound is deliberately large (its wall-clock cost is on the order of
+    // seconds of `PAUSE`, not milliseconds) so it never fires for a legitimate
+    // in-flight fault.
+    //
+    // Only wait when this process actually OWNS the address space it is about
+    // to free.  A `CLONE_VM`/vfork child that shares the parent's CR3 records
+    // that CR3 in `proc.cr3` but has `vm_space == None` (nothing to free); its
+    // CR3 is legitimately live on other CPUs for as long as the *parent* has
+    // running threads, so waiting on it would spin to the full bound on a
+    // routine (posix_spawn / failed-exec `_exit`) exit for no benefit.  Gate on
+    // `vm_space.is_some()`, and also exclude the kernel CR3 (a kernel-only
+    // process records it; it is loaded everywhere and, again, has nothing to
+    // free).
+    const CR3_DRAIN_SPIN_BOUND: u64 = 100_000_000;
+    let (drain_cr3, owns_vm_space) = {
+        let procs = PROCESS_TABLE.lock();
+        match procs.iter().find(|p| p.pid == pid) {
+            Some(p) => (p.cr3, p.vm_space.is_some()),
+            None => (0, false),
+        }
+    };
+    if owns_vm_space
+        && drain_cr3 != 0
+        && drain_cr3 != crate::mm::vmm::get_kernel_cr3()
+    {
+        let mut spins: u64 = 0;
+        while crate::mm::tlb::cr3_active_on_other_cpu(drain_cr3)
+            && spins < CR3_DRAIN_SPIN_BOUND
+        {
+            core::hint::spin_loop();
+            spins += 1;
+        }
+        if spins >= CR3_DRAIN_SPIN_BOUND {
+            crate::serial_println!(
+                "[PROC] WARN free_process_memory(pid={}) proceeding with CR3 {:#x} \
+                 still active on another CPU after {} spins (wedged sibling?)",
+                pid, drain_cr3, spins,
+            );
+        }
+    }
+
     // Take the VmSpace out of the Process.  Setting cr3=0 prevents the scheduler
     // from accidentally switching to the freed PML4.
     let vm_space = {


### PR DESCRIPTION
## Summary

Closes a use-after-free in process teardown: `free_process_memory` could free an address space's user page tables while a sibling thread — force-marked `Dead` by `exit_group` but still executing on another CPU with the process's CR3 loaded (user mode, or stalled mid-`#PF`) — was still using them. Its next PTE walk or its `SYSRETQ` back to user mode would then land on freed, possibly reallocated frames (Intel SDM Vol. 3A §4.10). `exit_thread`'s `all_dead → free_process_memory` had no cross-CPU guard (only `exit_group_inner`'s coarser scan did). Widened — not introduced — by PR #703's write-fault-path `drop(PROCESS_TABLE)`.

## Fix

At the single chokepoint (top of `free_process_memory`, before the `VmSpace` is taken), **synchronously spin-wait for the address space to drain off every other CPU** (`tlb::cr3_active_on_other_cpu`) before freeing. A `Dead` thread is never re-selected and drops its CR3 at its CPU's next context switch, so the wait resolves once that sibling reaches its own reschedule point.

**Why synchronous, not deferred:** a *deferred* free (gate-and-retry-later) has no resolution point that is both interrupt-safe and guaranteed to run — the periodic reaper is IF=0 (the shootdown is unsafe there), not every `Dead` thread re-reaches `exit_thread`, and a `waitpid`-based retry can permanently wedge a blocking `wait4(2)` (three review iterations rejected two deferred variants for exactly these reasons). Keeping the free synchronous means the exit-path, `waitpid`, and orphan-reap machinery need no change and cannot lose or deadlock the free.

Verified correctness points (independently reviewed, 3 rounds):
- Spins **before** `vm_space.take()`, so a sibling faulting during the wait still finds `Some(VmSpace)` and resolves normally (no spurious SIGSEGV).
- No lock held across the wait (CR3 read releases `PROCESS_TABLE` before the leaf `CR3_ACTIVE_CPUS` lock). Caller marked `Dead` only after this returns, and this kernel doesn't preempt Ring 0 — the spinner is never descheduled mid-wait.
- Self- and kernel-CR3 excluded; SMP=1 inert.
- **Waits only when the process owns the address space (`vm_space.is_some()`)** — a `CLONE_VM`/vfork child shares the parent's CR3 but owns no `vm_space`; without this gate every routine `posix_spawn`/failed-exec `_exit` would spin to the bound (caught + fixed in review).
- `CR3_DRAIN_SPIN_BOUND` safety valve (wall-clock order of seconds): on expiry, log + proceed — no worse than the pre-fix unconditional free.

Adds `tlb::cr3_active_on_other_cpu`.

## Verification (SMP=2, KVM, Firefox → Wikipedia, heavy multi-threaded teardown)

10-minute boot: process frees complete cleanly, **spin-safety-valve WARN never fires** (drain resolves every time), **0** bugcheck/panic/hang/corruption, `TLB/TIMEOUT`=0, machine progresses normally (sc 18M, multiple content procs) — the vfork/`CLONE_VM` path exits fast (no stall).

## Follow-up (tracked, not in this PR)

Now that `free_process_memory` self-protects against the on-CPU-sibling race, `exit_group_inner`'s pre-existing `any_sibling_on_cpu` pre-check — which *skips* the free (rather than deferring) when a sibling is on-CPU, a latent leak — is redundant; replacing it with an unconditional call would close that leak as a side effect.

Cite: Intel SDM Vol. 3A §4.10 (paging-structure caches / CR3 validity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)