### PR TITLE
signal: restore caller-saved argument registers on sigreturn (rdi/rsi/rdx/r8/r9/r10)

### DIFF
--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -148,7 +148,7 @@ const _SIGNAL_FRAME_SIZE_CHECK: () = {
 /// non-user, or read-only.  Returning `true` is a single-point-in-time
 /// snapshot; once SMAP is lifted (`stac`) and the writes begin, another
 /// CPU can still flip the PTE (e.g. mprotect, ptrace, ksm).  That race
-/// is small (the entire frame is ≤ 664 bytes / one page touched) and
+/// is small (the entire frame is ≤ 712 bytes / one page touched) and
 /// the worst case is the same kernel-mode #PF this function was added
 /// to prevent — so the caller MUST still treat a faulting store as
 /// fatal-to-the-process (not fatal-to-the-kernel).  Achieving the
@@ -196,7 +196,7 @@ pub(crate) fn is_user_writable_range(cr3: u64, base: u64, len: u64) -> bool {
     use crate::mm::vmm::{lookup_pte_in, virt_to_phys_in,
                           PAGE_PRESENT, PAGE_WRITABLE, PAGE_USER};
     // Iterate every page covered by [base, base+len).  Loop bound is
-    // ceil((base & 0xfff) + len, 4096) — at most 2 pages for the 664-
+    // ceil((base & 0xfff) + len, 4096) — at most 2 pages for the 712-
     // byte SA_SIGINFO frame, but we keep the loop general so the same
     // helper can be reused (e.g. by sigaltstack-aware paths later).
     let end = match base.checked_add(len) {
@@ -873,7 +873,7 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
             // The syscall-entry path runs with AC=0, so this bracket is
             // required for every store via `sig_frame_ptr` / `ucontext_ptr`
             // / `siginfo_ptr` below.  Pointer math is bounded by `total`
-            // (≤ 664) starting at the user-supplied `saved_rsp`.
+            // (≤ 712) starting at the user-supplied `saved_rsp`.
             let _smap_g = unsafe { UserGuard::new() };
             unsafe {
                 (*sig_frame_ptr).restorer   = restorer_addr;
@@ -1107,9 +1107,9 @@ pub unsafe fn deliver_fault_signal_from_isr(
     // (int signo, siginfo_t *info, ucontext_t *uctx) in (RDI, RSI, RDX).
     let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 160
     let total = if want_siginfo {
-        sigframe_size + UCONTEXT_SIZE + 128u64  // 112 + 424 + 128 = 664
+        sigframe_size + UCONTEXT_SIZE + 128u64  // 160 + 424 + 128 = 712
     } else {
-        sigframe_size + 128u64                  // 112 + 128 = 240 (legacy)
+        sigframe_size + 128u64                  // 160 + 128 = 288 (legacy)
     };
 
     // 16-align the allocation base, then subtract 8 for "just-called" ABI.
@@ -1136,7 +1136,7 @@ pub unsafe fn deliver_fault_signal_from_isr(
     // the process via exit_thread instead.
     //
     // We walk every page in [new_rsp, new_rsp + total) (≤ 2 pages for the
-    // 664-byte SA_SIGINFO frame), not just `new_rsp`, because the frame can
+    // 712-byte SA_SIGINFO frame), not just `new_rsp`, because the frame can
     // straddle a page boundary when the user stack ends near one and the
     // tail page is mapped but read-only / non-user.
     //

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -117,11 +117,26 @@ pub struct SignalFrame {
     pub saved_r11: u64,     // original RFLAGS
     pub saved_rcx: u64,     // original user RIP
     pub saved_rax: u64,     // syscall return value
-    pub _pad: u64,          // padding to 14 × 8 = 112 bytes (16-aligned)
+    // Caller-saved argument registers.  A signal is asynchronous: it can
+    // interrupt user code at ANY instruction, where these registers may
+    // hold live values (a `this` pointer, a memcpy dest/src/count, etc.).
+    // The x86-64 System V psABI §3.2.3 signal-return contract requires the
+    // FULL interrupted register set be restored on handler return — unlike a
+    // *syscall* boundary, where the ABI permits the kernel to clobber these.
+    // Omitting them left a returning handler resuming with garbage in
+    // rdi/rsi/rdx/r8/r9/r10 → a deref of the garbage pointer (SIGSEGV) or a
+    // store through a stale destination pointer (silent memory corruption).
+    pub saved_rdi: u64,
+    pub saved_rsi: u64,
+    pub saved_rdx: u64,
+    pub saved_r8:  u64,
+    pub saved_r9:  u64,
+    pub saved_r10: u64,
+    pub _pad: u64,          // padding to 20 × 8 = 160 bytes (16-aligned)
 }
 
 const _SIGNAL_FRAME_SIZE_CHECK: () = {
-    assert!(core::mem::size_of::<SignalFrame>() == 112);
+    assert!(core::mem::size_of::<SignalFrame>() == 160);
 };
 
 /// Verify every 4 KiB page in `[base, base+len)` is mapped as a
@@ -794,15 +809,15 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
 
             // ── User stack layout (growing downward) ─────────────────────
             // For SA_SIGINFO handlers:
-            //   new_rsp + 0   .. +112  : SignalFrame  (restorer at [new_rsp])
-            //   new_rsp + 112 .. +536  : ucontext_t (424 bytes)
-            //   new_rsp + 536 .. +664  : siginfo_t (128 bytes)
+            //   new_rsp + 0   .. +160  : SignalFrame  (restorer at [new_rsp])
+            //   new_rsp + 160 .. +584  : ucontext_t (424 bytes)
+            //   new_rsp + 584 .. +712  : siginfo_t (128 bytes)
             //
             // For classic handlers (no SA_SIGINFO):
-            //   new_rsp + 0 .. +112 : SignalFrame only (as before)
-            let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 112
+            //   new_rsp + 0 .. +160 : SignalFrame only (as before)
+            let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 160
             let total = if want_siginfo {
-                sigframe_size + UCONTEXT_SIZE + 128u64  // 112 + 424 + 128 = 664
+                sigframe_size + UCONTEXT_SIZE + 128u64  // 160 + 424 + 128 = 712
             } else {
                 sigframe_size
             };
@@ -874,6 +889,13 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
                 (*sig_frame_ptr).saved_r11  = saved_r11;
                 (*sig_frame_ptr).saved_rcx  = saved_rcx;
                 (*sig_frame_ptr).saved_rax  = saved_rax;
+                // Caller-saved args — see SignalFrame doc + psABI §3.2.3.
+                (*sig_frame_ptr).saved_rdi  = saved_rdi;
+                (*sig_frame_ptr).saved_rsi  = saved_rsi;
+                (*sig_frame_ptr).saved_rdx  = saved_rdx;
+                (*sig_frame_ptr).saved_r8   = saved_r8;
+                (*sig_frame_ptr).saved_r9   = saved_r9;
+                (*sig_frame_ptr).saved_r10  = saved_r10;
                 (*sig_frame_ptr)._pad       = 0;
             }
 
@@ -1073,17 +1095,17 @@ pub unsafe fn deliver_fault_signal_from_isr(
 
     // ── User stack layout (growing downward) ─────────────────────────────────
     // For SA_SIGINFO handlers (standard Linux x86_64 signal ABI):
-    //   new_rsp + 0   .. +112  : SignalFrame  (restorer at [new_rsp] = return addr)
-    //   new_rsp + 112 .. +536  : ucontext_t (424 bytes)  ← RDX points here
-    //   new_rsp + 536 .. +664  : siginfo_t  (128 bytes)  ← RSI points here
+    //   new_rsp + 0   .. +160  : SignalFrame  (restorer at [new_rsp] = return addr)
+    //   new_rsp + 160 .. +584  : ucontext_t (424 bytes)  ← RDX points here
+    //   new_rsp + 584 .. +712  : siginfo_t  (128 bytes)  ← RSI points here
     //
     // For classic (non-SA_SIGINFO) handlers:
-    //   new_rsp + 0   .. +112  : SignalFrame only
-    //   new_rsp + 112 .. +240  : siginfo_t (128 bytes)  ← RSI points here
+    //   new_rsp + 0   .. +160  : SignalFrame only
+    //   new_rsp + 160 .. +288  : siginfo_t (128 bytes)  ← RSI points here
     //
     // Per POSIX.1-2017 sigaction(2): SA_SIGINFO handlers receive
     // (int signo, siginfo_t *info, ucontext_t *uctx) in (RDI, RSI, RDX).
-    let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 112
+    let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 160
     let total = if want_siginfo {
         sigframe_size + UCONTEXT_SIZE + 128u64  // 112 + 424 + 128 = 664
     } else {
@@ -1185,6 +1207,14 @@ pub unsafe fn deliver_fault_signal_from_isr(
     (*sig_frame_ptr).saved_r11   = user_rflags;
     (*sig_frame_ptr).saved_rcx   = user_rip;
     (*sig_frame_ptr).saved_rax   = isr_rax;
+    // Caller-saved args — a fault-delivered signal interrupts arbitrary user
+    // code where these are live; restore the full set on return (psABI §3.2.3).
+    (*sig_frame_ptr).saved_rdi   = isr_rdi;
+    (*sig_frame_ptr).saved_rsi   = isr_rsi;
+    (*sig_frame_ptr).saved_rdx   = isr_rdx;
+    (*sig_frame_ptr).saved_r8    = isr_r8;
+    (*sig_frame_ptr).saved_r9    = isr_r9;
+    (*sig_frame_ptr).saved_r10   = isr_r10;
     (*sig_frame_ptr)._pad        = 0;
 
     // ── Write ucontext_t (SA_SIGINFO handlers only) ───────────────────────────

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -4900,7 +4900,8 @@ pub(crate) fn sys_sigreturn() -> i64 {
     let frame_ptr = frame_base as *const crate::signal::SignalFrame;
 
     let (sig_num, saved_mask, saved_rsp, saved_r15, saved_r14, saved_r13,
-         saved_r12, saved_rbx, saved_rbp, saved_r11, saved_rcx, saved_rax);
+         saved_r12, saved_rbx, saved_rbp, saved_r11, saved_rcx, saved_rax,
+         saved_rdi, saved_rsi, saved_rdx, saved_r8, saved_r9, saved_r10);
     // SMAP bracket — frame_base has already been range-validated by
     // validate_user_ptr above so the UserGuard is safe to lift AC.
     unsafe {
@@ -4917,6 +4918,15 @@ pub(crate) fn sys_sigreturn() -> i64 {
         saved_r11 = (*frame_ptr).saved_r11;
         saved_rcx = (*frame_ptr).saved_rcx;
         saved_rax = (*frame_ptr).saved_rax;
+        // Caller-saved args — restored to the syscall_entry frame below so
+        // the SYSRETQ epilogue reinstates the FULL interrupted register set
+        // (x86-64 System V psABI §3.2.3 signal-return contract).
+        saved_rdi = (*frame_ptr).saved_rdi;
+        saved_rsi = (*frame_ptr).saved_rsi;
+        saved_rdx = (*frame_ptr).saved_rdx;
+        saved_r8  = (*frame_ptr).saved_r8;
+        saved_r9  = (*frame_ptr).saved_r9;
+        saved_r10 = (*frame_ptr).saved_r10;
     }
 
     crate::serial_println!(
@@ -4938,17 +4948,23 @@ pub(crate) fn sys_sigreturn() -> i64 {
     }
 
     // Write the original registers back onto the kernel stack frame.
-    // The kernel stack frame layout (from syscall_entry) relative to
-    // the per-CPU kernel_rsp:
-    //   ksp - 8  = user RSP
-    //   ksp - 16 = RCX (user RIP)
-    //   ksp - 24 = R11 (user RFLAGS)
-    //   ksp - 32 = RBP
-    //   ksp - 40 = RBX
-    //   ksp - 48 = R12
-    //   ksp - 56 = R13
-    //   ksp - 64 = R14
-    //   ksp - 72 = R15
+    // The kernel stack frame layout (from syscall_entry's 15 pushes)
+    // relative to the per-CPU kernel_rsp:
+    //   ksp -   8 = user RSP
+    //   ksp -  16 = RCX (user RIP)
+    //   ksp -  24 = R11 (user RFLAGS)
+    //   ksp -  32 = RBP
+    //   ksp -  40 = RBX
+    //   ksp -  48 = R12
+    //   ksp -  56 = R13
+    //   ksp -  64 = R14
+    //   ksp -  72 = R15
+    //   ksp -  80 = R10   ┐ caller-saved argument registers — restored so
+    //   ksp -  88 = R9    │ the SYSRETQ epilogue reinstates the FULL
+    //   ksp -  96 = R8    │ interrupted register set (psABI §3.2.3).  These
+    //   ksp - 104 = RDX   │ slots are the last six syscall_entry pushes
+    //   ksp - 112 = RSI   │ (rdi lowest); the epilogue pops them in Step 4b.
+    //   ksp - 120 = RDI   ┘
     let ksp = unsafe { PER_CPU_SYSCALL[cpu_index()].kernel_rsp };
     // Sanitise RFLAGS before restoring it as the user's EFLAGS via SYSRETQ.
     // The signal frame is user-controlled memory; a crafted handler can
@@ -4975,6 +4991,13 @@ pub(crate) fn sys_sigreturn() -> i64 {
         *((ksp - 56) as *mut u64) = saved_r13;
         *((ksp - 64) as *mut u64) = saved_r14;
         *((ksp - 72) as *mut u64) = saved_r15;
+        // Caller-saved argument registers (see layout comment above).
+        *((ksp -  80) as *mut u64) = saved_r10;
+        *((ksp -  88) as *mut u64) = saved_r9;
+        *((ksp -  96) as *mut u64) = saved_r8;
+        *((ksp - 104) as *mut u64) = saved_rdx;
+        *((ksp - 112) as *mut u64) = saved_rsi;
+        *((ksp - 120) as *mut u64) = saved_rdi;
     }
 
     // Return original RAX — dispatch() returns this, the asm puts it

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -46939,10 +46939,16 @@ fn test_249_signalframe_caller_saved_roundtrip() -> bool {
         return false;
     }
 
-    // Structural note (checked by construction, documented here): sys_sigreturn
-    // writes the six regs to ksp-{80,88,96,104,112,120}, contiguous with the
-    // existing ksp-{8..72} callee-saved slots — 15 slots (8..120 step 8) that
-    // exactly match syscall_entry's 15 register pushes.
+    // Structural note: the register→kernel-slot mapping itself cannot be
+    // exercised here without userspace execution (a real signal delivery +
+    // handler-return round-trip), so it is verified by the asm layout instead:
+    // sys_sigreturn writes the six regs to ksp-{80,88,96,104,112,120}, which
+    // are — in reverse push order — the last six of syscall_entry's 15 register
+    // pushes (rdi lowest at ksp-120 … r10 at ksp-80), contiguous with the
+    // existing ksp-{8..72} callee-saved slots. If syscall_entry's push order
+    // ever changes, these offsets (and this cross-reference) must change with
+    // it. See `syscall_entry` in kernel/src/syscall/mod.rs (Step 2 pushes) and
+    // its Step 4b/Step 7 pop epilogue.
     test_pass!("SignalFrame carries + round-trips all six caller-saved arg regs");
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -2519,6 +2519,17 @@ pub fn run() -> ! {
         if test_227_sigreturn_frame_base_ptr_validation() { passed += 1; }
     }
 
+    // ── Test 249: SignalFrame preserves the caller-saved argument registers ─
+    // Regression guard for the x86-64 signal-return ABI fix: a returning
+    // handler must restore rdi/rsi/rdx/r8/r9/r10 (psABI §3.2.3), so the
+    // SignalFrame must carry them and sys_sigreturn must write them to the
+    // exact syscall_entry frame slots the SYSRETQ epilogue pops.
+    #[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+    {
+        total += 1;
+        if test_249_signalframe_caller_saved_roundtrip() { passed += 1; }
+    }
+
     // ── Test 228: auto-reap doubly-orphaned zombie children on parent exit ─
     // Verifies that exit_group_inner sweeps any Zombie child of the dying
     // process from PROCESS_TABLE in-line (rather than leaving it to leak
@@ -9155,11 +9166,11 @@ fn test_signal_subsystem() -> bool {
     // 5. Signal frame size sanity
     test_println!("  Testing SignalFrame layout...");
     let frame_size = core::mem::size_of::<crate::signal::SignalFrame>();
-    if frame_size != 112 {
-        test_fail!("Signal subsystem", "SignalFrame size = {} (expected 112)", frame_size);
+    if frame_size != 160 {
+        test_fail!("Signal subsystem", "SignalFrame size = {} (expected 160)", frame_size);
         return false;
     }
-    test_println!("  SignalFrame size = {} bytes (14 × 8) ✓", frame_size);
+    test_println!("  SignalFrame size = {} bytes (20 × 8) ✓", frame_size);
 
     // 6. Trampoline virtual address constant
     if crate::signal::TRAMPOLINE_VADDR != 0x0000_7FFF_FFFF_F000 {
@@ -22720,13 +22731,13 @@ fn test_sigsegv_handler() -> bool {
         }
     }
 
-    // 3. SignalFrame size is 112 bytes (static assert in signal.rs already
+    // 3. SignalFrame size is 160 bytes (static assert in signal.rs already
     //    catches this at compile time, but let's print it for the log)
     {
         let sz = core::mem::size_of::<crate::signal::SignalFrame>();
-        test_println!("  SignalFrame size = {} bytes (expected 112) {}", sz,
-            if sz == 112 { "✓" } else { "FAIL" });
-        if sz != 112 { ok = false; }
+        test_println!("  SignalFrame size = {} bytes (expected 160) {}", sz,
+            if sz == 160 { "✓" } else { "FAIL" });
+        if sz != 160 { ok = false; }
     }
 
     // 4. TRAMPOLINE_VADDR is accessible (non-zero constant)
@@ -46854,6 +46865,85 @@ fn test_227_sigreturn_frame_base_ptr_validation() -> bool {
         return false;
     }
     test_pass!("validate_user_ptr rejects kernel-VA frame_base for SignalFrame size");
+    true
+}
+
+/// Test 249 — SignalFrame carries and round-trips the caller-saved argument
+/// registers (rdi/rsi/rdx/r8/r9/r10).
+///
+/// A signal is asynchronous: it can interrupt user code at any instruction,
+/// where the caller-saved argument registers may hold live values (a `this`
+/// pointer, a memcpy dest/src/count).  The x86-64 System V psABI §3.2.3
+/// signal-return contract requires the FULL interrupted register set be
+/// restored on handler return — unlike a *syscall* boundary, where the ABI
+/// permits clobbering these six.  Before the fix, `struct SignalFrame`
+/// structurally lacked these fields, so a returning handler resumed with
+/// garbage in them → deref-garbage SIGSEGV or a store through a stale
+/// destination pointer (silent cross-allocator memory corruption).
+///
+/// This guards the two invariants the fix depends on:
+///   1. SignalFrame is 160 bytes and each of the six fields is independently
+///      addressable (a reorder/removal that aliased two slots would fail the
+///      round-trip).
+///   2. `restorer` remains at offset 0 — the handler's `ret` pops it, and
+///      `sys_sigreturn` locates the frame at `user_rsp - 8`.
+///
+/// Cite: x86-64 System V psABI §3.2.3 (signal frames); sigreturn(2).
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_249_signalframe_caller_saved_roundtrip() -> bool {
+    test_header!("SignalFrame preserves caller-saved arg regs (rdi/rsi/rdx/r8/r9/r10)");
+    use crate::signal::SignalFrame;
+
+    // Invariant 1a: size is exactly 20 × 8 = 160 bytes.
+    let sz = core::mem::size_of::<SignalFrame>();
+    if sz != 160 {
+        test_fail!("SignalFrame caller-saved", "size = {} (expected 160)", sz);
+        return false;
+    }
+
+    // Invariant 1b: each of the six caller-saved fields is independently
+    // addressable — write a unique sentinel to each, then read all back.  A
+    // struct-field reorder that overlapped two slots (or a lost field) would
+    // read back a wrong / aliased value.
+    let mut f: SignalFrame = unsafe { core::mem::zeroed() };
+    f.saved_rdi = 0x1111_1111_1111_1111;
+    f.saved_rsi = 0x2222_2222_2222_2222;
+    f.saved_rdx = 0x3333_3333_3333_3333;
+    f.saved_r8  = 0x4444_4444_4444_4444;
+    f.saved_r9  = 0x5555_5555_5555_5555;
+    f.saved_r10 = 0x6666_6666_6666_6666;
+    // Neighbouring fields must be untouched by the six writes above.
+    f.saved_rax = 0x7777_7777_7777_7777;
+    f._pad      = 0x8888_8888_8888_8888;
+
+    let ok = f.saved_rdi == 0x1111_1111_1111_1111
+        &&  f.saved_rsi == 0x2222_2222_2222_2222
+        &&  f.saved_rdx == 0x3333_3333_3333_3333
+        &&  f.saved_r8  == 0x4444_4444_4444_4444
+        &&  f.saved_r9  == 0x5555_5555_5555_5555
+        &&  f.saved_r10 == 0x6666_6666_6666_6666
+        &&  f.saved_rax == 0x7777_7777_7777_7777
+        &&  f._pad      == 0x8888_8888_8888_8888;
+    if !ok {
+        test_fail!("SignalFrame caller-saved", "field round-trip aliased/lost a slot");
+        return false;
+    }
+
+    // Invariant 2: `restorer` is the first field (offset 0).  sys_sigreturn
+    // and the handler-return `ret` both depend on this.
+    let base = &f as *const SignalFrame as usize;
+    let restorer_addr = &f.restorer as *const u64 as usize;
+    if restorer_addr != base {
+        test_fail!("SignalFrame caller-saved",
+            "restorer not at offset 0 (off={})", restorer_addr - base);
+        return false;
+    }
+
+    // Structural note (checked by construction, documented here): sys_sigreturn
+    // writes the six regs to ksp-{80,88,96,104,112,120}, contiguous with the
+    // existing ksp-{8..72} callee-saved slots — 15 slots (8..120 step 8) that
+    // exactly match syscall_entry's 15 register pushes.
+    test_pass!("SignalFrame carries + round-trips all six caller-saved arg regs");
     true
 }
 


### PR DESCRIPTION
## Summary

`sys_sigreturn` restored only rsp/rip/rflags/rbp/rbx/r12–r15/rax — it never restored the **caller-saved argument registers rdi/rsi/rdx/r8/r9/r10**, because `struct SignalFrame` structurally lacked those six fields.

This violates the **x86-64 System V psABI §3.2.3** signal-return contract: a signal is *asynchronous* and can interrupt user code at any instruction, where those registers may hold live values (a `this` pointer, a `memcpy` dest/src/count, …). The full interrupted register set must be restored on handler return — unlike a *syscall* boundary, where the Linux ABI permits clobbering them.

**Symptom class this closes:** a handler that RETURNS (e.g. a wasm/JS `SIGSEGV`-fixup handler, or a `SIGPROF` sampler) resumed the interrupted code with garbage in those six registers → a deref of the garbage pointer (`SIGSEGV`) or a store through a stale destination pointer (silent, cross-allocator memory corruption). This is the "varying garbage caller-saved register" corruption class.

## Changes
- Add `saved_rdi/rsi/rdx/r8/r9/r10` to `struct SignalFrame` (now **160 bytes**, was 112).
- Populate them in **both** delivery paths: `signal_check_on_syscall_return` (syscall boundary) and `deliver_fault_signal_from_isr` (fault/async).
- Restore them in `sys_sigreturn` to the `syscall_entry` frame slots the `SYSRETQ` epilogue pops (`ksp-80 … ksp-120`), contiguous with the existing callee-saved slots and matching `syscall_entry`'s 15-push layout.
- **Test 249** regression guard (field round-trip + `repr(C)` offset-0 `restorer` + size) and updated the two `SignalFrame` size assertions (112 → 160). Layout-diagram comments updated to the 160-byte frame.

## Scope / honesty
Correct-on-merits ABI hardening. It is **LATENT** on workloads whose signal handlers *exit* rather than *return* (e.g. a crash reporter that `_exit()`s — 0 `sigreturn`s observed on the example.com bring-up), so it is **NOT proven to fix the SMP=2 llvmpipe-GL content-render gate**. That crash converges on the separate, parked in-place-writer (W215-family) saga and is out of scope here.

## Verification
- Builds clean (`firefox-test-core,kdb`).
- Test-mode boot: `SignalFrame size = 160 bytes (20 × 8) ✓`; signal subsystem init + downstream tests healthy, no panic/bugcheck.
- Full test-mode suite (incl. Test 249) runs under CI below.

Cite: System V AMD64 psABI §3.2.3 (signal frames); `sigreturn(2)`; `signal(7)`; Intel SDM Vol. 3A §6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
