### PR TITLE
proc: unconditional free_process_memory in exit_group + tick-bounded CR3-drain wait

### DIFF
--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2201,15 +2201,21 @@ pub fn free_process_memory(pid: Pid) {
     // held: the not-yet-`Dead` caller (both call sites mark the caller `Dead`
     // only just before `schedule()`, after this returns) is preemptible and
     // resumes the wait after any preemption, and each sibling drains via its own
-    // CPU's timer, independent of this one.  `CR3_DRAIN_SPIN_BOUND` is a safety
-    // valve against a sibling that legitimately holds the CR3 for a long
-    // kernel excursion (this kernel does not preempt Ring 0, so a `Dead`
-    // sibling finishing a slow I/O-backed `#PF` keeps its CR3 until it reaches
-    // its own reschedule point) or is pathologically wedged — on expiry we log
-    // and proceed to free, no worse than the pre-fix unconditional free.  The
-    // bound is deliberately large (its wall-clock cost is on the order of
-    // seconds of `PAUSE`, not milliseconds) so it never fires for a legitimate
-    // in-flight fault.
+    // CPU's timer, independent of this one.  The wait is bounded by wall-clock
+    // TICKS, not a raw spin count: the sibling drains when its CPU takes a timer
+    // tick and reschedules off the now-`Dead` thread (~1-2 ticks), and a
+    // spin-count bound is unreliable — `PAUSE` latency varies by orders of
+    // magnitude across host / KVM / TCG, so a fixed count is either a
+    // multi-second stall or (as observed under KVM) expires before even one
+    // tick, abandoning the wait prematurely and proceeding with the CR3 still
+    // live.  `get_ticks()` is TSC-derived (Intel SDM Vol. 3B §17.17,
+    // constant-rate TSC), so it advances even if this CPU's LAPIC timer is dead
+    // and the loop is guaranteed to terminate.  `CR3_DRAIN_MAX_TICKS` is a
+    // safety valve against a sibling that legitimately holds the CR3 for a long
+    // kernel excursion (this kernel does not preempt Ring 0, so a `Dead` sibling
+    // finishing a slow I/O-backed `#PF` keeps its CR3 until it reaches its own
+    // reschedule point) or is pathologically wedged — on expiry we log and
+    // proceed to free, no worse than the pre-fix unconditional free.
     //
     // Only wait when this process actually OWNS the address space it is about
     // to free.  A `CLONE_VM`/vfork child that shares the parent's CR3 records
@@ -2220,7 +2226,7 @@ pub fn free_process_memory(pid: Pid) {
     // `vm_space.is_some()`, and also exclude the kernel CR3 (a kernel-only
     // process records it; it is loaded everywhere and, again, has nothing to
     // free).
-    const CR3_DRAIN_SPIN_BOUND: u64 = 100_000_000;
+    const CR3_DRAIN_MAX_TICKS: u64 = 30; // ~300 ms at 100 Hz — a few ticks + slow-I/O margin
     let (drain_cr3, owns_vm_space) = {
         let procs = PROCESS_TABLE.lock();
         match procs.iter().find(|p| p.pid == pid) {
@@ -2232,18 +2238,27 @@ pub fn free_process_memory(pid: Pid) {
         && drain_cr3 != 0
         && drain_cr3 != crate::mm::vmm::get_kernel_cr3()
     {
-        let mut spins: u64 = 0;
-        while crate::mm::tlb::cr3_active_on_other_cpu(drain_cr3)
-            && spins < CR3_DRAIN_SPIN_BOUND
-        {
+        let start_tick = crate::arch::x86_64::irq::get_ticks();
+        let mut timed_out = false;
+        let mut i: u32 = 0;
+        while crate::mm::tlb::cr3_active_on_other_cpu(drain_cr3) {
             core::hint::spin_loop();
-            spins += 1;
+            // Sample the (rdtsc-backed) clock only every ~1024 spins so the
+            // inner wait stays a tight `PAUSE` loop.
+            i = i.wrapping_add(1);
+            if i & 0x3FF == 0
+                && crate::arch::x86_64::irq::get_ticks().wrapping_sub(start_tick)
+                    >= CR3_DRAIN_MAX_TICKS
+            {
+                timed_out = true;
+                break;
+            }
         }
-        if spins >= CR3_DRAIN_SPIN_BOUND {
+        if timed_out {
             crate::serial_println!(
                 "[PROC] WARN free_process_memory(pid={}) proceeding with CR3 {:#x} \
-                 still active on another CPU after {} spins (wedged sibling?)",
-                pid, drain_cr3, spins,
+                 still active on another CPU after {} ticks (wedged sibling?)",
+                pid, drain_cr3, CR3_DRAIN_MAX_TICKS,
             );
         }
     }

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2865,49 +2865,27 @@ fn exit_group_inner(pid: Pid, calling_tid: Tid, exit_code: i64, yield_self: bool
     // user VA.  Per Intel SDM Vol. 3A §4.10, CR3-referenced PML4 entries
     // must remain valid while any logical processor has the CR3 loaded.
     //
-    // Guard: if any sibling is still Running, defer the PMM teardown.
-    // The sibling's own syscall dispatch tail (dispatch() in
-    // subsys/linux/syscall.rs) checks for Dead state on return and calls
-    // exit_thread(), which checks all_dead and performs the PMM teardown
-    // as the final owner.  This keeps the common single-thread path fast
-    // (no sibling → free immediately) while making the multi-thread path
-    // safe (CLONE_THREAD: wait for Running siblings to drain off-CPU).
+    // Free the process's user address space.
     //
-    // Contention note: THREAD_TABLE is a spin::Mutex.  This lock
-    // acquisition is on the exit path — interrupts are enabled and the
-    // calling CPU is about to schedule away, so contention with a
-    // concurrent timer ISR or AP scheduler is bounded to a short
-    // critical section (one iter + state compare).  If SMP thread counts
-    // grow large enough that the linear scan becomes a latency concern,
-    // consider an atomic per-process Running-thread counter as a fast
-    // pre-check before taking the lock.
+    // `free_process_memory` now self-protects against the cross-CPU teardown
+    // race this site used to guard by hand: before freeing, it waits for the
+    // address space to drain off every other CPU (its CR3 drain-wait), so a
+    // sibling force-marked `Dead` up front but still physically executing on
+    // another CPU cannot have its page tables freed out from under it — its
+    // next PTE walk / `SYSRETQ` would otherwise land on freed frames (Intel SDM
+    // Vol. 3A §4.10).
     //
-    // CROSS-CPU detection: the `state == Running` test that used to live here
-    // was defeated by this function's own earlier pass, which forced every
-    // sibling to `Dead` (so none read as Running and the guard always fell
-    // through to an immediate free).  A sibling marked Dead can still be
-    // physically executing on another CPU mid-syscall; freeing the user page
-    // tables out from under it lets its SYSRETQ land on a now-unmapped user VA
-    // (Intel SDM Vol. 3A §4.10).  Detect "still on a CPU" via the per-CPU
-    // current-PID slots — the address-space analogue of the reaper's
-    // `is_tid_current_on_any_cpu` kstack guard.
-    let any_sibling_on_cpu = {
-        let calling_cpu_tid = current_tid();
-        let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
-            .min(crate::arch::x86_64::apic::MAX_CPUS);
-        (0..ncpus).any(|c| {
-            let ctid = current_tid_on_cpu(c);
-            current_pid_on_cpu(c) == pid
-                && ctid != 0
-                // Exclude the exit_group caller itself (it is mid-teardown on
-                // its own stack; it frees the rest after it yields).
-                && !(calling_tid != 0 && ctid == calling_tid)
-                && ctid != calling_cpu_tid
-        })
-    };
-    if !any_sibling_on_cpu {
-        free_process_memory(pid);
-    }
+    // The former `any_sibling_on_cpu` pre-check (a `current_pid_on_cpu` scan)
+    // is therefore redundant — and it was worse than redundant: when a sibling
+    // WAS on-CPU it *skipped* `free_process_memory` entirely rather than
+    // deferring it, and nothing ever retried (the last sibling's own
+    // `exit_thread` is the only other caller, and a sibling whose remaining
+    // on-CPU execution is pure user-mode code never re-reaches it).  The
+    // address space then leaked: the orphan-reap sweep / `waitpid` later drops
+    // the still-`Some` `VmSpace`, whose `Drop` frees no page-table frames.
+    // Calling unconditionally — and letting the drain-wait handle the on-CPU
+    // sibling — closes that pre-existing leak.
+    free_process_memory(pid);
 
     // Vfork isolated-stack cleanup: same rationale as exit_thread (see
     // there for the longer comment).  We harvest the field from the


### PR DESCRIPTION
Two commits forming one coherent teardown fix, following PR #704.

## 1. `exit_group_inner` frees unconditionally — close the skipped-free leak (`474ba50d`)

`exit_group_inner` guarded its `free_process_memory` call with an `any_sibling_on_cpu` scan that, when a sibling was on-CPU, **skipped the free entirely** (not deferred it) — and nothing ever retried, so the address space leaked (the orphan-reap sweep / `waitpid` later drops the still-`Some` `VmSpace`, whose `Drop` frees no page-table frames). PR #704 moved the cross-CPU teardown-race protection *into* `free_process_memory` (its CR3-drain wait), making that hand-rolled pre-check redundant — and its skip-behaviour now purely a leak. Call unconditionally and let the drain-wait handle the on-CPU sibling. (The CR3-keyed drain-wait is also strictly broader than the old PID-keyed scan — it incidentally closes a vfork/`CLONE_VM` gap the scan had.)

## 2. Bound the CR3-drain wait by TSC ticks, not spin count (`230baf1a`)

#704's drain-wait used a fixed `100_000_000`-iteration `PAUSE` bound. `PAUSE` latency varies by orders of magnitude across host/KVM/TCG, so a count sized to mean "seconds" can expire in **under one 10ms timer tick** on another platform. Live SMP=2 testing (a ~24-thread Firefox `exit_group`, once commit 1 began exercising this path) showed exactly that: the wait hit the bound and freed while a `Dead` sibling of the *same process* was still draining off the other CPU — the very UAF the wait exists to close. (Root confirmed from the serial: the un-draining CR3 was the process's own last Dead thread, not a shared address space.)

Bound by wall-clock ticks instead: sample `irq::get_ticks()` (TSC-derived — constant-rate TSC per Intel SDM Vol. 3B §17.17, so it advances even if this CPU's LAPIC timer is dead, guaranteeing termination) every ~1024 spins, give up after ~300ms. The normal drain completes in 1-2 ticks, so the safety valve now fires only for a genuinely wedged sibling. **This also hardens #704's merged drain-wait** (same mis-calibration, never triggered from `exit_thread`'s timing). Commit 1's correctness depends on this.

## Verification (SMP=2, KVM, Firefox → Wikipedia)

Exercised the exact triggering scenario — **254 group exits, 462 threads, 3 vfork parents** — with **spin-WARN = 0** (the pre-fix bound produced it; the tick bound eliminates it), 12 PIDs freed (leak closed), **0** bugcheck/panic/corruption, `TLB/TIMEOUT`=0. Independently reviewed **GO** (all invariants from #704's 3-round review preserved; termination guaranteed; hot path unchanged).

Cite: Intel SDM Vol. 3A §4.10 (CR3 validity), Vol. 3B §17.17 (constant-rate TSC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)