### PR TITLE
mm/cache, vfs: ramfs/tmpfs MAP_SHARED↔read coherence (supersedes #635; F1 SMP-UAF fix)

### DIFF
--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -98,6 +98,91 @@ pub fn lookup(mount_idx: usize, inode: u64, page_offset: u64) -> Option<u64> {
         .map(|e| e.phys)
 }
 
+/// PHYS → kernel-higher-half direct-map offset.  Same constant as
+/// `mm/pmm.rs`; the page cache reads/writes cached frames through this map.
+/// Per Intel SDM Vol. 3A §4.10.5 the higher-half identity map covers every
+/// PMM frame, so `PHYS_OFFSET + phys` is always a valid kernel VA for an
+/// allocated frame.
+const PHYS_OFFSET: u64 = 0xFFFF_8000_0000_0000;
+
+/// Write a cache frame back to its in-memory filesystem's inode buffer.
+///
+/// ## Why this exists — ramfs/tmpfs MAP_SHARED dual-storage coherence
+///
+/// An in-memory filesystem (ramfs / tmpfs) keeps a file's bytes in TWO
+/// places once a page is demand-faulted:
+///
+///   1. the inode's own buffer (`RamInode::File::data`), which is what
+///      `FileSystemOps::read` / `write` / `stat.size` operate on; and
+///   2. the page-cache frame the demand-fault path installs, which a
+///      `mmap(MAP_SHARED)` PTE aliases directly.
+///
+/// A `MAP_SHARED + PROT_WRITE` store lands ONLY in the cache frame — the CPU
+/// writes the frame through the aliasing PTE; the kernel is never on that
+/// write path, so the inode buffer is never updated.  If the frame is then
+/// evicted (and freed), a subsequent `read(2)` (which goes to the inode
+/// buffer via `FileSystemOps::read`) returns the STALE, never-updated bytes
+/// — for a freshly-`ftruncate`d memfd, all zeros.  This is the
+/// dual-storage incoherence that empties Firefox's WebRender display-list /
+/// blob transport.
+///
+/// This helper restores coherence by flushing the cache frame's current
+/// bytes back into the inode buffer just before the frame leaves the cache,
+/// so the inode buffer becomes the authoritative copy of any mmap writes for
+/// any later cache-miss `read`.  For block-backed filesystems (ext2 / fat32)
+/// `is_in_memory()` is false and this is a no-op — those filesystems re-read
+/// the on-disk image and never alias a writable cache frame in this way, so
+/// they are unaffected.
+///
+/// Per POSIX.1-2017 mmap(2): a `MAP_SHARED` write "shall change the
+/// underlying file object" and be visible to a subsequent `read(2)`.
+///
+/// ## Lock order
+///
+/// This MUST be called with NO cache lock held.  It snapshots the
+/// filesystem handle via [`crate::vfs::fs_at`] (which takes and immediately
+/// drops `MOUNTS`), then dispatches `FileSystemOps::write`, which on
+/// ramfs/tmpfs takes only the inode mutex.  Lock order is therefore
+/// cache → (released) → MOUNTS → (released) → inode — no cycle, no nesting.
+/// Callers that hold the cache lock collect `(mount_idx, inode, page_offset,
+/// phys)` while locked and invoke this after releasing the lock, exactly as
+/// the quarantine-free deferral does.
+///
+/// `phys` must still be a live frame (the caller holds a reference, e.g. the
+/// cache's own reference that has not yet been dropped) so the direct-map
+/// read is valid.  Best-effort: a write error (e.g. a read-only tmpfs, which
+/// has no MAP_SHARED writers anyway) is ignored.
+fn writeback_frame_to_inode(mount_idx: usize, inode: u64, page_offset: u64, phys: u64) {
+    let fs = match crate::vfs::fs_at(mount_idx) {
+        Some((fs, _)) => fs,
+        None => return,
+    };
+    if !fs.is_in_memory() {
+        return;
+    }
+    // Snapshot the frame's 4 KiB through the higher-half direct map.  The
+    // frame is alive (caller holds a reference), so the read is valid.
+    let mut frame = [0u8; 4096];
+    let src = (PHYS_OFFSET + phys) as *const u8;
+    // SAFETY: `phys` is a live, page-aligned PMM frame; the higher-half
+    // identity map covers it (Intel SDM Vol. 3A §4.10.5).  We copy exactly
+    // one 4 KiB page into a stack buffer.
+    unsafe {
+        core::ptr::copy_nonoverlapping(src, frame.as_mut_ptr(), 4096);
+    }
+    // Write the page's bytes back into the inode buffer at this file offset,
+    // bounded to the file's current size so we do not zero-extend a sealed /
+    // shrunk file.  ramfs `write` grows the buffer as needed; we cap the
+    // write at `stat.size` so a partial last page does not artificially
+    // extend the file past its real end.
+    let file_size = fs.stat(inode).map(|s| s.size).unwrap_or(0);
+    if page_offset >= file_size {
+        return; // page is entirely past EOF — nothing authoritative to flush.
+    }
+    let span = core::cmp::min(4096u64, file_size - page_offset) as usize;
+    let _ = fs.write(inode, page_offset, &frame[..span]);
+}
+
 /// Look up a cached page and atomically acquire a guard reference on it.
 ///
 /// The reference count is incremented while the cache lock is still held, so
@@ -487,6 +572,14 @@ pub fn insert_with_expected(
     }
 
     if let Some(old_phys) = evicted_zero_rc {
+        // Flush any MAP_SHARED mmap writes held only in the evicted frame
+        // back to the in-memory inode buffer before the frame is retired —
+        // this collision eviction is the dominant fault-path eviction on the
+        // single-CPU path, and the evicted frame (rc now 0, no other holder)
+        // is the last copy of those bytes.  No-op for block-backed
+        // filesystems.  Done after the cache lock is released
+        // (cache → MOUNTS → inode); the frame is alive until quarantine.
+        writeback_frame_to_inode(mount_idx, inode, page_offset, old_phys);
         // Defer PMM release through the quarantine to ensure any stale
         // TLB entry on a sibling CPU is retired before the frame is
         // recycled.  See module-level doc for the quiescent-state
@@ -720,33 +813,50 @@ pub fn truncate_range(mount_idx: usize, inode: u64, old_size: u64, new_size: u64
 
 /// Evict a page from the cache, releasing the cache's reference.
 /// Returns the physical address of the evicted page, if any.
+///
+/// Before the frame leaves the cache, its bytes are written back to the
+/// inode buffer for in-memory filesystems (ramfs / tmpfs) so any
+/// `MAP_SHARED` mmap write that landed only in the frame survives the
+/// eviction and is visible to a subsequent cache-miss `read(2)` — see
+/// [`writeback_frame_to_inode`].  The writeback is deferred to AFTER the
+/// cache lock is released (lock order: cache → MOUNTS → inode); the frame is
+/// still alive at that point because the caller takes ownership of it and
+/// frees it only after this function returns.
 pub fn evict(mount_idx: usize, inode: u64, page_offset: u64) -> Option<u64> {
-    let mut cache = PAGE_CACHE.lock();
-    if let Some(entry) = cache.remove(&(mount_idx, inode, page_offset)) {
-        // Caller takes ownership of the phys frame; freeing it (with proper
-        // shootdown) is the caller's responsibility.  Here we only release
-        // the cache's reference.
-        let _ = crate::mm::refcount::page_ref_dec(entry.phys);
-        // W215 diagnostic Arm-1 / Arm-2.
-        #[cfg(feature = "firefox-test-core")]
-        {
-            crate::mm::w215_diag::prov_record(
-                entry.phys,
-                crate::mm::w215_diag::KIND_EVICT,
-                crate::mm::w215_diag::pack_cache_key(inode, page_offset),
-            );
-            crate::mm::w215_diag::preins_check_op(
-                entry.phys,
-                crate::mm::w215_diag::OP_EVICT,
-                ((page_offset >> 12) & 0xFFFF_FFFF) as u32,
-            );
-            #[cfg(feature = "w215-diag")]
-            crate::mm::w215_crc::record_evict(entry.phys);
+    let evicted_phys: u64;
+    {
+        let mut cache = PAGE_CACHE.lock();
+        if let Some(entry) = cache.remove(&(mount_idx, inode, page_offset)) {
+            // Caller takes ownership of the phys frame; freeing it (with proper
+            // shootdown) is the caller's responsibility.  Here we only release
+            // the cache's reference.
+            let _ = crate::mm::refcount::page_ref_dec(entry.phys);
+            // W215 diagnostic Arm-1 / Arm-2.
+            #[cfg(feature = "firefox-test-core")]
+            {
+                crate::mm::w215_diag::prov_record(
+                    entry.phys,
+                    crate::mm::w215_diag::KIND_EVICT,
+                    crate::mm::w215_diag::pack_cache_key(inode, page_offset),
+                );
+                crate::mm::w215_diag::preins_check_op(
+                    entry.phys,
+                    crate::mm::w215_diag::OP_EVICT,
+                    ((page_offset >> 12) & 0xFFFF_FFFF) as u32,
+                );
+                #[cfg(feature = "w215-diag")]
+                crate::mm::w215_crc::record_evict(entry.phys);
+            }
+            evicted_phys = entry.phys;
+        } else {
+            return None;
         }
-        Some(entry.phys)
-    } else {
-        None
-    }
+    } // release cache lock before the FS writeback (cache → MOUNTS → inode)
+
+    // Flush any MAP_SHARED mmap writes held only in the frame back to the
+    // in-memory inode buffer before the caller frees the frame.
+    writeback_frame_to_inode(mount_idx, inode, page_offset, evicted_phys);
+    Some(evicted_phys)
 }
 
 /// Mark all dirty pages for a given inode as clean.

--- a/kernel/src/mm/cache.rs
+++ b/kernel/src/mm/cache.rs
@@ -639,7 +639,7 @@ pub fn update_range(mount_idx: usize, inode: u64, offset: u64, data: &[u8]) {
         return;
     }
     const PAGE: u64 = 4096;
-    const PHYS_OFFSET: u64 = 0xFFFF_8000_0000_0000;
+    // PHYS_OFFSET is the module-level const (mm/cache.rs).
 
     let start = offset;
     let end = offset.saturating_add(data.len() as u64);
@@ -728,7 +728,7 @@ pub fn update_range(mount_idx: usize, inode: u64, offset: u64, data: &[u8]) {
 /// the cache lock is released to preserve the cache → TLB → PMM lock order.
 pub fn truncate_range(mount_idx: usize, inode: u64, old_size: u64, new_size: u64) {
     const PAGE: u64 = 4096;
-    const PHYS_OFFSET: u64 = 0xFFFF_8000_0000_0000;
+    // PHYS_OFFSET is the module-level const (mm/cache.rs).
 
     // The lowest offset whose page contents are stale after the resize.
     let boundary = core::cmp::min(old_size, new_size);

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -58694,11 +58694,118 @@ fn test_641_crossproc_mapshared_memfd_visibility() -> bool {
     }
     test_println!("  D fallocate(0,{}): backing inode grown to {} ✓", PAGE, dsize);
 
-    // A, B (no-eviction visibility), C (eviction dual-storage coherence via
-    // writeback-to-inode) and D (fallocate sizing) are ALL gating assertions;
-    // all passed if we reach here.  C is the FF Wikipedia render gate and is
-    // now a hard must-pass (was a documented latent gap before the
-    // mm::cache writeback-on-eviction fix).
+    // ════════════════════════════════════════════════════════════════════
+    // E. Production collision-eviction writeback.  Case C drives the
+    //    standalone `cache::evict` writeback; the path that actually fires in
+    //    production is the collision eviction inside `cache::insert` (two
+    //    inserts on the SAME (mount,inode,off) key — the second evicts the
+    //    first).  Reproduce it: fault-in a frame, store the sentinel into it
+    //    (the mmap write), then `cache::insert` a DIFFERENT frame on the same
+    //    key.  The collision eviction must write the OLD frame's sentinel back
+    //    to the inode buffer so a later cache-miss fs.read still sees it.
+    // ════════════════════════════════════════════════════════════════════
+    let epath = "/tmp/.crossvis641e";
+    let _ = crate::vfs::remove(epath);
+    if crate::vfs::create_file(epath).is_err() {
+        test_fail!(NAME, "E: create_file({}) failed", epath); return false;
+    }
+    if crate::vfs::truncate_path(epath, PAGE as u64).is_err() {
+        test_fail!(NAME, "E: truncate_path failed"); let _ = crate::vfs::remove(epath); return false;
+    }
+    let (emount, einode) = match crate::vfs::resolve_path(epath) {
+        Ok(t) => t,
+        Err(e) => { test_fail!(NAME, "E: resolve_path {:?}", e); let _ = crate::vfs::remove(epath); return false; }
+    };
+    let e_old = match fault_in(emount, einode, foff) {
+        Some(p) => p,
+        None => { test_fail!(NAME, "E: fault_in OOM"); let _ = crate::vfs::remove(epath); return false; }
+    };
+    producer_store(e_old); // mmap write lands only in the cache frame
+    // A different frame for the same key → collision eviction of e_old, which
+    // must writeback e_old's sentinel to the inode buffer.
+    let e_new = match crate::mm::pmm::alloc_page() {
+        Some(p) => p,
+        None => { test_fail!(NAME, "E: alloc_page OOM"); let _ = crate::vfs::remove(epath); return false; }
+    };
+    unsafe { core::ptr::write_bytes((PHYS_OFF + e_new) as *mut u8, 0, PAGE); }
+    crate::mm::cache::insert(emount, einode, foff, e_new); // evicts e_old → writeback e_old
+    // Read the inode buffer DIRECTLY now — BEFORE evicting e_new — to prove the
+    // collision writeback of e_old reached the inode.  (Evicting e_new first
+    // would itself write e_new's zero bytes back over the inode, masking the
+    // collision writeback under test: every in-memory eviction writes back,
+    // and the last one wins.  That ordering is correct in production — the
+    // resident frame is authoritative — but here it would defeat the probe.)
+    let e_inode_bytes = {
+        let mut scratch = [0u8; 64];
+        if let Some((fs, _)) = crate::vfs::fs_at(emount) {
+            let _ = fs.read(einode, sent_off as u64, &mut scratch);
+        }
+        scratch[..sentinel.len()] == sentinel[..]
+    };
+    // Cleanup: evict e_new (drops cache ref → rc 0) and free it; e_old was
+    // already retired via quarantine by the collision eviction above.
+    if let Some(p) = crate::mm::cache::evict(emount, einode, foff) {
+        crate::mm::pmm::free_page(p);
+    }
+    let _ = crate::vfs::remove(epath);
+    if !e_inode_bytes {
+        test_fail!(NAME, "E: collision-eviction did NOT write the sentinel back to the inode buffer");
+        return false;
+    }
+    test_println!("  E collision-eviction: production cache::insert eviction wrote sentinel back to inode ✓");
+
+    // ════════════════════════════════════════════════════════════════════
+    // F. fd_read cache-authoritative overlay.  A resident cache frame holds
+    //    an mmap write the inode buffer never received.  `read(2)` (fd_read)
+    //    on an in-memory FS must observe the frame's bytes, not the stale
+    //    inode buffer.  Build a real fd, fault a frame in, store the sentinel
+    //    into the RESIDENT frame, then fd_read and assert the overlay.
+    // ════════════════════════════════════════════════════════════════════
+    let fpath = "/tmp/.crossvis641f";
+    let _ = crate::vfs::remove(fpath);
+    if crate::vfs::create_file(fpath).is_err() {
+        test_fail!(NAME, "F: create_file failed"); return false;
+    }
+    if crate::vfs::truncate_path(fpath, PAGE as u64).is_err() {
+        test_fail!(NAME, "F: truncate_path failed"); let _ = crate::vfs::remove(fpath); return false;
+    }
+    let (fmount, finode) = match crate::vfs::resolve_path(fpath) {
+        Ok(t) => t,
+        Err(e) => { test_fail!(NAME, "F: resolve_path {:?}", e); let _ = crate::vfs::remove(fpath); return false; }
+    };
+    let f_phys = match fault_in(fmount, finode, foff) {
+        Some(p) => p,
+        None => { test_fail!(NAME, "F: fault_in OOM"); let _ = crate::vfs::remove(fpath); return false; }
+    };
+    producer_store(f_phys); // mmap write into the RESIDENT frame only
+    let fpid = crate::proc::current_pid_lockless();
+    let ffd = match crate::vfs::open(fpid, fpath, crate::vfs::flags::O_RDONLY) {
+        Ok(fd) => fd,
+        Err(e) => {
+            test_fail!(NAME, "F: open {:?}", e);
+            if let Some(p) = crate::mm::cache::evict(fmount, finode, foff) { crate::mm::pmm::free_page(p); }
+            let _ = crate::vfs::remove(fpath); return false;
+        }
+    };
+    let mut fbuf = [0u8; PAGE];
+    let fn_read = crate::vfs::fd_read(fpid, ffd, fbuf.as_mut_ptr(), PAGE).unwrap_or(0);
+    let f_overlay_ok = fn_read >= sent_off + sentinel.len()
+        && fbuf[sent_off..sent_off + sentinel.len()] == sentinel[..];
+    let _ = crate::syscall::dispatch_linux_kernel(3, ffd as u64, 0, 0, 0, 0, 0); // close(ffd)
+    if let Some(p) = crate::mm::cache::evict(fmount, finode, foff) { crate::mm::pmm::free_page(p); }
+    let _ = crate::vfs::remove(fpath);
+    if !f_overlay_ok {
+        test_fail!(NAME, "F: fd_read did NOT overlay the resident frame's mmap write (read {} bytes)", fn_read);
+        return false;
+    }
+    test_println!("  F fd_read overlay: read(2) observed the resident frame's mmap write ✓");
+
+    // A, B (no-eviction visibility), C (standalone evict writeback), D
+    // (fallocate sizing), E (production collision-eviction writeback) and F
+    // (fd_read cache-authoritative overlay) are ALL gating assertions; all
+    // passed if we reach here.  C/E/F are the ramfs/tmpfs MAP_SHARED↔read
+    // coherence guards (were latent/absent before the mm::cache
+    // writeback-on-eviction + fd_read overlay fix).
     test_pass!(NAME);
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -58620,34 +58620,32 @@ fn test_641_crossproc_mapshared_memfd_visibility() -> bool {
     };
     let c_visible = frame_has_sentinel(cons_phys_c);
     if !c_visible {
-        // KNOWN LATENT GAP (documented, NON-FATAL): the producer's MAP_SHARED
-        // write does NOT survive cache eviction → ramfs/tmpfs dual-storage
-        // incoherence.  An mmap MAP_SHARED+PROT_WRITE store lands ONLY in the
-        // page-cache frame; ramfs keeps a SEPARATE inode Vec that is the
-        // authoritative source for fs.read.  After eviction the consumer's
-        // cache-miss fs.read returns the (never-updated) Vec → zeros.
-        //
-        // This gap is INERT on the single-CPU Firefox render path: there is no
-        // LRU/pressure eviction, and on SMP=1 there are no concurrent-fault
-        // insert-collisions, so a live mmap-written memfd page is never evicted
-        // — the consumer always cache-HITs the producer's resident frame (A/B).
-        // It becomes reachable under SMP concurrent-fault insert-collisions,
-        // ftruncate-shrink-then-regrow, or a future cache-pressure evictor.
-        //
-        // Recorded (not asserted) so the regression guard documents the gap
-        // without failing CI; the forward fix is page-cache writeback on
-        // eviction for ramfs/tmpfs (or making the cache frame authoritative for
-        // ramfs reads).  POSIX mmap(2) MAP_SHARED coherence.
+        // ramfs/tmpfs dual-storage incoherence (the FF Wikipedia blob/display-
+        // list render gate): a MAP_SHARED+PROT_WRITE store lands ONLY in the
+        // page-cache frame, while ramfs keeps a SEPARATE inode buffer that is
+        // the source for fs.read.  If a cache-miss fs.read after eviction
+        // returns zeros, the producer's mmap write was LOST — exactly the gate
+        // (the parent reads a degenerate, mostly-zero blob → BlobReader::new
+        // crashes).  The fix (mm::cache writeback-on-eviction to the inode
+        // buffer) MUST make this read coherent.  POSIX.1-2017 mmap(2)
+        // MAP_SHARED: a write "shall change the underlying file object" and be
+        // visible to a subsequent read(2).  Reclaim the leaked frame before
+        // failing so a fail leaves no PMM leak / stale cache entry.
         crate::serial_println!(
-            "[T641/DUAL-STORAGE] KNOWN-LATENT: producer MAP_SHARED write LOST across \
+            "[T641/DUAL-STORAGE] FAIL: producer MAP_SHARED write LOST across \
              cache eviction — consumer cache-miss fs.read returned zeros \
-             (mount={} inode={} foff={}); inert on SMP=1 FF path (no eviction)",
+             (mount={} inode={} foff={})",
             mount, inode, foff);
-        test_println!("  C eviction-then-remap: KNOWN-LATENT dual-storage gap recorded \
-                       (inert on SMP=1 FF render path) ⚠");
-    } else {
-        test_println!("  C eviction-then-remap: producer write survived eviction ✓");
+        if let Some(p) = crate::mm::cache::evict(mount, inode, foff) {
+            crate::mm::pmm::free_page(p);
+        }
+        test_fail!(NAME, "C: producer MAP_SHARED write LOST across eviction \
+                          (ramfs/tmpfs dual-storage incoherence)");
+        let _ = crate::vfs::remove(path);
+        return false;
     }
+    test_println!("  C eviction-then-remap: producer write survived eviction \
+                   via writeback-to-inode ✓");
     // Reclaim the consumer's freshly-faulted frame: evict its cache entry
     // (drops the cache ref → rc 0) and return it to the PMM, so the test
     // leaves no leaked frame and no stale (mount,inode,foff) cache entry.
@@ -58696,9 +58694,11 @@ fn test_641_crossproc_mapshared_memfd_visibility() -> bool {
     }
     test_println!("  D fallocate(0,{}): backing inode grown to {} ✓", PAGE, dsize);
 
-    // A and B (the on-path no-eviction visibility contract) and D (fallocate
-    // sizing) are the gating assertions; all passed if we reach here.  C is a
-    // documented latent gap (non-fatal, inert on the SMP=1 FF render path).
+    // A, B (no-eviction visibility), C (eviction dual-storage coherence via
+    // writeback-to-inode) and D (fallocate sizing) are ALL gating assertions;
+    // all passed if we reach here.  C is the FF Wikipedia render gate and is
+    // now a hard must-pass (was a documented latent gap before the
+    // mm::cache writeback-on-eviction fix).
     test_pass!(NAME);
     true
 }

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -462,6 +462,28 @@ pub trait FileSystemOps: Send + Sync {
     /// Flush any dirty in-memory state to the backing store.
     fn sync(&self) -> VfsResult<()> { Ok(()) }
 
+    /// Whether this filesystem stores file content purely in RAM with NO
+    /// distinct backing store (ramfs / tmpfs).
+    ///
+    /// In-memory filesystems keep two copies of a file's bytes once a page is
+    /// demand-faulted: the inode's own buffer (authoritative for `read` /
+    /// `write` / `stat.size`) and the page-cache frame the demand-fault path
+    /// installs (what an `mmap` PTE aliases).  A `MAP_SHARED` + `PROT_WRITE`
+    /// store lands ONLY in the page-cache frame — the hardware writes the
+    /// frame directly through the aliasing PTE, never the inode buffer.
+    ///
+    /// For a block-backed filesystem (ext2 / fat32) the on-disk image is the
+    /// single source of truth and a `read` re-reads it, so this hazard does
+    /// not arise; those filesystems return the default `false`.
+    ///
+    /// The page cache uses this to keep the two copies coherent for in-memory
+    /// filesystems: it writes a cache frame back to the inode buffer before
+    /// the frame is evicted, and `fd_read` reads through a resident cache
+    /// frame in preference to the inode buffer.  This satisfies POSIX
+    /// mmap(2) `MAP_SHARED` visibility — "writes ... shall be visible in all
+    /// processes mapping the same region" and to a subsequent `read(2)`.
+    fn is_in_memory(&self) -> bool { false }
+
     /// Rename / move an entry from one directory to another.
     fn rename(&self, _old_parent: u64, _old_name: &str, _new_parent: u64, _new_name: &str) -> VfsResult<()> {
         Err(VfsError::Unsupported)
@@ -2547,14 +2569,23 @@ pub fn close(pid: crate::proc::Pid, fd_num: usize) -> VfsResult<()> {
 ///
 /// Forward-direction coherency (write(2) visible to a subsequent read or
 /// mmap reader) is maintained by `fd_write` / `write_file` via
-/// `mm::cache::update_range`.  The reverse direction — a write through a
-/// MAP_SHARED+PROT_WRITE PTE visible to a subsequent `read(2)` — is not
-/// currently served from the page cache; this path goes straight to
-/// `fs.read`, which on tmpfs/ramfs returns the in-memory file content
-/// (consistent with mmap'd writes IF those writes have also been flushed
-/// back to FS storage).  Adding a read-through cache lookup here is a
-/// follow-up — see W215 docs/W215_CRC_MISMATCH_INVESTIGATION_*.md for the
-/// scope discussion.
+/// `mm::cache::update_range`.
+///
+/// The reverse direction — a write through a MAP_SHARED+PROT_WRITE PTE
+/// visible to a subsequent `read(2)` — is handled for in-memory filesystems
+/// (ramfs / tmpfs), where it is the dual-storage hazard: the inode buffer
+/// (`fs.read`) and the mmap-aliased page-cache frame are two distinct copies,
+/// and an mmap store lands only in the frame.  This path keeps the two
+/// coherent in both directions:
+///   * resident frames — after the `fs.read` below, any cache-resident page
+///     for the read range is overlaid onto the result (cache-authoritative
+///     read), so an mmap write held in a still-resident frame is observed;
+///   * evicted frames — `mm::cache` writes a frame's bytes back into the
+///     inode buffer before the frame leaves the cache, so a cache-miss
+///     `fs.read` after an eviction observes the mmap write too.
+/// Together these satisfy POSIX mmap(2) MAP_SHARED visibility for ramfs/tmpfs.
+/// Block-backed filesystems (ext2 / fat32) are not in-memory and re-read the
+/// on-disk image, so they are unaffected and skip the overlay.
 pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize) -> VfsResult<usize> {
     // SMAP bracket — fd_read writes data into `buf` which is typically
     // a user-VA from the syscall path.  The function does not call
@@ -2831,6 +2862,58 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                 }
                 done
             };
+
+            // ── In-memory MAP_SHARED coherence: cache-authoritative read ──────
+            //
+            // For an in-memory filesystem (ramfs / tmpfs) the bounce read above
+            // pulled bytes from the inode buffer.  A `mmap(MAP_SHARED |
+            // PROT_WRITE)` store, however, lands ONLY in the page-cache frame
+            // the demand-fault path aliases — the inode buffer is not on that
+            // write path.  So while a written frame is still cache-resident,
+            // the inode buffer can be stale.  Overlay any cache-resident page's
+            // current bytes onto the just-read buffer so a `read(2)` observes
+            // the mmap write per POSIX mmap(2) MAP_SHARED visibility.  (Evicted
+            // frames are already reconciled into the inode buffer by the
+            // writeback-on-eviction path in `mm::cache`, so this only needs to
+            // cover the resident-frame case.)  Block-backed filesystems
+            // (ext2 / fat32) are not in-memory and never reach this — their
+            // on-disk image is the single source of truth.
+            if n > 0 {
+                let is_in_mem = fs_at(mount_idx)
+                    .map(|(fs, _)| fs.is_in_memory())
+                    .unwrap_or(false);
+                if is_in_mem {
+                    const PAGE: u64 = 4096;
+                    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
+                    let read_end = offset + n as u64;
+                    let mut pg = offset & !(PAGE - 1);
+                    while pg < read_end {
+                        if let Some(phys) = crate::mm::cache::lookup(mount_idx, inode, pg) {
+                            // Intersect [pg, pg+PAGE) with [offset, read_end).
+                            let seg_start = core::cmp::max(pg, offset);
+                            let seg_end = core::cmp::min(pg + PAGE, read_end);
+                            let in_page_off = (seg_start - pg) as usize;
+                            let buf_off = (seg_start - offset) as usize;
+                            let len = (seg_end - seg_start) as usize;
+                            // SAFETY: `phys` is a live cache frame (cache holds
+                            // a reference); the higher-half map covers it
+                            // (Intel SDM Vol. 3A §4.10.5).  `in_page_off + len
+                            // <= PAGE` and `buf_off + len <= n <= count` by the
+                            // intersection bounds above, so the copy stays in
+                            // bounds of both the frame and `buffer`.
+                            let src = (PHYS_OFF + phys + in_page_off as u64) as *const u8;
+                            unsafe {
+                                core::ptr::copy_nonoverlapping(
+                                    src,
+                                    buffer.as_mut_ptr().add(buf_off),
+                                    len,
+                                );
+                            }
+                        }
+                        pg += PAGE;
+                    }
+                }
+            }
 
             // Update offset.
             {

--- a/kernel/src/vfs/mod.rs
+++ b/kernel/src/vfs/mod.rs
@@ -2888,19 +2888,35 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                     let read_end = offset + n as u64;
                     let mut pg = offset & !(PAGE - 1);
                     while pg < read_end {
-                        if let Some(phys) = crate::mm::cache::lookup(mount_idx, inode, pg) {
+                        // Acquire a guard reference under the cache lock so the
+                        // frame cannot be freed/recycled during the copy below.
+                        // A ref-less `cache::lookup` would return a bare `phys`
+                        // whose liveness ends the moment the cache lock is
+                        // dropped — a concurrent evict / collision-insert /
+                        // truncate on another CPU could free and recycle the
+                        // frame mid-copy, so the copy would pull a recycled
+                        // frame's bytes (another file's data) into the user
+                        // buffer.  `lookup_and_acquire` increments the refcount
+                        // while the cache lock is held (cache.rs), closing that
+                        // window.
+                        if let Some(phys) =
+                            crate::mm::cache::lookup_and_acquire(mount_idx, inode, pg)
+                        {
                             // Intersect [pg, pg+PAGE) with [offset, read_end).
                             let seg_start = core::cmp::max(pg, offset);
                             let seg_end = core::cmp::min(pg + PAGE, read_end);
                             let in_page_off = (seg_start - pg) as usize;
                             let buf_off = (seg_start - offset) as usize;
                             let len = (seg_end - seg_start) as usize;
-                            // SAFETY: `phys` is a live cache frame (cache holds
-                            // a reference); the higher-half map covers it
-                            // (Intel SDM Vol. 3A §4.10.5).  `in_page_off + len
-                            // <= PAGE` and `buf_off + len <= n <= count` by the
-                            // intersection bounds above, so the copy stays in
-                            // bounds of both the frame and `buffer`.
+                            // SAFETY: `lookup_and_acquire` incremented `phys`'s
+                            // refcount under the cache lock, so the frame stays
+                            // live for the whole copy even if a sibling CPU
+                            // evicts the cache entry concurrently (Intel SDM
+                            // Vol. 3A §4.10.5); the higher-half map covers every
+                            // PMM frame.  `in_page_off + len <= PAGE` and
+                            // `buf_off + len <= n <= count` by the intersection
+                            // bounds above, so the copy stays in bounds of both
+                            // the frame and `buffer`.
                             let src = (PHYS_OFF + phys + in_page_off as u64) as *const u8;
                             unsafe {
                                 core::ptr::copy_nonoverlapping(
@@ -2908,6 +2924,16 @@ pub fn fd_read(pid: crate::proc::Pid, fd_num: usize, buf: *mut u8, count: usize)
                                     buffer.as_mut_ptr().add(buf_off),
                                     len,
                                 );
+                            }
+                            // Release the guard reference.  If a concurrent
+                            // eviction dropped the cache's own reference during
+                            // the copy, this guard is the last holder: route the
+                            // frame through the TLB quarantine free — the same
+                            // deferred-free protocol the eviction path uses,
+                            // since a sibling CPU may still hold a translation
+                            // (Intel SDM Vol. 3A §4.10.5).
+                            if crate::mm::refcount::page_ref_dec(phys) == 0 {
+                                crate::mm::tlb::quarantine_free(phys);
                             }
                         }
                         pg += PAGE;

--- a/kernel/src/vfs/ramfs.rs
+++ b/kernel/src/vfs/ramfs.rs
@@ -115,6 +115,10 @@ impl FileSystemOps for RamFs {
         "ramfs"
     }
 
+    fn is_in_memory(&self) -> bool {
+        true
+    }
+
     fn create_file(&self, parent_inode: u64, name: &str) -> VfsResult<u64> {
         let mut inodes = self.inodes.lock();
 

--- a/kernel/src/vfs/tmpfs.rs
+++ b/kernel/src/vfs/tmpfs.rs
@@ -60,6 +60,11 @@ impl FileSystemOps for TmpFs {
         "tmpfs"
     }
 
+    fn is_in_memory(&self) -> bool {
+        // Backed entirely by the embedded RamFs — same dual-storage model.
+        true
+    }
+
     fn create_file(&self, parent_inode: u64, name: &str) -> VfsResult<u64> {
         self.check_writable()?;
         self.inner.create_file(parent_inode, name)


### PR DESCRIPTION
Supersedes #635 (closed in favour of this branch). Independent review of #635 returned REQUEST_CHANGES with one blocking finding (F1) and one re-validate ask (F2); this successor branch applies the F1 fix and re-validates on current master with SMP=2.

## What this change does (unchanged from #635)

Restores ramfs/tmpfs `MAP_SHARED` <-> `read(2)` coherence in both directions. An in-memory filesystem keeps a file's bytes in two places once a page is demand-faulted: the inode's own buffer (served to `read(2)`/`write(2)`/`stat`) and the page-cache frame an `mmap(MAP_SHARED|PROT_WRITE)` PTE aliases. A store through that PTE lands only in the cache frame; the inode buffer is never updated. Two halves close the gap:

- Writeback-on-eviction (`mm/cache`): before an in-memory-FS cache frame leaves the cache (`cache::evict` and the collision eviction in `cache::insert`), flush its bytes back into the inode buffer, so a later cache-miss `read(2)` observes the mmap write.
- Cache-authoritative read (`vfs::fd_read`): for in-memory filesystems, overlay any still-resident cache page's current bytes onto the read result, so an mmap write held in a resident frame is observed by `read(2)`.

Scoped to ramfs/tmpfs via `FileSystemOps::is_in_memory()` (default false). Block-backed filesystems re-read the on-disk image (single source of truth) and are unaffected.

The mechanism is complementary to #637, not redundant: #637's `WriteThrough` makes a `MAP_SHARED` store land in the cache frame in place (co-mappers see it via a cache HIT) but never reconciles that frame with the inode buffer that `FileSystemOps::read` serves, so the reverse direction (mmap write -> subsequent `read(2)`) is still incoherent on master. Tests 641 C/E/F encode exactly that contract and fail on master today.

Per POSIX.1-2017 `mmap(2)` (MAP_SHARED writes visible to `read(2)`) and `write(2)`.

## F1 (blocking) fix — reference-less overlay read was an SMP use-after-free

The #635 overlay looked a resident page up with the ref-less `cache::lookup`, which releases the cache lock before returning a bare physical address, then copied from that frame into the **user** buffer with no reference held. On SMP a concurrent `cache::evict` / collision-`insert` / `truncate_range` on another CPU could drop the frame's last reference and free+recycle it mid-copy, so the copy would pull a recycled frame's bytes (another file's data) into the reader's buffer — a `read(2)` correctness violation and an information leak, reachable only in the SMP eviction regime the overlay exists to serve.

Fix (`vfs/mod.rs`, commit 8be691e):

- Acquire a guard reference under the cache lock with `cache::lookup_and_acquire` (increments the refcount while the cache lock is held), so the frame cannot be freed or recycled for the duration of the copy even if a sibling CPU evicts the entry.
- After the copy, release the guard with `page_ref_dec`. If a concurrent eviction dropped the cache's own reference during the copy, the guard is the last holder and the frame reaches refcount zero here; route it through `tlb::quarantine_free` — the same deferred, TLB-safe free the eviction path uses (a sibling CPU may still hold a translation). Discarding the decrement result would leak the frame in that race.
- The SAFETY comment is corrected to state the actual invariant (the acquired guard reference), not the false "cache holds a reference" claim.

Holding the cache lock across the copy is not an option: `buffer` is the user buffer, so a user-faulting copy under the cache spinlock would deadlock the page-fault path. The acquire-under-lock / copy-without-lock / put-after (freeing on zero) shape is the standard page-cache read discipline.

Refs: POSIX.1-2017 `read(2)` (returned bytes are the file's data), `mmap(2)`; Intel SDM Vol. 3A section 4.10.5 (TLB / frame-reuse ordering).

## F2 (re-validate) — eviction-writeback lock order on current master

The eviction-writeback adds an `fs.write` (MOUNTS + inode mutex) into the collision-eviction path of `cache::insert`, which runs on the #PF demand-fault path. #635's CI ran against pre-#703/#708 master. On current master the file-backed #PF path drops PROCESS_TABLE before any MOUNTS/FS work and holds no `mm_sem`; the writeback runs only after the cache lock is released (lock order cache -> MOUNTS -> inode, no nesting), and ramfs `write` touches only the inode Vec (no re-entry into the cache/fault path). The SMP=2 641E run below exercises exactly this collision-eviction writeback and clears it empirically.

## Validation (harness-only)

Rebased onto current master (the review asked for a099a254; master advanced by one unrelated commit, #720, zero overlap with the 5 FS files touched here — rebased onto the newer tip for a clean CI base).

### SMP=1 TCG (`--no-kvm`, matches CI) — full suite; Test 641 A–F all pass

```
  TEST: cross-proc MAP_SHARED memfd write-visibility (Test 641)
  A no-eviction: consumer aliases producer frame + sees write ✓
  B write-after-map: later producer write visible via existing mapping ✓
  C eviction-then-remap: producer write survived eviction via writeback-to-inode ✓
  D fallocate(0,4096): backing inode grown to 4096 ✓
  E collision-eviction: production cache::insert eviction wrote sentinel back to inode ✓
  F fd_read overlay: read(2) observed the resident frame's mmap write ✓
[TEST-JSON] {"name":"cross-proc MAP_SHARED memfd write-visibility (Test 641)","result":"pass","elapsed_ticks":2}
```

Suite: `[TEST SUITE] ✗ 5 TESTS FAILED` (440 pass / 5 fail). None of the 5 are in VFS/cache/ramfs/tmpfs/ext2; each is outside this change's subsystem:
- `TCC compile` (`Cannot read /disk/bin/tcc: NotFound`) and `busybox basic` (`/disk/bin/busybox: NotFound`) — CI-allowlisted missing-binary env-fails.
- `glibc_hello` (`create_user_process failed: InterpNotFound`) — the dynamic linker is absent from the local test image; passes on a fully-staged CI image.
- `test236` (`pmm::alloc_pages(64) failed`) — contiguous PMM allocation (memory subsystem); this change is refcount- and allocation-neutral.
- `test_522_tcp_rx_poll_bell` (`read 0 bytes, expected 18`) — TCP RX (networking), a known flaky (dedicated `w223/ci-allowlist-test522` branch).

(The three `/disk` env-fails are an artifact of the local test image, not a regression — see note below.)

### SMP=2 (2 CPUs online) — Test 641 C and E (the eviction paths where both the coherence gap and the F1 race are reachable)

```
[SMP] AP 1 online (after SIPI #1), 2 CPU(s) online
  C eviction-then-remap: producer write survived eviction via writeback-to-inode ✓
  E collision-eviction: production cache::insert eviction wrote sentinel back to inode ✓
  F fd_read overlay: read(2) observed the resident frame's mmap write ✓
[TEST-JSON] {"name":"cross-proc MAP_SHARED memfd write-visibility (Test 641)","result":"pass","elapsed_ticks":2}
```

Test 641 passes in full (A–F) with two CPUs online. The F1 overlay path (case F) and both eviction-writeback paths (C, E) run clean under SMP with no UAF, deadlock, or `[REFCOUNT/DEC-UNDERFLOW]`.

### F2 empirical clearance

Case E on the SMP=2 run is exactly the production collision-eviction writeback: it faults a frame in, stores the sentinel into it, then `cache::insert`s a colliding key so the collision eviction fires and writes the evicted frame's bytes back into the inode buffer via `fs.write` (MOUNTS + inode mutex) on the #PF-adjacent path. It passed with no deadlock and no refcount underflow — the lock-order interaction the review asked to re-validate on current master (post-#703/#708/#719) is clear.

Note on the local image: the SMP runs used a private copy of `build/data.img`. During worktree setup the harness auto-regenerated the data image (flagged separately); the regenerated image is missing a few staged `/disk` binaries (`tcc`, `busybox`, glibc interpreter), which accounts for the three `/disk` env-fails above. These are image-provisioning artifacts, not code regressions — the FS coherence gate (Test 641) and every other VFS/cache/ext2/ramfs/tmpfs test pass.

## Metadata hygiene

Both original #635 commits carried a real-email author and a session-URL trailer; both are corrected on this branch (author/committer normalized to the noreply identity, session trailers stripped, `Co-Authored-By` preserved).

Original reviewer to re-verdict before merge.
