### PR TITLE
mm: close the mm_sem + PROCESS_TABLE lock-vs-shootdown reentrancy deadlocks on the #PF fast path (follow-up to #703)

### DIFF
--- a/kernel/src/arch/x86_64/idt.rs
+++ b/kernel/src/arch/x86_64/idt.rs
@@ -1461,7 +1461,10 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
     // For vfork children (sharing parent's CR3), also check the parent's VmSpace
     // if the child's own VmSpace doesn't have a matching VMA.
     let (parent_pid_for_fallback, own_cr3) = {
-        let procs = crate::proc::PROCESS_TABLE.lock();
+        // IF=0 fault-entry acquire: drain incoming shootdowns while spinning so
+        // a peer `clone_for_fork` holding PROCESS_TABLE across its CoW shootdown
+        // cannot deadlock against us (see `proc::lock_process_table_draining`).
+        let procs = crate::proc::lock_process_table_draining();
         let proc = match procs.iter().find(|p| p.pid == pid) {
             Some(p) => p,
             None => return false,
@@ -1473,7 +1476,9 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
     // Try own process first; if it has no VMA for this address, try the parent.
     // This handles vfork children that share the parent's page tables.
     let target_pid = {
-        let procs = crate::proc::PROCESS_TABLE.lock();
+        // IF=0 fault-entry acquire — drain incoming shootdowns while spinning
+        // (see the acquire above and `proc::lock_process_table_draining`).
+        let procs = crate::proc::lock_process_table_draining();
         let has_vma = procs.iter().find(|p| p.pid == pid)
             .and_then(|p| p.vm_space.as_ref())
             .and_then(|vs| vs.find_vma(faulting_addr))
@@ -1494,7 +1499,9 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
         }
     };
 
-    let mut procs = crate::proc::PROCESS_TABLE.lock();
+    // IF=0 fault-entry acquire — drain incoming shootdowns while spinning
+    // (see the two acquires above and `proc::lock_process_table_draining`).
+    let mut procs = crate::proc::lock_process_table_draining();
     let proc = match procs.iter_mut().find(|p| p.pid == target_pid) {
         Some(p) => p,
         None => return false,
@@ -1557,7 +1564,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             let pte = crate::mm::vmm::read_pte(cr3, page_addr);
             let old_phys = pte & 0x000F_FFFF_FFFF_F000;
             let new_pte = old_phys | page_flags | PAGE_PRESENT;
-            crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            crate::mm::vmm::write_pte_fault_path(cr3, page_addr, new_pte);
             // Release PROCESS_TABLE before the cross-CPU shootdown.  The
             // shootdown IPI needs every target CPU to run its handler to ACK,
             // but any peer CPU that is itself in `handle_page_fault` spins on
@@ -1697,7 +1704,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             // pays for itself by keeping the source readable as a single
             // entry-point for the whole CoW arm.
             let new_pte = old_phys | page_flags | PAGE_PRESENT;
-            crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            crate::mm::vmm::write_pte_fault_path(cr3, page_addr, new_pte);
             // Release PROCESS_TABLE before the shootdown (lock-vs-IPI deadlock;
             // see the MAP_SHARED arm above).
             drop(procs);
@@ -1746,7 +1753,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
             // an NX-marked TLB entry for the same page and #PF on the
             // first ifetch.
             let new_pte = pte & !crate::mm::vmm::PAGE_NO_EXECUTE;
-            crate::mm::vmm::write_pte(cr3, page_addr, new_pte);
+            crate::mm::vmm::write_pte_fault_path(cr3, page_addr, new_pte);
             // Release PROCESS_TABLE before the shootdown (lock-vs-IPI deadlock;
             // see the MAP_SHARED arm above).  `vma` is not read past its
             // PROT_EXEC test in the guard, so the borrow is already released.
@@ -3535,7 +3542,7 @@ fn handle_page_fault(faulting_addr: u64, error_code: u64, frame: &mut InterruptF
                 // Identity-map device memory (no allocation needed)
                 let offset = page_addr - vma.base;
                 let phys = phys_base + offset;
-                crate::mm::vmm::map_page_in(cr3, page_addr, phys, page_flags | crate::mm::vmm::PAGE_NO_CACHE);
+                crate::mm::vmm::map_page_in_fault_path(cr3, page_addr, phys, page_flags | crate::mm::vmm::PAGE_NO_CACHE);
                 crate::mm::vmm::invlpg(page_addr);
                 return true;
             }

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -1095,6 +1095,38 @@ fn service_incoming_shootdown_and_drain(cpu: usize) {
     drain_pending_force_flush(cpu);
 }
 
+/// Service this CPU's own incoming shootdown slot if SMP is active; a no-op
+/// on a single-CPU boot.
+///
+/// Exposes [`service_incoming_shootdown_and_drain`] outside this module for
+/// the lock-vs-IPI reentrancy fix on the `#PF` fast path: a page-fault handler
+/// that spins (with interrupts disabled) to acquire a lock — `mm_sem` in read
+/// mode (`crate::mm::vma::mm_sem_read_draining`) or `PROCESS_TABLE`
+/// (`crate::proc::lock_process_table_draining`) — held by a peer CPU that is
+/// simultaneously waiting on a TLB-shootdown ACK from *this* CPU would deadlock
+/// (this CPU cannot ACK the shootdown IPI while it is IF-masked, and the peer
+/// cannot release the lock until its shootdown completes). Draining our own
+/// incoming shootdown slot on every spin iteration lets the peer's ACK from
+/// this CPU complete even while this CPU is blocked acquiring the lock. This is
+/// the same deadlock CLASS the `PROCESS_TABLE`-vs-write-fault-path shootdown
+/// fix (PR #703) addressed, applied to a lock the writer legitimately holds
+/// across its shootdown.
+///
+/// Checking `SMP_ACTIVE` first means a single-CPU boot pays exactly one
+/// relaxed atomic load per contended spin iteration and never reaches
+/// `apic::cpu_index()` (an `RDTSCP`) or touches a shootdown slot — inert on
+/// SMP=1, matching the same guard `shootdown_range` uses before doing any
+/// cross-CPU work.  The routine is lock-free and EOI-free (a compare-exchange
+/// on this CPU's own slot, an `invlpg` if the target CR3 matches, and a
+/// force-flush drain), so it is safe to call with interrupts disabled while
+/// holding no lock this CPU is still trying to acquire.
+#[inline]
+pub(crate) fn drain_incoming_shootdown_if_smp() {
+    if SMP_ACTIVE.load(Ordering::Acquire) {
+        service_incoming_shootdown_and_drain(apic::cpu_index());
+    }
+}
+
 /// IPI handler.  Invoked from [`crate::arch::x86_64::idt`] when the LAPIC
 /// delivers a [`TLB_SHOOTDOWN_VECTOR`] interrupt to this CPU.
 ///

--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -19,7 +19,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::sync::atomic::{AtomicU64, Ordering};
-use spin::{Mutex, RwLock};
+use spin::{Mutex, RwLock, RwLockReadGuard};
 
 /// VMA protection flags (mmap-compatible).
 pub type VmProt = u32;
@@ -452,6 +452,93 @@ pub fn mm_sem_for_cr3(cr3: u64) -> Option<Arc<RwLock<()>>> {
     }
     let reg = MM_REGISTRY.lock();
     reg.get(&cr3).cloned()
+}
+
+/// Acquire `sem.read()` for a `#PF`-fast-path caller, servicing this CPU's
+/// own incoming TLB-shootdown slot on every contended spin iteration instead
+/// of blocking outright.
+///
+/// # The `mm_sem`/shootdown reentrancy deadlock this closes
+///
+/// `free_process_memory`, `free_vm_space`, and `clone_for_fork` hold
+/// `mm_sem.write()` across a `mm::tlb::shootdown_*` call.  That ordering is
+/// load-bearing per the W216 exclusion invariant documented on
+/// [`VmSpace::mm_sem`] above — no concurrent faulter may install a mapping
+/// while teardown/fork is walking page tables and returning frames to the
+/// PMM — so, unlike the `PROCESS_TABLE`-vs-shootdown deadlock fixed by
+/// dropping `PROCESS_TABLE` before its shootdown (PR #703), `mm_sem.write()`
+/// cannot simply be released before the shootdown here.  The writer must keep
+/// the lock.
+///
+/// A `#PF` is delivered on an interrupt gate (IF=0 for the duration of the
+/// handler; Intel SDM Vol. 3A §6.8.1/§6.12.1), so a peer CPU concurrently
+/// installing a PTE via `map_page_in_if_absent`, `map_page_in_cow_if_unchanged`,
+/// or the fault-path callers of `map_page_in` / `write_pte` takes `mm_sem`
+/// in read mode with interrupts disabled.  If that reader spins on a plain
+/// `RwLock::read()` because a writer already holds `mm_sem.write()`, and the
+/// writer's own `shootdown_full_user` / `shootdown_range` call is
+/// simultaneously spinning on the ACK from that exact reader CPU, the two
+/// sides deadlock: the writer never receives its ACK, because IF=0 leaves the
+/// shootdown IPI vector pending in the reader CPU's LAPIC IRR (unserviceable
+/// until the reader returns from the page-fault handler and re-enables
+/// interrupts, per Intel SDM Vol. 3A §10.6.1), and the reader never acquires
+/// `mm_sem`, because the writer never reaches the point where it drops it.
+/// This is the same deadlock CLASS fixed for `PROCESS_TABLE` vs. the
+/// write-fault-path shootdown — a lock held across a TLB shootdown whose
+/// target is itself blocked acquiring that lock — applied to `mm_sem`.
+///
+/// # The fix
+///
+/// Mirrors the reentrancy already used to break the analogous livelock
+/// between two shootdown *initiators* (the ACK-spin in
+/// `mm::tlb::shootdown_range_inner`, which services incoming shootdowns on
+/// every iteration): instead of blocking, a contended reader here services
+/// its OWN incoming shootdown slot via
+/// [`crate::mm::tlb::drain_incoming_shootdown_if_smp`] on every iteration.
+/// That routine is lock-free and EOI-free, so it is safe to call with
+/// interrupts disabled while `mm_sem` / `VMM_LOCK` are NOT held by this CPU
+/// (they are not: this CPU is still spinning to acquire `mm_sem`, and
+/// `VMM_LOCK` is taken only after `mm_sem`).  The W216 mutual exclusion is
+/// preserved exactly — the reader still cannot proceed until the writer is
+/// done — this only stops the reader from presenting as IF=0 dead weight to
+/// the writer's shootdown while it waits.
+///
+/// # Cost
+///
+/// The common case (a live fault racing a teardown/fork writer is rare) is
+/// `try_read()` succeeding immediately — identical cost to a plain
+/// `RwLock::read()`.  Only on contention does the loop run, and each iteration
+/// costs one relaxed atomic load (`drain_incoming_shootdown_if_smp`'s
+/// `SMP_ACTIVE` check) plus, only when SMP is active AND a shootdown is
+/// actually incoming, one lock-free compare-exchange + `invlpg`.  On SMP=1 the
+/// drain is a single relaxed load per iteration and never sends or receives an
+/// IPI.
+///
+/// # Scope — why this is not just `RwLock::read()` everywhere
+///
+/// This wrapper is used ONLY by the acquisitions that can run with IF=0:
+/// `map_page_in_if_absent`, `map_page_in_cow_if_unchanged`, and the
+/// `_fault_path` wrappers of `map_page_in` / `write_pte` (see
+/// `kernel/src/mm/vmm.rs`).  Every other `mm_sem_for_cr3(...).read()` site —
+/// ELF/PE loading, the non-fault-path `map_page_in` / `write_pte` callers
+/// (`sysv_shm`, `signal.rs`'s trampoline setup, `ptrace` POKETEXT/POKEDATA,
+/// process/PE bring-up, the `vdso`/`usermode` setup helpers,
+/// `unmap_and_free_range_in`'s own inner read acquisition) — runs with
+/// interrupts enabled, where a plain blocking `RwLock::read()` cannot produce
+/// this deadlock: the shootdown IPI targeting that CPU is still serviceable by
+/// the ordinary ISR while it spins.  Leaving those on the plain acquire keeps
+/// this change scoped to the actual IF=0 hazard.
+pub(crate) fn mm_sem_read_draining(sem: &RwLock<()>) -> RwLockReadGuard<'_, ()> {
+    if let Some(guard) = sem.try_read() {
+        return guard;
+    }
+    loop {
+        crate::mm::tlb::drain_incoming_shootdown_if_smp();
+        if let Some(guard) = sem.try_read() {
+            return guard;
+        }
+        core::hint::spin_loop();
+    }
 }
 
 // ============================================================================

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -564,6 +564,34 @@ pub fn map_page_in(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -
     // `None` arm is a no-op (no concurrent fork to serialise against).
     let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
     let _mm_read = _mm_guard.as_ref().map(|s| s.read());
+    map_page_in_impl(pml4_phys, virt_addr, phys_addr, flags)
+}
+
+/// `#PF`-fast-path variant of [`map_page_in`] — identical semantics, used by
+/// the single install site inside `handle_page_fault` that runs with IF=0
+/// (the `PAGE_NO_CACHE` MMIO-mapping arm).  Acquires `mm_sem` via
+/// [`crate::mm::vma::mm_sem_read_draining`] instead of a plain blocking
+/// `RwLock::read()` — see that function's docs for the mm_sem/shootdown
+/// reentrancy deadlock this avoids.  Every other `map_page_in` call site
+/// (ELF/PE loading, fork, `vdso`/`usermode` bring-up, `sysv_shm`, the signal
+/// trampoline) runs with interrupts enabled and stays on the plain
+/// `map_page_in` above.
+///
+/// # Safety
+/// `pml4_phys` must point to a valid PML4 page table.
+pub fn map_page_in_fault_path(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -> bool {
+    let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
+    let _mm_read = _mm_guard
+        .as_ref()
+        .map(|s| crate::mm::vma::mm_sem_read_draining(s));
+    map_page_in_impl(pml4_phys, virt_addr, phys_addr, flags)
+}
+
+/// Shared body of [`map_page_in`] / [`map_page_in_fault_path`] — everything
+/// after the `mm_sem` acquisition, which the two wrappers perform differently.
+/// Takes `VMM_LOCK` itself, preserving the `mm_sem` (outer) → `VMM_LOCK`
+/// (inner) ordering documented on `VmSpace::mm_sem`.
+fn map_page_in_impl(pml4_phys: u64, virt_addr: u64, phys_addr: u64, flags: u64) -> bool {
     let _lock = VMM_LOCK.lock();
 
     let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;
@@ -653,8 +681,16 @@ pub fn map_page_in_if_absent(
     phys_addr: u64,
     flags: u64,
 ) -> bool {
+    // mm_sem/shootdown reentrancy: every caller of this function is inside
+    // `handle_page_fault` (IF=0), so the plain `RwLock::read()` used elsewhere
+    // in this file risks the mm_sem-vs-shootdown-ACK deadlock documented on
+    // `mm::vma::mm_sem_read_draining` — use the draining acquire
+    // unconditionally here rather than forking a `_fault_path` sibling, since
+    // there is no non-fault-path caller to keep on the plain acquire.
     let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
-    let _mm_read = _mm_guard.as_ref().map(|s| s.read());
+    let _mm_read = _mm_guard
+        .as_ref()
+        .map(|s| crate::mm::vma::mm_sem_read_draining(s));
     let _lock = VMM_LOCK.lock();
 
     let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;
@@ -738,8 +774,15 @@ pub fn map_page_in_cow_if_unchanged(
     flags: u64,
     expected_phys: u64,
 ) -> bool {
+    // mm_sem/shootdown reentrancy: the sole caller of this function is the
+    // write-fault CoW arm inside `handle_page_fault` (IF=0) — see
+    // `mm::vma::mm_sem_read_draining` for the deadlock this closes.  No
+    // non-fault-path caller exists, so the draining acquire is used
+    // unconditionally rather than forking a sibling function.
     let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
-    let _mm_read = _mm_guard.as_ref().map(|s| s.read());
+    let _mm_read = _mm_guard
+        .as_ref()
+        .map(|s| crate::mm::vma::mm_sem_read_draining(s));
     let _lock = VMM_LOCK.lock();
 
     let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;
@@ -1001,7 +1044,27 @@ pub fn read_pte(pml4_phys: u64, virt_addr: u64) -> u64 {
 pub fn write_pte(pml4_phys: u64, virt_addr: u64, pte: u64) {
     let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
     let _mm_read = _mm_guard.as_ref().map(|s| s.read());
+    write_pte_impl(pml4_phys, virt_addr, pte)
+}
 
+/// `#PF`-fast-path variant of [`write_pte`] — identical semantics, used by the
+/// flag-rewrite call sites inside `handle_page_fault` (IF=0).  Acquires
+/// `mm_sem` via [`crate::mm::vma::mm_sem_read_draining`] instead of a plain
+/// blocking `RwLock::read()` — see that function's docs for the mm_sem/
+/// shootdown reentrancy deadlock this avoids.  The `ptrace` POKETEXT/POKEDATA
+/// path and the other IF=1 `write_pte` callers run with interrupts enabled and
+/// stay on the plain `write_pte` above.
+pub fn write_pte_fault_path(pml4_phys: u64, virt_addr: u64, pte: u64) {
+    let _mm_guard = crate::mm::vma::mm_sem_for_cr3(pml4_phys);
+    let _mm_read = _mm_guard
+        .as_ref()
+        .map(|s| crate::mm::vma::mm_sem_read_draining(s));
+    write_pte_impl(pml4_phys, virt_addr, pte)
+}
+
+/// Shared body of [`write_pte`] / [`write_pte_fault_path`] — everything after
+/// the `mm_sem` acquisition, which the two wrappers perform differently.
+fn write_pte_impl(pml4_phys: u64, virt_addr: u64, pte: u64) {
     let pml4_idx = ((virt_addr >> 39) & 0x1FF) as usize;
     let pdpt_idx = ((virt_addr >> 30) & 0x1FF) as usize;
     let pd_idx = ((virt_addr >> 21) & 0x1FF) as usize;

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -557,6 +557,62 @@ pub static PROCESS_TABLE: Mutex<Vec<Process>> = Mutex::new(Vec::new());
 /// Thread table.
 pub static THREAD_TABLE: Mutex<Vec<Thread>> = Mutex::new(Vec::new());
 
+/// Acquire `PROCESS_TABLE` from a `#PF` handler running with interrupts
+/// disabled, servicing this CPU's own incoming TLB-shootdown slot on every
+/// contended spin iteration instead of blocking outright.
+///
+/// # The `PROCESS_TABLE`/shootdown reentrancy deadlock this closes
+///
+/// `VmSpace::clone_for_fork` runs from the fork(2) path with `PROCESS_TABLE`
+/// held (the caller borrows the parent `Process` out of the table across the
+/// whole clone) and issues a `mm::tlb::shootdown_full_user` for the parent's
+/// CR3 to evict the sibling CPUs' now-stale writable CoW translations.  A
+/// sibling thread of the forking process taking a `#PF` on another CPU enters
+/// `handle_page_fault` on an interrupt gate (IF=0 for the handler's duration;
+/// Intel SDM Vol. 3A §6.8.1/§6.12.1) and acquires `PROCESS_TABLE` to look up
+/// its faulting VMA.  If it spins on a plain `PROCESS_TABLE.lock()` while the
+/// forking CPU holds the lock across its shootdown, and that shootdown is
+/// simultaneously spinning on the ACK from this exact CPU, both sides
+/// deadlock: the forking CPU never gets its ACK (IF=0 leaves the shootdown IPI
+/// pending in this CPU's LAPIC IRR until it returns from the fault and
+/// re-enables interrupts — Intel SDM Vol. 3A §10.6.1), and this CPU never
+/// acquires `PROCESS_TABLE` (the forking CPU never reaches the point where it
+/// drops it).  This is the same deadlock CLASS PR #703 fixed for the
+/// write-fault-path shootdown vs. `PROCESS_TABLE`; PR #703 dropped
+/// `PROCESS_TABLE` before *its own* shootdowns, but `clone_for_fork` is a
+/// separate holder PR #703 did not touch, and it cannot drop the lock without
+/// releasing the borrow of the parent `Process` mid-clone.
+///
+/// Unlike the write-fault path, `PROCESS_TABLE` here is not protecting the
+/// page-table copy — `clone_for_fork` holds `mm_sem.write()` for that exclusion
+/// (the mmap-lock analogue), and `PROCESS_TABLE` is held only incidentally, to
+/// keep the parent-`Process` borrow alive.  So the reader side can safely
+/// service its own shootdown while it waits: draining evicts this CPU's stale
+/// TLB (exactly the shootdown's intent) and violates no invariant `PROCESS_TABLE`
+/// guards.  The mutual exclusion is preserved exactly — this CPU still cannot
+/// proceed until the writer drops the lock.
+///
+/// # Scope
+///
+/// Used ONLY by the `handle_page_fault` acquisitions, which run with IF=0.
+/// Every other `PROCESS_TABLE.lock()` site runs with interrupts enabled, where
+/// a plain blocking acquire cannot produce this deadlock: the shootdown IPI is
+/// still serviceable by the ordinary ISR while that CPU spins.  The common
+/// (uncontended) case is `try_lock()` succeeding immediately — identical cost
+/// to a plain `lock()`; only on contention does the drain loop run.
+pub fn lock_process_table_draining() -> spin::MutexGuard<'static, Vec<Process>> {
+    if let Some(guard) = PROCESS_TABLE.try_lock() {
+        return guard;
+    }
+    loop {
+        crate::mm::tlb::drain_incoming_shootdown_if_smp();
+        if let Some(guard) = PROCESS_TABLE.try_lock() {
+            return guard;
+        }
+        core::hint::spin_loop();
+    }
+}
+
 /// Bounded-spin acquire of `THREAD_TABLE` with a loud panic on exhaustion.
 ///
 /// Used (under `firefox-test`) at hot read-only call sites that previously

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2356,6 +2356,15 @@ pub fn run() -> ! {
     total += 1;
     if test_699_tlb_shootdown_ack_spin_reentrancy() { passed += 1; }
 
+    // ── Test 706: #PF-fast-path draining lock acquires (mm_sem + PROCESS_TABLE) ──
+    // Reader-side reentrancy fix for the mm_sem / PROCESS_TABLE lock-vs-shootdown
+    // deadlock class (follow-up to PR #703): a contended #PF-fast-path acquire
+    // services its own incoming shootdown slot instead of blocking IF=0.  This
+    // guards the three primitives' mechanics (fast-path returns a real guard,
+    // inert drain, W216 read-excludes-write preserved).
+    total += 1;
+    if test_706_pf_fastpath_draining_acquire() { passed += 1; }
+
     // ── Test 651: per-CPU LAPIC-timer liveness decision state machine ──
     // The hardware-free core of the SMP dead-CPU-timer self-heal: ISR-advance
     // recovery, tolerance window, sticky-dead, bounded futile re-arm cap.
@@ -45057,6 +45066,65 @@ fn test_699_tlb_shootdown_ack_spin_reentrancy() -> bool {
     }
 
     test_pass!("TLB shootdown ACK-spin reentrancy (mutual-livelock break)");
+    true
+}
+
+// ── Test 706: #PF-fast-path draining lock acquires (mm_sem + PROCESS_TABLE) ──
+//
+// The reader-side reentrancy fix for the lock-vs-shootdown deadlock class that
+// PR #703 opened (mm_sem/PROCESS_TABLE held across a shootdown by a teardown/
+// fork writer vs. an IF=0 #PF peer spinning on the same lock).  A live trigger
+// needs a genuine SMP timing race (writer + IF=0 faulter on the same CR3), so
+// this is a mechanical regression guard for the three primitives rather than a
+// deadlock reproducer: it proves the uncontended fast path returns a REAL
+// guard, the drain call is safe + inert when no shootdown is pending, and the
+// W216 read-excludes-write invariant the draining acquire must preserve holds.
+fn test_706_pf_fastpath_draining_acquire() -> bool {
+    test_header!("#PF-fast-path draining lock acquires (mm_sem + PROCESS_TABLE)");
+    use spin::RwLock;
+
+    // (1) drain_incoming_shootdown_if_smp() must be safe and inert to call
+    //     while holding no lock (the exact context the draining spin uses it
+    //     in).  On the single-CPU test runner SMP_ACTIVE is false, so it is a
+    //     single relaxed load and never touches a shootdown slot; idempotent.
+    crate::mm::tlb::drain_incoming_shootdown_if_smp();
+    crate::mm::tlb::drain_incoming_shootdown_if_smp();
+
+    // (2) mm_sem_read_draining() fast path returns a genuine read guard on an
+    //     uncontended sem, preserving W216: while the read guard is held a
+    //     writer is EXCLUDED but a second reader is ADMITTED (shared read).
+    let sem = RwLock::new(());
+    {
+        let g = crate::mm::vma::mm_sem_read_draining(&sem);
+        if sem.try_write().is_some() {
+            test_fail!("pf/drain", "mm_sem read guard did not exclude a writer");
+            return false;
+        }
+        if sem.try_read().is_none() {
+            test_fail!("pf/drain", "mm_sem read guard wrongly excluded a second reader");
+            return false;
+        }
+        drop(g);
+    }
+    // Guard really released: a writer is now admitted.
+    if sem.try_write().is_none() {
+        test_fail!("pf/drain", "writer still excluded after mm_sem read guard dropped");
+        return false;
+    }
+
+    // (3) lock_process_table_draining() acquires PROCESS_TABLE via its fast
+    //     path and releases on drop — a plain lock must then succeed (the
+    //     draining acquire must not leave the lock wedged).
+    {
+        let procs = crate::proc::lock_process_table_draining();
+        let _ = procs.len(); // guard is usable
+    }
+    if crate::proc::PROCESS_TABLE.try_lock().is_none() {
+        test_fail!("pf/drain", "PROCESS_TABLE still held after draining guard dropped");
+        return false;
+    }
+
+    test_pass!("#PF-fast-path draining lock acquires (mm_sem + PROCESS_TABLE)");
     true
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #703. PR #703 fixed a lock-vs-IPI deadlock between `PROCESS_TABLE` and the write-fault-path TLB shootdown by dropping `PROCESS_TABLE` before each of `handle_page_fault`'s own shootdowns. The **same deadlock class** survives with two other locks that a teardown/fork writer legitimately holds across its shootdown and **cannot** simply drop:

- **`mm_sem.write()`** — held across `shootdown_full_user` by `free_process_memory`, `free_vm_space`, and `VmSpace::clone_for_fork`. The write hold IS the W216 exclusion invariant (no concurrent faulter may install a mapping while teardown/fork walks page tables and returns frames to the PMM), so it cannot be released before the shootdown.
- **`PROCESS_TABLE`** — held across `clone_for_fork`'s shootdown by the fork(2) caller, which borrows the parent `Process` out of the table for the whole clone. PR #703 dropped `PROCESS_TABLE` before *its own* shootdowns, but `clone_for_fork` is a separate holder it did not touch, and the lock cannot be dropped without releasing that borrow mid-clone.

`clone_for_fork` has **both** hazards; `free_process_memory` / `free_vm_space` own their `VmSpace` locally (they have already dropped `PROCESS_TABLE`) so they have only the `mm_sem` hazard.

## The deadlock

A `#PF` is delivered on an interrupt gate (IF=0 for the handler's duration; Intel SDM Vol. 3A §6.8.1/§6.12.1). A peer CPU faulting on the writer's address space acquires the same lock — `mm_sem` in read mode inside the fault-path PTE installers, or `PROCESS_TABLE` at fault entry to look up the faulting VMA. If it spins on a plain blocking acquire while the writer holds the lock, and the writer's shootdown is simultaneously spinning on the ACK from that exact CPU, both sides deadlock: IF=0 leaves the shootdown IPI pending in the reader's LAPIC IRR (unserviceable until the reader returns from the fault and re-enables interrupts, Intel SDM Vol. 3A §10.6.1), and the reader never acquires the lock because the writer never reaches its release point → the `[TLB/TIMEOUT]` symptom #703 fixed, driven by fork/exit/execve teardown racing a live `#PF` on a sibling CPU.

## The fix — reader-side reentrancy (not a writer-side lock drop)

Mirrors the reentrancy already used to break the analogous livelock between two shootdown *initiators* (the ACK-spin in `shootdown_range_inner` services incoming shootdowns on every iteration). A contended `#PF`-fast-path reader services its **own** incoming shootdown slot on every spin iteration, so the writer's ACK from this CPU completes even while this CPU is blocked acquiring the lock. The mutual exclusion is preserved exactly — the reader still cannot proceed until the writer is done.

- `mm::tlb::drain_incoming_shootdown_if_smp()` — `SMP_ACTIVE`-gated wrapper around the existing lock-free, EOI-free `service_incoming_shootdown_and_drain`.
- `mm::vma::mm_sem_read_draining()` — `try_read()` first (identical cost to a plain acquire uncontended), then drain-and-retry on contention. Used by `map_page_in_if_absent`, `map_page_in_cow_if_unchanged`, and the new `*_fault_path` wrappers of `map_page_in` / `write_pte`. The plain `map_page_in` / `write_pte` keep their blocking read for the many IF=1 callers (ELF/PE load, sysv_shm, signal trampoline, ptrace, vdso/usermode bring-up), which cannot hit this deadlock. Only the four `handle_page_fault` install sites were repointed.
- `proc::lock_process_table_draining()` — same pattern for `PROCESS_TABLE` (a `spin::Mutex`), used by the three IF=0 `handle_page_fault` entry acquisitions. Every IF=1 `PROCESS_TABLE.lock()` site is unchanged.

### Why this is MT-fork-safe

A naive writer-side fix for `clone_for_fork` (take `parent.vm_space` out / drop the lock mid-clone) SIGSEGVs a concurrently faulting sibling thread of the forking parent. This reader-side fix keeps `clone_for_fork` unchanged: a concurrently faulting sibling still finds `vm_space == Some`, looks up its VMA under a drain-reentrant `PROCESS_TABLE` acquire, and serialises its PTE install behind the parent's `mm_sem.write()` (also drain-reentrant), exactly as the W216 invariant requires. `PROCESS_TABLE` here is not protecting the page-table copy — `mm_sem.write()` is (the mmap-lock analogue) — so a peer draining while it waits on `PROCESS_TABLE` violates no invariant.

## Verification

- **SMP=2 FF workload** (`firefox-test-core`, 2048 MiB, `--ff-url https://example.com`): rendered content to a full PNG and every process did a clean `exit_group(0)`. Full-log signature scan: **TLB/TIMEOUT 0, BUGCHECK 0, WARN free_process_memory 0, SIGSEGV 0, STARVE/double_dispatch 0, #GP/#UD 0** (non-UMIP). Fullest exercise of the fork / exit / teardown + fault-path installer paths this touches.
- **Build**: green for both `firefox-test-core,kdb` and `test-mode`; no new warnings on the touched symbols.
- **Latency**: the class is latent (writer + reader are usually different CR3s, so `[TLB/TIMEOUT]` was 0 through prior teardown-heavy soaks). The fix is deliberately additive; on SMP=1 every drain is a single relaxed atomic load and never sends or receives an IPI. Test 706 is a mechanical regression guard for the three primitives (a live deadlock trigger needs a genuine SMP timing race).

Intel SDM Vol. 3A §10.6.1 (IPI delivery to a masked target), §6.8.1/§6.12.1 (interrupt-gate IF handling), §4.10.4.2 (TLB-shootdown invalidation ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
