### PR TITLE
mm/madvise: stop zeroing anonymous frames in place (W215 root cause)

### DIFF
--- a/kernel/src/subsys/linux/syscall.rs
+++ b/kernel/src/subsys/linux/syscall.rs
@@ -6239,19 +6239,6 @@ fn sys_select_linux(
     ready
 }
 
-/// W215 telemetry: number of MADV_DONTNEED/MADV_FREE per-page zero-fills
-/// suppressed by the file-backed guard.  Read from kdb / serial logging.
-#[cfg(feature = "firefox-test-core")]
-static MADV_ZERO_SUPPRESSED: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(0);
-
-/// Number of zero-fills the W215 file-backed guard has suppressed.  Always 0
-/// on non-firefox-test builds.
-#[cfg(feature = "firefox-test-core")]
-pub fn madv_zero_suppressed_count() -> u64 {
-    MADV_ZERO_SUPPRESSED.load(core::sync::atomic::Ordering::Relaxed)
-}
-
 /// madvise(addr, len, advice) — memory usage hint.
 ///
 /// MADV_DONTNEED (4) and MADV_FREE (8): free physical pages in range so the
@@ -6266,35 +6253,17 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     let start = addr & !0xFFF;
     let end   = (addr + len + 0xFFF) & !0xFFF;
 
-    // Capture cr3 AND a snapshot of file-backed VMA ranges that overlap
-    // [start, end).  The snapshot is used below to suppress the per-page
-    // zero-fill on file-backed pages, which (when a frame is also held by
-    // the page cache) would silently corrupt the cache content shared with
-    // other VmSpaces and future faulters — the W215 root cause.  See the
-    // detailed rationale at the zero-fill site for the bug shape.
-    //
-    // Snapshot size is tiny in practice: a single madvise range typically
-    // overlaps one VMA, occasionally two when straddling an arena boundary.
-    let (cr3_opt, file_ranges) = {
+    // Resolve the calling process's CR3.  No per-VMA snapshot is needed: the
+    // clear-PTE path below is identical for anonymous and file-backed pages —
+    // neither is written in place, so there is nothing to gate on the backing
+    // type.  Each page simply re-faults on the next access (fresh zeros for
+    // anon, authoritative cache content for file-backed).
+    let cr3 = {
         let procs = crate::proc::PROCESS_TABLE.lock();
         let p = procs.iter().find(|p| p.pid == pid);
-        let cr3 = p.and_then(|p| p.vm_space.as_ref()).map(|vs| vs.cr3);
-        let mut ranges: alloc::vec::Vec<(u64, u64)> = alloc::vec::Vec::new();
-        if let Some(vs) = p.and_then(|p| p.vm_space.as_ref()) {
-            for vma in vs.areas.iter() {
-                if !vma.overlaps(start, end - start) { continue; }
-                if matches!(vma.backing, crate::mm::vma::VmBacking::File { .. }) {
-                    ranges.push((vma.base, vma.end()));
-                }
-            }
-        }
-        (cr3, ranges)
+        p.and_then(|p| p.vm_space.as_ref()).map(|vs| vs.cr3)
     };
-    let cr3 = match cr3_opt { Some(c) => c, None => return 0 };
-    // Closure: O(file_ranges.len()) per page, where len is typically 0-2.
-    let is_file_backed = |page: u64| -> bool {
-        file_ranges.iter().any(|&(b, e)| page >= b && page < e)
-    };
+    let cr3 = match cr3 { Some(c) => c, None => return 0 };
 
     // W216 H_5j-B: MADV_DONTNEED clears PTEs and frees frames; the area list
     // itself is not mutated, but the PFH install loop must abort if it has
@@ -6329,7 +6298,7 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     // the sibling thread reads kernel data through the stale mapping.
     //
     // Three-pass approach:
-    //   Pass 1 — zero and clear PTEs, collect physical addresses to free.
+    //   Pass 1 — clear PTEs, drop refs, collect physical addresses to free.
     //   Pass 2 — synchronous shootdown (IPI + ack) across all CPUs.
     //   Pass 3 — return frames to the PMM (safe after pass 2 completes).
     //
@@ -6343,7 +6312,6 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
     // no caller observes the batch boundary.
     //
     // Cite: madvise(2) (POSIX.1-2017); Intel SDM Vol. 3A §4.10.4-5.
-    const PHYS_OFF: u64 = 0xFFFF_8000_0000_0000;
     const BATCH: usize = 128;
 
     let mut page = start;
@@ -6359,43 +6327,37 @@ fn sys_madvise(addr: u64, len: u64, advice: u64) -> i64 {
             let pte = crate::mm::vmm::read_pte(cr3, page);
             if pte & 1 != 0 {
                 let phys = pte & 0x000F_FFFF_FFFF_F000;
-                // Zero the backing storage on anonymous pages only.  Per POSIX
-                // madvise(2), MADV_DONTNEED on an anonymous region must cause
-                // subsequent reads to return zeros, which the kernel achieves
-                // here by zeroing the frame in place before the deferred-free.
+                // Do NOT write into the frame here.  Both MADV_DONTNEED and
+                // MADV_FREE are served by clearing the PTE and dropping this
+                // mapping's page reference; the frame returns to the PMM only
+                // when its refcount reaches zero (below).  The next access
+                // re-faults — an anonymous page demand-faults a FRESH
+                // zero-filled frame, and a file-backed page re-faults through
+                // the page cache to the authoritative file content — so the
+                // observable result already matches POSIX madvise(2): after
+                // MADV_DONTNEED "subsequent accesses ... will succeed, but will
+                // result in ... zero-fill-on-demand pages".
                 //
-                // For file-backed VMAs the frame is typically co-owned by the
-                // page cache (the cache holds rc=1, this PTE holds rc=1, so a
-                // page_ref_dec returns new_rc=1 and the frame stays alive).
-                // An unconditional zero-fill in that case clobbers the cache
-                // content shared with every other VmSpace that holds — or will
-                // hold — a PTE to the same `(mount_idx, inode, page_offset)`.
-                // The next cache-hit faulter then maps in a frame whose
-                // contents are zero, and pid 1's instruction fetch from the
-                // shared libxul .text page reads zero bytes → SIGSEGV/#UD
-                // with RIP bytes all-zero (the W215 fingerprint).  POSIX is
-                // satisfied for file-backed ranges by clearing the PTE alone:
-                // the next access re-faults via `cache::lookup_and_acquire`
-                // and sees the authoritative file content.
-                if !is_file_backed(page) {
-                    unsafe {
-                        core::ptr::write_bytes(
-                            (PHYS_OFF + phys) as *mut u8,
-                            0,
-                            crate::mm::pmm::PAGE_SIZE,
-                        );
-                    }
-                } else {
-                    // Telemetry: count zero-fills suppressed by the file-backed
-                    // guard.  A non-zero count after a clean Firefox boot
-                    // confirms the W215 corruption path is being avoided in
-                    // practice; a zero count under the same workload would
-                    // mean the guard is dead code (e.g. file-backed regions
-                    // never receiving MADV_DONTNEED) and the actual writer is
-                    // elsewhere.
-                    #[cfg(feature = "firefox-test-core")]
-                    MADV_ZERO_SUPPRESSED.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                }
+                // Zeroing the frame in place (as a prior revision did for the
+                // anonymous arm) is both redundant and unsafe.  Redundant
+                // because the refault already yields zeros.  Unsafe because
+                // the frame may be SHARED: after fork, a copy-on-write
+                // anonymous frame is co-mapped by parent and child, so its
+                // refcount is >= 2.  An in-place zero from one side's madvise
+                // scribbles the co-mapper's live data while it still maps the
+                // frame — page_ref_dec only drops the count to >= 1, so the
+                // frame is NOT freed and the co-mapper keeps reading it.  The
+                // co-mapper then reads zeros where its allocator metadata used
+                // to be and faults: the W215 corruption fingerprint (victim
+                // frame served all-zero; a zeroing-provenance probe pins the
+                // last writer to THIS site with the frame live at zero time).
+                // Clearing the PTE alone is sufficient and leaves shared
+                // frames intact for their remaining mappers.
+                //
+                // Cite: madvise(2) (POSIX.1-2017) MADV_DONTNEED / MADV_FREE;
+                // Intel SDM Vol. 3A §4.10.5 (propagate paging-structure
+                // changes before a frame is reused).
+                //
                 // Clear the PTE.  Do NOT free the frame yet.
                 crate::mm::vmm::write_pte(cr3, page, 0);
                 any_unmap = true;

--- a/kernel/src/test_runner.rs
+++ b/kernel/src/test_runner.rs
@@ -1228,6 +1228,10 @@ pub fn run() -> ! {
     total += 1;
     if test_madvise_dontneed() { passed += 1; }
 
+    // ── Test 723: madvise must not zero frames in place (W215 regression) ─
+    total += 1;
+    if test_723_madvise_no_inplace_zero() { passed += 1; }
+
     // ── Test 95: X11 selection clipboard (ICCCM) ──────────────────────────
 
     total += 1;
@@ -25649,6 +25653,166 @@ fn test_madvise_dontneed() -> bool {
 
     crate::proc::unblock_process(pid);
     test_pass!("madvise MADV_DONTNEED — frees physical pages");
+    true
+}
+
+// ── Test 723: madvise MADV_DONTNEED/FREE must NOT zero frames in place ────────
+//
+// Regression guard for the W215 corruption root cause.  sys_madvise's
+// MADV_DONTNEED / MADV_FREE path previously zeroed each anonymous frame in
+// place before the deferred free.  On a SHARED frame (refcount >= 2) — the
+// state a copy-on-write anonymous page is in after fork — that in-place zero
+// scribbles a co-mapper's live data while the frame stays alive (page_ref_dec
+// only drops the count to >= 1, so the frame is not freed and the co-mapper
+// keeps reading it).  The co-mapper then reads zeros where its allocator
+// metadata used to be and faults: the W215 "victim frame served all-zero"
+// fingerprint.
+//
+// Two properties, verified against the REAL sys_madvise (Linux dispatch
+// nr=28 — not a reimplementation, so a reintroduced in-place write is caught):
+//   (a) SHARED-FRAME SURVIVAL — a refcount-2 frame madvise'd through one
+//       mapping keeps its bytes and is dec'd (not freed).  The pre-fix code
+//       fails this (bytes read back all-zero).
+//   (b) DONTNEED SEMANTICS — an unshared (refcount-1) frame madvise'd is
+//       PTE-cleared and freed; the next access demand-faults FRESH zeros,
+//       satisfying POSIX madvise(2) ("subsequent accesses ... will result in
+//       ... zero-fill-on-demand pages").
+//
+// Cite: madvise(2) (POSIX.1-2017); Intel SDM Vol. 3A §4.10.5.
+fn test_723_madvise_no_inplace_zero() -> bool {
+    test_header!("madvise MADV_DONTNEED/FREE — no in-place zero (W215 shared-frame survival)");
+    const PHYS_OFF: u64  = 0xFFFF_8000_0000_0000;
+    const PHYS_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+    const MADV_DONTNEED: u64 = 4;
+    // Distinctive, non-zero-at-every-offset frame stamp so an all-zero frame
+    // (the bug) is unambiguously distinguishable from the intact pattern.
+    let pat = |off: u64| -> u64 { 0x00C0_FFEE_0000_0000u64 ^ off.wrapping_mul(0x9E37_79B9_7F4A_7C15) };
+
+    let pid = crate::proc::current_pid_lockless();
+    let cr3 = {
+        let procs = crate::proc::PROCESS_TABLE.lock();
+        procs.iter().find(|p| p.pid == pid)
+            .and_then(|p| p.vm_space.as_ref()).map(|vs| vs.cr3).unwrap_or(0)
+    };
+    if cr3 == 0 {
+        test_fail!("madv_nozero", "runner has no VmSpace cr3");
+        return false;
+    }
+
+    // ---- (a) SHARED-FRAME SURVIVAL ----
+    let addr = crate::syscall::dispatch_linux_kernel(
+        9, 0, 0x1000, 3 /*PROT_RW*/, 0x22 /*MAP_PRIVATE|ANON*/, u64::MAX, 0);
+    if addr <= 0 {
+        test_fail!("madv_nozero", "mmap(a) failed: {}", addr);
+        return false;
+    }
+    let addr = addr as u64;
+    // Demand-fault the frame in via a real touch (anon page lifecycle).
+    unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::write_volatile(addr as *mut u8, 0x11);
+    }
+    let pte = crate::mm::vmm::read_pte(cr3, addr);
+    if pte & 1 == 0 {
+        test_fail!("madv_nozero", "anon page not present after touch (PTE={:#x})", pte);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    let frame = pte & PHYS_MASK;
+    // Stamp the whole frame through the kernel higher-half map.
+    for off in (0..0x1000u64).step_by(8) {
+        unsafe { core::ptr::write_volatile((PHYS_OFF + frame + off) as *mut u64, pat(off)); }
+    }
+    // Model the CoW sibling: a second live reference to the same frame — now
+    // SHARED (refcount 2), exactly as after fork.
+    crate::mm::refcount::page_ref_inc(frame);
+    let rc_shared = crate::mm::refcount::page_ref_count(frame);
+    if rc_shared < 2 {
+        test_fail!("madv_nozero", "expected shared rc>=2, got {}", rc_shared);
+        crate::mm::refcount::page_ref_dec(frame);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+
+    // madvise(DONTNEED) through THIS mapping — the real sys_madvise.
+    let r = crate::syscall::dispatch_linux_kernel(28, addr, 0x1000, MADV_DONTNEED, 0, 0, 0);
+    if r != 0 {
+        test_fail!("madv_nozero", "madvise(DONTNEED) returned {}", r);
+        crate::mm::refcount::page_ref_dec(frame);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    if crate::mm::vmm::read_pte(cr3, addr) & 1 != 0 {
+        test_fail!("madv_nozero", "PTE still present after DONTNEED");
+        crate::mm::refcount::page_ref_dec(frame);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    // Frame must have survived: rc 2 -> 1 (dec'd, NOT freed).
+    let rc_after = crate::mm::refcount::page_ref_count(frame);
+    if rc_after != 1 {
+        test_fail!("madv_nozero", "shared frame rc after DONTNEED = {} (want 1)", rc_after);
+        if rc_after != 0 { crate::mm::refcount::page_ref_dec(frame); }
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    // KEY ASSERTION: the shared frame's bytes were NOT zeroed in place.
+    let mut clobbered_off = u64::MAX;
+    for off in (0..0x1000u64).step_by(0x100) {
+        let got = unsafe { core::ptr::read_volatile((PHYS_OFF + frame + off) as *const u64) };
+        if got != pat(off) { clobbered_off = off; break; }
+    }
+    if clobbered_off != u64::MAX {
+        test_fail!("madv_nozero",
+            "shared frame {:#x} CLOBBERED at +{:#x} by in-place zero (W215 regression)",
+            frame, clobbered_off);
+        crate::mm::refcount::page_ref_dec(frame);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  (a) shared frame {:#x}: rc 2->1, bytes intact after DONTNEED ✓", frame);
+    // Release the modelled sibling ref → frame freed (rc 1 -> 0), balanced.
+    if crate::mm::refcount::page_ref_dec(frame) == 0 {
+        crate::mm::pmm::free_page(frame);
+    }
+    let _ = crate::syscall::dispatch_linux_kernel(11, addr, 0x1000, 0, 0, 0, 0);
+
+    // ---- (b) DONTNEED SEMANTICS: refault yields fresh zeros ----
+    let addr2 = crate::syscall::dispatch_linux_kernel(9, 0, 0x1000, 3, 0x22, u64::MAX, 0);
+    if addr2 <= 0 {
+        test_fail!("madv_nozero", "mmap(b) failed: {}", addr2);
+        return false;
+    }
+    let addr2 = addr2 as u64;
+    unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::write_volatile(addr2 as *mut u64, 0xA5A5_A5A5_A5A5_A5A5);
+    }
+    let r = crate::syscall::dispatch_linux_kernel(28, addr2, 0x1000, MADV_DONTNEED, 0, 0, 0);
+    if r != 0 {
+        test_fail!("madv_nozero", "madvise(b) returned {}", r);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr2, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    if crate::mm::vmm::read_pte(cr3, addr2) & 1 != 0 {
+        test_fail!("madv_nozero", "PTE(b) still present after DONTNEED");
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr2, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    // Next access demand-faults a fresh zero-filled frame.
+    let refault = unsafe {
+        let _g = crate::arch::x86_64::smap::UserGuard::new();
+        core::ptr::read_volatile(addr2 as *const u64)
+    };
+    if refault != 0 {
+        test_fail!("madv_nozero", "refault after DONTNEED read {:#x}, want 0", refault);
+        let _ = crate::syscall::dispatch_linux_kernel(11, addr2, 0x1000, 0, 0, 0, 0);
+        return false;
+    }
+    test_println!("  (b) DONTNEED then refault reads fresh zeros ✓");
+    let _ = crate::syscall::dispatch_linux_kernel(11, addr2, 0x1000, 0, 0, 0, 0);
+
+    test_pass!("madvise MADV_DONTNEED/FREE — no in-place zero (W215 shared-frame survival)");
     true
 }
 


### PR DESCRIPTION
## What

Removes the in-place zero-fill from `sys_madvise`'s `MADV_DONTNEED` / `MADV_FREE`
path. This is the root cause of the long-running **W215** page-corruption class.

## Mechanism

The anonymous arm of `sys_madvise` wrote `write_bytes(PHYS_OFF+phys, 0, PAGE)`
into each frame **in place** before the deferred free.

- **Unshared frame** — redundant. Clearing the PTE already makes the next access
  demand-fault a fresh zero-filled frame (POSIX `madvise(2)`: *"subsequent
  accesses ... will result in ... zero-fill-on-demand pages"*).
- **Shared frame** — corrupting. After `fork`, a copy-on-write anonymous frame is
  co-mapped by parent and child, so its refcount is ≥ 2. When one side
  `madvise(MADV_DONTNEED)`s its view, the in-place zero scribbles the frame while
  the co-mapper **still maps it**: `page_ref_dec` only lowers the count to ≥ 1, so
  the frame is **not** freed and the sibling keeps reading it — now all zeros where
  its allocator metadata used to be. The sibling's next metadata read faults.

That is precisely the W215 "victim frame served all-zero" fingerprint: a musl
mallocng group-header read of a **live, never-freed** anonymous frame that came
back zeroed (the `CR2=0x10` / `0x20` ld-musl face), plus the `CR2=0x0`
pointer-chase and `MOZ_RELEASE_ASSERT` faces.

## Evidence — positive attribution

An `exp#2` per-pfn zero-fill provenance probe (diagnostic-only, on the
`diag/w215-victim-classify` branch) placed a ring stamp immediately **before** the
in-place write. On a corrupting Wikipedia boot it named this exact site:

```
[W215/ZERO-LIVE] phys=0x53049000 pid=1 tid=20 off=0x0 len=0x1000 rc=1 sc=1 site=.../subsys/linux/syscall.rs  (the anon in-place zero)
... 30+ consecutive frames of a contiguous anon arena, pid 1 ...
```

This is the writer the saga never had, named by site + phys + refcount-at-zero-time.
Because the madvise zero is the **last** writer of a victim frame, a faulting
victim's `[W215/ZERO-PROV]` read reports `state=EXACT` at this site.

**Honest nuance (surfaced, not hidden):** `pte_share_count` is a thin alias of
`page_ref_count`, so `rc` and `sc` in that line are the same number. The
rate-limited live sample happened to capture the common `rc=1` traffic (pid 1
recycling whole anon arenas), not the rarer `rc≥2` *shared* event the corruption
requires. The shared-frame (`rc≥2`) clobber is therefore proven **deterministically**
by Test 723(a) below rather than relying on a lucky live capture; the live
`ZERO-LIVE` establishes that this site zeroes *live, mapped* frames at all. This is
consistent with the `exp#1` verdict (victim `INPLACE_NEVERFREED`, `rc≥1`, partial
zeros over surviving data) and with the refutations that must hold (free-shadow
`EMPTY` ⇒ not recycle/UAF; `[PMM/ALLOC-NONZERO-RC]=0` ⇒ not PMM double-alloc).

## Fix

Delete the in-place zero. Both advices are served by clearing the PTE and dropping
this mapping's page reference; the frame returns to the PMM only at refcount zero.
Shared frames are left intact for their remaining mappers; unshared frames still
refault to fresh zeros. The file-backed/anonymous VMA snapshot and its
`MADV_ZERO_SUPPRESSED` telemetry — whose sole purpose was to gate the in-place
zero — are removed with it; the clear-PTE path is identical for both backings.
The three-pass clear → shootdown → free structure is unchanged.

## Test plan — Test 723 (kernel suite, drives the REAL `sys_madvise` via dispatch nr=28)

- **(a) shared-frame survival** — a refcount-2 frame `madvise(DONTNEED)`'d through
  one mapping keeps its bytes and is dec'd (not freed).
  - **Fails on current master**: the in-place zero clobbers the frame → the check
    reads it back all-zero.
  - **Passes with this fix**: frame `rc 2→1`, bytes intact.
- **(b) DONTNEED semantics** — an unshared frame `madvise(DONTNEED)`'d is
  PTE-cleared and the next access demand-faults fresh zeros.

`cargo +nightly check` clean under both `--features test-mode` and
`--features firefox-test-core`. CI is the gate.

## Review

This is an mm-path change; it warrants an independent review of the refcount /
shootdown accounting around the deletion. Requesting one author-side review; a
second unseeded review is expected per project policy. **Do not merge** — the
coordinator merges.

## Citations

POSIX.1-2017 `madvise(2)` (`MADV_DONTNEED` / `MADV_FREE`); Intel SDM Vol. 3A
§4.10.5 (propagate paging-structure changes before a frame is reused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
