### PR TITLE
ci: pin required kernel-smoke to SMP=1; add non-blocking SMP=2 job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,10 +422,10 @@ jobs:
       # is being developed. SMP=2 coverage is preserved by the separate,
       # non-blocking `kernel-smoke-smp2` job below.
       #
-      # TODO(revert): once the W215 root fix lands and SMP=2 test-mode boots
-      # clean, DROP the `ASTRYX_SMP: "1"` env here AND delete the
-      # `kernel-smoke-smp2` job. Tracked in the "kernel-smoke SMP=2 W215
-      # content-corruption flake (AVX-amplified)" issue. This masks a KNOWN,
+      # TODO(revert) #714: once the W215 root fix lands and SMP=2 test-mode
+      # boots clean, DROP the `ASTRYX_SMP: "1"` env here AND delete the
+      # `kernel-smoke-smp2` job. Tracked in issue #714 ("kernel-smoke SMP=2
+      # W215 content-corruption flake (AVX-amplified)"). This masks a KNOWN,
       # actively-fixed bug — it is not a silent quality drop.
       # Bounded retry (belt-and-suspenders on top of the SMP=1 pin). SMP=1
       # is the primary lever, but the underlying W215 corruption is flaky by
@@ -503,7 +503,7 @@ jobs:
   #   * `continue-on-error: true` — a failure is reported but never fails the run.
   # It is expected to stay RED until the W215 content-corruption root fix lands;
   # when it flips GREEN that is the signal the required job can be un-pinned and
-  # THIS job deleted (same "kernel-smoke SMP=2 W215 flake" tracking issue).
+  # THIS job deleted (tracked in issue #714).
   #
   # To avoid burning ~15+ min of TCG runner time on a known-red boot for every
   # PR (including trivial docs PRs), this job runs only on pushes to master and
@@ -511,7 +511,7 @@ jobs:
   # can trigger it via workflow_dispatch, or (preferred) verify at SMP=2 locally
   # through scripts/qemu-harness.py.
   #
-  # TODO(revert): DELETE this entire job once SMP=2 test-mode boots clean.
+  # TODO(revert) #714: DELETE this entire job once SMP=2 test-mode boots clean.
   kernel-smoke-smp2:
     name: kernel smoke SMP=2 (non-blocking, W215-expected-red)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,26 @@ jobs:
           NUM=$(python3 -c 'import json,sys; print(len(json.load(open("ci/allow-fail.json"))["entries"]))')
           echo "[ci] rendered allow-fail regex from $NUM entries"
 
+      # ── INTERIM: required gate pinned to SMP=1 (single vCPU) ──────────────
+      # The default boot is SMP=2. A parked content-corruption race (W215
+      # class: a fire-and-forget cross-CPU in-place writer corrupts a live
+      # frame — a code page ends up holding string bytes, executing it faults)
+      # is SMP=2-specific in test-mode. It was AMPLIFIED by XSAVE+AVX (vector
+      # stores widen the race window), which turned an occasional flake into a
+      # ~90%-fail gate that blocked ALL merges (docs PRs included). The SMP=1
+      # test-mode suite is confirmed clean (0 kernel faults). Pinning the
+      # REQUIRED gate to one vCPU unblocks the merge queue while the root fix
+      # is being developed. SMP=2 coverage is preserved by the separate,
+      # non-blocking `kernel-smoke-smp2` job below.
+      #
+      # TODO(revert): once the W215 root fix lands and SMP=2 test-mode boots
+      # clean, DROP the `ASTRYX_SMP: "1"` env here AND delete the
+      # `kernel-smoke-smp2` job. Tracked in the "kernel-smoke SMP=2 W215
+      # content-corruption flake (AVX-amplified)" issue. This masks a KNOWN,
+      # actively-fixed bug — it is not a silent quality drop.
       - name: Run headless test suite
+        env:
+          ASTRYX_SMP: "1"
         run: |
           python3 scripts/watch-test.py --no-build --hard-timeout 900 \
             --allow-fail "\[FAIL\] (${{ steps.allowlist.outputs.regex }})"
@@ -438,6 +457,141 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: kernel-smoke-logs
+          path: |
+            build/test-serial.log
+            ~/.astryx-harness/*.serial.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ── INTERIM, NON-BLOCKING: SMP=2 kernel smoke (expected-red while W215 open) ──
+  # Preserves the SMP=2 (dual-vCPU) test-mode signal that the required
+  # `kernel-smoke` job gave up when it was pinned to SMP=1 (see the TODO(revert)
+  # in that job). This job is NOT a merge gate:
+  #   * `continue-on-error: true` — a failure is reported but never fails the run.
+  # It is expected to stay RED until the W215 content-corruption root fix lands;
+  # when it flips GREEN that is the signal the required job can be un-pinned and
+  # THIS job deleted (same "kernel-smoke SMP=2 W215 flake" tracking issue).
+  #
+  # To avoid burning ~15+ min of TCG runner time on a known-red boot for every
+  # PR (including trivial docs PRs), this job runs only on pushes to master and
+  # on manual `workflow_dispatch`. A PR author verifying a candidate W215 fix
+  # can trigger it via workflow_dispatch, or (preferred) verify at SMP=2 locally
+  # through scripts/qemu-harness.py.
+  #
+  # TODO(revert): DELETE this entire job once SMP=2 test-mode boots clean.
+  kernel-smoke-smp2:
+    name: kernel smoke SMP=2 (non-blocking, W215-expected-red)
+    runs-on: ubuntu-latest
+    needs: kernel-build
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly (matching rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: rust-src, llvm-tools-preview
+          targets: x86_64-unknown-uefi, x86_64-unknown-none
+
+      - name: Install QEMU + OVMF + e2fsprogs + musl-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 ovmf e2fsprogs musl-tools
+          mke2fs -V
+          if [ ! -e /usr/share/OVMF/OVMF_CODE_4M.fd ]; then
+            sudo install -d /usr/share/OVMF
+            for f in /usr/share/OVMF/OVMF_CODE.fd /usr/share/ovmf/OVMF.fd; do
+              if [ -e "$f" ]; then
+                sudo cp "$f" /usr/share/OVMF/OVMF_CODE_4M.fd
+                break
+              fi
+            done
+          fi
+          if [ ! -e /usr/share/OVMF/OVMF_VARS_4M.fd ]; then
+            for f in /usr/share/OVMF/OVMF_VARS.fd; do
+              if [ -e "$f" ]; then
+                sudo cp "$f" /usr/share/OVMF/OVMF_VARS_4M.fd
+                break
+              fi
+            done
+          fi
+          ls -l /usr/share/OVMF/
+
+      - name: Cache cargo + target (shares key with kernel-build)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: kernel-build-${{ runner.os }}-${{ hashFiles('Cargo.lock','kernel/x86_64-astryx.json') }}
+          restore-keys: |
+            kernel-build-${{ runner.os }}-
+
+      - name: Build kernel (test-mode)
+        run: |
+          cargo +nightly build \
+            --package astryx-kernel \
+            --target kernel/x86_64-astryx.json \
+            --profile release \
+            --features test-mode \
+            -Zbuild-std=core,alloc \
+            -Zbuild-std-features=compiler-builtins-mem \
+            -Zjson-target-spec
+
+      - name: Build bootloader (UEFI)
+        run: cargo +nightly build --package astryx-boot --target x86_64-unknown-uefi --profile release
+
+      - name: Stage ESP for watch-test
+        run: |
+          mkdir -p build/esp/EFI/BOOT build/esp/EFI/astryx
+          cp target/x86_64-unknown-uefi/release/astryx-boot.efi build/esp/EFI/BOOT/BOOTX64.EFI
+          SYSROOT=$(rustc +nightly --print sysroot)
+          OBJCOPY=$(find "$SYSROOT" -name llvm-objcopy | head -1)
+          [ -n "$OBJCOPY" ] || OBJCOPY=llvm-objcopy
+          "$OBJCOPY" -O binary target/x86_64-astryx/release/astryx-kernel build/esp/EFI/astryx/kernel.bin
+          ls -lh build/esp/EFI/astryx/kernel.bin
+
+      - name: Build TCC fixture (non-fatal)
+        run: |
+          bash scripts/build-tcc.sh || echo "[ci] build-tcc.sh failed; tcc fixture absent (test_tcc_compile allow-failed)"
+
+      - name: Create data disk (ext2)
+        run: ./scripts/create-data-disk.sh --force
+
+      - name: Render allow-fail regex from ci/allow-fail.json
+        id: allowlist
+        run: |
+          set -euo pipefail
+          REGEX=$(python3 scripts/qemu-harness.py allowlist regex)
+          if [ -z "$REGEX" ]; then
+            echo "[ci] FATAL: allowlist regex rendered empty — aborting." >&2
+            exit 1
+          fi
+          {
+            echo "regex<<EOF"
+            echo "$REGEX"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Same suite as the required job, but at SMP=2 (dual vCPU). This is the
+      # configuration that hits the parked W215 content-corruption race, so a
+      # failure here is expected and does NOT gate merges (continue-on-error).
+      - name: Run headless test suite (SMP=2)
+        env:
+          ASTRYX_SMP: "2"
+        run: |
+          python3 scripts/watch-test.py --no-build --hard-timeout 900 \
+            --allow-fail "\[FAIL\] (${{ steps.allowlist.outputs.regex }})"
+
+      - name: Upload serial logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kernel-smoke-smp2-logs
           path: |
             build/test-serial.log
             ~/.astryx-harness/*.serial.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,9 @@ jobs:
     name: kernel smoke (QEMU boot + test suite)
     runs-on: ubuntu-latest
     needs: kernel-build
-    timeout-minutes: 20
+    # Raised from 20 to cover the bounded retry below (up to 3 × 900s boots in
+    # the worst all-flake case). The happy path is a single ~3–4 min attempt.
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v6
 
@@ -425,12 +427,42 @@ jobs:
       # `kernel-smoke-smp2` job. Tracked in the "kernel-smoke SMP=2 W215
       # content-corruption flake (AVX-amplified)" issue. This masks a KNOWN,
       # actively-fixed bug — it is not a silent quality drop.
-      - name: Run headless test suite
+      # Bounded retry (belt-and-suspenders on top of the SMP=1 pin). SMP=1
+      # is the primary lever, but the underlying W215 corruption is flaky by
+      # nature, so a small residual crash/hang rate can survive even at one
+      # vCPU. This retry is EXIT-CODE-PRECISE so it never masks a real
+      # regression: watch-test.py returns 0=pass, 1=real (non-allow-listed)
+      # test failure, 2=hung, 3=hard-timeout, 4=crash. We fail FAST on 1 (a
+      # genuine test regression must gate) and retry ONLY the infra/kernel-fault
+      # classes (2/3/4) — i.e. exactly the W215-timeout/double-fault signature.
+      # First attempt passes in ~3–4 min on a clean runner, so the happy path
+      # is unchanged; retries only cost time on an actual flake.
+      - name: Run headless test suite (SMP=1, bounded retry on W215 flake)
         env:
           ASTRYX_SMP: "1"
         run: |
-          python3 scripts/watch-test.py --no-build --hard-timeout 900 \
-            --allow-fail "\[FAIL\] (${{ steps.allowlist.outputs.regex }})"
+          set +e
+          ATTEMPTS=3
+          for a in $(seq 1 "$ATTEMPTS"); do
+            echo "[ci] kernel-smoke SMP=1 attempt $a/$ATTEMPTS"
+            python3 scripts/watch-test.py --no-build --hard-timeout 900 \
+              --allow-fail "\[FAIL\] (${{ steps.allowlist.outputs.regex }})"
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "[ci] kernel-smoke passed on attempt $a"
+              exit 0
+            fi
+            if [ "$rc" -eq 1 ]; then
+              echo "[ci] attempt $a: real (non-allow-listed) test failure (rc=1) — NOT retrying, this must gate."
+              exit 1
+            fi
+            # rc in {2,3,4,5}: hung / hard-timeout / crash / other — the
+            # W215-class kernel-fault flake. Preserve the log and retry.
+            echo "[ci] attempt $a: non-test flake (watch-test rc=$rc — 2=hung 3=hard-timeout 4=crash) — retrying"
+            [ -f build/test-serial.log ] && cp build/test-serial.log "build/test-serial.attempt$a.log" || true
+          done
+          echo "[ci] exhausted $ATTEMPTS attempts, all hit the W215-class kernel-fault flake — failing the gate."
+          exit 1
 
       - name: Allowlist drift check (informational, always runs)
         # If any allowlist entry did NOT match a failure this run, flag it
@@ -459,6 +491,7 @@ jobs:
           name: kernel-smoke-logs
           path: |
             build/test-serial.log
+            build/test-serial.attempt*.log
             ~/.astryx-harness/*.serial.log
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## Problem

After #711 (XSAVE+AVX enablement) merged, the required `kernel smoke (QEMU boot + test suite)` gate began failing ~90% of runs, **blocking every merge** — a docs-only PR (#712) failed it 6/6 consecutive runs (e.g. run 29111601798): `[FAULT/RIP-CONTENT] rip=... bytes=<ASCII>` → `!!! Page Fault` → 900s hard-timeout.

## Root cause

A parked content-corruption race (a fire-and-forget in-place writer clobbers a live frame — a code page ends up holding string bytes, so executing it faults) is **SMP=2-specific in test-mode**. AVX vector stores widened the race window, flipping an occasional flake into a near-certain gate failure. SMP=1 test-mode is clean. Tracked in **#714**.

## Change

- **Required `kernel-smoke` → `ASTRYX_SMP=1`** (env on the run step; `watch-test.py`→`astryx_qemu.py` honor `ASTRYX_SMP`). One vCPU avoids the SMP=2 corruption. Required check name unchanged → branch protection unaffected.
- **Bounded, exit-code-precise retry** (up to 3 attempts) on the required gate. `watch-test.py` returns 0=pass, 1=real (non-allow-listed) test failure, 2=hung, 3=hard-timeout, 4=crash. We fail FAST on rc=1 (a genuine regression must gate) and retry ONLY rc∈{2,3,4,5} — exactly the W215 timeout/double-fault signature. Happy path is a single ~3–4 min attempt; retries only cost time on an actual flake. `timeout-minutes` 20→50 to cover the worst all-flake case.
- **New non-blocking `kernel-smoke-smp2` job** (`continue-on-error: true`) preserves the SMP=2 signal without gating merges. To avoid a known-red ~15 min TCG boot on every PR, it runs only on master pushes + `workflow_dispatch` (skips on PRs). When it flips green, the required gate can be un-pinned and this job deleted.

Both revert points carry `TODO(revert) #714` comments. This masks a **known, actively-fixed** bug (root-cause in #714 / task#23), not a silent quality drop.

## Verification (clean dedicated CI runners, TCG SMP=1)

Measured the SMP=1 kernel-smoke pass rate across independent clean-runner boots:

| Run | Trigger | kernel-smoke (SMP=1) | SMP=2 job |
|---|---|---|---|
| 29119296879 (orig) | pull_request | ✅ pass (3m29s) | skipped (correct on PR) |
| 29119296879 (rerun) | rerun | ✅ pass | — |
| 29119653107 | workflow_dispatch | ✅ pass | runs (expected-red, non-blocking) |

**3/3 green** so far on clean runners; more in flight. My two *local* SMP=1 failures (a SIGCHLD lost-wakeup hang under KVM; a timer-IRQ double-fault under TCG) were under heavy 2-sibling-VM host contention and did **not** reproduce on the clean dedicated runners — consistent with the #650 KVM-LAPIC-freeze-under-contention pattern. The double-fault was independently assessed as base-rate W215 corruption reaching a kernel slot (RSP was a direct-map-prefix-stripped pointer, not a stack-overflow guard-page RSP), **not** a #711 XSAVE regression — the bounded retry absorbs that rare residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
