### PR TITLE
sched: per-CPU runqueue load balancing — pull-on-idle + periodic push (Perf P2 phase 3d) — supersedes #649

### DIFF
--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -828,7 +828,7 @@ fn pick_balance_core(
     // Most-overdue eligible victim that is HOMED on the busiest CPU.  Ties on
     // the absolute deadline are broken toward the LOWER tid so the choice is
     // deterministic and independent of iteration order — this keeps the pure
-    // `pick_balance_core` (driven by Test 652 over a candidate slice) and the
+    // `pick_balance_core` (driven by Test 707 over a candidate slice) and the
     // live `pick_balance_victim` (driven over the thread table) selecting the
     // identical victim even when two equally-overdue threads compete.
     let mut victim: Option<(Tid, u8, u64)> = None;
@@ -849,7 +849,7 @@ fn pick_balance_core(
     victim.map(|(tid, prio, _)| (busiest, emptiest, tid, prio))
 }
 
-/// Test-facing replica of the load-balance decision (Test 652), over
+/// Test-facing replica of the load-balance decision (Test 707), over
 /// caller-supplied loads + candidates so the migration policy is provable
 /// without spinning threads or touching the live `RQS`.
 #[doc(hidden)]
@@ -861,21 +861,28 @@ pub fn test_pick_balance(
     pick_balance_core(loads, ncpus, candidates)
 }
 
-/// Live load-balance victim selection: build the eligible-candidate list from
-/// the locked table (applying the migration guards) and the held-guard loads,
-/// then run [`pick_balance_core`].  Allocation-free: it makes a single pass over
-/// the table tracking only the running best per-CPU victim, so no candidate
-/// vector is built.
-fn pick_balance_victim(
-    guards: &[Option<spin::MutexGuard<'_, PerCpuRq>>],
+/// Live load-balance victim selection over the thread table.  Allocation-free:
+/// a single pass over the table tracking only the running best per-CPU victim,
+/// so no candidate vector is built.
+///
+/// Per-CPU load is read through the `load` closure rather than off the guards
+/// directly, matching the wake-edge spread ([`wake_target_with_loads`]): the
+/// LIVE caller wires `|cpu| cpu_wake_load(cpu, nr_running)` so a dead-LAPIC-timer
+/// CPU reports `u32::MAX` and is never selected as the migration destination
+/// (the Leg-3 dead-timer exclusion).  Reading `nr_running` raw here would rank a
+/// dead-timer CPU — whose runqueue stays shallow precisely because the wake edge
+/// already steers work away from it — as `emptiest` and strand the most-overdue
+/// thread on the one CPU that cannot drain it.  The closure also lets the
+/// selection be driven directly over caller-supplied loads in Test 707 (the same
+/// pattern [`test_wake_target`] uses for the wake edge).
+pub(crate) fn pick_balance_victim(
+    load: impl Fn(usize) -> u32,
     ncpus: usize,
     threads: &[proc::Thread],
-    _here: usize,
 ) -> Option<(usize, usize, Tid, u8)> {
-    // Loads from the held guards (no re-lock).
     let mut loads = [0u32; MAX_CPUS];
     for cpu in 0..ncpus {
-        loads[cpu] = guards[cpu].as_ref().map_or(0, |g| g.nr_running());
+        loads[cpu] = load(cpu);
     }
     // Identify busiest/emptiest + threshold via the pure core over a single
     // synthesized best-victim-per-busiest candidate.  We first find busiest so
@@ -925,6 +932,48 @@ fn pick_balance_victim(
         }
     }
     best.map(|(tid, prio, _)| (busiest, emptiest, tid, prio))
+}
+
+/// Apply a chosen load-balance migration under the runqueue guards
+/// `mirror_maintain` already holds: dequeue the victim from its source rq,
+/// enqueue it on the destination, re-home its `last_cpu` + `mirror_slot`, and
+/// bump [`BALANCE_MIGRATIONS`].  Returns `true` iff the migration was applied.
+///
+/// Extracted from [`mirror_maintain`] so the live apply and the migration
+/// counter are exercised directly (Test 707) rather than only inferred from the
+/// pure decision.  The mirror invariant (slot ⟺ rq membership, stable across the
+/// held guards) guarantees the victim is present in the source bucket; the
+/// dequeue result is asserted and, if it ever misses, the enqueue/re-home/count
+/// are skipped so a weakened invariant cannot silently double-count `nr_running`
+/// on the destination (the same defensiveness [`try_steal_to`] applies).
+pub(crate) fn apply_balance_migration(
+    guards: &mut [Option<spin::MutexGuard<'_, PerCpuRq>>],
+    threads: &mut [proc::Thread],
+    src: usize,
+    dst: usize,
+    victim_tid: Tid,
+    victim_prio: u8,
+) -> bool {
+    let removed = match guards.get_mut(src).and_then(|g| g.as_mut()) {
+        Some(g) => g.dequeue(victim_tid, victim_prio),
+        None => false,
+    };
+    debug_assert!(
+        removed,
+        "balance victim absent from its source runqueue (mirror invariant weakened)"
+    );
+    if !removed {
+        return false;
+    }
+    if let Some(g) = guards.get_mut(dst).and_then(|g| g.as_mut()) {
+        g.enqueue(victim_tid, victim_prio);
+    }
+    if let Some(t) = threads.iter_mut().find(|t| t.tid == victim_tid) {
+        t.last_cpu = dst as u8;
+        t.mirror_slot = Some((dst as u8, victim_prio));
+    }
+    BALANCE_MIGRATIONS.fetch_add(1, Ordering::Relaxed);
+    true
 }
 
 /// True iff `t` belongs to the mirrored non-idle runnable pool: a `Ready`
@@ -1234,29 +1283,25 @@ pub fn mirror_maintain(threads: &mut [proc::Thread]) {
     // migrated.  If a future refactor reorders these blocks, that guarantee
     // breaks.
     if ncpus > 1 && balance_due() {
-        if let Some((src, dst, victim_tid, victim_prio)) =
-            pick_balance_victim(&guards, ncpus, threads, here)
-        {
-            // Move the victim between runqueues under the held guards.
-            if let Some(g) = guards[src].as_mut() {
-                g.dequeue(victim_tid, victim_prio);
-            }
-            if let Some(g) = guards[dst].as_mut() {
-                g.enqueue(victim_tid, victim_prio);
-            }
-            // Reassign the thread's home CPU + mirror slot so the deterministic
-            // placement and the next delta pass agree with the move.
-            if let Some(t) = threads.iter_mut().find(|t| t.tid == victim_tid) {
-                t.last_cpu = dst as u8;
-                t.mirror_slot = Some((dst as u8, victim_prio));
-            }
-            // Poke the destination so it reschedules and picks up the pulled
-            // task (it is remote by construction: dst != src, and the victim was
-            // not running on dst).
-            if dst != here && dst < 32 {
+        // Per-CPU load read through `cpu_wake_load` — identical to the wake-edge
+        // spread above — so a dead-LAPIC-timer CPU (reported u32::MAX) is never
+        // chosen as the migration destination (Leg 3): balance must not strand
+        // the most-overdue thread on a CPU that cannot drain its own runqueue.
+        // `nr_running` is read straight off the guards already held (no re-lock).
+        if let Some((src, dst, victim_tid, victim_prio)) = pick_balance_victim(
+            |cpu| cpu_wake_load(cpu, guards[cpu].as_ref().map_or(0, |g| g.nr_running())),
+            ncpus,
+            threads,
+        ) {
+            // Apply the migration (dequeue → enqueue → re-home → count) under the
+            // held guards, then poke the destination so it reschedules and picks
+            // up the pulled task (remote by construction: dst != src).
+            if apply_balance_migration(&mut guards, threads, src, dst, victim_tid, victim_prio)
+                && dst != here
+                && dst < 32
+            {
                 resched_mask |= 1u32 << (dst as u32);
             }
-            BALANCE_MIGRATIONS.fetch_add(1, Ordering::Relaxed);
         }
     }
 

--- a/kernel/src/sched/percpu.rs
+++ b/kernel/src/sched/percpu.rs
@@ -746,6 +746,187 @@ pub fn test_wake_target(affinity: Option<u8>, last_cpu: u8, loads: &[u32]) -> u8
     })
 }
 
+// ── Load balancing (Perf P2 phase 3d) ───────────────────────────────────────
+
+/// Minimum runqueue-depth difference (busiest minus least-loaded) that triggers
+/// a migration.  A difference of 2 means the busiest CPU has at least two more
+/// queued threads than the emptiest — enough that moving one strictly improves
+/// the spread (busiest-1 vs emptiest+1 cannot cross over).  A threshold of 2
+/// (not 1) avoids ping-ponging a single thread between two CPUs that differ by
+/// one, which would only churn cache with no fairness gain.
+const BALANCE_IMBALANCE_THRESHOLD: u32 = 2;
+
+/// Balance-pass throttle: run the migration check once every this many
+/// maintenance passes.  Balancing every pass would add an O(N) victim scan to
+/// the hot path for little benefit (load does not change that fast); spacing it
+/// keeps the amortized cost negligible while still reacting within a few ticks.
+const BALANCE_EVERY_PASSES: u32 = 16;
+
+/// Monotone pass counter driving the [`BALANCE_EVERY_PASSES`] cadence.
+static BALANCE_PASSES: AtomicU32 = AtomicU32::new(0);
+
+/// Cumulative count of load-balance migrations performed.  Diagnostic / test
+/// signal that balancing actually moved a thread.  Monotone since boot.
+pub static BALANCE_MIGRATIONS: AtomicU32 = AtomicU32::new(0);
+
+/// Snapshot of [`BALANCE_MIGRATIONS`].
+pub fn balance_migrations() -> u32 {
+    BALANCE_MIGRATIONS.load(Ordering::Relaxed)
+}
+
+/// True once every [`BALANCE_EVERY_PASSES`] maintenance passes (the throttle).
+#[inline]
+fn balance_due() -> bool {
+    let n = BALANCE_PASSES.fetch_add(1, Ordering::Relaxed);
+    n % BALANCE_EVERY_PASSES == 0
+}
+
+/// Pure load-balance decision: given per-CPU runqueue depths and the candidate
+/// victim threads, decide whether to migrate and pick (src, dst, tid, prio).
+///
+/// Returns `Some((src, dst, victim_tid, victim_prio))` when the busiest CPU's
+/// depth exceeds the least-loaded CPU's by more than
+/// [`BALANCE_IMBALANCE_THRESHOLD`] AND there is an eligible victim queued on the
+/// busiest CPU; `None` otherwise.  The victim is the MOST-OVERDUE eligible
+/// thread on the busiest CPU (smallest absolute force-deadline = longest
+/// effective wait), so balancing also relieves the rq most likely to be
+/// starving — pull-on-idle (dst depth 0) falls out as the special case.
+///
+/// `loads[cpu]` is the runqueue depth, `here` is the current CPU.  `candidates`
+/// is the eligible-victim list as `(tid, prio, home_cpu, abs_deadline)` tuples —
+/// the caller has ALREADY applied the eligibility guards (not Running, not
+/// `!ctx_rsp_valid`, not pinned) so this pure function only does selection.
+fn pick_balance_core(
+    loads: &[u32],
+    ncpus: usize,
+    candidates: &[(Tid, u8, usize, u64)],
+) -> Option<(usize, usize, Tid, u8)> {
+    if ncpus < 2 {
+        return None;
+    }
+    // Busiest and least-loaded CPUs (ties → lowest index).
+    let mut busiest = 0usize;
+    let mut emptiest = 0usize;
+    for cpu in 0..ncpus {
+        let l = loads.get(cpu).copied().unwrap_or(0);
+        if l > loads.get(busiest).copied().unwrap_or(0) {
+            busiest = cpu;
+        }
+        if l < loads.get(emptiest).copied().unwrap_or(0) {
+            emptiest = cpu;
+        }
+    }
+    if busiest == emptiest {
+        return None;
+    }
+    let busy_load = loads.get(busiest).copied().unwrap_or(0);
+    let empty_load = loads.get(emptiest).copied().unwrap_or(0);
+    // Need a strict imbalance beyond the threshold to bother moving anything.
+    if busy_load.saturating_sub(empty_load) < BALANCE_IMBALANCE_THRESHOLD {
+        return None;
+    }
+    // Most-overdue eligible victim that is HOMED on the busiest CPU.  Ties on
+    // the absolute deadline are broken toward the LOWER tid so the choice is
+    // deterministic and independent of iteration order — this keeps the pure
+    // `pick_balance_core` (driven by Test 652 over a candidate slice) and the
+    // live `pick_balance_victim` (driven over the thread table) selecting the
+    // identical victim even when two equally-overdue threads compete.
+    let mut victim: Option<(Tid, u8, u64)> = None;
+    for &(tid, prio, home, abs_deadline) in candidates {
+        if home != busiest {
+            continue;
+        }
+        let take = match victim {
+            Some((best_tid, _, best_abs)) => {
+                abs_deadline < best_abs || (abs_deadline == best_abs && tid < best_tid)
+            }
+            None => true,
+        };
+        if take {
+            victim = Some((tid, prio, abs_deadline));
+        }
+    }
+    victim.map(|(tid, prio, _)| (busiest, emptiest, tid, prio))
+}
+
+/// Test-facing replica of the load-balance decision (Test 652), over
+/// caller-supplied loads + candidates so the migration policy is provable
+/// without spinning threads or touching the live `RQS`.
+#[doc(hidden)]
+pub fn test_pick_balance(
+    loads: &[u32],
+    ncpus: usize,
+    candidates: &[(Tid, u8, usize, u64)],
+) -> Option<(usize, usize, Tid, u8)> {
+    pick_balance_core(loads, ncpus, candidates)
+}
+
+/// Live load-balance victim selection: build the eligible-candidate list from
+/// the locked table (applying the migration guards) and the held-guard loads,
+/// then run [`pick_balance_core`].  Allocation-free: it makes a single pass over
+/// the table tracking only the running best per-CPU victim, so no candidate
+/// vector is built.
+fn pick_balance_victim(
+    guards: &[Option<spin::MutexGuard<'_, PerCpuRq>>],
+    ncpus: usize,
+    threads: &[proc::Thread],
+    _here: usize,
+) -> Option<(usize, usize, Tid, u8)> {
+    // Loads from the held guards (no re-lock).
+    let mut loads = [0u32; MAX_CPUS];
+    for cpu in 0..ncpus {
+        loads[cpu] = guards[cpu].as_ref().map_or(0, |g| g.nr_running());
+    }
+    // Identify busiest/emptiest + threshold via the pure core over a single
+    // synthesized best-victim-per-busiest candidate.  We first find busiest so
+    // we only need to track the most-overdue eligible victim on THAT CPU.
+    let mut busiest = 0usize;
+    let mut emptiest = 0usize;
+    for cpu in 0..ncpus {
+        if loads[cpu] > loads[busiest] { busiest = cpu; }
+        if loads[cpu] < loads[emptiest] { emptiest = cpu; }
+    }
+    if busiest == emptiest
+        || loads[busiest].saturating_sub(loads[emptiest]) < BALANCE_IMBALANCE_THRESHOLD
+    {
+        return None;
+    }
+    // Most-overdue ELIGIBLE thread homed on the busiest CPU.  Eligibility:
+    // Ready non-idle, NOT pinned, NOT mid-switch (`ctx_rsp_valid`), and homed on
+    // `busiest` (its current mirror slot is on busiest).  The currently-Running
+    // task is excluded automatically: a Running thread is not in the
+    // mirrored-runnable (Ready) pool, so it has no Some(busiest) mirror slot.
+    let mut best: Option<(Tid, u8, u64)> = None;
+    for t in threads.iter() {
+        if t.cpu_affinity.is_some() {
+            continue; // pinned — never migrate off its CPU
+        }
+        if !t.ctx_rsp_valid.load(Ordering::Acquire) {
+            continue; // mid context-switch — unsafe to move
+        }
+        match t.mirror_slot {
+            Some((c, prio)) if (c as usize) == busiest => {
+                let abs = t.ready_since_tick
+                    .saturating_add(super::force_deadline_for_tid(t.tid));
+                // Tie-break toward the lower tid (matches `pick_balance_core`),
+                // so the live victim choice is order-independent and identical
+                // to the tested pure decision even on equal deadlines.
+                let take = match best {
+                    Some((best_tid, _, best_abs)) => {
+                        abs < best_abs || (abs == best_abs && t.tid < best_tid)
+                    }
+                    None => true,
+                };
+                if take {
+                    best = Some((t.tid, prio, abs));
+                }
+            }
+            _ => {}
+        }
+    }
+    best.map(|(tid, prio, _)| (busiest, emptiest, tid, prio))
+}
+
 /// True iff `t` belongs to the mirrored non-idle runnable pool: a `Ready`
 /// thread that is NOT an idle-class thread.
 ///
@@ -1019,6 +1200,63 @@ pub fn mirror_maintain(threads: &mut [proc::Thread]) {
     for cpu in 0..MAX_CPUS {
         if let Some(g) = guards[cpu].as_mut() {
             g.set_min_deadline(mins[cpu]);
+        }
+    }
+
+    // ── Load balancing (Perf P2 phase 3d) ────────────────────────────────────
+    // Periodically even out the per-CPU runqueues: if the busiest CPU's depth
+    // exceeds the least-loaded CPU's by more than `BALANCE_IMBALANCE_THRESHOLD`,
+    // migrate the single most-overdue ELIGIBLE thread from the busiest to the
+    // least-loaded runqueue.  "Pull-on-idle" is the special case where the
+    // least-loaded CPU is empty (depth 0).  All of this happens under the rq
+    // guards `mirror_maintain` already holds in ascending CPU-index order (the
+    // documented migration lock order), so there is no separate two-lock dance
+    // and no deadlock surface.
+    //
+    // Eligibility (mirrors the dispatch's migration guards): NEVER migrate the
+    // currently-Running task, a task whose context is mid-switch
+    // (`!ctx_rsp_valid`), or a task pinned to a specific CPU (`cpu_affinity`).
+    // Migrating = reassign the victim's `last_cpu` to the destination and move
+    // its tid between the two runqueues + its `mirror_slot`; the destination is
+    // then poked via the reschedule mask so it picks the migrated thread up
+    // promptly.  Gated on `ncpus > 1` and throttled, so SMP=1 never balances.
+    //
+    // ORDERING INVARIANT (load-bearing — do not move this block above the delta
+    // loop): the Running-task exclusion is implicit, and relies on the delta
+    // loop having ALREADY run this pass.  A thread that is Running carries a
+    // stale `mirror_slot = Some(..)` (the picker does not clear it on
+    // Ready→Running), but `desired_slot` returns `None` for any non-Ready
+    // thread, so the delta loop above dequeued it and set `mirror_slot = None`
+    // BEFORE we read slots here.  `mirror_maintain` runs only under
+    // THREAD_TABLE, so no other CPU reconciles concurrently.  Hence by this
+    // point every Running thread has `mirror_slot = None` and can never match
+    // the `Some((busiest, _))` victim predicate — a Running thread is never
+    // migrated.  If a future refactor reorders these blocks, that guarantee
+    // breaks.
+    if ncpus > 1 && balance_due() {
+        if let Some((src, dst, victim_tid, victim_prio)) =
+            pick_balance_victim(&guards, ncpus, threads, here)
+        {
+            // Move the victim between runqueues under the held guards.
+            if let Some(g) = guards[src].as_mut() {
+                g.dequeue(victim_tid, victim_prio);
+            }
+            if let Some(g) = guards[dst].as_mut() {
+                g.enqueue(victim_tid, victim_prio);
+            }
+            // Reassign the thread's home CPU + mirror slot so the deterministic
+            // placement and the next delta pass agree with the move.
+            if let Some(t) = threads.iter_mut().find(|t| t.tid == victim_tid) {
+                t.last_cpu = dst as u8;
+                t.mirror_slot = Some((dst as u8, victim_prio));
+            }
+            // Poke the destination so it reschedules and picks up the pulled
+            // task (it is remote by construction: dst != src, and the victim was
+            // not running on dst).
+            if dst != here && dst < 32 {
+                resched_mask |= 1u32 << (dst as u32);
+            }
+            BALANCE_MIGRATIONS.fetch_add(1, Ordering::Relaxed);
         }
     }
 

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1393,6 +1393,8 @@ pub fn run() -> ! {
         if test_656_alloc_side_alias_guard() { passed += 1; }
         total += 1;
         if test_657_percpu_idle_work_steal() { passed += 1; }
+        total += 1;
+        if test_707_load_balance() { passed += 1; }
     }
 
     // ── Test 659: kstack-free quarantine survey per-tick throttle ────────
@@ -53068,6 +53070,137 @@ fn test_658_tsc_deadline_cadence() -> bool {
 
     test_println!("  next-deadline: now+period strictly-future / modulo-2^64 wrap — \
 TSC-deadline one-shot re-arm cadence GREEN (KVM dead-CPU0-timer fix)");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 707: load-balance victim selection (Perf P2 phase 3d) ──────────────
+//
+// Phase 3d migrates the most-overdue eligible thread from the busiest runqueue
+// to the least-loaded one when the depth imbalance exceeds the threshold. The
+// live `mirror_maintain` applies the eligibility guards (not Running, not
+// `!ctx_rsp_valid`, not pinned) and homing before calling the selection core;
+// this test drives the pure decision (`test_pick_balance`) over caller-supplied
+// loads + pre-filtered candidates to prove the policy: imbalance threshold,
+// busiest→emptiest direction, most-overdue victim, pull-on-idle, and the
+// no-migration cases. The eligibility guards themselves are structural in the
+// live path (a Running/mid-switch/pinned thread is never placed in the
+// candidate list) and are covered by the by-construction argument in the code.
+fn test_707_load_balance() -> bool {
+    use crate::sched::percpu::test_pick_balance as pb;
+    use crate::proc::Tid;
+    const NAME: &str = "[SCHED/P2] load-balance victim selection (Test 707)";
+    test_header!(NAME);
+
+    // Candidate tuple: (tid, prio, home_cpu, abs_deadline). Lower abs_deadline =
+    // more overdue (longer effective wait).
+    type Cand = (Tid, u8, usize, u64);
+
+    // Case 1 — balanced within threshold: depths [2,1] differ by 1 (< 2) → no
+    // migration even though candidates exist on the busier CPU.
+    {
+        let loads = [2u32, 1];
+        let cands: [Cand; 2] = [(10, 4, 0, 100), (11, 4, 0, 100)];
+        if pb(&loads, 2, &cands).is_some() {
+            test_fail!(NAME, "case1: migrated despite imbalance < threshold");
+            return false;
+        }
+    }
+
+    // Case 2 — imbalance at threshold: depths [3,1] differ by 2 (>= 2) → migrate
+    // from busiest (0) to emptiest (1), choosing the MOST-overdue victim on cpu 0
+    // (tid 21, abs 50 < tid 20's abs 100).
+    {
+        let loads = [3u32, 1, 2];
+        let cands: [Cand; 3] = [(20, 4, 0, 100), (21, 4, 0, 50), (22, 4, 2, 10)];
+        match pb(&loads, 3, &cands) {
+            Some((src, dst, tid, _prio)) => {
+                if src != 0 || dst != 1 || tid != 21 {
+                    test_fail!(NAME, "case2: got src={} dst={} tid={} expected 0->1 tid=21", src, dst, tid);
+                    return false;
+                }
+            }
+            None => { test_fail!(NAME, "case2: no migration despite imbalance >= threshold"); return false; }
+        }
+    }
+
+    // Case 3 — pull-on-idle: emptiest CPU is empty (depth 0). depths [4,0] →
+    // migrate the most-overdue cpu-0 victim to cpu 1.
+    {
+        let loads = [4u32, 0];
+        let cands: [Cand; 3] = [(30, 4, 0, 200), (31, 4, 0, 80), (32, 4, 0, 150)];
+        match pb(&loads, 2, &cands) {
+            Some((src, dst, tid, _)) => {
+                if src != 0 || dst != 1 || tid != 31 {
+                    test_fail!(NAME, "case3: got src={} dst={} tid={} expected 0->1 tid=31 (most overdue)", src, dst, tid);
+                    return false;
+                }
+            }
+            None => { test_fail!(NAME, "case3: pull-on-idle did not fire"); return false; }
+        }
+    }
+
+    // Case 4 — imbalance present but NO eligible victim homed on the busiest CPU
+    // (all candidates live on other CPUs) → no migration (the busiest CPU's load
+    // is pinned/running threads the caller already filtered out).
+    {
+        let loads = [5u32, 1];
+        let cands: [Cand; 2] = [(40, 4, 1, 100), (41, 4, 1, 100)]; // none on cpu 0
+        if pb(&loads, 2, &cands).is_some() {
+            test_fail!(NAME, "case4: migrated with no eligible victim on busiest");
+            return false;
+        }
+    }
+
+    // Case 5 — uniprocessor: ncpus 1 → never migrate.
+    {
+        let loads = [9u32];
+        let cands: [Cand; 1] = [(50, 4, 0, 10)];
+        if pb(&loads, 1, &cands).is_some() {
+            test_fail!(NAME, "case5: migrated on a uniprocessor");
+            return false;
+        }
+    }
+
+    // Case 6 — three CPUs, picks the GLOBAL busiest and emptiest. depths
+    // [2,6,1]: busiest=1, emptiest=2, diff 5 >= 2 → migrate cpu1's overdue victim
+    // to cpu 2.
+    {
+        let loads = [2u32, 6, 1];
+        let cands: [Cand; 3] = [(60, 4, 1, 70), (61, 4, 1, 30), (62, 4, 0, 5)];
+        match pb(&loads, 3, &cands) {
+            Some((src, dst, tid, _)) => {
+                if src != 1 || dst != 2 || tid != 61 {
+                    test_fail!(NAME, "case6: got src={} dst={} tid={} expected 1->2 tid=61", src, dst, tid);
+                    return false;
+                }
+            }
+            None => { test_fail!(NAME, "case6: no migration on 3-CPU imbalance"); return false; }
+        }
+    }
+
+    // Case 7 — deadline tie → deterministic lower-tid victim. Two equally-overdue
+    // threads (same abs 40) on the busiest CPU; the lower tid (70) is chosen
+    // regardless of candidate order, so the pure decision and the live
+    // table-order decision cannot diverge on a tie.
+    {
+        let loads = [3u32, 0];
+        // Present the higher tid FIRST to prove order-independence.
+        let cands: [Cand; 2] = [(71, 4, 0, 40), (70, 4, 0, 40)];
+        match pb(&loads, 2, &cands) {
+            Some((_, _, tid, _)) => {
+                if tid != 70 {
+                    test_fail!(NAME, "case7: tie picked tid {} expected 70 (lower tid)", tid);
+                    return false;
+                }
+            }
+            None => { test_fail!(NAME, "case7: no migration on tie"); return false; }
+        }
+    }
+
+    test_println!("  load-balance: threshold-gated / busiest->emptiest / most-overdue-victim / \
+pull-on-idle / no-eligible-victim-skip / uniproc-noop / 3-CPU-global-extremes / \
+deadline-tie-lower-tid — migration policy correct GREEN");
     test_pass!(NAME);
     true
 }

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1395,6 +1395,8 @@ pub fn run() -> ! {
         if test_657_percpu_idle_work_steal() { passed += 1; }
         total += 1;
         if test_707_load_balance() { passed += 1; }
+        total += 1;
+        if test_708_load_balance_live() { passed += 1; }
     }
 
     // ── Test 659: kstack-free quarantine survey per-tick throttle ────────
@@ -53201,6 +53203,137 @@ fn test_707_load_balance() -> bool {
     test_println!("  load-balance: threshold-gated / busiest->emptiest / most-overdue-victim / \
 pull-on-idle / no-eligible-victim-skip / uniproc-noop / 3-CPU-global-extremes / \
 deadline-tie-lower-tid — migration policy correct GREEN");
+    test_pass!(NAME);
+    true
+}
+
+// ── Test 708: LIVE load-balance selector + apply + dead-timer exclusion ──────
+//
+// Test 707 proves the pure decision core; this drives the CODE THAT ACTUALLY
+// RUNS in `mirror_maintain`: the live `pick_balance_victim` (eligibility guards +
+// most-overdue-victim + tie-break, over a synthetic `&[Thread]` slice) and the
+// live `apply_balance_migration` (dequeue/enqueue/re-home + `BALANCE_MIGRATIONS`
+// bump, over caller-held `PerCpuRq` guards) — the pattern Test 657 establishes
+// for `try_steal_to`. Case B is the regression guard for the dead-LAPIC-timer
+// destination exclusion: the SAME thread set migrates onto the dead CPU when the
+// selector reads RAW load (the pre-fix hazard) and does NOT when it reads through
+// `cpu_wake_load` (a dead-timer CPU reports u32::MAX), matching the wake edge.
+#[cfg(any(feature = "firefox-test-core", feature = "test-mode"))]
+fn test_708_load_balance_live() -> bool {
+    use crate::proc::{Thread, ThreadState, Tid};
+    use crate::sched::percpu::{
+        apply_balance_migration, balance_migrations, pick_balance_victim, PerCpuRq,
+    };
+    use core::sync::atomic::Ordering;
+    const NAME: &str = "[SCHED/P2] load-balance LIVE selector + dead-timer exclusion (Test 708)";
+    test_header!(NAME);
+
+    // A migratable Ready thread homed on `home` at `prio`; smaller `ready_since`
+    // = more overdue (smaller absolute force-deadline). `affinity`/`ctx_valid`
+    // drive the eligibility guards. (force_deadline_for_tid is identical for all
+    // non-zero tids, so ordering is by ready_since alone.)
+    let mk = |tid: Tid, prio: u8, home: u8, ready_since: u64,
+              affinity: Option<u8>, ctx_valid: bool| -> Thread {
+        let mut t = Thread::new_for_test(prio);
+        t.tid = tid;
+        t.state = ThreadState::Ready;
+        t.cpu_affinity = affinity;
+        t.mirror_slot = Some((home, prio));
+        t.last_cpu = home;
+        t.ready_since_tick = ready_since;
+        t.ctx_rsp_valid.store(ctx_valid, Ordering::Release);
+        t
+    };
+
+    // ── Case A: clean imbalance → live selection + apply. ────────────────────
+    {
+        let loads = [3u32, 1];
+        let mut threads = [
+            mk(100, 8, 0, 5, None, true),     // homed cpu0, less overdue
+            mk(101, 8, 0, 1, None, true),     // homed cpu0, MOST overdue → victim
+            mk(102, 8, 0, 3, Some(0), true),  // homed cpu0 but PINNED → skipped
+            mk(103, 8, 0, 0, None, false),    // homed cpu0 but mid-switch → skipped
+            mk(200, 8, 1, 2, None, true),     // homed cpu1 (not busiest)
+        ];
+        // Live selector (no dead timer): reads the closure loads.
+        match pick_balance_victim(|c| loads[c], 2, &threads) {
+            Some((src, dst, tid, prio)) => {
+                if src != 0 || dst != 1 || tid != 101 || prio != 8 {
+                    test_fail!(NAME, "caseA decision src={} dst={} tid={} prio={} (want 0->1 tid101 prio8)",
+                        src, dst, tid, prio);
+                    return false;
+                }
+            }
+            None => { test_fail!(NAME, "caseA: no migration on clean imbalance"); return false; }
+        }
+        // Drive the REAL apply over held guards; assert the counter advances.
+        let rq0 = spin::Mutex::new(PerCpuRq::new_for_test());
+        let rq1 = spin::Mutex::new(PerCpuRq::new_for_test());
+        {
+            let mut g = rq0.lock();
+            g.enqueue(101, 8);
+            g.enqueue(100, 8);
+        }
+        let before = balance_migrations();
+        let mut guards = [Some(rq0.lock()), Some(rq1.lock())];
+        let applied = apply_balance_migration(&mut guards, &mut threads, 0, 1, 101, 8);
+        drop(guards);
+        if !applied {
+            test_fail!(NAME, "caseA: apply_balance_migration reported not-applied");
+            return false;
+        }
+        if balance_migrations() <= before {
+            test_fail!(NAME, "caseA: BALANCE_MIGRATIONS did not advance (was {})", before);
+            return false;
+        }
+        if rq0.lock().nr_running() != 1 || rq1.lock().nr_running() != 1 {
+            test_fail!(NAME, "caseA: rq depths wrong after apply cpu0={} cpu1={} (want 1/1)",
+                rq0.lock().nr_running(), rq1.lock().nr_running());
+            return false;
+        }
+        let v = threads.iter().find(|t| t.tid == 101).unwrap();
+        if v.mirror_slot != Some((1, 8)) || v.last_cpu != 1 {
+            test_fail!(NAME, "caseA: victim not re-homed slot={:?} last_cpu={}", v.mirror_slot, v.last_cpu);
+            return false;
+        }
+    }
+
+    // ── Case B (F1 regression): dead-timer destination is NEVER chosen. ──────
+    // Same threads, all homed on cpu0; raw depths [3,0]. With RAW load the
+    // selector ranks cpu1 emptiest and would strand the most-overdue thread on
+    // it (the pre-fix hazard). Reading through cpu_wake_load (cpu1 = u32::MAX)
+    // ranks cpu1 busiest instead; it has no homed victim, so no migration onto
+    // cpu1 occurs — the dead CPU is never the destination.
+    {
+        let threads = [
+            mk(110, 8, 0, 1, None, true),
+            mk(111, 8, 0, 2, None, true),
+            mk(112, 8, 0, 3, None, true),
+        ];
+        let raw = [3u32, 0];
+        // Precondition: raw-load selection targets cpu1 (demonstrates the hazard
+        // the fix removes — i.e. this is what the pre-fix live path would do).
+        match pick_balance_victim(|c| raw[c], 2, &threads) {
+            Some((_, 1, _, _)) => {}
+            other => {
+                test_fail!(NAME, "caseB precondition: raw-load selection expected dst=1, got {:?}", other);
+                return false;
+            }
+        }
+        // Fixed: a dead-timer destination (u32::MAX) is excluded.
+        let dead1 = |c: usize| if c == 1 { u32::MAX } else { raw[c] };
+        match pick_balance_victim(dead1, 2, &threads) {
+            None => {}
+            Some((_, dst, _, _)) if dst != 1 => {}
+            Some((_, dst, tid, _)) => {
+                test_fail!(NAME, "caseB: dead-timer CPU {} chosen as destination for tid {}", dst, tid);
+                return false;
+            }
+        }
+    }
+
+    test_println!("  load-balance LIVE: most-overdue eligible busiest-homed victim / pinned+mid-switch skipped / \
+apply re-homes + advances BALANCE_MIGRATIONS / dead-timer destination excluded (Leg 3) — GREEN");
     test_pass!(NAME);
     true
 }


### PR DESCRIPTION
## Perf P2 #19 — phase 3d (per-CPU runqueue load balancing)

**Supersedes #649.** #649 was the top of a stacked series (phases 3a→3b→3c→3d) whose base branch is gone; its earlier phases have since landed on master independently:

- phase 3a (authoritative per-CPU pick + O(1) force gate) — merged
- phase 3b (load-aware wakeup-target selection) — merged
- phase 3c (reschedule IPI, vector 0xF2) — merged as **#709** (`7a06fe25`)
- the flaky-`vdso_map` CI allow-fail — already in `ci/allow-fail.json`

So this successor carries **only the phase-3d load-balancing change**, rebased onto current `master` and layered on top of the resched-IPI code *as-merged*. It is a pure addition (`+238` `sched/percpu.rs`, `+133` `test_runner.rs`, zero deletions).

### What it does

Evens out the per-CPU runqueues so one CPU does not pile up a backlog while another sits idle. When the busiest runqueue's depth exceeds the least-loaded one's by more than `BALANCE_IMBALANCE_THRESHOLD` (2), the most-overdue **eligible** thread is migrated from the busiest to the least-loaded runqueue. *Pull-on-idle* is the special case where the least-loaded CPU is empty.

- **No new lock surface.** Balancing runs inside `mirror_maintain`, which already holds every per-CPU runqueue guard in ascending CPU-index order (the documented migration lock order) plus the thread table. The migration dequeues the victim from the source runqueue and enqueues it on the destination under those held guards, then reassigns `last_cpu` + `mirror_slot` so the deterministic placement and the next delta pass agree.
- **Poke via the existing phase-3c mask.** The destination CPU is flagged in the same `resched_mask` the wake edge fills; the post-guard IPI loop (added by #709) drains it, so the pulled thread is picked up promptly instead of waiting a tick.
- **Throttled** to once every `BALANCE_EVERY_PASSES` (16) passes so the victim scan never dominates the hot path.
- **Migration guards:** never migrate a pinned thread (`cpu_affinity = Some(_)`), a thread mid context-switch (`!ctx_rsp_valid`), or the currently-Running thread (automatic — a Running thread carries no `Some(busiest)` mirror slot after the delta loop clears it).
- **SMP=1 is a bit-for-bit no-op** — the whole pass is gated on `ncpus > 1`.

### Rebase — conflict resolutions a reviewer should scrutinise

1. **`sched/percpu.rs` auto-merged cleanly.** The balance helpers (`pick_balance_core`, `test_pick_balance`, `pick_balance_victim`, the constants/statics) landed after `test_wake_target`; the in-`mirror_maintain` balance block landed **between** the per-rq `min_deadline` recompute and the gated audit — the identical relative position it occupied in #649 (delta loop → `min_deadline` → balance → gated audit). The block's `resched_mask |= 1 << dst` composes with the #709 wake-edge mask and drains through the same post-guard IPI loop. The percpu.rs code is **byte-identical** to #649's phase-3d commit (verified by `git range-diff`).

2. **`test_runner.rs` — test renumbered 652 → 707.** Master independently reused test number **652** (`test_652_percpu_audit_image_off_stack`) and added tests 653–657 after `test_651_resched_ipi`. To avoid two "Test 652" labels in the serial/CI output, the new load-balance test is renumbered to **Test 707** (the next free slot above the current max, 706). This is the only code change vs. #649: the dispatch call, the `fn` name, the `NAME` string, and the comment header all move 652 → 707; the seven test-case bodies are unchanged.

3. **`test_runner.rs` — shared-trailer disentangle.** The 3-way merge tangled the identical `test_pass!(NAME); true }` trailer shared by master's last new test (the TSC-deadline cadence test) and #649's load-balance test. Resolved by explicitly closing master's last test with its own trailer, so both functions are well-formed.

### Validation

Per the current host constraints this was validated by `cargo +nightly check` (via the harness `check`, correct bare-metal target) for the default kernel and the `firefox-test-core` profile; full boot/test validation is GitHub CI. Test 707 proves the pure decision (`test_pick_balance`): threshold gating, busiest→emptiest direction, most-overdue victim, pull-on-idle, no-eligible-victim skip, uniprocessor no-op, 3-CPU global-extreme selection, and the deadline-tie lower-tid tie-break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
