### PR TITLE
harness: coerce session pid to int in _pid_alive (fix list/status crash on stale session JSON)

### DIFF
--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -911,12 +911,27 @@ def _session_path(sid: str) -> Path:
 def _events_path(sid: str) -> Path:
     return HARNESS_DIR / f"{sid}.events.jsonl"
 
+def _normalize_pid(value):
+    """Session JSONs written by older harness versions may carry the pid as
+    a string, and signal sites pass it straight to os.kill — normalize at
+    the read boundary. Malformed or non-positive values become None so a
+    corrupt record reads as a dead session (os.kill with 0/negative pids
+    would signal a process group, never a single stale QEMU)."""
+    try:
+        pid = int(value)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
 def _load_session(sid: str) -> dict:
     p = _session_path(sid)
     if not p.exists():
         _err(f"Unknown session: {sid}")
     with p.open() as f:
-        return json.load(f)
+        data = json.load(f)
+    if "pid" in data:
+        data["pid"] = _normalize_pid(data["pid"])
+    return data
 
 def _save_session(data: dict):
     p = _session_path(data["sid"])
@@ -924,12 +939,11 @@ def _save_session(data: dict):
         json.dump(data, f)
 
 def _pid_alive(pid) -> bool:
-    # Session JSONs written by older harness versions can carry the pid as a
-    # string; coerce before signalling so `list`/`status` don't crash on a
-    # stale record. A non-numeric pid means a malformed record → not alive.
-    try:
-        pid = int(pid)
-    except (TypeError, ValueError):
+    # Defence in depth for callers that read session JSON without
+    # `_load_session` (e.g. the `list` sweep does its own json.load): a
+    # malformed pid reads as not-alive rather than crashing the subcommand.
+    pid = _normalize_pid(pid)
+    if pid is None:
         return False
     try:
         os.kill(pid, 0)

--- a/scripts/qemu-harness.py
+++ b/scripts/qemu-harness.py
@@ -923,7 +923,14 @@ def _save_session(data: dict):
     with p.open("w") as f:
         json.dump(data, f)
 
-def _pid_alive(pid: int) -> bool:
+def _pid_alive(pid) -> bool:
+    # Session JSONs written by older harness versions can carry the pid as a
+    # string; coerce before signalling so `list`/`status` don't crash on a
+    # stale record. A non-numeric pid means a malformed record → not alive.
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
     try:
         os.kill(pid, 0)
         return True


### PR DESCRIPTION
## Problem
A session JSON written by an older harness version stored the pid as a string. `_pid_alive` passed it straight to `os.kill` → `TypeError: 'str' object cannot be interpreted as an integer`, crashing `list` (and any subcommand walking sessions) whenever such a record is present in `~/.astryx-harness/`.

## Fix
Coerce the pid to `int` at `_pid_alive` entry; a non-numeric pid is treated as not-alive, so a malformed record degrades to a dead session instead of an unusable subcommand. `_pid_running` inherits the guard via its `_pid_alive` gate.

Additive — no JSON output-field changes.

## Verification
`python3 scripts/qemu-harness.py list` crashed before the fix with the stale record present; after, it returns the live-session JSON correctly (verified against a running session).