### PR TITLE
mm: don't write-protect the kernel identity map on kernel_cr3 fork/mprotect (task#4 WP guard)

### DIFF
--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -796,7 +796,8 @@ impl VmSpace {
     /// Also syncs `self.cr3 = actual_cr3` so subsequent VmSpace operations
     /// (demand-paging, CoW handling) use the correct page tables.
     pub fn clone_for_fork(&mut self, actual_cr3: u64) -> Option<Self> {
-        use crate::mm::vmm::{PAGE_PRESENT, PAGE_WRITABLE, PAGE_HUGE, ADDR_MASK};
+        use crate::mm::vmm::{PAGE_PRESENT, PAGE_WRITABLE, PAGE_HUGE, ADDR_MASK,
+                             get_kernel_cr3, is_identity_map_phys};
         use crate::mm::pmm;
         use crate::mm::refcount::page_ref_inc;
 
@@ -840,6 +841,23 @@ impl VmSpace {
             );
             self.cr3 = actual_cr3;
         }
+
+        // task#4 identity-map guard.  A fork whose page tables ARE the kernel's
+        // own (`actual_cr3 == kernel_cr3`) is only ever the in-kernel test
+        // runner (a `vm_space == None` process runs on `kernel_cr3`).  For such
+        // a fork the CoW write-protect pass below would clear `PAGE_WRITABLE`
+        // on the kernel's 1:1 identity map (PML4[0]); the running kernel writes
+        // through that map (e.g. the BSP bootstrap stack), so the next kernel
+        // store to a now-read-only identity page faults — a #PF that re-pushes
+        // onto the same read-only stack and escalates to #DF, or a getrandom /
+        // sysinfo kernel-context write that fault-loops.  When this flag is set
+        // the leaf loops below leave identity leaves (`phys == va`, low VA)
+        // writable and CoW every other (non-identity, high-VA) leaf normally.
+        // A real user address space never satisfies `actual_cr3 == kernel_cr3`
+        // — its PML4[0] is built empty and never shares a page-table page with
+        // the kernel identity map — so this is inert for every real fork(2).
+        let kernel_cr3 = get_kernel_cr3();
+        let fork_on_kernel_cr3 = kernel_cr3 != 0 && actual_cr3 == kernel_cr3;
 
         // Per-fork [FORK-COW] dump (START line + one line per VMA, ~100 VMAs
         // per Firefox process).  ALWAYS-ON historically — this taxed every
@@ -904,8 +922,16 @@ impl VmSpace {
 
                     // 1 GB huge page — write-protect in both, no CoW split.
                     if pdpte & PAGE_HUGE != 0 {
-                        let flags_ro = (pdpte & !ADDR_MASK) & !PAGE_WRITABLE;
                         let phys_1g  = pdpte & !0x3FFF_FFFFu64;
+                        let va_1g    = ((pml4_idx as u64) << 39) | ((pdpt_idx as u64) << 30);
+                        if fork_on_kernel_cr3 && is_identity_map_phys(va_1g, phys_1g) {
+                            // Kernel identity 1 GiB page: keep it writable in
+                            // both parent and child (copy the PDPTE verbatim).
+                            *parent_pdpt.add(pdpt_idx) = pdpte;
+                            *child_pdpt .add(pdpt_idx) = pdpte;
+                            continue;
+                        }
+                        let flags_ro = (pdpte & !ADDR_MASK) & !PAGE_WRITABLE;
                         *parent_pdpt.add(pdpt_idx) = phys_1g | flags_ro;
                         *child_pdpt .add(pdpt_idx) = phys_1g | flags_ro;
                         continue;
@@ -928,9 +954,23 @@ impl VmSpace {
                         // 2 MB huge page — write-protect in both and ref-count sub-pages.
                         if pde & PAGE_HUGE != 0 {
                             let phys_2m     = pde & 0x000F_FFFF_FFE0_0000u64;
-                            let flags_ro    = (pde & !ADDR_MASK) & !PAGE_WRITABLE;
-                            *parent_pd.add(pd_idx) = phys_2m | flags_ro;
-                            *child_pd .add(pd_idx) = phys_2m | flags_ro;
+                            let va_2m       = ((pml4_idx as u64) << 39)
+                                            | ((pdpt_idx as u64) << 30)
+                                            | ((pd_idx as u64) << 21);
+                            let (parent_pde, child_pde) =
+                                if fork_on_kernel_cr3 && is_identity_map_phys(va_2m, phys_2m) {
+                                    // Kernel identity 2 MiB page: keep writable
+                                    // in both (copy the PDE verbatim).  The
+                                    // sub-page ref-count accounting is unchanged
+                                    // from the normal path so teardown stays
+                                    // balanced — only the writable bit differs.
+                                    (pde, pde)
+                                } else {
+                                    let flags_ro = (pde & !ADDR_MASK) & !PAGE_WRITABLE;
+                                    (phys_2m | flags_ro, phys_2m | flags_ro)
+                                };
+                            *parent_pd.add(pd_idx) = parent_pde;
+                            *child_pd .add(pd_idx) = child_pde;
                             for sub in 0..512u64 {
                                 page_ref_inc(phys_2m + sub * 0x1000);
                             }
@@ -952,13 +992,24 @@ impl VmSpace {
                             if pte & PAGE_PRESENT == 0 { continue; }
 
                             let phys       = pte & ADDR_MASK;
-                            let flags_ro   = (pte & !ADDR_MASK) & !PAGE_WRITABLE;
+                            let va         = ((pml4_idx as u64) << 39)
+                                           | ((pdpt_idx as u64) << 30)
+                                           | ((pd_idx as u64) << 21)
+                                           | ((pt_idx as u64) << 12);
 
-                            // Write-protect parent PTE in place.
-                            *parent_pt.add(pt_idx) = phys | flags_ro;
+                            // Kernel identity leaf under kernel_cr3: keep the
+                            // parent (and child) PTE writable — never CoW the
+                            // kernel's own 1:1 map.  Otherwise write-protect in
+                            // place as usual.
+                            let entry = if fork_on_kernel_cr3 && is_identity_map_phys(va, phys) {
+                                pte
+                            } else {
+                                phys | ((pte & !ADDR_MASK) & !PAGE_WRITABLE)
+                            };
 
-                            // Child PTE: same physical page, read-only.
-                            *child_pt.add(pt_idx) = phys | flags_ro;
+                            // Parent PTE in place; child PTE: same physical page.
+                            *parent_pt.add(pt_idx) = entry;
+                            *child_pt.add(pt_idx)  = entry;
 
                             // Keep page alive until both mappings are gone.
                             page_ref_inc(phys);

--- a/kernel/src/mm/vma.rs
+++ b/kernel/src/mm/vma.rs
@@ -957,22 +957,32 @@ impl VmSpace {
                             let va_2m       = ((pml4_idx as u64) << 39)
                                             | ((pdpt_idx as u64) << 30)
                                             | ((pd_idx as u64) << 21);
-                            let (parent_pde, child_pde) =
-                                if fork_on_kernel_cr3 && is_identity_map_phys(va_2m, phys_2m) {
-                                    // Kernel identity 2 MiB page: keep writable
-                                    // in both (copy the PDE verbatim).  The
-                                    // sub-page ref-count accounting is unchanged
-                                    // from the normal path so teardown stays
-                                    // balanced — only the writable bit differs.
-                                    (pde, pde)
-                                } else {
-                                    let flags_ro = (pde & !ADDR_MASK) & !PAGE_WRITABLE;
-                                    (phys_2m | flags_ro, phys_2m | flags_ro)
-                                };
+                            let identity =
+                                fork_on_kernel_cr3 && is_identity_map_phys(va_2m, phys_2m);
+                            let (parent_pde, child_pde) = if identity {
+                                // Kernel identity 2 MiB page: keep it writable in
+                                // both (copy the PDE verbatim) AND take no
+                                // reference on its sub-pages.  The child holds a
+                                // writable alias to a kernel-owned frame it must
+                                // never be able to free, so it owns no reference;
+                                // the sub-page page_ref_inc below is skipped,
+                                // mirroring the write-protect skip.  Identity
+                                // leaves are covered by no VMA, so teardown
+                                // (free_process_memory walks VMAs;
+                                // free_user_page_tables skips huge leaves)
+                                // decrements none of them — skipping the inc
+                                // keeps inc and dec both absent = balanced.
+                                (pde, pde)
+                            } else {
+                                let flags_ro = (pde & !ADDR_MASK) & !PAGE_WRITABLE;
+                                (phys_2m | flags_ro, phys_2m | flags_ro)
+                            };
                             *parent_pd.add(pd_idx) = parent_pde;
                             *child_pd .add(pd_idx) = child_pde;
-                            for sub in 0..512u64 {
-                                page_ref_inc(phys_2m + sub * 0x1000);
+                            if !identity {
+                                for sub in 0..512u64 {
+                                    page_ref_inc(phys_2m + sub * 0x1000);
+                                }
                             }
                             continue;
                         }
@@ -1001,7 +1011,9 @@ impl VmSpace {
                             // parent (and child) PTE writable — never CoW the
                             // kernel's own 1:1 map.  Otherwise write-protect in
                             // place as usual.
-                            let entry = if fork_on_kernel_cr3 && is_identity_map_phys(va, phys) {
+                            let identity =
+                                fork_on_kernel_cr3 && is_identity_map_phys(va, phys);
+                            let entry = if identity {
                                 pte
                             } else {
                                 phys | ((pte & !ADDR_MASK) & !PAGE_WRITABLE)
@@ -1011,8 +1023,15 @@ impl VmSpace {
                             *parent_pt.add(pt_idx) = entry;
                             *child_pt.add(pt_idx)  = entry;
 
-                            // Keep page alive until both mappings are gone.
-                            page_ref_inc(phys);
+                            // Take a reference to keep the page alive until both
+                            // mappings are gone — EXCEPT for a kernel identity
+                            // leaf, which the child aliases writable but must
+                            // never free, and which no VMA covers so teardown
+                            // decrements none of them; inc and dec both absent =
+                            // balanced (mirrors the write-protect skip).
+                            if !identity {
+                                page_ref_inc(phys);
+                            }
                             total_pages_cow += 1;
                         }
                     }

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -96,6 +96,33 @@ pub fn get_kernel_cr3() -> u64 {
     KERNEL_CR3.load(core::sync::atomic::Ordering::Relaxed)
 }
 
+/// Top of the kernel's low 1:1 identity window (PML4[0]).
+///
+/// The bootloader identity-maps the first 4 GiB of physical address space at
+/// virtual address 0 (`bootloader/src/paging.rs`: four 1 GiB PDs of 2 MiB
+/// huge pages).  Any leaf whose virtual address is below this bound and whose
+/// masked physical address equals its virtual address is part of that map.
+pub const IDENTITY_WINDOW_TOP: u64 = 0x1_0000_0000;
+
+/// True when a leaf (or large-page) mapping `va → phys` belongs to the
+/// kernel's low 1:1 identity map (PML4[0]).
+///
+/// The 1:1 property (`phys == va`, within the identity window) is the
+/// discriminator.  Fork-CoW (`VmSpace::clone_for_fork`) and `mprotect`(2) must
+/// never write-protect or retag such a leaf when they run on `kernel_cr3`:
+/// the running kernel writes through the identity map (e.g. the BSP bootstrap
+/// stack), so clearing `PAGE_WRITABLE` there faults the kernel itself.
+///
+/// Only the in-kernel test runner (`vm_space == None`, running on
+/// `kernel_cr3`) can name these mappings — a normal user address space never
+/// shares a page-table page with the kernel identity map and never maps
+/// `phys == va`, so a low-VA user `mmap`/`mprotect` (e.g. an in-kernel
+/// mprotect test) is left to the normal path.  See fork(2) / mprotect(2).
+#[inline]
+pub fn is_identity_map_phys(va: u64, phys: u64) -> bool {
+    va < IDENTITY_WINDOW_TOP && phys == va
+}
+
 /// Initialize the VMM.
 ///
 /// 1. Reserves the physical pages that back the higher-half kernel heap

--- a/kernel/src/mm/vmm.rs
+++ b/kernel/src/mm/vmm.rs
@@ -102,6 +102,12 @@ pub fn get_kernel_cr3() -> u64 {
 /// virtual address 0 (`bootloader/src/paging.rs`: four 1 GiB PDs of 2 MiB
 /// huge pages).  Any leaf whose virtual address is below this bound and whose
 /// masked physical address equals its virtual address is part of that map.
+///
+/// This bound is COUPLED to that bootloader extent — it is the single source
+/// of truth.  If the bootloader is ever changed to identity-map beyond 4 GiB,
+/// this constant MUST be raised in lockstep; otherwise `is_identity_map_phys`
+/// under-covers and the fork/mprotect guards would write-protect or retag the
+/// now-uncovered identity leaves (the exact fault class task#4 closes).
 pub const IDENTITY_WINDOW_TOP: u64 = 0x1_0000_0000;
 
 /// True when a leaf (or large-page) mapping `va → phys` belongs to the

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -8039,7 +8039,7 @@ pub fn sys_clock_gettime(clk_id: u64, tp: u64) -> i64 {
 fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
     use crate::mm::vma::{page_align_down, page_align_up, PROT_READ, PROT_WRITE, PROT_EXEC};
     use crate::mm::vmm::{read_pte, write_pte, PAGE_PRESENT, PAGE_WRITABLE,
-                         PAGE_USER, PAGE_NO_EXECUTE};
+                         PAGE_USER, PAGE_NO_EXECUTE, PAGE_HUGE};
 
     if len == 0 {
         return 0;
@@ -8066,6 +8066,40 @@ fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
         None => return -22,
     };
     let cr3 = space.cr3;
+
+    // task#4 identity-map guard.  Refuse to retag the kernel's own 1:1
+    // identity map (PML4[0]).  Only a caller running on `kernel_cr3` — the
+    // in-kernel test runner, whose lazily-created VmSpace adopts `kernel_cr3`
+    // (see sys_mmap's from_existing_cr3 path) — can name identity pages.  A
+    // normal user address space never maps `phys == va`, so this rejects
+    // nothing a real program does.  Without the guard an mprotect(PROT_READ)
+    // on an identity-mapped page would clear PAGE_WRITABLE on a kernel-owned
+    // mapping (the running kernel writes through it), faulting the kernel.
+    // The check runs before any VMA-list mutation so the refusal is clean.
+    // Per mprotect(2), EINVAL is the error for an unsupported range request.
+    {
+        let kernel_cr3 = crate::mm::vmm::get_kernel_cr3();
+        if kernel_cr3 != 0 && cr3 == kernel_cr3 {
+            let mut p = base;
+            while p < end {
+                let pte = read_pte(cr3, p);
+                if pte & PAGE_PRESENT != 0 {
+                    // A 2 MiB huge leaf reports its 2 MiB-aligned identity
+                    // (phys == va) at the aligned base; a 4 KiB leaf reports
+                    // it at the page.
+                    let (phys, va) = if pte & PAGE_HUGE != 0 {
+                        (pte & 0x000F_FFFF_FFE0_0000, p & !0x1F_FFFF)
+                    } else {
+                        (pte & 0x000F_FFFF_FFFF_F000, p)
+                    };
+                    if crate::mm::vmm::is_identity_map_phys(va, phys) {
+                        return -22; // EINVAL
+                    }
+                }
+                p = p.wrapping_add(0x1000);
+            }
+        }
+    }
 
     // W216 H_5j-B: mprotect rewrites VMA prot/areas in place; bump generation
     // to invalidate any in-flight PFH install loop that snapshotted the old

--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -8084,15 +8084,19 @@ fn sys_mprotect(addr: u64, len: u64, prot: u64) -> i64 {
             while p < end {
                 let pte = read_pte(cr3, p);
                 if pte & PAGE_PRESENT != 0 {
-                    // A 2 MiB huge leaf reports its 2 MiB-aligned identity
-                    // (phys == va) at the aligned base; a 4 KiB leaf reports
-                    // it at the page.
-                    let (phys, va) = if pte & PAGE_HUGE != 0 {
-                        (pte & 0x000F_FFFF_FFE0_0000, p & !0x1F_FFFF)
+                    // Identity (phys == va) is detected at leaf granularity.
+                    // read_pte returns a huge leaf without telling us whether it
+                    // is a 1 GiB PDPTE or a 2 MiB PDE, so a huge leaf is checked
+                    // at BOTH alignments and refused if either matches (identity
+                    // has phys == va at every granularity; a non-identity huge
+                    // leaf matches neither).  A 4 KiB leaf is checked at the page.
+                    let hit = if pte & PAGE_HUGE != 0 {
+                        crate::mm::vmm::is_identity_map_phys(p & !0x1F_FFFF,       pte & 0x000F_FFFF_FFE0_0000)
+                     || crate::mm::vmm::is_identity_map_phys(p & !0x3FFF_FFFF,     pte & 0x000F_FFFF_C000_0000)
                     } else {
-                        (pte & 0x000F_FFFF_FFFF_F000, p)
+                        crate::mm::vmm::is_identity_map_phys(p, pte & 0x000F_FFFF_FFFF_F000)
                     };
-                    if crate::mm::vmm::is_identity_map_phys(va, phys) {
+                    if hit {
                         return -22; // EINVAL
                     }
                 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -778,6 +778,11 @@ pub fn run() -> ! {
     total += 1;
     if test_mprotect_syscall() { passed += 1; }
 
+    // ── Test 49b: task#4 identity-range write-protect guard ───────────────
+
+    total += 1;
+    if test_task4_identity_wp_guard() { passed += 1; }
+
     // ── Test 50: eventfd (counter signaling fd) ───────────────────────────
 
     total += 1;
@@ -14696,6 +14701,131 @@ fn test_mprotect_syscall() -> bool {
     test_println!("  munmap ✓");
 
     test_pass!("mprotect page-table protection changes");
+    true
+}
+
+/// Test 49b — task#4 identity-range write-protect guard.
+///
+/// `VmSpace::clone_for_fork` and `sys_mprotect` must never clear
+/// `PAGE_WRITABLE` on (nor otherwise retag) the kernel's 1:1 identity map
+/// (PML4[0]) when they run on `kernel_cr3`.  Only the in-kernel test runner
+/// (a `vm_space == None` process runs on `kernel_cr3`, and its lazily-created
+/// VmSpace adopts `kernel_cr3`) can name identity pages; a real user address
+/// space never maps `phys == va`, so the guard is identity-scoped, not
+/// cr3-wholesale (Test 49 above mprotects a HIGH-VA anon page on this same
+/// `kernel_cr3` and still succeeds).
+///
+/// A live `clone_for_fork(kernel_cr3)` is deliberately NOT exercised here: it
+/// would write-protect the runner's own non-identity high-VA mmaps (the same
+/// destructive mechanism), making the suite flaky.  The fork site shares the
+/// exact `is_identity_map_phys` discriminator and the same "keep writable"
+/// decision as the mprotect site, which this test drives end-to-end.
+/// See fork(2) / mprotect(2).
+fn test_task4_identity_wp_guard() -> bool {
+    use crate::mm::vmm::{is_identity_map_phys, get_kernel_cr3, read_pte,
+                         PAGE_PRESENT, PAGE_HUGE, PAGE_WRITABLE, IDENTITY_WINDOW_TOP};
+    test_header!("task#4: identity-range write-protect guard (fork/mprotect on kernel_cr3)");
+
+    // 1. Predicate unit checks — the discriminator shared by both guard sites.
+    //    Identity iff phys == va AND va inside the low identity window.
+    let cases: [(u64, u64, bool); 6] = [
+        (0x0020_0000, 0x0020_0000, true),   // 2 MiB identity
+        (0x3fe0_e000, 0x3fe0_e000, true),   // bootstrap-stack-region identity
+        (0x0020_0000, 0x0020_1000, false),  // phys != va
+        (0x7f00_0000_0000, 0x0000_1000, false), // high user VA, low phys
+        (IDENTITY_WINDOW_TOP, IDENTITY_WINDOW_TOP, false), // at/above window top
+        (0x0000_1000, 0x0000_2000, false),  // low but phys != va
+    ];
+    for (va, phys, want) in cases.iter() {
+        if is_identity_map_phys(*va, *phys) != *want {
+            test_fail!("task4_identity_wp_guard",
+                "is_identity_map_phys({:#x},{:#x}) != {}", va, phys, want);
+            return false;
+        }
+    }
+    test_println!("  is_identity_map_phys discriminator: 6/6 cases ✓");
+
+    // 2. mprotect guard end-to-end.  Ensure the runner has a VmSpace by
+    //    mmapping an anonymous page (returns a HIGH, non-identity VA).
+    let addr = crate::syscall::dispatch_linux_kernel(
+        9, 0, 0x1000, 3 /*PROT_READ|WRITE*/, 0x22 /*MAP_PRIVATE|ANON*/, u64::MAX, 0);
+    if addr <= 0 {
+        test_fail!("task4_identity_wp_guard", "mmap failed: {}", addr);
+        return false;
+    }
+
+    // Read the running process's VmSpace CR3.  The guard only applies when it
+    // equals kernel_cr3; if the runner is on a distinct CR3, the end-to-end
+    // sub-check is not applicable (the predicate check above still gates it).
+    let pid = crate::proc::current_pid_lockless();
+    let space_cr3 = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == pid)
+            .and_then(|p| p.vm_space.as_ref())
+            .map(|vs| vs.cr3)
+            .unwrap_or(0)
+    };
+    let kcr3 = get_kernel_cr3();
+
+    if space_cr3 == kcr3 && kcr3 != 0 {
+        // Find a present low identity page in kernel_cr3 to target.  Low
+        // (< 4 MiB) candidates can be ELF-overlaid (phys != va), so the scan
+        // includes the bootstrap-stack region and 1-2 GiB identity ranges
+        // which are never overlaid.
+        let mut ident_va = 0u64;
+        for cand in [0x3fe0_0000u64, 0x4000_0000, 0x8000_0000,
+                     0x0020_0000, 0x0040_0000, 0x0100_0000] {
+            let pte = read_pte(kcr3, cand);
+            if pte & PAGE_PRESENT == 0 { continue; }
+            let (phys, va) = if pte & PAGE_HUGE != 0 {
+                (pte & 0x000F_FFFF_FFE0_0000, cand & !0x1F_FFFF)
+            } else {
+                (pte & 0x000F_FFFF_FFFF_F000, cand)
+            };
+            if is_identity_map_phys(va, phys) { ident_va = cand; break; }
+        }
+
+        if ident_va != 0 {
+            // (a) mprotect of an identity page → EINVAL (refused).
+            let r = crate::syscall::dispatch_linux_kernel(
+                10, ident_va, 0x1000, 1 /*PROT_READ*/, 0, 0, 0);
+            if r != -22 {
+                test_fail!("task4_identity_wp_guard",
+                    "mprotect(identity {:#x}) = {} (expected -22/EINVAL)", ident_va, r);
+                let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+                return false;
+            }
+            // (b) the identity PTE must still be WRITABLE (guard refused, did
+            //     not clear PAGE_WRITABLE).  Huge or 4 KiB, the leaf carries W.
+            let pte_after = read_pte(kcr3, ident_va);
+            if pte_after & PAGE_WRITABLE == 0 {
+                test_fail!("task4_identity_wp_guard",
+                    "identity PTE {:#x} lost PAGE_WRITABLE after refused mprotect", ident_va);
+                let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+                return false;
+            }
+            // (c) identity-SCOPED, not cr3-wholesale: mprotect of the HIGH-VA
+            //     anon page on this same kernel_cr3 still succeeds.
+            let r2 = crate::syscall::dispatch_linux_kernel(
+                10, addr as u64, 0x1000, 1 /*PROT_READ*/, 0, 0, 0);
+            if r2 != 0 {
+                test_fail!("task4_identity_wp_guard",
+                    "mprotect(non-identity {:#x}) = {} (expected 0 — guard must be identity-scoped)", addr, r2);
+                let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+                return false;
+            }
+            test_println!("  mprotect(identity {:#x})→EINVAL, PTE stays writable, high-VA mprotect→0 ✓", ident_va);
+        } else {
+            test_println!("  no present low identity page found to target — SKIP mprotect sub-check");
+        }
+    } else {
+        test_println!("  runner VmSpace cr3={:#x} != kernel_cr3={:#x} — SKIP mprotect sub-check", space_cr3, kcr3);
+    }
+
+    // Clean up the anon page.
+    let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+
+    test_pass!("task#4 identity-range write-protect guard");
     true
 }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -14785,7 +14785,16 @@ fn test_task4_identity_wp_guard() -> bool {
             if is_identity_map_phys(va, phys) { ident_va = cand; break; }
         }
 
-        if ident_va != 0 {
+        if ident_va == 0 {
+            // The kernel identity map always has present low pages; not finding
+            // one means the guard lost its live coverage — fail rather than
+            // silently downgrade to a predicate-only pass.
+            test_fail!("task4_identity_wp_guard",
+                "on kernel_cr3 but found no present identity page to target");
+            let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+            return false;
+        }
+        {
             // (a) mprotect of an identity page → EINVAL (refused).
             let r = crate::syscall::dispatch_linux_kernel(
                 10, ident_va, 0x1000, 1 /*PROT_READ*/, 0, 0, 0);
@@ -14815,11 +14824,16 @@ fn test_task4_identity_wp_guard() -> bool {
                 return false;
             }
             test_println!("  mprotect(identity {:#x})→EINVAL, PTE stays writable, high-VA mprotect→0 ✓", ident_va);
-        } else {
-            test_println!("  no present low identity page found to target — SKIP mprotect sub-check");
         }
     } else {
-        test_println!("  runner VmSpace cr3={:#x} != kernel_cr3={:#x} — SKIP mprotect sub-check", space_cr3, kcr3);
+        // In test-mode the PID-0 runner runs on kernel_cr3, so its lazily
+        // created VmSpace adopts kernel_cr3 — this is the invariant the guard
+        // relies on for its only live coverage.  If it no longer holds, fail
+        // loudly rather than silently downgrade to a predicate-only pass.
+        test_fail!("task4_identity_wp_guard",
+            "runner VmSpace cr3={:#x} != kernel_cr3={:#x} — guard's live coverage lost", space_cr3, kcr3);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+        return false;
     }
 
     // Clean up the anon page.

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -14824,6 +14824,48 @@ fn test_task4_identity_wp_guard() -> bool {
                 return false;
             }
             test_println!("  mprotect(identity {:#x})→EINVAL, PTE stays writable, high-VA mprotect→0 ✓", ident_va);
+
+            // (d) F1 regression — the fork guard must take NO reference on an
+            //     identity frame (it skips page_ref_inc mirroring the WP skip);
+            //     otherwise every clone_for_fork(kernel_cr3) leaks ~1M refcount
+            //     increments that no VMA-based teardown can ever decrement.
+            //     Unmap the anon page first so the driven fork walks an
+            //     identity-only low half (no non-identity leaf to CoW), then
+            //     confirm a known identity frame's refcount is unchanged across
+            //     fork AND the child's teardown (which decrements no identity
+            //     leaf).  from_existing_cr3 keeps self.cr3 == kernel_cr3 so
+            //     clone_for_fork performs no cr3 sync; the child is a distinct
+            //     cr3 that free_vm_space tears down cleanly, and dropping the
+            //     handle is safe (shared sem strong_count > 2; Drop frees no
+            //     page tables).
+            let _ = crate::syscall::dispatch_linux_kernel(11, addr as u64, 0x1000, 0, 0, 0, 0);
+            if let Some(sem) = crate::mm::vma::mm_sem_for_cr3(kcr3) {
+                let mut vs = crate::mm::vma::VmSpace::from_existing_cr3(kcr3, sem);
+                let before = crate::mm::refcount::page_ref_count(ident_va);
+                match vs.clone_for_fork(kcr3) {
+                    Some(child) => {
+                        let after_fork = crate::mm::refcount::page_ref_count(ident_va);
+                        crate::proc::free_vm_space(child);
+                        let after_free = crate::mm::refcount::page_ref_count(ident_va);
+                        drop(vs);
+                        if after_fork != before || after_free != before {
+                            test_fail!("task4_identity_wp_guard",
+                                "identity frame {:#x} refcount {}→{}(fork)→{}(teardown), expected unchanged — F1 leak",
+                                ident_va, before, after_fork, after_free);
+                            return false;
+                        }
+                        test_println!("  identity frame {:#x} refcount balanced across kernel_cr3 fork+teardown ({}) ✓", ident_va, before);
+                    }
+                    None => {
+                        drop(vs);
+                        test_println!("  clone_for_fork(kernel_cr3) → None (OOM) — SKIP fork-balance");
+                    }
+                }
+            } else {
+                test_fail!("task4_identity_wp_guard",
+                    "no mm_sem registered for kernel_cr3 — cannot drive fork-balance check");
+                return false;
+            }
         }
     } else {
         // In test-mode the PID-0 runner runs on kernel_cr3, so its lazily


### PR DESCRIPTION
## Summary

A process running on the kernel's own page tables (`actual_cr3 == kernel_cr3`) is only ever the in-kernel test runner: a `vm_space == None` process runs on `kernel_cr3`, and its lazily-created VmSpace (`sys_mmap`'s `from_existing_cr3` path) adopts `kernel_cr3`. For such a caller, two mm paths would retag the kernel's 1:1 identity map (PML4[0]):

- **`VmSpace::clone_for_fork`** write-protects every present leaf of the parent for copy-on-write. On `kernel_cr3` those leaves ARE the identity map, so the pass clears `PAGE_WRITABLE` on the kernel's own mappings. The running kernel writes through the identity map (e.g. the BSP bootstrap stack); the next store to a now-read-only identity page faults, and a `#PF` that re-pushes onto the same read-only stack escalates to `#DF` (a `getrandom`/`sysinfo` kernel-context write to such a page instead fault-loops).
- **`sys_mprotect`** retags PTEs in place and would clear `PAGE_WRITABLE` on an identity page the same way.

## The guard (identity-range-scoped, not cr3-wholesale)

A shared discriminator `mm::vmm::is_identity_map_phys(va, phys)` — a present leaf whose masked physical address equals its virtual address, inside the low 1:1 window (`< 4 GiB`).

- **fork** (`clone_for_fork`, all three WP sites — 4 KiB / 2 MiB / 1 GiB): when forking on `kernel_cr3`, identity leaves are left writable and copied verbatim instead of write-protected; every other (non-identity, high-VA) leaf is CoW'd exactly as before.
- **mprotect** (`sys_mprotect`): a range that covers an identity page under `kernel_cr3` is refused with `-EINVAL` before any VMA-list mutation.

**Refcount accounting:** identity leaves take **no reference** — the child holds a writable alias to a kernel-owned frame it must never free, so `page_ref_inc` is skipped for them, mirroring the write-protect skip. This is required for balance: teardown decrements per VMA (`free_process_memory` walks `vm_space.areas`; `free_user_page_tables` frees only structure pages and skips huge leaves), and the identity map is covered by no VMA, so a kept increment would never be decremented (~1M leaked increments per `clone_for_fork(kernel_cr3)`). Skipping the increment keeps inc and dec both absent = balanced. (Corrected from the initial revision, which kept the increment on a false "accounting unchanged" premise — see the F1 fix below.)

**Why identity-scoped:** a normal user address space never maps `phys == va` (its pages are backed by unrelated frames) and never satisfies `actual_cr3 == kernel_cr3`, so this is inert for every real `fork(2)`/`mprotect(2)`. An in-kernel mprotect test that maps a HIGH user VA into `kernel_cr3` and mprotects it still succeeds because that page is not identity (Test 49). A naive `cr3 == kernel_cr3` wholesale refuse would break that test.

## Test

**Test 49b** exercises the discriminator (6 cases), the mprotect guard end-to-end (identity page → `EINVAL`, its PTE stays writable, a HIGH-VA page on the same `kernel_cr3` still retags to `0`), and — after the F1 fix — the **fork guard directly**: it drives a real `clone_for_fork(kernel_cr3)` (after unmapping the anon page so the walk is identity-only) and asserts a known identity frame's `page_ref_count` is unchanged across the fork AND the child's teardown. That assertion fails if the increment ever returns.

## Review round 2 (F1–F4)

- **F1 (was blocking): fixed the identity-frame refcount leak** — skip `page_ref_inc` for identity leaves (2 MiB sub-loop + 4 KiB), and corrected the false balance comment.
- **F2**: added the direct `page_ref_count`-across-fork+teardown assertion above.
- **F3**: the mprotect huge-leaf pre-check now tests both 1 GiB and 2 MiB alignment (`read_pte` does not report the level), so a 1 GiB identity leaf cannot be mis-masked.
- **F4**: documented that `IDENTITY_WINDOW_TOP` is coupled to the bootloader's 4 GiB identity extent and must move in lockstep.

## Verification

- **SMP=1, TCG (`--no-kvm`, matches CI):** Tests 49 / 49b / 297 pass; Test 49b reports the identity frame's refcount balanced (0) across fork+teardown. No new deterministic failures — the pre-existing environmental/allow-listed set only (TCC/busybox/glibc-interp missing from the local disk image; `test236` fragmentation; `test_522` allow-listed). (`kuser_shared` is a pre-existing RTC-read-race flake — its SystemTime derives from the 1-second-resolution RTC, `nt::kuser_shared::update_time_fields` → `rtc::read_unix_time`; it passed on re-run and in every prior run, and this change touches no time path.)
- **SMP=2 test-mode flake A/B:** reported separately (the #714 fault-rate metric) — 0 faults on both arms; the SMP=2 gate is the parked W101 pipe-test wedge, not faults. This PR is independent of that CI-containment decision.

Refs: `fork(2)`, `mprotect(2)`, Intel SDM Vol. 3A §4.10.5 (paging-structure change propagation), §4.6 (access rights).
