### PR TITLE
proc: enrich the CR3-drain WARN with the still-active CPU's identity

### DIFF
--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -452,6 +452,15 @@ pub fn cr3_active_on_other_cpu(cr3: u64) -> bool {
     (snapshot_active_mask(cr3) & !self_mask) != 0
 }
 
+/// Public snapshot of the per-CPU active-CPU bitmask for `cr3` (bit `n` set ⇒
+/// CPU `n` is bookkept as currently running on `cr3`).  Returns 0 for an
+/// untracked `cr3`.  Intended for diagnostics that need to name *which* CPUs a
+/// teardown is waiting on — e.g. the `free_process_memory` CR3-drain warning —
+/// rather than just the boolean any-other-CPU predicate above.
+pub fn active_cpu_mask(cr3: u64) -> u64 {
+    snapshot_active_mask(cr3)
+}
+
 /// Local `invlpg` over `[va_lo, va_hi)`.  Used by both the sender and
 /// the IPI handler.
 #[inline]

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2255,11 +2255,54 @@ pub fn free_process_memory(pid: Pid) {
             }
         }
         if timed_out {
+            // Enrich the warning with the identity of every CPU still bookkept
+            // on `drain_cr3` (excluding self) and what it is running.  A live
+            // GDB/QMP autopsy proved this warning is a true positive: the
+            // masked CPU's real hardware CR3 equals `drain_cr3` because a
+            // sibling thread of this same process is genuinely still executing
+            // in non-preemptible Ring 0 on the shared address space.  Printing
+            // `cpu=N running pid=X tid=Y (same_proc=…)` lets a future occurrence
+            // be triaged from the log line alone: `same_proc=true` is the
+            // expected slow-sibling drain; a foreign pid would flag a genuine
+            // anomaly worth investigating.  All reads here are lock-free (the
+            // per-CPU current-TID slots) or non-blocking (`THREAD_TABLE`
+            // try-lock, skipped on contention) — this exit path runs with
+            // IF=1 but must never allocate, block, or escalate to a panic.
+            let self_bit = 1u64 << (crate::arch::x86_64::apic::cpu_index() as u64);
+            let others = crate::mm::tlb::active_cpu_mask(drain_cr3) & !self_bit;
             crate::serial_println!(
                 "[PROC] WARN free_process_memory(pid={}) proceeding with CR3 {:#x} \
-                 still active on another CPU after {} ticks (wedged sibling?)",
-                pid, drain_cr3, CR3_DRAIN_MAX_TICKS,
+                 still active on another CPU after {} ticks (wedged sibling?); \
+                 active_other_mask={:#x}",
+                pid, drain_cr3, CR3_DRAIN_MAX_TICKS, others,
             );
+            let ncpus = (crate::arch::x86_64::apic::cpu_count() as usize)
+                .min(crate::arch::x86_64::apic::MAX_CPUS);
+            for cpu in 0..ncpus {
+                if others & (1u64 << (cpu as u64)) == 0 {
+                    continue;
+                }
+                let other_tid = current_tid_on_cpu(cpu);
+                // Non-blocking pid resolution: never panic or spin in the WARN
+                // path.  `?`-less try-lock so a contended THREAD_TABLE just
+                // yields an unknown pid rather than stalling teardown.
+                let other_pid = THREAD_TABLE
+                    .try_lock()
+                    .and_then(|threads| {
+                        threads.iter().find(|t| t.tid == other_tid).map(|t| t.pid)
+                    });
+                match other_pid {
+                    Some(op) => crate::serial_println!(
+                        "[PROC]   cpu={} still on CR3 {:#x} running pid={} tid={} (same_proc={})",
+                        cpu, drain_cr3, op, other_tid, op == pid,
+                    ),
+                    None => crate::serial_println!(
+                        "[PROC]   cpu={} still on CR3 {:#x} running tid={} (pid unresolved: \
+                         THREAD_TABLE contended or tid absent)",
+                        cpu, drain_cr3, other_tid,
+                    ),
+                }
+            }
         }
     }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -2268,6 +2268,12 @@ pub fn free_process_memory(pid: Pid) {
             // per-CPU current-TID slots) or non-blocking (`THREAD_TABLE`
             // try-lock, skipped on contention) — this exit path runs with
             // IF=1 but must never allocate, block, or escalate to a panic.
+            //
+            // `others` is re-sampled here (a separate read from the
+            // `cr3_active_on_other_cpu` predicate that drove the timeout), so if
+            // the sibling drains in the sub-microsecond window between the two
+            // it may read 0 with no per-CPU sub-lines — a near-miss, not a
+            // contradiction of the headline.
             let self_bit = 1u64 << (crate::arch::x86_64::apic::cpu_index() as u64);
             let others = crate::mm::tlb::active_cpu_mask(drain_cr3) & !self_bit;
             crate::serial_println!(
@@ -2283,6 +2289,16 @@ pub fn free_process_memory(pid: Pid) {
                     continue;
                 }
                 let other_tid = current_tid_on_cpu(cpu);
+                if other_tid == 0 {
+                    // Idle sentinel: the CPU drained to the per-CPU idle thread
+                    // between the timeout decision and this snapshot — a benign
+                    // near-miss, distinct from a lookup failure below.
+                    crate::serial_println!(
+                        "[PROC]   cpu={} still on CR3 {:#x} now idle (drained after the deadline)",
+                        cpu, drain_cr3,
+                    );
+                    continue;
+                }
                 // Non-blocking pid resolution: never panic or spin in the WARN
                 // path.  `?`-less try-lock so a contended THREAD_TABLE just
                 // yields an unknown pid rather than stalling teardown.


### PR DESCRIPTION
## What

`free_process_memory` bounds its wait for a process's address space to drain off other CPUs before freeing its page tables (~300 ms tick bound); on timeout it prints a WARN and proceeds. The prior line gave only `pid + CR3 + tick bound`, so a reader could not distinguish a **genuine still-active sibling** from a hypothetical **stale bookkeeping bit** without a fresh live investigation.

This enriches the WARN so it self-triages from the log line alone:

```
[PROC] WARN free_process_memory(pid=3) proceeding with CR3 0x7f1d8000 still active on another CPU after 30 ticks (wedged sibling?); active_other_mask=0x2
[PROC]   cpu=1 still on CR3 0x7f1d8000 running pid=5 tid=82 (same_proc=false)
```

- `active_other_mask` — the per-CR3 active-CPU mask (excluding self).
- Per still-active CPU — the thread it is currently running (pid/tid) and whether that pid matches the process being torn down.

`same_proc=true` is the **expected** case: a sibling thread of the same multithreaded process still executing in non-preemptible Ring 0 on the shared address space. A foreign pid would flag a real anomaly worth investigating.

## Why

A prior GDB/QMP autopsy of this exact WARN proved it is a **true positive** — at the WARN instant the masked CPU's real hardware CR3 equalled `drain_cr3` because a sibling thread genuinely still held it (Intel SDM Vol. 3A §4.10: freeing page tables under a CPU still on that CR3 would fault its next PTE walk / `SYSRETQ` onto freed frames). This change makes any future occurrence self-diagnosing without repeating that investigation.

## Safety

- New `tlb::active_cpu_mask()` is a read-only public snapshot of the existing per-CR3 mask.
- All reads on this exit path are **lock-free** (per-CPU current-TID slots) or **non-blocking** (`THREAD_TABLE` try-lock, skipped on contention). The path runs with IF=1 but never allocates, blocks, or escalates to a panic.
- Behaviour is otherwise unchanged — only the diagnostic on the already-taken timeout branch is expanded. Severity stays WARN.

## Validation

- Builds clean (`firefox-test-core,kdb`).
- The enriched print path was exercised end-to-end via a throwaway forced-WARN build (reverted before this commit): the per-CPU sub-lines formatted correctly, `THREAD_TABLE` try-lock resolved a genuinely-running thread (`pid=5 tid=82`), idle CPUs (`tid=0`) were handled gracefully, and FF continued to render its PNG with **zero panics/bugchecks** — confirming the WARN path does not destabilize teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)