### PR TITLE
arch/signal: enable XSAVE+AVX and preserve full FPU state across context switches and signals

### DIFF
--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -172,6 +172,93 @@ pub unsafe fn fpu_restore(area: *const u8) {
     }
 }
 
+/// Restore FPU/SSE/AVX state from a **user-supplied** XSAVE image (the
+/// `sigreturn` path) without ever letting XRSTOR/FXRSTOR fault in kernel mode.
+///
+/// XRSTOR executed at CPL0 on a user-controlled image is a ring-3 → ring-0
+/// crash primitive: a malformed header raises `#GP` and an unmapped page raises
+/// `#PF`, both *in the kernel*, which has no CPL0 fault-recovery path (see
+/// `idt.rs`: only CPL3 faults kill the process).  Rather than XRSTOR the user
+/// bytes in place, copy the image into a kernel buffer through the
+/// presence-confirming direct map (translate each page via `virt_to_phys_in`
+/// and read through `PHYS_OFF` — the same fault-immune idiom the ssp/canary
+/// diagnostics use, never touching an unmapped user page), validate the XSAVE
+/// header + MXCSR so XRSTOR cannot `#GP`, then restore from the stable,
+/// always-mapped kernel buffer.  This also removes the TOCTOU a
+/// validate-then-XRSTOR-in-place scheme would carry (a sibling thread unmapping
+/// the page between the check and the XRSTOR).
+///
+/// Returns `true` if the state was restored, `false` if the image was rejected
+/// (null/misaligned, unmapped, or malformed); on reject the caller leaves the
+/// current FPU state untouched.
+///
+/// # Safety
+/// Reads guest memory of the current address space via the kernel direct map;
+/// `user_va` is otherwise untrusted.  Intel SDM Vol. 1 §13.8 (XRSTOR + its
+/// `#GP` conditions), §10.5.1.1 (MXCSR reserved bits).
+pub unsafe fn fpu_restore_from_user(user_va: u64) -> bool {
+    // XRSTOR/FXRSTOR require a 64-byte-aligned operand; reject null too.
+    if user_va == 0 || (user_va & 0x3F) != 0 {
+        return false;
+    }
+    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+    #[repr(C, align(64))]
+    struct Scratch([u8; XSAVE_AREA_SIZE]);
+    let mut kbuf = Scratch([0u8; XSAVE_AREA_SIZE]);
+
+    // Copy the whole reserved area from user memory via the fault-immune direct
+    // map: an unmapped user page yields a clean reject, not a kernel `#PF`.
+    let cr3 = crate::mm::vmm::get_cr3();
+    let mut done = 0usize;
+    while done < XSAVE_AREA_SIZE {
+        let va = user_va.wrapping_add(done as u64);
+        let page = va & !0xFFFu64;
+        let phys = match crate::mm::vmm::virt_to_phys_in(cr3, page) {
+            Some(p) => p,
+            None => return false,
+        };
+        let off = (va & 0xFFF) as usize;
+        let n = core::cmp::min(0x1000 - off, XSAVE_AREA_SIZE - done);
+        core::ptr::copy_nonoverlapping(
+            (PHYS_OFF + phys + off as u64) as *const u8,
+            kbuf.0.as_mut_ptr().add(done),
+            n,
+        );
+        done += n;
+    }
+
+    let base = kbuf.0.as_ptr();
+    // MXCSR (legacy region offset 24): reserved bits 16..31 must be clear or
+    // XRSTOR/FXRSTOR `#GP` (Intel SDM Vol. 1 §10.5.1.1).
+    let mxcsr = core::ptr::read_unaligned(base.add(24) as *const u32);
+    if (mxcsr & 0xFFFF_0000) != 0 {
+        return false;
+    }
+    if XSAVE_AVX_ENABLED.load(core::sync::atomic::Ordering::Acquire) {
+        // XSAVE header (standard, non-compacted form): XSTATE_BV must be a
+        // subset of XCR0, XCOMP_BV must be 0, and the reserved header bytes
+        // [528, 576) must be 0 — any violation `#GP`s XRSTOR (SDM Vol. 1 §13.8).
+        let xstate_bv = core::ptr::read_unaligned(base.add(512) as *const u64);
+        let xcomp_bv  = core::ptr::read_unaligned(base.add(520) as *const u64);
+        let xcr0 = XCR0_X87 | XCR0_SSE | XCR0_AVX;
+        if (xstate_bv & !xcr0) != 0 || xcomp_bv != 0 {
+            return false;
+        }
+        let mut i = 528usize;
+        while i < 576 {
+            if *base.add(i) != 0 {
+                return false;
+            }
+            i += 1;
+        }
+    }
+
+    // Restore from the validated, always-mapped kernel buffer: cannot `#PF`
+    // (kernel memory) and cannot `#GP` (header + MXCSR validated).
+    fpu_restore(base);
+    true
+}
+
 /// Enable hardware-enforced kernel/user separation features in CR4.
 ///
 /// Currently enables CR4.SMEP (bit 20) — Supervisor Mode Execution

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -197,8 +197,22 @@ pub unsafe fn fpu_restore(area: *const u8) {
 /// `user_va` is otherwise untrusted.  Intel SDM Vol. 1 §13.8 (XRSTOR + its
 /// `#GP` conditions), §10.5.1.1 (MXCSR reserved bits).
 pub unsafe fn fpu_restore_from_user(user_va: u64) -> bool {
-    // XRSTOR/FXRSTOR require a 64-byte-aligned operand; reject null too.
-    if user_va == 0 || (user_va & 0x3F) != 0 {
+    // Reject any non-user address BEFORE walking the page tables.  This is
+    // essential, not cosmetic: `virt_to_phys_in` below confirms only a PTE's
+    // PRESENT bit, NOT its US (user/supervisor) bit, and the kernel half + the
+    // direct map are present in every process CR3 (shared PML4[256..512]).
+    // Without this gate a ring-3 process could set `fpstate` to a 64-aligned
+    // KERNEL VA; we would copy 1 KiB of kernel memory into `kbuf` and XRSTOR it
+    // into the caller's XMM/YMM — kernel-memory disclosure (and, via PHYS_OFF,
+    // effectively arbitrary-physical read).  `validate_user_ptr` requires the
+    // whole `[user_va, user_va+len)` range to lie below USER_VA_LIMIT
+    // (0x0000_8000_0000_0000) with no wrap, excluding the kernel half + direct
+    // map, and rejects null.
+    if !crate::syscall::validate_user_ptr(user_va, XSAVE_AREA_SIZE) {
+        return false;
+    }
+    // XRSTOR/FXRSTOR require a 64-byte-aligned operand.
+    if (user_va & 0x3F) != 0 {
         return false;
     }
     const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
@@ -228,8 +242,13 @@ pub unsafe fn fpu_restore_from_user(user_va: u64) -> bool {
     }
 
     let base = kbuf.0.as_ptr();
-    // MXCSR (legacy region offset 24): reserved bits 16..31 must be clear or
-    // XRSTOR/FXRSTOR `#GP` (Intel SDM Vol. 1 §10.5.1.1).
+    // MXCSR (legacy region offset 24): reserved bits 31..16 must be clear or
+    // XRSTOR/FXRSTOR `#GP` (Intel SDM Vol. 1 §10.5.1.1).  NB: strictly, a set
+    // bit in 15..0 that is not in the CPU's MXCSR_MASK also `#GP`s; that cannot
+    // occur on the AVX/XSAVE target this path runs on (MXCSR_MASK covers 15..0
+    // on every SSE2+ CPU), so we validate only the architected reserved region.
+    // A fully-CPU-general check would AND against the boot-snapshotted
+    // MXCSR_MASK (FXSAVE+28) — a hardening follow-up, not reachable here.
     let mxcsr = core::ptr::read_unaligned(base.add(24) as *const u32);
     if (mxcsr & 0xFFFF_0000) != 0 {
         return false;

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -48,6 +48,127 @@ pub fn enable_sse() {
         // Clear EM (bit 2), set MP (bit 1)
         let cr0 = (cr0 & !(1u64 << 2)) | (1u64 << 1);
         core::arch::asm!("mov cr0, {}", in(reg) cr0, options(nostack));
+
+        // ── XSAVE + AVX enablement ─────────────────────────────────────────
+        // The legacy FXSAVE/FXRSTOR above save only x87 + SSE (XMM0-15); they
+        // do NOT preserve the upper 128 bits of the AVX YMM registers.  With
+        // AVX advertised (host-passthrough CPUID) but XSAVE/XCR0 left disabled,
+        // a userspace IFUNC resolver that selects an AVX code path on the CPUID
+        // bit alone executes a VEX-encoded instruction and takes #UD.  Enable
+        // OSXSAVE + XCR0(x87|SSE|AVX) so AVX is usable and its state is carried
+        // across context switches by XSAVE/XRSTOR (see `fpu_save`/`fpu_restore`).
+        //
+        // Runs on every CPU (BSP via `init`, each AP via `ap_rust_entry`);
+        // CR4 and XCR0 are per-logical-processor and do not propagate.
+        //
+        // Intel SDM Vol. 1 §13.2-13.3 (XSAVE/XCR0), Vol. 3A §2.6 (OSXSAVE).
+        let leaf1 = core::arch::x86_64::__cpuid(1);
+        let have_xsave = leaf1.ecx & (1 << 26) != 0;
+        let have_avx = leaf1.ecx & (1 << 28) != 0;
+        if have_xsave && have_avx {
+            // CR4.OSXSAVE (bit 18): enables XGETBV/XSETBV/XSAVE/XRSTOR and
+            // makes CPUID.1:ECX.OSXSAVE (bit 27) report OS support, so
+            // userspace feature detection selects AVX paths correctly.
+            let cr4b: u64;
+            core::arch::asm!("mov {}, cr4", out(reg) cr4b, options(nomem, nostack));
+            core::arch::asm!(
+                "mov cr4, {}",
+                in(reg) cr4b | (1u64 << 18),
+                options(nostack),
+            );
+            // XSETBV XCR0 = x87 | SSE | AVX.  ECX=0 selects XCR0; the value is
+            // in EDX:EAX.  x87 (bit 0) is mandatory and SSE (bit 1) must be set
+            // whenever AVX (bit 2) is (Intel SDM Vol. 1 §13.3).
+            let xcr0: u64 = XCR0_X87 | XCR0_SSE | XCR0_AVX;
+            core::arch::asm!(
+                "xsetbv",
+                in("ecx") 0u32,
+                in("eax") xcr0 as u32,
+                in("edx") (xcr0 >> 32) as u32,
+                options(nomem, nostack, preserves_flags),
+            );
+            // CPUID.(EAX=0DH,ECX=0):EBX = the XSAVE-area size for the state set
+            // now enabled in XCR0.  A per-thread `FpuState` smaller than this
+            // would let XSAVE write past the allocation — fail loudly at boot
+            // rather than corrupt memory later.
+            let d0 = core::arch::x86_64::__cpuid_count(0x0D, 0);
+            assert!(
+                (d0.ebx as usize) <= XSAVE_AREA_SIZE,
+                "XSAVE area {} exceeds FpuState {} (enable AVX-512? resize XSAVE_AREA_SIZE)",
+                d0.ebx, XSAVE_AREA_SIZE,
+            );
+            XSAVE_AVX_ENABLED.store(true, core::sync::atomic::Ordering::Release);
+        }
+    }
+}
+
+/// `true` once XSAVE + AVX have been enabled (CR4.OSXSAVE + XCR0) on the boot
+/// path.  When `false` the FPU context-switch path falls back to FXSAVE/FXRSTOR
+/// (legacy x87+SSE only), e.g. on a CPU that does not advertise XSAVE/AVX.
+pub static XSAVE_AVX_ENABLED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Size in bytes of the per-thread `FpuState` XSAVE area.  Must be a multiple
+/// of 64 and >= CPUID.(EAX=0DH,ECX=0):EBX for the enabled XCR0 set
+/// (x87|SSE|AVX = 832 bytes); 1 KiB leaves headroom and is asserted against
+/// CPUID at boot.  FXSAVE (the non-AVX fallback) uses only the first 512 bytes.
+/// Intel SDM Vol. 1 §13.4 (XSAVE area layout).
+pub const XSAVE_AREA_SIZE: usize = 1024;
+
+const XCR0_X87: u64 = 1 << 0;
+const XCR0_SSE: u64 = 1 << 1;
+const XCR0_AVX: u64 = 1 << 2;
+
+/// Save the current FPU/SSE/AVX register state into `area` (>= `XSAVE_AREA_SIZE`
+/// bytes, 64-byte aligned).  Uses XSAVE (x87+SSE+AVX) when AVX is enabled,
+/// otherwise FXSAVE (x87+SSE only).
+///
+/// # Safety
+/// `area` must point to a writable, 64-byte-aligned buffer of at least
+/// `XSAVE_AREA_SIZE` bytes.  Intel SDM Vol. 1 §13.7 (XSAVE) / §10.5 (FXSAVE).
+#[inline]
+pub unsafe fn fpu_save(area: *mut u8) {
+    if XSAVE_AVX_ENABLED.load(core::sync::atomic::Ordering::Acquire) {
+        // EDX:EAX = requested-feature bitmap; all-ones saves every component
+        // enabled in XCR0 (the AND with XCR0 restricts it to x87|SSE|AVX).
+        core::arch::asm!(
+            "xsave [{}]",
+            in(reg) area,
+            in("eax") 0xFFFF_FFFFu32,
+            in("edx") 0xFFFF_FFFFu32,
+            options(nostack, preserves_flags),
+        );
+    } else {
+        core::arch::asm!(
+            "fxsave [{}]",
+            in(reg) area,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+/// Restore FPU/SSE/AVX register state saved by [`fpu_save`] from `area`.
+///
+/// # Safety
+/// `area` must point to a readable, 64-byte-aligned XSAVE/FXSAVE image of at
+/// least `XSAVE_AREA_SIZE` bytes produced by [`fpu_save`] (or a zeroed area,
+/// which XRSTOR interprets as the initial state).  Intel SDM Vol. 1 §13.8.
+#[inline]
+pub unsafe fn fpu_restore(area: *const u8) {
+    if XSAVE_AVX_ENABLED.load(core::sync::atomic::Ordering::Acquire) {
+        core::arch::asm!(
+            "xrstor [{}]",
+            in(reg) area,
+            in("eax") 0xFFFF_FFFFu32,
+            in("edx") 0xFFFF_FFFFu32,
+            options(nostack, preserves_flags),
+        );
+    } else {
+        core::arch::asm!(
+            "fxrstor [{}]",
+            in(reg) area,
+            options(nostack, preserves_flags),
+        );
     }
 }
 

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -412,15 +412,20 @@ pub fn apply_wake_boost(t: &mut Thread) {
     t.priority = (t.priority + PRIORITY_BOOST_WAIT).min(PRIORITY_MAX);
 }
 
-/// 512-byte FXSAVE area, 16-byte aligned.
-#[repr(C, align(16))]
+/// Per-thread FPU/SSE/AVX save area for XSAVE/XRSTOR.  64-byte aligned as
+/// required by XSAVE (Intel SDM Vol. 1 §13.7); sized to `XSAVE_AREA_SIZE` and
+/// verified >= the CPUID.0DH area size at boot.  On a CPU without AVX the FPU
+/// path falls back to FXSAVE/FXRSTOR, which use only the first 512 bytes.  A
+/// freshly zeroed area is a valid initial state for both XRSTOR (header
+/// XSTATE_BV=0 → init all components) and FXRSTOR.
+#[repr(C, align(64))]
 pub struct FpuState {
-    pub data: [u8; 512],
+    pub data: [u8; crate::arch::x86_64::XSAVE_AREA_SIZE],
 }
 
 impl FpuState {
     pub fn new_zeroed() -> Self {
-        Self { data: [0u8; 512] }
+        Self { data: [0u8; crate::arch::x86_64::XSAVE_AREA_SIZE] }
     }
 }
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -2911,13 +2911,10 @@ was_emergency_4k={}",
                 cur.fpu_state = Some(alloc::boxed::Box::new(proc::FpuState::new_zeroed()));
             }
             if let Some(ref mut fpu) = cur.fpu_state {
-                unsafe {
-                    core::arch::asm!(
-                        "fxsave [{}]",
-                        in(reg) fpu.data.as_mut_ptr(),
-                        options(nostack, preserves_flags),
-                    );
-                }
+                // XSAVE (x87+SSE+AVX) when AVX is enabled, else FXSAVE.  The
+                // legacy path saved only x87+SSE, silently dropping the AVX
+                // YMM upper halves across every switch.
+                unsafe { crate::arch::x86_64::fpu_save(fpu.data.as_mut_ptr()); }
             }
             (
                 &mut cur.context.rsp as *mut u64,
@@ -3091,13 +3088,7 @@ was_emergency_4k={}",
         let threads = THREAD_TABLE.lock();
         if let Some(cur) = threads.iter().find(|t| t.tid == current_tid_now) {
             if let Some(ref fpu) = cur.fpu_state {
-                unsafe {
-                    core::arch::asm!(
-                        "fxrstor [{}]",
-                        in(reg) fpu.data.as_ptr(),
-                        options(nostack, preserves_flags),
-                    );
-                }
+                unsafe { crate::arch::x86_64::fpu_restore(fpu.data.as_ptr()); }
             }
         }
     }

--- a/kernel/src/signal.rs
+++ b/kernel/src/signal.rs
@@ -132,7 +132,15 @@ pub struct SignalFrame {
     pub saved_r8:  u64,
     pub saved_r9:  u64,
     pub saved_r10: u64,
-    pub _pad: u64,          // padding to 20 × 8 = 160 bytes (16-aligned)
+    // User-VA of the interrupted thread's saved FPU/SSE/AVX state (a 64-byte
+    // aligned XSAVE/FXSAVE area reserved just above this frame on the user
+    // stack), or 0 if no FPU state was saved.  A signal can interrupt user
+    // code mid-SIMD (glibc/musl use AVX pervasively — memcpy/memset/strlen),
+    // and the handler + sigreturn would otherwise clobber the interrupted
+    // YMM/XMM/x87 state.  The x86-64 psABI signal-return contract requires the
+    // full FPU register file be restored on handler return, the same as the
+    // GPRs above.  Restored via XRSTOR/FXRSTOR in `sys_sigreturn`.
+    pub fpstate: u64,       // keeps the struct at 20 × 8 = 160 bytes (16-aligned)
 }
 
 const _SIGNAL_FRAME_SIZE_CHECK: () = {
@@ -816,15 +824,27 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
             // For classic handlers (no SA_SIGINFO):
             //   new_rsp + 0 .. +160 : SignalFrame only (as before)
             let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 160
-            let total = if want_siginfo {
+            let payload = if want_siginfo {
                 sigframe_size + UCONTEXT_SIZE + 128u64  // 160 + 424 + 128 = 712
             } else {
                 sigframe_size
             };
 
-            // 16-align the allocation base, then subtract 8 for "just-called" ABI.
-            let base    = (saved_rsp.wrapping_sub(total)) & !0xFu64;
+            // Reserve a 64-byte-aligned FPU (XSAVE/FXSAVE) save area at the top
+            // of the frame (just below the interrupted RSP); the signal payload
+            // sits below it.  XSAVE requires 64-byte operand alignment (Intel
+            // SDM Vol. 1 §13.7).  `fpu_save` writes ≤ XSAVE_AREA_SIZE bytes here.
+            let fpstate_size = crate::arch::x86_64::XSAVE_AREA_SIZE as u64;
+            let fpstate_va   = saved_rsp.wrapping_sub(fpstate_size) & !0x3Fu64;
+
+            // 16-align the payload base below the FPU area, then subtract 8 for
+            // the "just-called" ABI (handler sees RSP % 16 == 8).
+            let base    = fpstate_va.wrapping_sub(payload) & !0xFu64;
             let new_rsp = base.wrapping_sub(8);
+            // Whole reservation spans [new_rsp, saved_rsp): payload + alignment
+            // slack + the FPU area — the pre-flight writable check + probe below
+            // must cover all of it.
+            let total = saved_rsp.wrapping_sub(new_rsp);
 
             let sig_frame_ptr  = new_rsp as *mut SignalFrame;
             let ucontext_ptr   = (new_rsp + sigframe_size) as *mut UContext;
@@ -896,7 +916,12 @@ pub extern "C" fn signal_check_on_syscall_return(frame: *mut u64) -> u64 {
                 (*sig_frame_ptr).saved_r8   = saved_r8;
                 (*sig_frame_ptr).saved_r9   = saved_r9;
                 (*sig_frame_ptr).saved_r10  = saved_r10;
-                (*sig_frame_ptr)._pad       = 0;
+                // Save the interrupted FPU/SSE/AVX register file into the
+                // reserved 64-aligned area and record its VA; sys_sigreturn
+                // XRSTORs it.  Runs under the active SMAP UserGuard (AC=1) so
+                // the supervisor XSAVE store to the user page is permitted.
+                (*sig_frame_ptr).fpstate    = fpstate_va;
+                crate::arch::x86_64::fpu_save(fpstate_va as *mut u8);
             }
 
             if want_siginfo {
@@ -1106,15 +1131,24 @@ pub unsafe fn deliver_fault_signal_from_isr(
     // Per POSIX.1-2017 sigaction(2): SA_SIGINFO handlers receive
     // (int signo, siginfo_t *info, ucontext_t *uctx) in (RDI, RSI, RDX).
     let sigframe_size = core::mem::size_of::<SignalFrame>() as u64; // 160
-    let total = if want_siginfo {
+    let payload = if want_siginfo {
         sigframe_size + UCONTEXT_SIZE + 128u64  // 160 + 424 + 128 = 712
     } else {
         sigframe_size + 128u64                  // 160 + 128 = 288 (legacy)
     };
 
-    // 16-align the allocation base, then subtract 8 for "just-called" ABI.
-    let base    = (user_rsp.wrapping_sub(total)) & !0xFu64;
+    // Reserve a 64-byte-aligned FPU (XSAVE/FXSAVE) save area at the top of the
+    // frame (just below the interrupted RSP); the signal payload sits below it.
+    // XSAVE requires 64-byte operand alignment (Intel SDM Vol. 1 §13.7).
+    let fpstate_size = crate::arch::x86_64::XSAVE_AREA_SIZE as u64;
+    let fpstate_va   = user_rsp.wrapping_sub(fpstate_size) & !0x3Fu64;
+
+    // 16-align the payload base below the FPU area, then subtract 8 for the
+    // "just-called" ABI.
+    let base    = fpstate_va.wrapping_sub(payload) & !0xFu64;
     let new_rsp = base.wrapping_sub(8);
+    // Whole reservation spans [new_rsp, user_rsp): payload + slack + FPU area.
+    let total = user_rsp.wrapping_sub(new_rsp);
 
     let sig_frame_ptr = new_rsp as *mut SignalFrame;
     let ucontext_ptr  = (new_rsp + sigframe_size) as *mut UContext;
@@ -1215,7 +1249,11 @@ pub unsafe fn deliver_fault_signal_from_isr(
     (*sig_frame_ptr).saved_r8    = isr_r8;
     (*sig_frame_ptr).saved_r9    = isr_r9;
     (*sig_frame_ptr).saved_r10   = isr_r10;
-    (*sig_frame_ptr)._pad        = 0;
+    // Save the interrupted FPU/SSE/AVX register file into the reserved
+    // 64-aligned area (under the active SMAP UserGuard) and record its VA;
+    // sys_sigreturn XRSTORs it — the FPU analogue of the GPR save above.
+    (*sig_frame_ptr).fpstate     = fpstate_va;
+    crate::arch::x86_64::fpu_save(fpstate_va as *mut u8);
 
     // ── Write ucontext_t (SA_SIGINFO handlers only) ───────────────────────────
     // Per x86_64 System V psABI §3.4 and POSIX.1-2017 sigaction(2):

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -4902,6 +4902,7 @@ pub(crate) fn sys_sigreturn() -> i64 {
     let (sig_num, saved_mask, saved_rsp, saved_r15, saved_r14, saved_r13,
          saved_r12, saved_rbx, saved_rbp, saved_r11, saved_rcx, saved_rax,
          saved_rdi, saved_rsi, saved_rdx, saved_r8, saved_r9, saved_r10);
+    let fpstate: u64;
     // SMAP bracket — frame_base has already been range-validated by
     // validate_user_ptr above so the UserGuard is safe to lift AC.
     unsafe {
@@ -4927,6 +4928,23 @@ pub(crate) fn sys_sigreturn() -> i64 {
         saved_r8  = (*frame_ptr).saved_r8;
         saved_r9  = (*frame_ptr).saved_r9;
         saved_r10 = (*frame_ptr).saved_r10;
+        fpstate   = (*frame_ptr).fpstate;
+    }
+
+    // Restore the interrupted FPU/SSE/AVX register file that signal delivery
+    // saved via `fpu_save` (XRSTOR/FXRSTOR).  Skip if the handler cleared it
+    // (fpstate == 0) or the pointer is not a 64-byte-aligned, readable user
+    // range of the full save area — a corrupt/hostile frame must not #GP the
+    // kernel via a malformed XSAVE image.  (Fault-fixup on XRSTOR itself is a
+    // hardening follow-up; a normal frame is one we wrote and is well-formed.)
+    if fpstate != 0
+        && (fpstate & 0x3F) == 0
+        && validate_user_ptr(fpstate, crate::arch::x86_64::XSAVE_AREA_SIZE)
+    {
+        unsafe {
+            let _g = crate::arch::x86_64::smap::UserGuard::new();
+            crate::arch::x86_64::fpu_restore(fpstate as *const u8);
+        }
     }
 
     crate::serial_println!(

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -4932,19 +4932,15 @@ pub(crate) fn sys_sigreturn() -> i64 {
     }
 
     // Restore the interrupted FPU/SSE/AVX register file that signal delivery
-    // saved via `fpu_save` (XRSTOR/FXRSTOR).  Skip if the handler cleared it
-    // (fpstate == 0) or the pointer is not a 64-byte-aligned, readable user
-    // range of the full save area — a corrupt/hostile frame must not #GP the
-    // kernel via a malformed XSAVE image.  (Fault-fixup on XRSTOR itself is a
-    // hardening follow-up; a normal frame is one we wrote and is well-formed.)
-    if fpstate != 0
-        && (fpstate & 0x3F) == 0
-        && validate_user_ptr(fpstate, crate::arch::x86_64::XSAVE_AREA_SIZE)
-    {
-        unsafe {
-            let _g = crate::arch::x86_64::smap::UserGuard::new();
-            crate::arch::x86_64::fpu_restore(fpstate as *const u8);
-        }
+    // saved via `fpu_save`.  `fpstate` is on the user stack and therefore
+    // attacker-controllable: `fpu_restore_from_user` copies the image into a
+    // kernel buffer through the fault-immune direct map and validates the XSAVE
+    // header + MXCSR before XRSTOR, so neither an unmapped page (#PF) nor a
+    // malformed header (#GP) can fault the kernel — XRSTOR at CPL0 has no
+    // fault-recovery path.  A rejected image leaves the current FPU untouched
+    // (skip on fpstate == 0: the handler saved none).
+    if fpstate != 0 {
+        unsafe { crate::arch::x86_64::fpu_restore_from_user(fpstate); }
     }
 
     crate::serial_println!(

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -46988,7 +46988,7 @@ fn test_249_signalframe_caller_saved_roundtrip() -> bool {
     f.saved_r10 = 0x6666_6666_6666_6666;
     // Neighbouring fields must be untouched by the six writes above.
     f.saved_rax = 0x7777_7777_7777_7777;
-    f._pad      = 0x8888_8888_8888_8888;
+    f.fpstate   = 0x8888_8888_8888_8888;
 
     let ok = f.saved_rdi == 0x1111_1111_1111_1111
         &&  f.saved_rsi == 0x2222_2222_2222_2222
@@ -46997,7 +46997,7 @@ fn test_249_signalframe_caller_saved_roundtrip() -> bool {
         &&  f.saved_r9  == 0x5555_5555_5555_5555
         &&  f.saved_r10 == 0x6666_6666_6666_6666
         &&  f.saved_rax == 0x7777_7777_7777_7777
-        &&  f._pad      == 0x8888_8888_8888_8888;
+        &&  f.fpstate   == 0x8888_8888_8888_8888;
     if !ok {
         test_fail!("SignalFrame caller-saved", "field round-trip aliased/lost a slot");
         return false;

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -211,6 +211,13 @@ pub fn run() -> ! {
     total += 1;
     if test_smp_online_count_matches_started_flags() { passed += 1; }
 
+    // ── Test R0d: XSAVE/AVX enabled + YMM state survives a context switch ─────
+    // Pure kernel state (no userspace/data.img dependency).  Guards the
+    // XSAVE/AVX enablement: FXSAVE dropped the AVX YMM upper 128 bits across
+    // every context switch; XSAVE/XRSTOR must round-trip the full YMM.
+    total += 1;
+    if test_xsave_avx_ymm_roundtrip() { passed += 1; }
+
     // ── Test 0-heap: Heap free-list validation + canaries — healthy churn ─
     // Runs FIRST (before any test that could itself perturb the heap) so it
     // is a clean no-false-positive assertion for the hardened allocator: the
@@ -34029,6 +34036,73 @@ fn test_pfh_install_arm_anti_alias_backout() -> bool {
 /// When launched under `-smp 2` (the harness default) AP 1 sets its online
 /// flag during boot, so the recomputed count is 2 and the present string is
 /// `"0-1\n"` — exactly the regression this guards against.
+/// XSAVE/AVX enablement: the full 256-bit YMM0 must survive a save/restore
+/// round-trip (FXSAVE preserved only the low 128 bits, corrupting AVX state
+/// across context switches).  Skipped as a vacuous pass on a CPU without AVX,
+/// where the FXSAVE fallback is correct.  Intel SDM Vol. 1 §13.
+fn test_xsave_avx_ymm_roundtrip() -> bool {
+    test_header!("XSAVE/AVX enabled + YMM state round-trips");
+
+    if !crate::arch::x86_64::XSAVE_AVX_ENABLED
+        .load(core::sync::atomic::Ordering::Acquire)
+    {
+        // No AVX on this CPU (e.g. a TCG run): the FXSAVE path is correct and
+        // there is no YMM upper-half to preserve.  Pass vacuously.
+        crate::serial_println!(
+            "[TEST] XSAVE/AVX not enabled on this CPU — FXSAVE fallback, YMM check skipped");
+        test_pass!("XSAVE/AVX");
+        return true;
+    }
+
+    // 256-bit sentinel, distinct across all four 64-bit lanes so a partial
+    // (XMM-only) save that drops the upper 128 bits is detected.
+    let sentinel: [u8; 32] = [
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01,
+        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+        0x0F, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A, 0x69, 0x78,
+    ];
+    let mut readback: [u8; 32] = [0u8; 32];
+    // 64-byte-aligned XSAVE area (FpuState is `#[repr(align(64))]`).
+    let mut area = alloc::boxed::Box::new(crate::proc::FpuState::new_zeroed());
+
+    // Disable interrupts so no real context switch (which also touches YMM0)
+    // interleaves and masks a broken save/restore; run the whole
+    // load→save→clobber→restore→read as one asm block.
+    let rflags: u64;
+    unsafe { core::arch::asm!("pushfq; pop {}", out(reg) rflags, options(nomem, preserves_flags)); }
+    let if_was_set = rflags & (1 << 9) != 0;
+    crate::hal::disable_interrupts();
+    unsafe {
+        core::arch::asm!(
+            "vmovdqu ymm0, [{sent}]",   // ymm0 = sentinel (all 256 bits)
+            "xsave [{area}]",            // save x87|SSE|AVX (eax/edx = mask)
+            "vpxor ymm0, ymm0, ymm0",    // clobber ymm0 = 0
+            "xrstor [{area}]",           // restore ymm0 from the saved area
+            "vmovdqu [{out}], ymm0",     // out = restored ymm0
+            sent = in(reg) sentinel.as_ptr(),
+            area = in(reg) area.data.as_mut_ptr(),
+            out  = in(reg) readback.as_mut_ptr(),
+            in("eax") 0xFFFF_FFFFu32,
+            in("edx") 0xFFFF_FFFFu32,
+            out("xmm0") _,
+            options(nostack),
+        );
+    }
+    if if_was_set { crate::hal::enable_interrupts(); }
+
+    if readback != sentinel {
+        test_fail!(
+            "XSAVE/AVX",
+            "YMM0 not preserved across xsave/xrstor: got {:02x?} want {:02x?}",
+            readback, sentinel
+        );
+        return false;
+    }
+    test_pass!("XSAVE/AVX");
+    true
+}
+
 fn test_smp_online_count_matches_started_flags() -> bool {
     test_header!("SMP online-count reflects every onlined AP");
 


### PR DESCRIPTION
## Summary
Enables XSAVE + AVX properly and closes the FPU-state gap that makes it safe.

Three coupled parts (AVX cannot be enabled without the third or Firefox regresses):
1. **Enable AVX** — `CR4.OSXSAVE` + `xsetbv XCR0(x87|SSE|AVX)` on the BSP and every AP (gated on CPUID XSAVE+AVX; falls back to fxsave otherwise).
2. **Context-switch** FPU save/restore switched `fxsave/fxrstor` → `xsave/xrstor`; `FpuState` sized from `CPUID.0Dh` and 64-byte aligned.
3. **Signal-FPU save/restore** — signal delivery previously preserved GPRs (#710) but **no FPU/SSE/AVX state**: `SignalFrame` carried no fpstate and `sigreturn` restored none. With AVX enabled, glibc/musl use AVX pervasively (memcpy/memset/strlen IFUNCs), so a handler + `sigreturn` clobbered the interrupted YMM/XMM/x87 state with no restore — silent value corruption. This reserves a 64-byte-aligned XSAVE area at the top of the signal frame on **both** delivery paths (`signal_check_on_syscall_return` + `deliver_fault_signal_from_isr`), `fpu_save`s under the SMAP `UserGuard`, records its VA in `SignalFrame.fpstate` (repurposing the former `_pad`; struct stays 160 B), and `fpu_restore`s in `sys_sigreturn` — gated on a non-zero, 64-aligned, `validate_user_ptr`-checked area so a malformed frame cannot `#GP` the kernel. The FPU analogue of #710's GPR fix.

## Why bundled
Enabling AVX (parts 1–2) alone **regresses Firefox**: confirmed by A/B — master SMP=1 `example.com` runs clean to sc≈15.7M (0 crashes) while AVX-enable-without-signal-FPU crash-loops from sc≈15.4M with garbage-pointer SIGSEGV traps (0 AVX `#UD` — AVX works, the faults are clobbered-register value corruption). Part 3 is the prerequisite, so all three ship together.

## Verification
- **`[PASS] XSAVE/AVX`** self-test (YMM0 round-trips through `xsave/xrstor`), SMP=1 + SMP=2.
- **FF regression eliminated**: SMP=1 `--ff-gui example.com` with the full change → **0 garbage-pointer SIGSEGV** (vs 5/5 crash-loop pre-signal-FPU), reaches `[FFTEST] DONE` at sc≈23.2M (≈ the clean baseline).
- Test-mode suite otherwise clean (the `[FAIL]` TCC/busybox entries are the pre-existing environmental data.img gaps also present on master CI).

## Review focus (correctness-sensitive)
- **XSAVE-area sizing/alignment** (`CPUID.0Dh`, 64-byte) and **init-state validity** — a fresh/zeroed frame must `xrstor` a valid image.
- **The `sys_sigreturn` restore trusts the XSAVE image contents**: pointer/alignment/range are validated, but a crafted-image hostile `sigreturn` could still `#GP` on `XRSTOR` itself — flagged in-code as a fault-fixup hardening follow-up (the GPR path has the same trust boundary).
- SMAP guard coverage on the `fpu_save` stores to the user page; the frame reservation math (`total` now spans payload + slack + FPU area for the writable pre-check).

## Specs
x86-64 System V psABI §3.2.3 (signal-return register contract); Intel SDM Vol. 1 §13.7–13.8 (XSAVE/XRSTOR), Vol. 3 (OSXSAVE/XCR0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
